### PR TITLE
Add database module with SQLite support and refactor module registry

### DIFF
--- a/cmd/XXX/main.go
+++ b/cmd/XXX/main.go
@@ -1,5 +1,0 @@
-package main
-
-func main() {
-
-}

--- a/engine/runtime.go
+++ b/engine/runtime.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-go-golems/go-go-goja/modules"
 	// Blank imports ensure module init() functions run so they can register themselves.
+	_ "github.com/go-go-golems/go-go-goja/modules/database"
 	_ "github.com/go-go-golems/go-go-goja/modules/exec"
 	_ "github.com/go-go-golems/go-go-goja/modules/fs"
 

--- a/go.mod
+++ b/go.mod
@@ -5,12 +5,12 @@ go 1.24.3
 require (
 	github.com/dop251/goja v0.0.0-20250309171923-bcd7cc6bf64c
 	github.com/dop251/goja_nodejs v0.0.0-20240728170619-29b559befffc
+	github.com/mattn/go-sqlite3 v1.14.28
 )
 
 require (
 	github.com/dlclark/regexp2 v1.11.4 // indirect
 	github.com/go-sourcemap/sourcemap v2.1.4+incompatible // indirect
 	github.com/google/pprof v0.0.0-20240727154555-813a5fbdbec8 // indirect
-	github.com/mattn/go-sqlite3 v1.14.28 // indirect
 	golang.org/x/text v0.16.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -11,5 +11,6 @@ require (
 	github.com/dlclark/regexp2 v1.11.4 // indirect
 	github.com/go-sourcemap/sourcemap v2.1.4+incompatible // indirect
 	github.com/google/pprof v0.0.0-20240727154555-813a5fbdbec8 // indirect
+	github.com/mattn/go-sqlite3 v1.14.28 // indirect
 	golang.org/x/text v0.16.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/go-sourcemap/sourcemap v2.1.4+incompatible h1:a+iTbH5auLKxaNwQFg0B+TC
 github.com/go-sourcemap/sourcemap v2.1.4+incompatible/go.mod h1:F8jJfvm2KbVjc5NqelyYJmf/v5J0dwNLS2mL4sNA1Jg=
 github.com/google/pprof v0.0.0-20240727154555-813a5fbdbec8 h1:FKHo8hFI3A+7w0aUQuYXQ+6EN5stWmeY/AZqtM8xk9k=
 github.com/google/pprof v0.0.0-20240727154555-813a5fbdbec8/go.mod h1:K1liHPHnj73Fdn/EKuT8nrFqBihUSKXoLYU0BuatOYo=
+github.com/mattn/go-sqlite3 v1.14.28 h1:ThEiQrnbtumT+QMknw63Befp/ce/nUPgBPMlRFEum7A=
+github.com/mattn/go-sqlite3 v1.14.28/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 golang.org/x/text v0.16.0 h1:a94ExnEXNtEwYLGJSIUxnWoxoRz/ZcCsV63ROupILh4=
 golang.org/x/text v0.16.0/go.mod h1:GhwF1Be+LQoKShO3cGOHzqOgRrGaYc9AvblQOmPVHnI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=

--- a/modules/database/database.go
+++ b/modules/database/database.go
@@ -40,10 +40,18 @@ Functions:
 // Loader exposes the database functions to the JavaScript module.
 func (m *DBModule) Loader(vm *goja.Runtime, moduleObj *goja.Object) {
 	exports := moduleObj.Get("exports").(*goja.Object)
-	exports.Set("configure", m.Configure)
-	exports.Set("query", m.Query)
-	exports.Set("exec", m.Exec)
-	exports.Set("close", m.Close)
+	if err := exports.Set("configure", m.Configure); err != nil {
+		log.Printf("database: failed to set configure function: %v", err)
+	}
+	if err := exports.Set("query", m.Query); err != nil {
+		log.Printf("database: failed to set query function: %v", err)
+	}
+	if err := exports.Set("exec", m.Exec); err != nil {
+		log.Printf("database: failed to set exec function: %v", err)
+	}
+	if err := exports.Set("close", m.Close); err != nil {
+		log.Printf("database: failed to set close function: %v", err)
+	}
 }
 
 // Configure sets up the database connection.
@@ -96,7 +104,11 @@ func (m *DBModule) Query(query string, args ...interface{}) ([]map[string]interf
 		log.Printf("database: query error: %v", err)
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() {
+		if err := rows.Close(); err != nil {
+			log.Printf("database: failed to close rows: %v", err)
+		}
+	}()
 
 	cols, err := rows.Columns()
 	if err != nil {

--- a/modules/database/database.go
+++ b/modules/database/database.go
@@ -1,0 +1,174 @@
+package databasemod
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/dop251/goja"
+	"github.com/go-go-golems/go-go-goja/modules"
+	_ "github.com/mattn/go-sqlite3" // Driver for sqlite3
+)
+
+// DBModule provides a database connection for a goja runtime.
+type DBModule struct {
+	db *sql.DB
+}
+
+var _ modules.NativeModule = (*DBModule)(nil)
+
+// Name returns the module name.
+func (m *DBModule) Name() string { return "database" }
+
+// Doc returns the documentation for the module.
+func (m *DBModule) Doc() string {
+	return `
+Database module provides a simple SQL interface.
+
+Functions:
+  configure(driverName, dataSourceName): Configures the database connection.
+    Example: require('database').configure('sqlite3', ':memory:');
+  query(sql, ...args): Executes a query and returns rows.
+    Example: require('database').query('SELECT * FROM users WHERE id = ?', 1);
+  exec(sql, ...args): Executes a statement and returns result summary.
+    Example: require('database').exec('INSERT INTO users (name) VALUES (?)', 'John');
+  close(): Closes the database connection.
+`
+}
+
+// Loader exposes the database functions to the JavaScript module.
+func (m *DBModule) Loader(vm *goja.Runtime, moduleObj *goja.Object) {
+	exports := moduleObj.Get("exports").(*goja.Object)
+	exports.Set("configure", m.Configure)
+	exports.Set("query", m.Query)
+	exports.Set("exec", m.Exec)
+	exports.Set("close", m.Close)
+}
+
+// Configure sets up the database connection.
+func (m *DBModule) Configure(driverName, dataSourceName string) error {
+	if m.db != nil {
+		if err := m.db.Close(); err != nil {
+			log.Printf("database: failed to close existing connection: %v", err)
+		}
+	}
+
+	db, err := sql.Open(driverName, dataSourceName)
+	if err != nil {
+		log.Printf("database: failed to open connection to %s: %v", dataSourceName, err)
+		return err
+	}
+	m.db = db
+	log.Printf("database: configured for driver %s", driverName)
+	return nil
+}
+
+// Close closes the database connection.
+func (m *DBModule) Close() error {
+	if m.db != nil {
+		log.Printf("database: closing connection")
+		return m.db.Close()
+	}
+	return nil
+}
+
+// Query executes a SQL query and returns results as JavaScript objects.
+func (m *DBModule) Query(query string, args ...interface{}) ([]map[string]interface{}, error) {
+	if m.db == nil {
+		return nil, fmt.Errorf("database not configured, call require('database').configure(...) first")
+	}
+
+	startTime := time.Now()
+	log.Printf("database: executing query: %s", query)
+
+	var flatArgs []interface{}
+	for _, arg := range args {
+		if slice, ok := arg.([]interface{}); ok {
+			flatArgs = append(flatArgs, slice...)
+		} else {
+			flatArgs = append(flatArgs, arg)
+		}
+	}
+
+	rows, err := m.db.Query(query, flatArgs...)
+	if err != nil {
+		log.Printf("database: query error: %v", err)
+		return nil, err
+	}
+	defer rows.Close()
+
+	cols, err := rows.Columns()
+	if err != nil {
+		return nil, err
+	}
+
+	var result []map[string]interface{}
+	for rows.Next() {
+		vals := make([]interface{}, len(cols))
+		scan := make([]interface{}, len(cols))
+		for i := range vals {
+			scan[i] = &vals[i]
+		}
+
+		if err := rows.Scan(scan...); err != nil {
+			log.Printf("database: row scan error: %v", err)
+			continue
+		}
+
+		rec := make(map[string]interface{})
+		for i, col := range cols {
+			rec[col] = vals[i]
+		}
+		result = append(result, rec)
+	}
+
+	duration := time.Since(startTime)
+	log.Printf("database: query completed in %v, returned %d rows", duration, len(result))
+
+	return result, nil
+}
+
+// Exec executes a SQL statement without returning rows.
+func (m *DBModule) Exec(query string, args ...interface{}) (map[string]interface{}, error) {
+	if m.db == nil {
+		return nil, fmt.Errorf("database not configured, call require('database').configure(...) first")
+	}
+
+	startTime := time.Now()
+	log.Printf("database: executing exec: %s", query)
+
+	var flatArgs []interface{}
+	for _, arg := range args {
+		if slice, ok := arg.([]interface{}); ok {
+			flatArgs = append(flatArgs, slice...)
+		} else {
+			flatArgs = append(flatArgs, arg)
+		}
+	}
+
+	result, err := m.db.Exec(query, flatArgs...)
+	if err != nil {
+		log.Printf("database: exec error: %v", err)
+		return map[string]interface{}{
+			"error":   err.Error(),
+			"success": false,
+		}, err
+	}
+
+	rowsAffected, _ := result.RowsAffected()
+	lastInsertId, _ := result.LastInsertId()
+
+	duration := time.Since(startTime)
+	log.Printf("database: exec completed in %v, affected %d rows", duration, rowsAffected)
+
+	return map[string]interface{}{
+		"success":      true,
+		"rowsAffected": rowsAffected,
+		"lastInsertId": lastInsertId,
+	}, nil
+}
+
+func init() {
+	modules.Register(&DBModule{})
+}

--- a/modules/exec/exec.go
+++ b/modules/exec/exec.go
@@ -14,6 +14,11 @@ var _ modules.NativeModule = (*m)(nil)
 
 func (m) Name() string { return "exec" }
 
+// Doc returns the documentation for the module.
+func (m) Doc() string {
+	return "The exec module provides a simple way to run external commands."
+}
+
 // Loader attaches the exported Go functions to the JS module.exports object.
 func (m) Loader(vm *goja.Runtime, moduleObj *goja.Object) {
 	exports := moduleObj.Get("exports").(*goja.Object)

--- a/modules/fs/fs.go
+++ b/modules/fs/fs.go
@@ -17,6 +17,17 @@ var _ modules.NativeModule = (*m)(nil)
 
 func (m) Name() string { return "fs" }
 
+// Doc returns the documentation for the module.
+func (m) Doc() string {
+	return `
+The fs module provides basic file system operations.
+
+Functions:
+  readFileSync(path): Reads a file and returns its content as a string.
+  writeFileSync(path, data): Writes data to a file.
+`
+}
+
 // Loader attaches the exported Go functions to the JS `exports` object.
 func (m) Loader(vm *goja.Runtime, moduleObj *goja.Object) {
 	exports := moduleObj.Get("exports").(*goja.Object)

--- a/testdata/database.js
+++ b/testdata/database.js
@@ -1,0 +1,46 @@
+const { configure, query, exec, close } = require('database');
+
+console.log("database module loaded");
+
+// Configure for an in-memory SQLite database
+const err = configure('sqlite3', ':memory:');
+if (err) {
+    console.error("Failed to configure database:", err);
+    throw new Error("DB configuration failed");
+}
+console.log("database configured for in-memory sqlite3");
+
+// Create a table
+let result, err = exec("CREATE TABLE users (id INT, name TEXT)");
+if (err) {
+    console.error("Failed to create table:", err);
+    throw new Error("CREATE TABLE failed");
+}
+console.log("CREATE TABLE successful:", JSON.stringify(result));
+
+// Insert data
+result, err = exec("INSERT INTO users (id, name) VALUES (?, ?)", 1, "John Doe");
+if (err) {
+    console.error("Failed to insert data:", err);
+    throw new Error("INSERT failed");
+}
+console.log("INSERT successful:", JSON.stringify(result));
+
+// Query data
+let rows, qErr = query("SELECT * FROM users");
+if (qErr) {
+    console.error("Failed to query data:", qErr);
+    throw new Error("SELECT failed");
+}
+
+if (rows.length !== 1 || rows[0].name !== "John Doe") {
+    console.error("Query result mismatch:", JSON.stringify(rows));
+    throw new Error("Query result validation failed");
+}
+console.log("SELECT successful:", JSON.stringify(rows));
+
+// Close the database connection
+close();
+
+console.log("database test successful");
+console.log("OK"); 


### PR DESCRIPTION
## Changes

### Database Module
- Add new `database` module with SQL interface for JavaScript runtime
- Support SQLite3 driver with `configure()`, `query()`, `exec()`, and `close()` 
  functions
- Return query results as JavaScript objects with column names as keys
- Include comprehensive error handling and logging
- Add test coverage demonstrating table creation, data insertion, and querying

### Module Registry Refactoring
- Refactor module registration system to use proper Registry pattern
- Add `Doc()` method to NativeModule interface for documentation strings
- Implement `GetModule()` and `GetDocumentation()` methods for introspection
- Maintain backward compatibility with existing `Register()` and `EnableAll()` 
  functions
- Add documentation strings to existing `exec` and `fs` modules

### Dependencies
- Add `github.com/mattn/go-sqlite3` dependency for SQLite support

## Breaking Changes
- NativeModule interface now requires `Doc()` method implementation
- Existing modules must be updated to implement documentation method