### PR TITLE
feat(tooling): Add interactive AST/CST parse editor

### DIFF
--- a/cmd/ast-parse-editor/app/model.go
+++ b/cmd/ast-parse-editor/app/model.go
@@ -1,0 +1,549 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/dop251/goja/parser"
+	"github.com/go-go-golems/go-go-goja/pkg/jsparse"
+)
+
+type focusPane int
+
+const (
+	focusEditor focusPane = iota
+	focusTSSExpr
+	focusASTSExpr
+)
+
+type astParsedMsg struct {
+	Seq      uint64
+	ParseErr error
+	ASTSExpr string
+}
+
+// Model drives the live 3-pane AST parse editor.
+type Model struct {
+	filename string
+
+	lines     []string
+	cursorRow int
+	cursorCol int
+
+	editorScroll int
+	tsScroll     int
+	astScroll    int
+
+	focus focusPane
+
+	width  int
+	height int
+
+	tsParser *jsparse.TSParser
+	tsRoot   *jsparse.TSNode
+	tsSExpr  string
+
+	astSExpr    string
+	astParseErr error
+
+	parseSeq      uint64
+	pendingSeq    uint64
+	parseDebounce time.Duration
+}
+
+// NewModel creates a new live editor model.
+func NewModel(filename, source string) *Model {
+	lines := strings.Split(source, "\n")
+	if len(lines) == 0 {
+		lines = []string{""}
+	}
+
+	tsParser, _ := jsparse.NewTSParser()
+	m := &Model{
+		filename:      filename,
+		lines:         lines,
+		focus:         focusEditor,
+		tsParser:      tsParser,
+		parseDebounce: 120 * time.Millisecond,
+	}
+	m.reparseCST()
+	return m
+}
+
+// Init implements tea.Model.
+func (m *Model) Init() tea.Cmd {
+	return m.scheduleASTParse()
+}
+
+// Update implements tea.Model.
+func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		return m, nil
+	case tea.KeyMsg:
+		return m.handleKey(msg)
+	case astParsedMsg:
+		if msg.Seq != m.pendingSeq {
+			return m, nil
+		}
+		m.astParseErr = msg.ParseErr
+		if msg.ParseErr == nil {
+			m.astSExpr = msg.ASTSExpr
+		} else {
+			m.astSExpr = ""
+		}
+		m.astScroll = clamp(m.astScroll, 0, maxInt(0, len(strings.Split(m.astTextForView(), "\n"))-1))
+		return m, nil
+	}
+	return m, nil
+}
+
+func (m *Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "q", "ctrl+c":
+		m.Close()
+		return m, tea.Quit
+	case "tab":
+		m.focus = (m.focus + 1) % 3
+		return m, nil
+	}
+
+	switch m.focus {
+	case focusEditor:
+		return m.handleEditorKey(msg)
+	case focusTSSExpr:
+		return m.handleScrollKey(msg, &m.tsScroll, m.tsSExpr)
+	case focusASTSExpr:
+		return m.handleScrollKey(msg, &m.astScroll, m.astTextForView())
+	default:
+		return m, nil
+	}
+}
+
+func (m *Model) handleEditorKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "up":
+		m.moveCursor(-1, 0)
+		return m, nil
+	case "down":
+		m.moveCursor(1, 0)
+		return m, nil
+	case "left":
+		m.moveCursor(0, -1)
+		return m, nil
+	case "right":
+		m.moveCursor(0, 1)
+		return m, nil
+	case "home":
+		m.cursorCol = 0
+		return m, nil
+	case "end":
+		m.cursorCol = len([]rune(m.lines[m.cursorRow]))
+		return m, nil
+	case "enter":
+		m.insertNewline()
+		return m, m.postEdit()
+	case "backspace":
+		m.deleteBack()
+		return m, m.postEdit()
+	}
+
+	if runes := msg.Runes; len(runes) > 0 {
+		for _, r := range runes {
+			m.insertChar(r)
+		}
+		return m, m.postEdit()
+	}
+
+	return m, nil
+}
+
+func (m *Model) handleScrollKey(msg tea.KeyMsg, scroll *int, content string) (tea.Model, tea.Cmd) {
+	lines := strings.Split(content, "\n")
+	maxScroll := maxInt(0, len(lines)-1)
+
+	switch msg.String() {
+	case "up", "k":
+		*scroll = clamp(*scroll-1, 0, maxScroll)
+	case "down", "j":
+		*scroll = clamp(*scroll+1, 0, maxScroll)
+	case "pgup":
+		*scroll = clamp(*scroll-10, 0, maxScroll)
+	case "pgdown":
+		*scroll = clamp(*scroll+10, 0, maxScroll)
+	case "g":
+		*scroll = 0
+	case "G":
+		*scroll = maxScroll
+	}
+	return m, nil
+}
+
+func (m *Model) postEdit() tea.Cmd {
+	m.reparseCST()
+	return m.scheduleASTParse()
+}
+
+func (m *Model) source() string {
+	return strings.Join(m.lines, "\n")
+}
+
+func (m *Model) scheduleASTParse() tea.Cmd {
+	m.parseSeq++
+	seq := m.parseSeq
+	source := m.source()
+	m.pendingSeq = seq
+	return parseASTCmd(seq, m.filename, source, m.parseDebounce)
+}
+
+func parseASTCmd(seq uint64, filename, source string, delay time.Duration) tea.Cmd {
+	run := func() tea.Msg {
+		program, parseErr := parser.ParseFile(nil, filename, source, 0)
+
+		astSExpr := ""
+		if parseErr == nil && program != nil {
+			astSExpr = jsparse.ASTToSExpr(program, source, &jsparse.SExprOptions{
+				IncludeSpan: true,
+				IncludeText: true,
+				MaxDepth:    80,
+				MaxNodes:    8000,
+			})
+		}
+
+		return astParsedMsg{
+			Seq:      seq,
+			ParseErr: parseErr,
+			ASTSExpr: astSExpr,
+		}
+	}
+
+	if delay <= 0 {
+		return run
+	}
+	return tea.Tick(delay, func(time.Time) tea.Msg {
+		return run()
+	})
+}
+
+func (m *Model) reparseCST() {
+	if m.tsParser == nil {
+		m.tsRoot = nil
+		m.tsSExpr = "(tree-sitter unavailable)"
+		return
+	}
+
+	m.tsRoot = m.tsParser.Parse([]byte(m.source()))
+	if m.tsRoot == nil {
+		m.tsSExpr = "(no parse)"
+		return
+	}
+
+	m.tsSExpr = jsparse.CSTToSExpr(m.tsRoot, &jsparse.SExprOptions{
+		IncludeSpan:  true,
+		IncludeText:  true,
+		IncludeFlags: true,
+		MaxDepth:     80,
+		MaxNodes:     8000,
+	})
+}
+
+func (m *Model) astTextForView() string {
+	if m.astParseErr != nil {
+		return fmt.Sprintf("(parse-error %q)", m.astParseErr.Error())
+	}
+	if strings.TrimSpace(m.astSExpr) == "" {
+		return "(waiting-for-valid-parse)"
+	}
+	return m.astSExpr
+}
+
+func (m *Model) moveCursor(dy, dx int) {
+	m.cursorRow = clamp(m.cursorRow+dy, 0, len(m.lines)-1)
+	lineLen := len([]rune(m.lines[m.cursorRow]))
+	m.cursorCol = clamp(m.cursorCol+dx, 0, lineLen)
+	m.ensureCursorVisible()
+}
+
+func (m *Model) ensureCursorVisible() {
+	vh := maxInt(1, m.contentHeight()-1)
+	if m.cursorRow < m.editorScroll {
+		m.editorScroll = m.cursorRow
+	}
+	if m.cursorRow >= m.editorScroll+vh {
+		m.editorScroll = m.cursorRow - vh + 1
+	}
+}
+
+func (m *Model) insertChar(ch rune) {
+	line := m.lines[m.cursorRow]
+	runes := []rune(line)
+	col := clamp(m.cursorCol, 0, len(runes))
+
+	runes = append(runes[:col], append([]rune{ch}, runes[col:]...)...)
+	m.lines[m.cursorRow] = string(runes)
+	m.cursorCol = col + 1
+	m.ensureCursorVisible()
+}
+
+func (m *Model) insertNewline() {
+	line := m.lines[m.cursorRow]
+	runes := []rune(line)
+	col := clamp(m.cursorCol, 0, len(runes))
+
+	before := string(runes[:col])
+	after := string(runes[col:])
+	m.lines[m.cursorRow] = before
+
+	newLines := make([]string, 0, len(m.lines)+1)
+	newLines = append(newLines, m.lines[:m.cursorRow+1]...)
+	newLines = append(newLines, after)
+	newLines = append(newLines, m.lines[m.cursorRow+1:]...)
+	m.lines = newLines
+
+	m.cursorRow++
+	m.cursorCol = 0
+	m.ensureCursorVisible()
+}
+
+func (m *Model) deleteBack() {
+	if m.cursorCol > 0 {
+		line := m.lines[m.cursorRow]
+		runes := []rune(line)
+		col := clamp(m.cursorCol, 0, len(runes))
+		runes = append(runes[:col-1], runes[col:]...)
+		m.lines[m.cursorRow] = string(runes)
+		m.cursorCol = col - 1
+		m.ensureCursorVisible()
+		return
+	}
+
+	if m.cursorRow > 0 {
+		prev := m.lines[m.cursorRow-1]
+		cur := m.lines[m.cursorRow]
+		m.lines[m.cursorRow-1] = prev + cur
+		m.lines = append(m.lines[:m.cursorRow], m.lines[m.cursorRow+1:]...)
+		m.cursorRow--
+		m.cursorCol = len([]rune(prev))
+		m.ensureCursorVisible()
+	}
+}
+
+// View implements tea.Model.
+func (m *Model) View() string {
+	if m.width <= 0 || m.height <= 0 {
+		return "Initializing..."
+	}
+
+	header := m.renderHeader()
+	status := m.renderStatus()
+	help := m.renderHelp()
+
+	contentHeight := m.contentHeight()
+	leftW := m.width / 3
+	midW := m.width / 3
+	rightW := m.width - leftW - midW
+
+	editor := m.renderEditorPane(leftW, contentHeight)
+	ts := m.renderTextPane(" TS SEXP ", m.tsSExpr, m.tsScroll, midW, contentHeight, m.focus == focusTSSExpr)
+	ast := m.renderTextPane(" AST SEXP ", m.astTextForView(), m.astScroll, rightW, contentHeight, m.focus == focusASTSExpr)
+
+	content := lipgloss.JoinHorizontal(lipgloss.Top, editor, ts, ast)
+	return lipgloss.JoinVertical(lipgloss.Left, header, content, status, help)
+}
+
+func (m *Model) contentHeight() int {
+	h := m.height - 3 // header + status + help
+	if h < 3 {
+		h = 3
+	}
+	return h
+}
+
+func (m *Model) renderHeader() string {
+	style := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color("15")).
+		Background(lipgloss.Color("62")).
+		Width(m.width).
+		Padding(0, 1)
+
+	focus := "EDITOR"
+	switch m.focus {
+	case focusEditor:
+		// keep default
+	case focusTSSExpr:
+		focus = "TS SEXP"
+	case focusASTSExpr:
+		focus = "AST SEXP"
+	}
+	title := fmt.Sprintf("File: %s", m.filename)
+	mode := fmt.Sprintf("AST PARSE EDITOR [%s]", focus)
+	gap := m.width - len(title) - len(mode) - 2
+	if gap < 1 {
+		gap = 1
+	}
+
+	return style.Render(title + strings.Repeat(" ", gap) + mode)
+}
+
+func (m *Model) renderStatus() string {
+	style := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("15")).
+		Background(lipgloss.Color("236")).
+		Width(m.width).
+		Padding(0, 1)
+
+	parts := []string{
+		fmt.Sprintf("cursor: %d:%d", m.cursorRow+1, m.cursorCol+1),
+		fmt.Sprintf("lines: %d", len(m.lines)),
+		fmt.Sprintf("seq: %d", m.pendingSeq),
+	}
+
+	if m.tsRoot != nil && m.tsRoot.HasError() {
+		parts = append(parts, "ts: error-recovered")
+	} else {
+		parts = append(parts, "ts: ok")
+	}
+
+	if m.astParseErr != nil {
+		parts = append(parts, "ast: invalid")
+	} else if strings.TrimSpace(m.astSExpr) == "" {
+		parts = append(parts, "ast: pending")
+	} else {
+		parts = append(parts, "ast: valid")
+	}
+
+	return style.Render(strings.Join(parts, " | "))
+}
+
+func (m *Model) renderHelp() string {
+	style := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("244")).
+		Width(m.width).
+		Padding(0, 1)
+
+	return style.Render("Tab:focus pane | Editor: type, Enter, Backspace, arrows | TS/AST panes: j/k or arrows to scroll | q:quit")
+}
+
+func (m *Model) renderEditorPane(width, height int) string {
+	var lines []string
+	headerStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color("15")).
+		Background(lipgloss.Color("240"))
+	if m.focus == focusEditor {
+		headerStyle = headerStyle.Background(lipgloss.Color("33"))
+	}
+
+	title := " EDITOR "
+	header := headerStyle.Render(title) + strings.Repeat("─", maxInt(0, width-len(title)))
+	lines = append(lines, padRight(header, width))
+
+	contentHeight := maxInt(1, height-1)
+	gutterWidth := len(fmt.Sprintf("%d", len(m.lines))) + 1
+	cursorStyle := lipgloss.NewStyle().Reverse(true).Bold(true)
+	gutterNormal := lipgloss.NewStyle().Foreground(lipgloss.Color("244"))
+	gutterCursor := lipgloss.NewStyle().Foreground(lipgloss.Color("226")).Bold(true)
+
+	for i := 0; i < contentHeight; i++ {
+		lineIdx := m.editorScroll + i
+		if lineIdx >= len(m.lines) {
+			lines = append(lines, strings.Repeat(" ", width))
+			continue
+		}
+
+		raw := m.lines[lineIdx]
+		runes := []rune(raw)
+		lineNum := fmt.Sprintf("%*d ", gutterWidth, lineIdx+1)
+		gs := gutterNormal
+		if lineIdx == m.cursorRow {
+			gs = gutterCursor
+		}
+		gutter := gs.Render(lineNum)
+
+		var content strings.Builder
+		for c := 0; c < len(runes); c++ {
+			ch := string(runes[c])
+			if lineIdx == m.cursorRow && c == m.cursorCol && m.focus == focusEditor {
+				content.WriteString(cursorStyle.Render(ch))
+			} else {
+				content.WriteString(ch)
+			}
+		}
+		if lineIdx == m.cursorRow && m.cursorCol >= len(runes) && m.focus == focusEditor {
+			content.WriteString(cursorStyle.Render(" "))
+		}
+
+		lines = append(lines, padRight(gutter+content.String(), width))
+	}
+
+	return lipgloss.NewStyle().Width(width).MaxWidth(width).Render(strings.Join(lines, "\n"))
+}
+
+func (m *Model) renderTextPane(title, body string, scroll, width, height int, focused bool) string {
+	var lines []string
+	headerStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color("15")).
+		Background(lipgloss.Color("240"))
+	if focused {
+		headerStyle = headerStyle.Background(lipgloss.Color("33"))
+	}
+
+	header := headerStyle.Render(title) + strings.Repeat("─", maxInt(0, width-len(title)))
+	lines = append(lines, padRight(header, width))
+
+	contentHeight := maxInt(1, height-1)
+	bodyLines := strings.Split(body, "\n")
+	start := clamp(scroll, 0, maxInt(0, len(bodyLines)-1))
+
+	for i := 0; i < contentHeight; i++ {
+		idx := start + i
+		if idx >= len(bodyLines) {
+			lines = append(lines, strings.Repeat(" ", width))
+			continue
+		}
+		lines = append(lines, padRight(bodyLines[idx], width))
+	}
+
+	return lipgloss.NewStyle().Width(width).MaxWidth(width).Render(strings.Join(lines, "\n"))
+}
+
+// Close releases parser resources.
+func (m *Model) Close() {
+	if m.tsParser != nil {
+		m.tsParser.Close()
+		m.tsParser = nil
+	}
+}
+
+func padRight(s string, width int) string {
+	w := ansi.StringWidth(s)
+	if w >= width {
+		return ansi.Truncate(s, width, "")
+	}
+	return s + strings.Repeat(" ", width-w)
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func clamp(v, lo, hi int) int {
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
+}

--- a/cmd/ast-parse-editor/app/model_test.go
+++ b/cmd/ast-parse-editor/app/model_test.go
@@ -1,0 +1,105 @@
+package app
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func applyCmd(t *testing.T, m *Model, cmd tea.Cmd) *Model {
+	t.Helper()
+	if cmd == nil {
+		return m
+	}
+	msg := cmd()
+	next, nextCmd := m.Update(msg)
+	nm, ok := next.(*Model)
+	if !ok {
+		t.Fatalf("expected *Model, got %T", next)
+	}
+	_ = nextCmd
+	return nm
+}
+
+func newTestModel(t *testing.T, src string) *Model {
+	t.Helper()
+	m := NewModel("test.js", src)
+	m.parseDebounce = 0
+
+	cmd := m.Init()
+	m = applyCmd(t, m, cmd)
+	return m
+}
+
+func TestInitialParseProducesASTSExpr(t *testing.T) {
+	m := newTestModel(t, "const x = 1;")
+
+	if m.astParseErr != nil {
+		t.Fatalf("expected no parse error, got %v", m.astParseErr)
+	}
+	if m.astSExpr == "" {
+		t.Fatal("expected non-empty AST S-expression")
+	}
+}
+
+func TestEditToInvalidSourceClearsASTPane(t *testing.T) {
+	m := newTestModel(t, "const obj = {};\nobj")
+	m.cursorRow = 1
+	m.cursorCol = len([]rune(m.lines[1]))
+
+	key := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'.'}}
+	next, cmd := m.Update(key)
+	var ok bool
+	m, ok = next.(*Model)
+	if !ok {
+		t.Fatalf("expected *Model after key update, got %T", next)
+	}
+	m = applyCmd(t, m, cmd)
+
+	if m.astParseErr == nil {
+		t.Fatal("expected parse error after typing trailing dot")
+	}
+	if m.astSExpr != "" {
+		t.Fatalf("expected AST pane to clear on invalid parse, got: %s", m.astSExpr)
+	}
+}
+
+func TestCSTSExprChangesAfterEdit(t *testing.T) {
+	m := newTestModel(t, "const x = 1;")
+	old := m.tsSExpr
+	m.cursorRow = 0
+	m.cursorCol = len([]rune(m.lines[0]))
+
+	key := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{';'}}
+	next, cmd := m.Update(key)
+	var ok bool
+	m, ok = next.(*Model)
+	if !ok {
+		t.Fatalf("expected *Model after key update, got %T", next)
+	}
+	m = applyCmd(t, m, cmd)
+
+	if m.tsSExpr == old {
+		t.Fatal("expected CST S-expression to change after edit")
+	}
+}
+
+func TestStaleASTParseMessageIsIgnored(t *testing.T) {
+	m := newTestModel(t, "const x = 1;")
+	old := m.astSExpr
+	m.pendingSeq = 5
+
+	next, _ := m.Update(astParsedMsg{
+		Seq:      4,
+		ParseErr: nil,
+		ASTSExpr: "(Program stale)",
+	})
+	nm, ok := next.(*Model)
+	if !ok {
+		t.Fatalf("expected *Model, got %T", next)
+	}
+
+	if nm.astSExpr != old {
+		t.Fatalf("expected stale AST message to be ignored, got: %s", nm.astSExpr)
+	}
+}

--- a/cmd/ast-parse-editor/app/model_test.go
+++ b/cmd/ast-parse-editor/app/model_test.go
@@ -42,6 +42,20 @@ func TestInitialParseProducesASTSExpr(t *testing.T) {
 	}
 }
 
+func TestInitialParseForEmptySourceProducesProgramAST(t *testing.T) {
+	m := newTestModel(t, "")
+
+	if m.astParseErr != nil {
+		t.Fatalf("expected no parse error for empty source, got %v", m.astParseErr)
+	}
+	if m.astSExpr != "(Program)" {
+		t.Fatalf("expected Program AST for empty source, got %q", m.astSExpr)
+	}
+	if m.astTextForView() == "(waiting-for-valid-parse)" {
+		t.Fatal("expected AST pane to show valid parse for empty source")
+	}
+}
+
 func TestEditToInvalidSourceClearsASTPane(t *testing.T) {
 	m := newTestModel(t, "const obj = {};\nobj")
 	m.cursorRow = 1

--- a/cmd/ast-parse-editor/app/model_test.go
+++ b/cmd/ast-parse-editor/app/model_test.go
@@ -56,6 +56,50 @@ func TestInitialParseForEmptySourceProducesProgramAST(t *testing.T) {
 	}
 }
 
+func TestCursorNodeHighlightInitialized(t *testing.T) {
+	m := newTestModel(t, "const x = 1;")
+
+	if m.cursorNode == nil {
+		t.Fatal("expected cursor node to be resolved")
+	}
+	if m.highlightStartLine < 1 || m.highlightEndLine < 1 {
+		t.Fatalf("expected valid highlight range, got start=%d:%d end=%d:%d",
+			m.highlightStartLine, m.highlightStartCol, m.highlightEndLine, m.highlightEndCol)
+	}
+}
+
+func TestCursorNodeHighlightMovesWithCursor(t *testing.T) {
+	m := newTestModel(t, "const x = 1;")
+
+	m.moveCursor(0, 6) // on "x"
+	if m.cursorNode == nil || m.cursorNode.Text != "x" {
+		got := "<nil>"
+		if m.cursorNode != nil {
+			got = m.cursorNode.Text
+		}
+		t.Fatalf("expected cursor node text x, got %s", got)
+	}
+
+	m.moveCursor(0, 4) // on "1"
+	if m.cursorNode == nil || m.cursorNode.Text != "1" {
+		got := "<nil>"
+		if m.cursorNode != nil {
+			got = m.cursorNode.Text
+		}
+		t.Fatalf("expected cursor node text 1, got %s", got)
+	}
+}
+
+func TestCursorNodeHighlightEmptySourceIsSafe(t *testing.T) {
+	m := newTestModel(t, "")
+	m.updateCursorNodeHighlight()
+
+	if m.highlightStartLine != 0 || m.highlightStartCol != 0 || m.highlightEndLine != 0 || m.highlightEndCol != 0 {
+		t.Fatalf("expected empty highlight range, got start=%d:%d end=%d:%d",
+			m.highlightStartLine, m.highlightStartCol, m.highlightEndLine, m.highlightEndCol)
+	}
+}
+
 func TestEditToInvalidSourceClearsASTPane(t *testing.T) {
 	m := newTestModel(t, "const obj = {};\nobj")
 	m.cursorRow = 1

--- a/cmd/ast-parse-editor/app/model_test.go
+++ b/cmd/ast-parse-editor/app/model_test.go
@@ -106,6 +106,37 @@ func TestCursorNodeHighlightMovesWithCursor(t *testing.T) {
 	}
 }
 
+func TestSExprSelectionLinesTrackCursor(t *testing.T) {
+	src := "const greeting = 'hi';\nconsole.log(greeting);"
+	m := newTestModel(t, src)
+
+	if m.tsSExprSelectedLine < 0 {
+		t.Fatalf("expected initial TS SEXP selection line, got %d", m.tsSExprSelectedLine)
+	}
+	if m.astSExprSelectedLine < 0 {
+		t.Fatalf("expected initial AST SEXP selection line, got %d", m.astSExprSelectedLine)
+	}
+	startTS := m.tsSExprSelectedLine
+	startAST := m.astSExprSelectedLine
+
+	m.cursorRow = 1
+	m.cursorCol = len([]rune("console.log(greet"))
+	m.moveCursor(0, 0)
+
+	if m.tsSExprSelectedLine < 0 {
+		t.Fatalf("expected TS SEXP selection line after move, got %d", m.tsSExprSelectedLine)
+	}
+	if m.astSExprSelectedLine < 0 {
+		t.Fatalf("expected AST SEXP selection line after move, got %d", m.astSExprSelectedLine)
+	}
+	if m.tsSExprSelectedLine == startTS {
+		t.Fatalf("expected TS SEXP selection line to change from %d", startTS)
+	}
+	if m.astSExprSelectedLine == startAST {
+		t.Fatalf("expected AST SEXP selection line to change from %d", startAST)
+	}
+}
+
 func TestCursorNodeHighlightEmptySourceIsSafe(t *testing.T) {
 	m := newTestModel(t, "")
 	m.updateCursorNodeHighlight()
@@ -135,6 +166,9 @@ func TestEditToInvalidSourceClearsASTPane(t *testing.T) {
 	}
 	if m.astSExpr != "" {
 		t.Fatalf("expected AST pane to clear on invalid parse, got: %s", m.astSExpr)
+	}
+	if m.astSExprSelectedLine != -1 {
+		t.Fatalf("expected AST SEXP selection line to clear on invalid parse, got %d", m.astSExprSelectedLine)
 	}
 }
 

--- a/cmd/ast-parse-editor/main.go
+++ b/cmd/ast-parse-editor/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/go-go-golems/go-go-goja/cmd/ast-parse-editor/app"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "Usage: ast-parse-editor <file.js>\n")
+		os.Exit(1)
+	}
+
+	filename := filepath.Clean(os.Args[1])
+	if filename == "." {
+		fmt.Fprintln(os.Stderr, "Error: invalid input file path")
+		os.Exit(1)
+	}
+
+	// #nosec G304,G703 -- this command intentionally reads a user-provided file path.
+	src, err := os.ReadFile(filename)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error reading input file: %v\n", err)
+		os.Exit(1)
+	}
+
+	model := app.NewModel(filename, string(src))
+	p := tea.NewProgram(model, tea.WithAltScreen())
+	if _, err := p.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/ast-parse-editor/main.go
+++ b/cmd/ast-parse-editor/main.go
@@ -9,26 +9,40 @@ import (
 	"github.com/go-go-golems/go-go-goja/cmd/ast-parse-editor/app"
 )
 
+const defaultFilename = "untitled.js"
+
+func loadInput(args []string) (string, string, error) {
+	switch len(args) {
+	case 0:
+		return defaultFilename, "", nil
+	case 1:
+		filename := filepath.Clean(args[0])
+		if filename == "." || filename == "" {
+			return "", "", fmt.Errorf("invalid input file path")
+		}
+
+		// #nosec G304,G703 -- this command intentionally reads a user-provided file path.
+		src, err := os.ReadFile(filename)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return filename, "", nil
+			}
+			return "", "", fmt.Errorf("reading input file %q: %w", filename, err)
+		}
+		return filename, string(src), nil
+	default:
+		return "", "", fmt.Errorf("usage: ast-parse-editor [file.js]")
+	}
+}
+
 func main() {
-	if len(os.Args) < 2 {
-		fmt.Fprintf(os.Stderr, "Usage: ast-parse-editor <file.js>\n")
-		os.Exit(1)
-	}
-
-	filename := filepath.Clean(os.Args[1])
-	if filename == "." {
-		fmt.Fprintln(os.Stderr, "Error: invalid input file path")
-		os.Exit(1)
-	}
-
-	// #nosec G304,G703 -- this command intentionally reads a user-provided file path.
-	src, err := os.ReadFile(filename)
+	filename, src, err := loadInput(os.Args[1:])
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error reading input file: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
 
-	model := app.NewModel(filename, string(src))
+	model := app.NewModel(filename, src)
 	p := tea.NewProgram(model, tea.WithAltScreen())
 	if _, err := p.Run(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)

--- a/cmd/ast-parse-editor/main_test.go
+++ b/cmd/ast-parse-editor/main_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadInputNoArgsStartsEmptyScratchBuffer(t *testing.T) {
+	filename, src, err := loadInput(nil)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if filename != defaultFilename {
+		t.Fatalf("expected default filename %q, got %q", defaultFilename, filename)
+	}
+	if src != "" {
+		t.Fatalf("expected empty source, got %q", src)
+	}
+}
+
+func TestLoadInputReadsExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.js")
+	want := "const x = 1;"
+	if err := os.WriteFile(path, []byte(want), 0o600); err != nil {
+		t.Fatalf("write test file: %v", err)
+	}
+
+	filename, src, err := loadInput([]string{path})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if filename != path {
+		t.Fatalf("expected filename %q, got %q", path, filename)
+	}
+	if src != want {
+		t.Fatalf("expected source %q, got %q", want, src)
+	}
+}
+
+func TestLoadInputMissingFileStartsEmptyBuffer(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "new-file.js")
+
+	filename, src, err := loadInput([]string{path})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if filename != path {
+		t.Fatalf("expected filename %q, got %q", path, filename)
+	}
+	if src != "" {
+		t.Fatalf("expected empty source, got %q", src)
+	}
+}
+
+func TestLoadInputRejectsMultipleArgs(t *testing.T) {
+	_, _, err := loadInput([]string{"a.js", "b.js"})
+	if err == nil {
+		t.Fatal("expected error for multiple args")
+	}
+	if !strings.Contains(err.Error(), "usage: ast-parse-editor [file.js]") {
+		t.Fatalf("expected usage error, got %v", err)
+	}
+}

--- a/pkg/jsparse/sexp.go
+++ b/pkg/jsparse/sexp.go
@@ -55,7 +55,13 @@ func ASTToSExpr(program *ast.Program, src string, opts *SExprOptions) string {
 		return ""
 	}
 	idx := BuildIndex(program, src)
-	return ASTIndexToSExpr(idx, opts)
+	out := ASTIndexToSExpr(idx, opts)
+	if strings.TrimSpace(out) == "" {
+		// Empty source can parse to a program with zero-width positions; preserve a
+		// minimal valid AST view so editor panes still show parse success.
+		return "(Program)"
+	}
+	return out
 }
 
 func normalizeSExprOptions(opts *SExprOptions) SExprOptions {

--- a/pkg/jsparse/sexp.go
+++ b/pkg/jsparse/sexp.go
@@ -1,0 +1,211 @@
+package jsparse
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/dop251/goja/ast"
+)
+
+// SExprOptions controls how CST/AST trees are rendered as S-expressions.
+type SExprOptions struct {
+	IncludeSpan  bool
+	IncludeText  bool
+	IncludeFlags bool
+	MaxDepth     int
+	MaxNodes     int
+	Compact      bool
+}
+
+const (
+	defaultSExprMaxDepth = 64
+	defaultSExprMaxNodes = 5000
+)
+
+type sexprRenderer struct {
+	opts      SExprOptions
+	nodeCount int
+}
+
+// CSTToSExpr renders a tree-sitter snapshot as a LISP S-expression string.
+func CSTToSExpr(root *TSNode, opts *SExprOptions) string {
+	if root == nil {
+		return ""
+	}
+	r := &sexprRenderer{opts: normalizeSExprOptions(opts)}
+	var b strings.Builder
+	r.writeCSTNode(&b, root, 0)
+	return b.String()
+}
+
+// ASTIndexToSExpr renders an indexed goja AST as a LISP S-expression string.
+func ASTIndexToSExpr(idx *Index, opts *SExprOptions) string {
+	if idx == nil || idx.RootID < 0 {
+		return ""
+	}
+	r := &sexprRenderer{opts: normalizeSExprOptions(opts)}
+	var b strings.Builder
+	r.writeASTNode(&b, idx, idx.RootID, 0)
+	return b.String()
+}
+
+// ASTToSExpr builds an AST index from the program/source and renders it as S-expression.
+func ASTToSExpr(program *ast.Program, src string, opts *SExprOptions) string {
+	if program == nil {
+		return ""
+	}
+	idx := BuildIndex(program, src)
+	return ASTIndexToSExpr(idx, opts)
+}
+
+func normalizeSExprOptions(opts *SExprOptions) SExprOptions {
+	cfg := SExprOptions{
+		IncludeText:  true,
+		IncludeFlags: true,
+		MaxDepth:     defaultSExprMaxDepth,
+		MaxNodes:     defaultSExprMaxNodes,
+	}
+	if opts == nil {
+		return cfg
+	}
+	cfg = *opts
+	if cfg.MaxDepth <= 0 {
+		cfg.MaxDepth = defaultSExprMaxDepth
+	}
+	if cfg.MaxNodes <= 0 {
+		cfg.MaxNodes = defaultSExprMaxNodes
+	}
+	return cfg
+}
+
+func (r *sexprRenderer) shouldTruncate(depth int) bool {
+	if depth > r.opts.MaxDepth {
+		return true
+	}
+	if r.nodeCount >= r.opts.MaxNodes {
+		return true
+	}
+	r.nodeCount++
+	return false
+}
+
+func (r *sexprRenderer) writeTruncated(b *strings.Builder) {
+	b.WriteString("(...)")
+}
+
+func (r *sexprRenderer) writeCSTNode(b *strings.Builder, n *TSNode, depth int) {
+	if n == nil {
+		b.WriteString("(nil)")
+		return
+	}
+	if r.shouldTruncate(depth) {
+		r.writeTruncated(b)
+		return
+	}
+
+	b.WriteString("(")
+	b.WriteString(sexprAtom(n.Kind))
+
+	if r.opts.IncludeFlags {
+		if n.IsError {
+			b.WriteString(" :error true")
+		}
+		if n.IsMissing {
+			b.WriteString(" :missing true")
+		}
+	}
+	if r.opts.IncludeSpan {
+		b.WriteString(" :range (")
+		b.WriteString(strconv.Itoa(n.StartRow))
+		b.WriteString(" ")
+		b.WriteString(strconv.Itoa(n.StartCol))
+		b.WriteString(" ")
+		b.WriteString(strconv.Itoa(n.EndRow))
+		b.WriteString(" ")
+		b.WriteString(strconv.Itoa(n.EndCol))
+		b.WriteString(")")
+	}
+	if r.opts.IncludeText && len(n.Children) == 0 && n.Text != "" {
+		b.WriteString(" ")
+		b.WriteString(strconv.Quote(n.Text))
+	}
+
+	if len(n.Children) > 0 {
+		for _, child := range n.Children {
+			if r.opts.Compact {
+				b.WriteString(" ")
+			} else {
+				b.WriteString("\n")
+				writeIndent(b, depth+1)
+			}
+			r.writeCSTNode(b, child, depth+1)
+		}
+		if !r.opts.Compact {
+			b.WriteString("\n")
+			writeIndent(b, depth)
+		}
+	}
+
+	b.WriteString(")")
+}
+
+func (r *sexprRenderer) writeASTNode(b *strings.Builder, idx *Index, id NodeID, depth int) {
+	n := idx.Nodes[id]
+	if n == nil {
+		b.WriteString("(missing-node)")
+		return
+	}
+	if r.shouldTruncate(depth) {
+		r.writeTruncated(b)
+		return
+	}
+
+	b.WriteString("(")
+	b.WriteString(sexprAtom(n.Kind))
+
+	if r.opts.IncludeSpan {
+		b.WriteString(" :span (")
+		b.WriteString(strconv.Itoa(n.Start))
+		b.WriteString(" ")
+		b.WriteString(strconv.Itoa(n.End))
+		b.WriteString(")")
+	}
+	if r.opts.IncludeText && n.Label != "" {
+		b.WriteString(" :label ")
+		b.WriteString(strconv.Quote(n.Label))
+	}
+
+	if len(n.ChildIDs) > 0 {
+		for _, childID := range n.ChildIDs {
+			if r.opts.Compact {
+				b.WriteString(" ")
+			} else {
+				b.WriteString("\n")
+				writeIndent(b, depth+1)
+			}
+			r.writeASTNode(b, idx, childID, depth+1)
+		}
+		if !r.opts.Compact {
+			b.WriteString("\n")
+			writeIndent(b, depth)
+		}
+	}
+
+	b.WriteString(")")
+}
+
+func writeIndent(b *strings.Builder, depth int) {
+	for i := 0; i < depth; i++ {
+		b.WriteString("  ")
+	}
+}
+
+func sexprAtom(s string) string {
+	if s == "" {
+		return "\"\""
+	}
+	if strings.ContainsAny(s, " \t\r\n()\"") {
+		return strconv.Quote(s)
+	}
+	return s
+}

--- a/pkg/jsparse/sexp_test.go
+++ b/pkg/jsparse/sexp_test.go
@@ -108,6 +108,18 @@ func TestASTToSExprHandlesNilProgram(t *testing.T) {
 	}
 }
 
+func TestASTToSExprHandlesEmptyProgram(t *testing.T) {
+	program, err := parser.ParseFile(nil, "empty.js", "", 0)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	out := ASTToSExpr(program, "", nil)
+	if out != "(Program)" {
+		t.Fatalf("expected Program fallback for empty source, got: %q", out)
+	}
+}
+
 func TestCSTToSExprDeterministic(t *testing.T) {
 	root := &TSNode{
 		Kind: "program",

--- a/pkg/jsparse/sexp_test.go
+++ b/pkg/jsparse/sexp_test.go
@@ -1,0 +1,109 @@
+package jsparse
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dop251/goja/parser"
+)
+
+func TestCSTToSExprEscapesLeafText(t *testing.T) {
+	root := &TSNode{
+		Kind: "program",
+		Children: []*TSNode{
+			{
+				Kind: "identifier",
+				Text: "a\"b\nc",
+			},
+		},
+	}
+
+	out := CSTToSExpr(root, nil)
+	if !strings.Contains(out, "\"a\\\"b\\nc\"") {
+		t.Fatalf("expected escaped leaf text in output, got: %s", out)
+	}
+}
+
+func TestCSTToSExprIncludesFlags(t *testing.T) {
+	root := &TSNode{
+		Kind:    "ERROR",
+		IsError: true,
+		Children: []*TSNode{
+			{
+				Kind:      "identifier",
+				Text:      "x",
+				IsMissing: true,
+			},
+		},
+	}
+
+	out := CSTToSExpr(root, nil)
+	if !strings.Contains(out, ":error true") {
+		t.Fatalf("expected :error flag in output, got: %s", out)
+	}
+	if !strings.Contains(out, ":missing true") {
+		t.Fatalf("expected :missing flag in output, got: %s", out)
+	}
+}
+
+func TestASTIndexToSExprRendersProgram(t *testing.T) {
+	src := `const x = 1;`
+	program, err := parser.ParseFile(nil, "test.js", src, 0)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	idx := BuildIndex(program, src)
+	out := ASTIndexToSExpr(idx, &SExprOptions{IncludeSpan: true, IncludeText: true})
+
+	if !strings.Contains(out, "(Program") {
+		t.Fatalf("expected Program root in output, got: %s", out)
+	}
+	if !strings.Contains(out, "(Identifier") {
+		t.Fatalf("expected Identifier node in output, got: %s", out)
+	}
+	if !strings.Contains(out, ":span (") {
+		t.Fatalf("expected span metadata in output, got: %s", out)
+	}
+}
+
+func TestCSTToSExprTruncatesByDepth(t *testing.T) {
+	root := &TSNode{
+		Kind: "program",
+		Children: []*TSNode{
+			{
+				Kind: "stmt",
+				Children: []*TSNode{
+					{Kind: "identifier", Text: "x"},
+				},
+			},
+		},
+	}
+
+	out := CSTToSExpr(root, &SExprOptions{MaxDepth: 1})
+	if !strings.Contains(out, "(...)") {
+		t.Fatalf("expected truncation marker in output, got: %s", out)
+	}
+}
+
+func TestASTIndexToSExprTruncatesByNodeCount(t *testing.T) {
+	src := `const a = 1; const b = 2;`
+	program, err := parser.ParseFile(nil, "test.js", src, 0)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	idx := BuildIndex(program, src)
+	out := ASTIndexToSExpr(idx, &SExprOptions{MaxNodes: 1})
+
+	if !strings.Contains(out, "(...)") {
+		t.Fatalf("expected node-count truncation marker in output, got: %s", out)
+	}
+}
+
+func TestASTToSExprHandlesNilProgram(t *testing.T) {
+	out := ASTToSExpr(nil, "", nil)
+	if out != "" {
+		t.Fatalf("expected empty output for nil program, got: %q", out)
+	}
+}

--- a/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/README.md
+++ b/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/README.md
@@ -1,0 +1,21 @@
+# Live AST parse editor with tree-sitter and goja SEXP panes
+
+This is the document workspace for ticket GOJA-001-AST-PARSE-EDITOR.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr doc add --ticket GOJA-001-AST-PARSE-EDITOR --doc-type design-doc --title "My Design"`
+- Import sources: `docmgr import file --ticket GOJA-001-AST-PARSE-EDITOR --file /path/to/doc.md`
+- Update metadata: `docmgr meta update --ticket GOJA-001-AST-PARSE-EDITOR --field Status --value review`

--- a/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/analysis/01-tree-sitter-ast-live-sexp-editor-analysis.md
+++ b/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/analysis/01-tree-sitter-ast-live-sexp-editor-analysis.md
@@ -10,6 +10,12 @@ DocType: analysis
 Intent: long-term
 Owners: []
 RelatedFiles:
+    - Path: go-go-goja/cmd/ast-parse-editor/app/model.go
+      Note: Implemented Task 2 3-pane model based on analysis design
+    - Path: go-go-goja/cmd/ast-parse-editor/app/model_test.go
+      Note: Implemented Task 2 behavior tests validating analysis assumptions
+    - Path: go-go-goja/cmd/ast-parse-editor/main.go
+      Note: Implemented Task 2 command bootstrap for analysis blueprint
     - Path: go-go-goja/cmd/inspector/app/drawer.go
       Note: Current live editor buffer and CST rendering path
     - Path: go-go-goja/cmd/inspector/app/model.go
@@ -42,6 +48,7 @@ LastUpdated: 2026-02-13T15:56:00-05:00
 WhatFor: Plan and de-risk implementation of a live AST parse editor with LISP S-expression output.
 WhenToUse: Use when implementing or reviewing GOJA-001-AST-PARSE-EDITOR.
 ---
+
 
 
 

--- a/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/analysis/01-tree-sitter-ast-live-sexp-editor-analysis.md
+++ b/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/analysis/01-tree-sitter-ast-live-sexp-editor-analysis.md
@@ -1,0 +1,304 @@
+---
+Title: Tree-sitter + AST live SEXP editor analysis
+Ticket: GOJA-001-AST-PARSE-EDITOR
+Status: active
+Topics:
+    - goja
+    - analysis
+    - tooling
+DocType: analysis
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: go-go-goja/cmd/inspector/app/drawer.go
+      Note: Current live editor buffer and CST rendering path
+    - Path: go-go-goja/cmd/inspector/app/model.go
+      Note: Current pane layout and drawer parse event loop
+    - Path: go-go-goja/cmd/inspector/main.go
+      Note: Current static parse/bootstrap flow
+    - Path: go-go-goja/pkg/doc/05-jsparse-framework-reference.md
+      Note: Declared reusable boundary between jsparse and inspector UI
+    - Path: go-go-goja/pkg/jsparse/analyze.go
+      Note: Reusable analyze bundle and parse diagnostics entrypoint
+    - Path: go-go-goja/pkg/jsparse/completion.go
+      Note: CST completion context extraction and ERROR-node handling
+    - Path: go-go-goja/pkg/jsparse/index.go
+      Note: AST indexing and deterministic child ordering for AST SEXP
+    - Path: go-go-goja/pkg/jsparse/index_test.go
+      Note: Evidence for partial AST behavior on parse errors
+    - Path: go-go-goja/pkg/jsparse/resolve.go
+      Note: Scope and binding resolution for live semantic context
+    - Path: go-go-goja/pkg/jsparse/sexp.go
+      Note: Implemented SEXP renderer APIs proposed in this analysis
+    - Path: go-go-goja/pkg/jsparse/sexp_test.go
+      Note: Validation coverage for newly implemented SEXP renderer APIs
+    - Path: go-go-goja/pkg/jsparse/treesitter.go
+      Note: TSParser and TSNode snapshot data model
+    - Path: go-go-goja/pkg/jsparse/treesitter_test.go
+      Note: Evidence for tree-sitter error recovery behavior
+ExternalSources: []
+Summary: Detailed analysis of the current go-go-goja tree-sitter + goja parser setup, and implementation blueprint for a 3-pane live editor showing CST SEXP and AST SEXP (when parse-valid).
+LastUpdated: 2026-02-13T15:56:00-05:00
+WhatFor: Plan and de-risk implementation of a live AST parse editor with LISP S-expression output.
+WhenToUse: Use when implementing or reviewing GOJA-001-AST-PARSE-EDITOR.
+---
+
+
+
+# Analysis: Live SEXP Editor (tree-sitter + goja AST)
+
+## Goal
+
+Design a new live editor experience in `go-go-goja` with:
+
+1. left pane: editable JavaScript source
+2. middle pane: live tree-sitter CST as LISP S-expression
+3. right pane: live goja AST as LISP S-expression, only when parse-valid
+
+while reusing as much of the existing `pkg/jsparse` + `cmd/inspector` stack as possible.
+
+## Current Architecture in `go-go-goja`
+
+### Startup parse path (static file)
+
+- `cmd/inspector/main.go:35` parses file text once with `parser.ParseFile`.
+- `cmd/inspector/main.go:40` builds index (`jsparse.BuildIndex`) and scope resolution (`jsparse.Resolve`) once.
+- `cmd/inspector/main.go:45` passes static data into the Bubble Tea model.
+
+Consequence: current AST pane is file-static; it does not follow live typing.
+
+### `pkg/jsparse` reusable parse stack
+
+- `pkg/jsparse/analyze.go:31` provides `Analyze(filename, source, opts)` and returns `Program`, `ParseErr`, `Index`, `Resolution`.
+- `pkg/jsparse/treesitter.go:10` defines `TSNode` snapshot nodes; `Parse` returns an owning tree (`pkg/jsparse/treesitter.go:46`).
+- `pkg/jsparse/index.go:31` builds AST index via reflection walk (`walkNode`), including line/column and source spans.
+- `pkg/jsparse/resolve.go:110` resolves lexical scopes/bindings in two passes.
+- `pkg/jsparse/completion.go:61` derives completion context from CST and `ERROR` nodes.
+
+### Current live typing path (drawer only)
+
+- Drawer text edits happen in `cmd/inspector/app/drawer.go` (`InsertChar`, `DeleteBack`, `InsertNewline`).
+- Every edit calls `Drawer.Reparse()` (`cmd/inspector/app/drawer.go:63`), which reparses tree-sitter snapshot.
+- `model.handleDrawerKey` triggers reparse and completion updates (`cmd/inspector/app/model.go:277` onward).
+- Drawer right-half currently renders flattened CST labels, not SEXP (`cmd/inspector/app/drawer.go:325`, `flattenTSNode` at `361`).
+
+Important note: `TSParser.Parse` is full reparse, not incremental edit-tree reuse (`pkg/jsparse/treesitter.go:44-53`), despite some historical comments/tests naming this as incremental.
+
+### Validation evidence (current behavior)
+
+- `GOWORK=off go test ./pkg/jsparse -count=1` passed.
+- `GOWORK=off go test ./cmd/inspector/... -count=1` passed.
+- `pkg/jsparse/treesitter_test.go:71` confirms error-recovery shape for `a.` (`ERROR` node includes `identifier` + `.`).
+- `pkg/jsparse/index_test.go:295` confirms goja parser can return partial AST on parse errors.
+- `pkg/jsparse/analyze_test.go:26` confirms diagnostics are produced from parse errors.
+- Focused experiment (`GOWORK=off go test ./pkg/jsparse -run 'TestTSParserErrorRecovery|TestBuildIndexWithParseError' -v -count=1`) showed:
+  - `Partial AST: 18 nodes` and `BadExpression` present for invalid goja parse path.
+  - tree-sitter `ERROR` node kept both identifier and dot (`foundIdent=true`, `foundDot=true`).
+
+## Gap Analysis vs Requested UX
+
+Requested: editor-left + CST-SEXP + AST-SEXP(valid only).
+
+Current:
+
+- Left pane is read-only source, not editor (`cmd/inspector/app/model.go:903`).
+- Live editor exists only inside optional bottom drawer (`cmd/inspector/app/model.go:839`, `865`).
+- CST view is tree-style labels, not SEXP (`cmd/inspector/app/drawer.go:346`).
+- AST view is static file AST tree labels (`cmd/inspector/app/model.go:1039`), not live SEXP.
+- AST parse status is tied to initial file parse (`m.parseErr` in `renderTreePane`, `cmd/inspector/app/model.go:1060`), not the live edited text.
+
+## SEXP Design
+
+## 1) CST SEXP (tree-sitter)
+
+Input: `*jsparse.TSNode`.
+
+Recommended deterministic format:
+
+- node: `(kind <children...>)`
+- leaf with text: `(identifier "foo")`
+- optional metadata (when enabled): `:range`, `:error`, `:missing`
+
+Example for broken input `obj.`:
+
+```lisp
+(program
+  (expression_statement
+    (ERROR :error true
+      (identifier "obj")
+      (. "."))))
+```
+
+Key implementation detail: keep child order as `TSNode.Children` for stable output.
+
+## 2) AST SEXP (goja)
+
+Input: `*ast.Program` plus source string.
+
+Validity rule (to match user request):
+
+- AST SEXP pane renders only when `parseErr == nil` and `program != nil`.
+- if invalid, pane shows parse error summary (first error line) and no AST SEXP.
+
+Recommended AST SEXP shape (index-backed):
+
+- derive structure from `Index`/`NodeRecord` tree (`pkg/jsparse/index.go`).
+- node form: `(Kind :span (start end) :label "...")`
+
+Example:
+
+```lisp
+(Program
+  (LexicalDeclaration :label "const"
+    (VariableExpression
+      (Identifier :label "\"x\"")
+      (NumberLiteral :label "1"))))
+```
+
+Rationale: this avoids duplicating AST traversal logic because `BuildIndex` already provides ordered children and spans.
+
+## 3) Shared rendering options
+
+Introduce one options struct for both renderers:
+
+```go
+type SExprOptions struct {
+    IncludeSpan bool
+    IncludeText bool
+    IncludeFlags bool // error/missing
+    MaxDepth int      // guard huge trees
+    MaxNodes int      // guard huge outputs
+    Compact bool
+}
+```
+
+## Implementation Blueprint
+
+## Phase 1: Add reusable SEXP renderers in `pkg/jsparse`
+
+Create:
+
+- `pkg/jsparse/sexp.go`
+- `pkg/jsparse/sexp_test.go`
+
+Add APIs:
+
+- `func CSTToSExpr(root *TSNode, opts *SExprOptions) string`
+- `func ASTIndexToSExpr(idx *Index, opts *SExprOptions) string`
+- optional convenience: `func ASTToSExpr(program *ast.Program, src string, opts *SExprOptions) string`
+
+Why this location: keeps rendering reusable and independent of Bubble Tea UI (consistent with `pkg/doc/05-jsparse-framework-reference.md:20-45`).
+
+## Phase 2: Build a dedicated 3-pane editor command
+
+Recommended to avoid destabilizing current inspector UX:
+
+- new command: `cmd/ast-parse-editor/main.go`
+- new app package: `cmd/ast-parse-editor/app/*`
+
+Reuse from existing inspector:
+
+- editor mechanics from drawer (`cmd/inspector/app/drawer.go`)
+- parser + analysis from `pkg/jsparse`
+
+Do not mutate existing `cmd/inspector` behavior in first pass.
+
+## Phase 3: Live parse loop (while typing)
+
+Per keypress:
+
+1. update editor buffer
+2. parse tree-sitter (`TSParser.Parse`) and regenerate CST SEXP synchronously
+3. trigger AST parse command (debounced 50-100ms) for responsiveness
+4. when AST parse result returns:
+   - if valid: rebuild index/resolution + regenerate AST SEXP
+   - if invalid: clear AST SEXP and show parse error banner
+
+Bubble Tea message sketch:
+
+```go
+type astParsedMsg struct {
+    Seq uint64
+    Program *ast.Program
+    ParseErr error
+    Index *jsparse.Index
+    ASTSExpr string
+}
+```
+
+Use sequence numbers to drop stale async results.
+
+## Phase 4: 3-pane rendering
+
+Replace current 2-pane content section with 3 equal columns:
+
+- `EDITOR`
+- `TS SEXP`
+- `AST SEXP`
+
+Each pane needs independent vertical scrolling state because SEXP output can exceed screen height.
+
+## File-by-File Change Map
+
+Existing files used as integration anchors:
+
+- `go-go-goja/pkg/jsparse/treesitter.go`: CST input model.
+- `go-go-goja/pkg/jsparse/index.go`: AST tree model for deterministic SEXP output.
+- `go-go-goja/pkg/jsparse/analyze.go`: parse/index/resolution bundle.
+- `go-go-goja/cmd/inspector/app/drawer.go`: editable text buffer operations.
+- `go-go-goja/cmd/inspector/app/model.go`: Bubble Tea layout/key handling reference.
+- `go-go-goja/cmd/inspector/main.go`: current parse/bootstrap flow.
+
+New files proposed:
+
+- `go-go-goja/pkg/jsparse/sexp.go`
+- `go-go-goja/pkg/jsparse/sexp_test.go`
+- `go-go-goja/cmd/ast-parse-editor/main.go`
+- `go-go-goja/cmd/ast-parse-editor/app/model.go`
+- `go-go-goja/cmd/ast-parse-editor/app/model_test.go`
+
+## Risks and Mitigations
+
+1. Output volume: SEXP can explode for large files.
+- Mitigation: `MaxDepth`, `MaxNodes`, pane scrolling, and truncation indicator.
+
+2. UI stalls from per-keystroke goja parse.
+- Mitigation: debounce + async parse commands.
+
+3. Non-ASCII cursor mismatch.
+- Existing editor tracks rune columns; tree-sitter columns are byte-based positions.
+- Mitigation: add rune<->byte conversion helpers before `NodeAtPosition` and source span mapping.
+
+4. Ambiguous AST validity.
+- goja can return partial AST with parse error (`index_test.go:295`).
+- Mitigation: treat AST pane as valid only when `parseErr == nil`.
+
+## Test Plan
+
+Unit tests:
+
+- `pkg/jsparse/sexp_test.go`
+  - CST leaf escaping
+  - ERROR/MISSING marker emission
+  - deterministic ordering
+  - depth/node truncation
+- AST SEXP tests from valid and invalid snippets
+
+Integration tests:
+
+- `cmd/ast-parse-editor/app/model_test.go`
+  - typing updates CST SEXP every edit
+  - AST SEXP appears on valid text
+  - AST pane shows error state on invalid text
+  - stale async parse results ignored by sequence check
+
+Regression checks (existing):
+
+- `GOWORK=off go test ./pkg/jsparse -count=1`
+- `GOWORK=off go test ./cmd/inspector/... -count=1`
+
+## Recommendation
+
+Implement as a new command (`cmd/ast-parse-editor`) with reusable SEXP code in `pkg/jsparse`, then optionally converge UX into `cmd/inspector` after behavior is stable.
+
+This gives fast delivery for requested UX and avoids regressions in the current inspector workflow.

--- a/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/changelog.md
+++ b/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/changelog.md
@@ -1,0 +1,47 @@
+# Changelog
+
+## 2026-02-13
+
+- Initial workspace created
+
+
+## 2026-02-13
+
+Created ticket scaffolding, mapped current inspector/jsparse parser flow, and produced implementation-ready analysis for a 3-pane live SEXP editor (tree-sitter CST + valid-only goja AST).
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/analysis/01-tree-sitter-ast-live-sexp-editor-analysis.md — Primary design and architecture analysis
+- /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/reference/01-diary.md — Detailed execution diary with commands and decisions
+
+
+## 2026-02-13
+
+Linked related files, validated frontmatter, and uploaded bundled analysis+diary to reMarkable at /ai/2026/02/13/GOJA-001-AST-PARSE-EDITOR.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/index.md — Updated overview and key links to delivered artifacts
+- /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/reference/01-diary.md — Updated Step 4 with upload/validation details and command outputs
+
+
+## 2026-02-13
+
+Ran focused parser recovery experiment tests, incorporated results into analysis, and cleaned diary chronology with final upload/validation details.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/analysis/01-tree-sitter-ast-live-sexp-editor-analysis.md — Added focused experiment evidence and parser recovery observations
+- /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/reference/01-diary.md — Finalized complete 4-step diary including command failures and fixes
+
+
+## 2026-02-13
+
+Implemented Task 1: added reusable CST/AST S-expression renderers and tests in pkg/jsparse (commit a185315), validated via tmux go test run.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/pkg/jsparse/sexp.go — New renderer implementation for CSTToSExpr
+- /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/pkg/jsparse/sexp_test.go — New renderer tests including escaping and truncation behavior
+- /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/reference/01-diary.md — Step 5 implementation diary with tmux test output and commit details
+

--- a/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/changelog.md
+++ b/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/changelog.md
@@ -80,3 +80,14 @@ Implemented Task 4 empty-source fix: AST pane now renders (Program) for valid em
 - /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/pkg/jsparse/sexp_test.go — Regression test for empty program rendering
 - /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/reference/01-diary.md — Step 8 records commands
 
+
+## 2026-02-13
+
+Implemented Task 5 CLI startup flow: ast-parse-editor now opens an empty buffer for no-arg and missing-file invocations, with loadInput tests and tmux verification (commit e3231e6).
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/cmd/ast-parse-editor/main.go — loadInput now supports scratch/no-file startup
+- /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/cmd/ast-parse-editor/main_test.go — Unit coverage for no-arg
+- /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/reference/01-diary.md — Step 9 records reproduction
+

--- a/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/changelog.md
+++ b/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/changelog.md
@@ -68,3 +68,15 @@ Implemented Task 3 hardening: deterministic SEXP tests, additional truncation ch
 - /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/pkg/jsparse/sexp_test.go — Added deterministic and additional truncation coverage for SEXP renderers
 - /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/reference/01-diary.md — Step 7 hardening diary update with tmux regression outputs
 
+
+## 2026-02-13
+
+Implemented Task 4 empty-source fix: AST pane now renders (Program) for valid empty files, with jsparse/model regression tests and tmux verification (commit 494d238).
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/cmd/ast-parse-editor/app/model_test.go — Regression test for empty-source model initialization
+- /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/pkg/jsparse/sexp.go — ASTToSExpr fallback for valid empty source
+- /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/pkg/jsparse/sexp_test.go — Regression test for empty program rendering
+- /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/reference/01-diary.md — Step 8 records commands
+

--- a/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/changelog.md
+++ b/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/changelog.md
@@ -57,3 +57,14 @@ Implemented Task 2: added cmd/ast-parse-editor with 3-pane live editor, immediat
 - /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/cmd/ast-parse-editor/main.go — New command entrypoint
 - /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/reference/01-diary.md — Step 6 diary update with tmux test run and lint-fix details
 
+
+## 2026-02-13
+
+Implemented Task 3 hardening: deterministic SEXP tests, additional truncation checks, and valid-invalid-valid parse transition coverage (commit ff8e43d).
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/cmd/ast-parse-editor/app/model_test.go — Added parse transition test and stale message behavior coverage
+- /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/pkg/jsparse/sexp_test.go — Added deterministic and additional truncation coverage for SEXP renderers
+- /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/reference/01-diary.md — Step 7 hardening diary update with tmux regression outputs
+

--- a/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/changelog.md
+++ b/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/changelog.md
@@ -45,3 +45,15 @@ Implemented Task 1: added reusable CST/AST S-expression renderers and tests in p
 - /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/pkg/jsparse/sexp_test.go — New renderer tests including escaping and truncation behavior
 - /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/reference/01-diary.md — Step 5 implementation diary with tmux test output and commit details
 
+
+## 2026-02-13
+
+Implemented Task 2: added cmd/ast-parse-editor with 3-pane live editor, immediate CST SEXP updates, debounced AST parse, and model tests (commit 3f03d3f).
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/cmd/ast-parse-editor/app/model.go — Core 3-pane model with async parse workflow
+- /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/cmd/ast-parse-editor/app/model_test.go — Model tests for parse state transitions and stale message handling
+- /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/cmd/ast-parse-editor/main.go — New command entrypoint
+- /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/reference/01-diary.md — Step 6 diary update with tmux test run and lint-fix details
+

--- a/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/index.md
+++ b/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/index.md
@@ -1,0 +1,69 @@
+---
+Title: Live AST parse editor with tree-sitter and goja SEXP panes
+Ticket: GOJA-001-AST-PARSE-EDITOR
+Status: active
+Topics:
+    - goja
+    - analysis
+    - tooling
+DocType: index
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: go-go-goja/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/analysis/01-tree-sitter-ast-live-sexp-editor-analysis.md
+      Note: Primary technical analysis deliverable
+    - Path: go-go-goja/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/reference/01-diary.md
+      Note: Detailed diary of commands
+ExternalSources: []
+Summary: Ticket index for analysis and delivery artifacts for a live tree-sitter + goja AST SEXP editor design.
+LastUpdated: 2026-02-13T15:56:00-05:00
+WhatFor: Central navigation for GOJA-001-AST-PARSE-EDITOR docs and outcomes.
+WhenToUse: Use to quickly locate the analysis, diary, tasks, changelog, and upload destination.
+---
+
+
+# Live AST parse editor with tree-sitter and goja SEXP panes
+
+## Overview
+
+This ticket captures a detailed implementation analysis for a new live 3-pane editor in `go-go-goja`:
+
+- left: editable JavaScript source
+- middle: tree-sitter CST rendered as LISP SEXP
+- right: goja AST rendered as LISP SEXP when parse-valid
+
+The analysis references current `pkg/jsparse` and `cmd/inspector` code paths and provides a file-by-file, phased implementation plan.
+
+## Key Links
+
+- Analysis: `analysis/01-tree-sitter-ast-live-sexp-editor-analysis.md`
+- Diary: `reference/01-diary.md`
+- Changelog: `changelog.md`
+- reMarkable upload target: `/ai/2026/02/13/GOJA-001-AST-PARSE-EDITOR/GOJA-001-AST-PARSE-EDITOR Analysis`
+
+## Status
+
+Current status: **active**
+
+## Topics
+
+- goja
+- analysis
+- tooling
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/reference/01-diary.md
+++ b/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/reference/01-diary.md
@@ -1,0 +1,433 @@
+---
+Title: Diary
+Ticket: GOJA-001-AST-PARSE-EDITOR
+Status: active
+Topics:
+    - goja
+    - analysis
+    - tooling
+DocType: reference
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: .ttmp.yaml
+      Note: Docmgr root and vocabulary configuration used during ticket creation
+    - Path: go-go-goja/cmd/inspector/app/drawer.go
+      Note: Reviewed while documenting live tree-sitter parse loop
+    - Path: go-go-goja/cmd/inspector/app/model.go
+      Note: Reviewed while documenting current live editor interactions
+    - Path: go-go-goja/pkg/jsparse/index.go
+      Note: Reviewed while capturing AST indexing behavior details
+    - Path: go-go-goja/pkg/jsparse/sexp.go
+      Note: Task 1 implementation of reusable CST/AST S-expression renderers (commit a185315)
+    - Path: go-go-goja/pkg/jsparse/sexp_test.go
+      Note: Task 1 unit tests for S-expression renderer behavior and truncation guards
+    - Path: go-go-goja/pkg/jsparse/treesitter.go
+      Note: Reviewed while capturing parser behavior details
+    - Path: go-go-goja/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/analysis/01-tree-sitter-ast-live-sexp-editor-analysis.md
+      Note: Primary analysis artifact produced during this diary run
+    - Path: go-go-goja/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/tasks.md
+      Note: Task execution checklist updated with Task 1 progress
+ExternalSources: []
+Summary: Step-by-step implementation diary capturing ticket setup, parser architecture analysis, validation commands, and delivery workflow for GOJA-001-AST-PARSE-EDITOR.
+LastUpdated: 2026-02-13T16:06:00-05:00
+WhatFor: Preserve the exact analysis workflow and decisions for later review or continuation.
+WhenToUse: Use when reviewing how conclusions were derived and what commands/results support them.
+---
+
+
+# Diary
+
+## Goal
+
+Capture a detailed chronological diary for `GOJA-001-AST-PARSE-EDITOR`, including exact commands, findings, tradeoffs, and delivery artifacts.
+
+## Step 1: Ticket + Document Scaffolding
+
+I started by creating the ticket workspace and initial documents before any deep analysis work. This ensured every subsequent finding was stored in the ticket from the beginning.
+
+I also checked the local `docmgr` configuration up front to avoid writing to the wrong docs root.
+
+### Prompt Context
+
+**User prompt (verbatim):**
+
+"Create a new ticket GOJA-001-AST-PARSE-EDITOR and analyze our current tree-sitter + ast parser setup in go-go-goja/ and how to create a LISP SEXP representation of the parse tree while typing live in an editor. So similar to our current inspector, except we have an editor on the left, and as we type, we show a SEXP view of the treesitter parse, and a SEX view of the AST parse if valid in a third pane.
+
+Create a detailed analysis document referencing all the necessary files and stuff, then store the file in the ticket and upload tor emarkable. Also keep a detailed frequent diary as you work."
+
+**Assistant interpretation:** Create the ticket, produce a file-referenced technical analysis, keep a detailed working diary, and upload resulting docs to reMarkable.
+
+**Inferred user intent:** Obtain implementation-ready design output with a full audit trail of how conclusions were derived.
+
+**Commit (code):** N/A (documentation/analysis task)
+
+### What I did
+
+- Verified docs root/config:
+  - `cat .ttmp.yaml`
+  - `docmgr status --summary-only`
+- Created ticket:
+  - `docmgr ticket create-ticket --ticket GOJA-001-AST-PARSE-EDITOR --title "Live AST parse editor with tree-sitter and goja SEXP panes" --topics goja,analysis,tooling`
+- Created docs:
+  - `docmgr doc add --ticket GOJA-001-AST-PARSE-EDITOR --doc-type analysis --title "Tree-sitter + AST live SEXP editor analysis"`
+  - `docmgr doc add --ticket GOJA-001-AST-PARSE-EDITOR --doc-type reference --title "Diary"`
+
+### Why
+
+- Ticket-first setup was required to keep all artifacts in the requested location.
+- Early diary creation was needed to satisfy “frequent detailed diary” during execution.
+
+### What worked
+
+- Ticket and both docs were created successfully under:
+  - `go-go-goja/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes`
+
+### What didn't work
+
+- N/A.
+
+### What I learned
+
+- Local `.ttmp.yaml` is already configured to `go-go-goja/ttmp`, so root-level docmgr commands are safe.
+
+### What was tricky to build
+
+- Not technically hard, but sequencing mattered: ticket creation must happen before `doc add` operations.
+
+### What warrants a second pair of eyes
+
+- Confirm ticket title wording is exactly what you want for long-term discoverability.
+
+### What should be done in the future
+
+- Add `analysis` as an explicit vocab docType if stricter vocabulary hygiene is desired.
+
+### Code review instructions
+
+- Validate ticket/doc existence:
+  - `docmgr ticket list --ticket GOJA-001-AST-PARSE-EDITOR`
+  - `docmgr doc list --ticket GOJA-001-AST-PARSE-EDITOR`
+
+### Technical details
+
+- Active docs root during run: `/home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/ttmp`
+
+## Step 2: Architecture Mapping of Current Parser Stack
+
+I mapped the current parsing and UI paths in `go-go-goja` with line-level references. The purpose was to identify exactly what is static today and what already updates while typing.
+
+This mapping established clear insertion points for adding CST/AST SEXP generation.
+
+### Prompt Context
+
+**User prompt (verbatim):** (see Step 1)
+
+**Assistant interpretation:** Analyze the current tree-sitter + goja parser setup in `go-go-goja/` with concrete references.
+
+**Inferred user intent:** Build the new design on verified current behavior rather than assumptions.
+
+**Commit (code):** N/A (documentation/analysis task)
+
+### What I did
+
+- Located parser/inspector files and symbols via ripgrep.
+- Reviewed these core files:
+  - `go-go-goja/cmd/inspector/main.go`
+  - `go-go-goja/cmd/inspector/app/model.go`
+  - `go-go-goja/cmd/inspector/app/drawer.go`
+  - `go-go-goja/pkg/jsparse/analyze.go`
+  - `go-go-goja/pkg/jsparse/treesitter.go`
+  - `go-go-goja/pkg/jsparse/index.go`
+  - `go-go-goja/pkg/jsparse/resolve.go`
+  - `go-go-goja/pkg/jsparse/completion.go`
+- Collected numbered references with `nl -ba` for all core files used in the final analysis.
+
+### Why
+
+- The requested analysis explicitly asked for “necessary files and stuff,” which requires concrete code anchors.
+
+### What worked
+
+- Reusable vs UI boundaries are already clean (`pkg/jsparse` vs `cmd/inspector/app`).
+- Existing drawer flow already provides live tree-sitter parse behavior that can be adapted.
+
+### What didn't work
+
+- N/A.
+
+### What I learned
+
+- Current AST pane is static-at-startup (file parse in `cmd/inspector/main.go`), while live typing behavior exists only in drawer CST/completion.
+- `TSParser.Parse` currently reparses from scratch each time (no incremental `tree.Edit` flow).
+
+### What was tricky to build
+
+- Distinguishing implementation reality from historical naming/comments required checking both source and tests.
+
+### What warrants a second pair of eyes
+
+- Decision whether to implement as a new command (`cmd/ast-parse-editor`) or modify `cmd/inspector` directly.
+
+### What should be done in the future
+
+- If this becomes a permanent feature, add a dedicated public doc page for the SEXP APIs in `pkg/doc/`.
+
+### Code review instructions
+
+- Start with these anchors:
+  - `go-go-goja/cmd/inspector/main.go:35`
+  - `go-go-goja/cmd/inspector/app/model.go:277`
+  - `go-go-goja/cmd/inspector/app/drawer.go:63`
+  - `go-go-goja/pkg/jsparse/treesitter.go:46`
+  - `go-go-goja/pkg/jsparse/analyze.go:31`
+  - `go-go-goja/pkg/jsparse/index.go:31`
+
+### Technical details
+
+- Existing reusable boundary is documented in `go-go-goja/pkg/doc/05-jsparse-framework-reference.md:20-45`.
+
+## Step 3: Validation Experiments + Implementation Blueprint
+
+I validated runtime behavior with tests and then wrote the full design blueprint document. This converted discovery into an implementation-ready plan with data formats, file mapping, and phased delivery.
+
+I also ran focused parser recovery experiments to capture concrete output behavior for invalid code scenarios.
+
+### Prompt Context
+
+**User prompt (verbatim):** (see Step 1)
+
+**Assistant interpretation:** Produce a practical plan for live tree-sitter SEXP and valid-only AST SEXP behavior.
+
+**Inferred user intent:** De-risk implementation before coding by validating assumptions and documenting decisions.
+
+**Commit (code):** N/A (documentation/analysis task)
+
+### What I did
+
+- Ran targeted suite checks:
+  - `cd go-go-goja && GOWORK=off go test ./pkg/jsparse -count=1`
+  - `cd go-go-goja && GOWORK=off go test ./cmd/inspector/... -count=1`
+- Ran focused parser recovery experiment:
+  - `cd go-go-goja && GOWORK=off go test ./pkg/jsparse -run 'TestTSParserErrorRecovery|TestBuildIndexWithParseError' -v -count=1`
+- Wrote analysis doc:
+  - `go-go-goja/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/analysis/01-tree-sitter-ast-live-sexp-editor-analysis.md`
+
+### Why
+
+- The requested behavior required explicit semantics for AST validity and deterministic SEXP generation.
+
+### What worked
+
+- All targeted tests passed.
+- Focused experiments confirmed expected parse recovery behavior in both parsers.
+- Analysis doc now contains implementation phases, proposed APIs, risks, and tests.
+
+### What didn't work
+
+- N/A.
+
+### What I learned
+
+- Existing stack already contains most primitives needed; main additions are SEXP renderers and a 3-pane editor command.
+- Performance risk is mostly in synchronous goja parse on every keystroke.
+
+### What was tricky to build
+
+- Choosing AST-pane validity semantics: goja can emit partial AST with parse errors, but requirement implies “render AST SEXP only when parse-valid.”
+
+### What warrants a second pair of eyes
+
+- Whether to clear AST pane immediately on parse error or keep last valid AST visible.
+
+### What should be done in the future
+
+- Add deterministic golden tests for SEXP output before UI integration.
+
+### Code review instructions
+
+- Review analysis artifact:
+  - `go-go-goja/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/analysis/01-tree-sitter-ast-live-sexp-editor-analysis.md`
+- Reproduce validation:
+  - `cd go-go-goja && GOWORK=off go test ./pkg/jsparse -count=1`
+  - `cd go-go-goja && GOWORK=off go test ./cmd/inspector/... -count=1`
+  - `cd go-go-goja && GOWORK=off go test ./pkg/jsparse -run 'TestTSParserErrorRecovery|TestBuildIndexWithParseError' -v -count=1`
+
+### Technical details
+
+- Test outputs:
+  - `ok github.com/go-go-golems/go-go-goja/pkg/jsparse`
+  - `ok github.com/go-go-golems/go-go-goja/cmd/inspector/app`
+- Focused experiment outputs:
+  - `Partial AST: 18 nodes`
+  - `Error recovery: ERROR has 2 children, foundIdent=true foundDot=true`
+
+## Step 4: Delivery, Linking, and reMarkable Upload
+
+I completed ticket integration work (`doc relate`, index/tasks/changelog updates), then uploaded the deliverables to reMarkable as a bundled PDF after a dry-run.
+
+This step closed the loop from analysis to final delivery artifact.
+
+### Prompt Context
+
+**User prompt (verbatim):** (see Step 1)
+
+**Assistant interpretation:** Ensure docs are stored in-ticket and uploaded to reMarkable.
+
+**Inferred user intent:** End-to-end completion, not just local documentation.
+
+**Commit (code):** N/A (documentation/analysis task)
+
+### What I did
+
+- Related files to docs:
+  - `docmgr doc relate --doc ...analysis/01-tree-sitter-ast-live-sexp-editor-analysis.md --file-note ...`
+  - `docmgr doc relate --doc ...reference/01-diary.md --file-note ...`
+  - `docmgr doc relate --doc .../index.md --file-note ...`
+- Updated ticket metadata docs:
+  - edited `index.md`
+  - edited `tasks.md`
+  - `docmgr changelog update --ticket GOJA-001-AST-PARSE-EDITOR --entry "..." --file-note "..."`
+- Validated frontmatter:
+  - `docmgr validate frontmatter --doc 2026/02/13/.../analysis/01-tree-sitter-ast-live-sexp-editor-analysis.md`
+  - `docmgr validate frontmatter --doc 2026/02/13/.../reference/01-diary.md`
+  - `docmgr validate frontmatter --doc 2026/02/13/.../index.md`
+- Ran reMarkable workflow:
+  - `remarquee status`
+  - `remarquee upload bundle --dry-run <analysis.md> <diary.md> --name "GOJA-001-AST-PARSE-EDITOR Analysis" --remote-dir "/ai/2026/02/13/GOJA-001-AST-PARSE-EDITOR" --toc-depth 2`
+  - `remarquee upload bundle <analysis.md> <diary.md> --name "GOJA-001-AST-PARSE-EDITOR Analysis" --remote-dir "/ai/2026/02/13/GOJA-001-AST-PARSE-EDITOR" --toc-depth 2`
+  - `remarquee cloud ls /ai/2026/02/13/GOJA-001-AST-PARSE-EDITOR --long --non-interactive`
+
+### Why
+
+- Dry-run before upload reduces risk and verifies bundle composition.
+- Frontmatter and relationships were updated to keep ticket docs queryable and consistent.
+
+### What worked
+
+- Upload succeeded:
+  - `OK: uploaded GOJA-001-AST-PARSE-EDITOR Analysis.pdf -> /ai/2026/02/13/GOJA-001-AST-PARSE-EDITOR`
+- Remote listing confirms presence:
+  - `[f] GOJA-001-AST-PARSE-EDITOR Analysis`
+- Frontmatter validation passed for analysis/diary/index docs.
+
+### What didn't work
+
+- I first ran `docmgr validate frontmatter --doc` with paths prefixed by `go-go-goja/ttmp/...`, causing docs-root duplication and failures:
+  - `Error: open .../go-go-goja/ttmp/go-go-goja/ttmp/...: no such file or directory`
+- Fix: reran validations with docs-root-relative paths (`2026/02/13/...`).
+
+### What I learned
+
+- Using docs-root-relative paths consistently avoids most `docmgr` path mistakes.
+- Bundling analysis + diary into one upload gives a better on-device review package.
+
+### What was tricky to build
+
+- The subtle part was keeping names/paths deterministic across dry-run, upload, and remote verification.
+
+### What warrants a second pair of eyes
+
+- Decide whether subsequent uploads should overwrite the same remote document name or use versioned naming.
+
+### What should be done in the future
+
+- Add a ticket-local upload naming/versioning convention when iterative revisions begin.
+
+### Code review instructions
+
+- Review final docs:
+  - `go-go-goja/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/analysis/01-tree-sitter-ast-live-sexp-editor-analysis.md`
+  - `go-go-goja/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/reference/01-diary.md`
+  - `go-go-goja/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/index.md`
+- Verify remote:
+  - `remarquee cloud ls /ai/2026/02/13/GOJA-001-AST-PARSE-EDITOR --long --non-interactive`
+
+### Technical details
+
+- Uploaded bundle name: `GOJA-001-AST-PARSE-EDITOR Analysis`
+- Remote dir: `/ai/2026/02/13/GOJA-001-AST-PARSE-EDITOR`
+- Included markdown inputs:
+  - `.../analysis/01-tree-sitter-ast-live-sexp-editor-analysis.md`
+  - `.../reference/01-diary.md`
+
+## Step 5: Task 1 Implementation (`pkg/jsparse` SEXP Renderers)
+
+I converted the high-level Task 1 into concrete code by adding reusable S-expression renderers to `pkg/jsparse`, then added dedicated unit tests. After formatting, I ran tests inside tmux as requested and committed the code as an isolated changeset.
+
+I also updated ticket task checkboxes so Task 1 reflects execution state.
+
+### Prompt Context
+
+**User prompt (verbatim):** "ok, add tasks to the ticket, and then start implementing one yb one. commit when appropriate, check off task, keep a frequent diary. Run in tmux for testing."
+
+**Assistant interpretation:** Break the ticket into executable tasks and begin implementation immediately, with per-task commits, task checkoffs, diary updates, and tmux-based test runs.
+
+**Inferred user intent:** Move from planning docs to iterative engineering execution with traceable progress.
+
+**Commit (code):** `a185315` — "jsparse: add CST/AST S-expression renderers"
+
+### What I did
+
+- Expanded `tasks.md` into Task 1/2/3 execution checklists.
+- Added implementation files:
+  - `go-go-goja/pkg/jsparse/sexp.go`
+  - `go-go-goja/pkg/jsparse/sexp_test.go`
+- Implemented APIs:
+  - `SExprOptions`
+  - `CSTToSExpr`
+  - `ASTIndexToSExpr`
+  - `ASTToSExpr`
+- Formatted code:
+  - `cd go-go-goja && gofmt -w pkg/jsparse/sexp.go pkg/jsparse/sexp_test.go`
+- Ran test in tmux:
+  - `tmux new-session -d -s goja001_task1 \"cd ... && GOWORK=off go test ./pkg/jsparse -count=1; echo __EXIT_CODE__$?; sleep 30\"`
+  - `tmux capture-pane -pt goja001_task1:0`
+- Committed code:
+  - `git add pkg/jsparse/sexp.go pkg/jsparse/sexp_test.go`
+  - `git commit -m \"jsparse: add CST/AST S-expression renderers\"`
+
+### Why
+
+- `pkg/jsparse` is the reusable layer; implementing SEXP there keeps the feature consumable by multiple tools (not only the new editor command).
+
+### What worked
+
+- `go test ./pkg/jsparse` passed in tmux (`__EXIT_CODE__0`).
+- Commit was successfully created with only the two new code files.
+
+### What didn't work
+
+- First tmux capture attempt failed due a lifecycle race:
+  - `can't find pane: goja001-task1`
+- Fix: reran with a session kept alive briefly (`sleep 30`) before capture.
+
+### What I learned
+
+- For short test commands in tmux, keeping the session alive after command completion avoids capture races.
+
+### What was tricky to build
+
+- Balancing default renderer behavior required explicit guardrails: depth and node-count truncation defaults prevent runaway output for large trees.
+
+### What warrants a second pair of eyes
+
+- Confirm whether the current S-expression metadata defaults (`IncludeText=true`, `IncludeFlags=true`) match your expected downstream UI output.
+
+### What should be done in the future
+
+- Add optional golden snapshot tests for SEXP output shape once the final display contract is frozen.
+
+### Code review instructions
+
+- Start at:
+  - `go-go-goja/pkg/jsparse/sexp.go`
+  - `go-go-goja/pkg/jsparse/sexp_test.go`
+- Validate quickly:
+  - `cd go-go-goja && GOWORK=off go test ./pkg/jsparse -count=1`
+
+### Technical details
+
+- tmux test pane output:
+  - `ok github.com/go-go-golems/go-go-goja/pkg/jsparse 0.005s`
+  - `__EXIT_CODE__0`

--- a/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/tasks.md
+++ b/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/tasks.md
@@ -21,15 +21,15 @@
 
 ## Task 2: New Live 3-Pane Editor Command
 
-- [ ] Add `cmd/ast-parse-editor/main.go`
-- [ ] Add `cmd/ast-parse-editor/app/model.go`
-- [ ] Implement 3-pane layout (editor, TS SEXP, AST SEXP)
-- [ ] Implement live tree-sitter parse on each edit
-- [ ] Implement debounced goja AST parse and valid-only AST pane rendering
-- [ ] Add keybindings/help/status for the new command
-- [ ] Add integration tests for command model behavior
-- [ ] Run command-level tests in tmux
-- [ ] Commit Task 2 and update diary/changelog
+- [x] Add `cmd/ast-parse-editor/main.go`
+- [x] Add `cmd/ast-parse-editor/app/model.go`
+- [x] Implement 3-pane layout (editor, TS SEXP, AST SEXP)
+- [x] Implement live tree-sitter parse on each edit
+- [x] Implement debounced goja AST parse and valid-only AST pane rendering
+- [x] Add keybindings/help/status for the new command
+- [x] Add integration tests for command model behavior
+- [x] Run command-level tests in tmux
+- [x] Commit Task 2 and update diary/changelog
 
 ## Task 3: Test Coverage and Hardening
 

--- a/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/tasks.md
+++ b/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/tasks.md
@@ -39,3 +39,12 @@
 - [x] Run focused regression tests in tmux
 - [x] Run `GOWORK=off go test ./pkg/jsparse ./cmd/ast-parse-editor/... -count=1`
 - [x] Commit Task 3 and update diary/changelog
+
+## Task 4: Empty Source Editing Validity
+
+- [x] Reproduce empty-file AST pane behavior (`(waiting-for-valid-parse)` regression)
+- [x] Make empty source parse render as valid AST S-expression (`(Program)`)
+- [x] Add regression tests in `pkg/jsparse/sexp_test.go`
+- [x] Add regression test in `cmd/ast-parse-editor/app/model_test.go`
+- [x] Run `GOWORK=off go test ./pkg/jsparse ./cmd/ast-parse-editor/... -count=1` in tmux
+- [x] Commit Task 4 and update diary/changelog

--- a/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/tasks.md
+++ b/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/tasks.md
@@ -1,0 +1,41 @@
+# Tasks
+
+## TODO
+
+- [x] Create ticket `GOJA-001-AST-PARSE-EDITOR`
+- [x] Produce detailed analysis of current tree-sitter + goja AST setup in `go-go-goja/`
+- [x] Write implementation blueprint for 3-pane live editor with CST/AST SEXP output
+- [x] Maintain detailed implementation diary during work
+- [x] Upload ticket docs bundle to reMarkable
+
+## Task 1: Reusable SEXP Renderers (`pkg/jsparse`)
+
+- [x] Add `pkg/jsparse/sexp.go`
+- [x] Implement `SExprOptions`
+- [x] Implement `CSTToSExpr(root *TSNode, opts *SExprOptions) string`
+- [x] Implement `ASTIndexToSExpr(idx *Index, opts *SExprOptions) string`
+- [x] Implement `ASTToSExpr(program *ast.Program, src string, opts *SExprOptions) string`
+- [x] Add `pkg/jsparse/sexp_test.go`
+- [x] Run `GOWORK=off go test ./pkg/jsparse -count=1`
+- [x] Commit Task 1 and update diary/changelog
+
+## Task 2: New Live 3-Pane Editor Command
+
+- [ ] Add `cmd/ast-parse-editor/main.go`
+- [ ] Add `cmd/ast-parse-editor/app/model.go`
+- [ ] Implement 3-pane layout (editor, TS SEXP, AST SEXP)
+- [ ] Implement live tree-sitter parse on each edit
+- [ ] Implement debounced goja AST parse and valid-only AST pane rendering
+- [ ] Add keybindings/help/status for the new command
+- [ ] Add integration tests for command model behavior
+- [ ] Run command-level tests in tmux
+- [ ] Commit Task 2 and update diary/changelog
+
+## Task 3: Test Coverage and Hardening
+
+- [ ] Add deterministic SEXP golden/assertion tests
+- [ ] Add truncation/depth guard tests
+- [ ] Add parse-error state transition tests (valid <-> invalid while typing)
+- [ ] Run focused regression tests in tmux
+- [ ] Run `GOWORK=off go test ./pkg/jsparse ./cmd/ast-parse-editor/... -count=1`
+- [ ] Commit Task 3 and update diary/changelog

--- a/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/tasks.md
+++ b/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/tasks.md
@@ -48,3 +48,13 @@
 - [x] Add regression test in `cmd/ast-parse-editor/app/model_test.go`
 - [x] Run `GOWORK=off go test ./pkg/jsparse ./cmd/ast-parse-editor/... -count=1` in tmux
 - [x] Commit Task 4 and update diary/changelog
+
+## Task 5: CLI Empty-Buffer Entry Flow
+
+- [x] Reproduce CLI failure when no argument is provided
+- [x] Reproduce CLI failure when target file path does not exist
+- [x] Allow `ast-parse-editor` to start with no args (`untitled.js`, empty source)
+- [x] Allow `ast-parse-editor <missing.js>` to start with empty source
+- [x] Add unit tests for `loadInput` behavior
+- [x] Run `GOWORK=off go test ./cmd/ast-parse-editor/... ./pkg/jsparse -count=1` in tmux
+- [x] Commit Task 5 and update diary/changelog

--- a/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/tasks.md
+++ b/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/tasks.md
@@ -33,9 +33,9 @@
 
 ## Task 3: Test Coverage and Hardening
 
-- [ ] Add deterministic SEXP golden/assertion tests
-- [ ] Add truncation/depth guard tests
-- [ ] Add parse-error state transition tests (valid <-> invalid while typing)
-- [ ] Run focused regression tests in tmux
-- [ ] Run `GOWORK=off go test ./pkg/jsparse ./cmd/ast-parse-editor/... -count=1`
-- [ ] Commit Task 3 and update diary/changelog
+- [x] Add deterministic SEXP golden/assertion tests
+- [x] Add truncation/depth guard tests
+- [x] Add parse-error state transition tests (valid <-> invalid while typing)
+- [x] Run focused regression tests in tmux
+- [x] Run `GOWORK=off go test ./pkg/jsparse ./cmd/ast-parse-editor/... -count=1`
+- [x] Commit Task 3 and update diary/changelog

--- a/ttmp/2026/02/13/GOJA-002-CURSOR-NODE-HIGHLIGHT--cursor-node-highlighting-in-ast-parse-editor/README.md
+++ b/ttmp/2026/02/13/GOJA-002-CURSOR-NODE-HIGHLIGHT--cursor-node-highlighting-in-ast-parse-editor/README.md
@@ -1,0 +1,21 @@
+# Cursor node highlighting in AST parse editor
+
+This is the document workspace for ticket GOJA-002-CURSOR-NODE-HIGHLIGHT.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr doc add --ticket GOJA-002-CURSOR-NODE-HIGHLIGHT --doc-type design-doc --title "My Design"`
+- Import sources: `docmgr import file --ticket GOJA-002-CURSOR-NODE-HIGHLIGHT --file /path/to/doc.md`
+- Update metadata: `docmgr meta update --ticket GOJA-002-CURSOR-NODE-HIGHLIGHT --field Status --value review`

--- a/ttmp/2026/02/13/GOJA-002-CURSOR-NODE-HIGHLIGHT--cursor-node-highlighting-in-ast-parse-editor/analysis/01-implementation-plan.md
+++ b/ttmp/2026/02/13/GOJA-002-CURSOR-NODE-HIGHLIGHT--cursor-node-highlighting-in-ast-parse-editor/analysis/01-implementation-plan.md
@@ -1,0 +1,114 @@
+---
+Title: Implementation plan
+Ticket: GOJA-002-CURSOR-NODE-HIGHLIGHT
+Status: active
+Topics:
+    - goja
+    - tooling
+    - ui
+DocType: analysis
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: go-go-goja/cmd/ast-parse-editor/app/model.go
+      Note: Current editor rendering and cursor handling implementation
+    - Path: go-go-goja/cmd/ast-parse-editor/app/model_test.go
+      Note: Existing editor model tests to extend for highlight behavior
+    - Path: go-go-goja/pkg/jsparse/treesitter.go
+      Note: NodeAtPosition and node span primitives for cursor-node mapping
+    - Path: go-go-goja/cmd/inspector/app/model.go
+      Note: Prior source-range highlight rendering pattern to reuse
+ExternalSources: []
+Summary: Plan for adding live source-pane highlight of the tree-sitter node under the cursor in ast-parse-editor.
+LastUpdated: 2026-02-13T16:30:00-05:00
+WhatFor: Define concrete implementation and test strategy for cursor-node highlighting.
+WhenToUse: Use when implementing or reviewing GOJA-002 cursor-node highlight behavior.
+---
+
+# GOJA-002 Implementation Plan
+
+## Goal
+
+Add a visible highlight in the editor pane for the CST node currently under the cursor while typing.
+
+## Current Baseline
+
+- Editor cursor rendering exists in `go-go-goja/cmd/ast-parse-editor/app/model.go`.
+- CST parse snapshot exists (`m.tsRoot`) and supports `NodeAtPosition` via `pkg/jsparse/treesitter.go`.
+- No persistent node-range highlight state is currently tracked in `ast-parse-editor`.
+
+## Scope
+
+In scope:
+
+- Highlight currently selected CST node range in editor pane.
+- Keep highlight updated on cursor movement and edits.
+- Show selected CST node metadata in status for observability.
+- Add regression tests for highlight state updates.
+
+Out of scope:
+
+- AST-node keyboard navigation modes (handled in GOJA-003).
+- Full lexical syntax coloring (handled in GOJA-003).
+
+## Design
+
+### 1. Model State Additions
+
+Add fields in `Model`:
+
+- `cursorNode *jsparse.TSNode` for latest CST node under cursor
+- `highlightStartLine`, `highlightStartCol`, `highlightEndLine`, `highlightEndCol` as 1-based range bounds
+
+### 2. Highlight Resolution
+
+Add helper `updateCursorNodeHighlight()`:
+
+- If `tsRoot == nil`, clear highlight.
+- Probe `NodeAtPosition(cursorRow, cursorCol)` and fallback `cursorCol-1`.
+- If node found, store pointer + convert node range into 1-based line/col highlight bounds.
+
+### 3. Update Triggers
+
+Call highlight refresh after:
+
+- cursor movement (`moveCursor`)
+- CST reparse after edits (`reparseCST`)
+- initial model creation
+
+### 4. Rendering
+
+Enhance `renderEditorPane`:
+
+- Apply highlight style over characters inside highlight range.
+- Keep cursor style precedence above highlight style.
+
+### 5. Status Line
+
+Append `node: <kind> (<start..end>)` when a node is resolved at cursor.
+
+## Test Plan
+
+Add tests in `go-go-goja/cmd/ast-parse-editor/app/model_test.go`:
+
+1. Initial cursor resolves highlight range on valid source.
+2. Moving cursor to another token updates highlight range.
+3. Empty source keeps sane highlight behavior (no panic, no invalid range).
+
+Run:
+
+- `GOWORK=off go test ./cmd/ast-parse-editor/... ./pkg/jsparse -count=1`
+
+## Risks and Mitigations
+
+- Boundary condition at end-of-line cursor:
+  - Mitigate with `cursorCol` and `cursorCol-1` lookup fallback.
+- Multiline node ranges:
+  - Reuse inspector-style inclusive/exclusive per-line checks.
+
+## Delivery Steps
+
+1. Implement model highlight state + resolver.
+2. Wire render and status updates.
+3. Add/adjust tests.
+4. Run tmux validation and commit.

--- a/ttmp/2026/02/13/GOJA-002-CURSOR-NODE-HIGHLIGHT--cursor-node-highlighting-in-ast-parse-editor/changelog.md
+++ b/ttmp/2026/02/13/GOJA-002-CURSOR-NODE-HIGHLIGHT--cursor-node-highlighting-in-ast-parse-editor/changelog.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## 2026-02-13
+
+- Initial workspace created
+
+
+## 2026-02-13
+
+Implemented cursor-node highlight in ast-parse-editor source pane with status metadata and regression tests; validated in tmux and committed (8aed063).
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/cmd/ast-parse-editor/app/model.go — Added cursor-node highlight state
+- /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/cmd/ast-parse-editor/app/model_test.go — Added highlight initialization
+- /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/ttmp/2026/02/13/GOJA-002-CURSOR-NODE-HIGHLIGHT--cursor-node-highlighting-in-ast-parse-editor/reference/01-diary.md — Step 2 details commands
+

--- a/ttmp/2026/02/13/GOJA-002-CURSOR-NODE-HIGHLIGHT--cursor-node-highlighting-in-ast-parse-editor/index.md
+++ b/ttmp/2026/02/13/GOJA-002-CURSOR-NODE-HIGHLIGHT--cursor-node-highlighting-in-ast-parse-editor/index.md
@@ -1,0 +1,56 @@
+---
+Title: Cursor node highlighting in AST parse editor
+Ticket: GOJA-002-CURSOR-NODE-HIGHLIGHT
+Status: active
+Topics:
+    - goja
+    - tooling
+    - ui
+DocType: index
+Intent: long-term
+Owners: []
+RelatedFiles: []
+ExternalSources: []
+Summary: ""
+LastUpdated: 2026-02-13T16:25:48.75092543-05:00
+WhatFor: ""
+WhenToUse: ""
+---
+
+# Cursor node highlighting in AST parse editor
+
+## Overview
+
+<!-- Provide a brief overview of the ticket, its goals, and current status -->
+
+## Key Links
+
+- **Related Files**: See frontmatter RelatedFiles field
+- **External Sources**: See frontmatter ExternalSources field
+
+## Status
+
+Current status: **active**
+
+## Topics
+
+- goja
+- tooling
+- ui
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/2026/02/13/GOJA-002-CURSOR-NODE-HIGHLIGHT--cursor-node-highlighting-in-ast-parse-editor/reference/01-diary.md
+++ b/ttmp/2026/02/13/GOJA-002-CURSOR-NODE-HIGHLIGHT--cursor-node-highlighting-in-ast-parse-editor/reference/01-diary.md
@@ -1,0 +1,203 @@
+---
+Title: Diary
+Ticket: GOJA-002-CURSOR-NODE-HIGHLIGHT
+Status: active
+Topics:
+    - goja
+    - tooling
+    - ui
+DocType: reference
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: cmd/ast-parse-editor/app/model.go
+      Note: |-
+        Primary implementation file for cursor-node highlight behavior
+        GOJA-002 implementation target
+    - Path: cmd/ast-parse-editor/app/model_test.go
+      Note: |-
+        Regression tests for highlight updates and cursor transitions
+        GOJA-002 regression coverage
+    - Path: pkg/jsparse/treesitter.go
+      Note: Cursor-to-node lookup primitive via NodeAtPosition
+    - Path: ttmp/2026/02/13/GOJA-002-CURSOR-NODE-HIGHLIGHT--cursor-node-highlighting-in-ast-parse-editor/analysis/01-implementation-plan.md
+      Note: Implementation blueprint and scope
+    - Path: ttmp/2026/02/13/GOJA-002-CURSOR-NODE-HIGHLIGHT--cursor-node-highlighting-in-ast-parse-editor/changelog.md
+      Note: GOJA-002 changelog entry for commit 8aed063
+    - Path: ttmp/2026/02/13/GOJA-002-CURSOR-NODE-HIGHLIGHT--cursor-node-highlighting-in-ast-parse-editor/tasks.md
+      Note: |-
+        Execution checklist and progress tracking
+        GOJA-002 completed task checklist
+ExternalSources: []
+Summary: Detailed execution diary for implementing cursor-node highlighting in ast-parse-editor.
+LastUpdated: 2026-02-13T16:29:51-05:00
+WhatFor: Preserve concrete commands, decisions, and validation details for GOJA-002.
+WhenToUse: Use when reviewing or continuing GOJA-002 implementation work.
+---
+
+
+# Diary
+
+## Goal
+
+Capture detailed, chronological implementation notes for GOJA-002 with exact commands, outcomes, and follow-up implications.
+
+## Step 1: Ticket Setup and Planning Baseline
+
+I created the GOJA-002 ticket workspace, added analysis/diary docs, and defined a concrete implementation plan plus executable task checklist before touching application code. This front-loads requirements so code changes can be done in focused, verifiable steps.
+
+The plan anchors on `TSNode.NodeAtPosition` and inspector-style range rendering so the editor can highlight the CST node under the cursor with minimal architectural churn.
+
+### Prompt Context
+
+**User prompt (verbatim):**
+
+"Add new ticket for :
+
+- Add highlighting of the node where the cursor is. 
+
+Add new ticket for: 
+- Add color syntax highlighting, allow me to switch modes and use the ast-parser selection thing from before. 
+
+Create a detailed implementation plan for each ticket, and add tasks, and then work on them, commit, check task off, keep a detailed diary."
+
+**Assistant interpretation:** Create two new tickets, produce detailed implementation plans, then implement each ticket with task checkoffs, commits, and detailed diary updates.
+
+**Inferred user intent:** Execute both UI feature requests end-to-end with disciplined project tracking.
+
+**Commit (code):** N/A (planning step)
+
+### What I did
+
+- Created ticket:
+  - `docmgr ticket create-ticket --ticket GOJA-002-CURSOR-NODE-HIGHLIGHT ...`
+- Added docs:
+  - `docmgr doc add --ticket GOJA-002-CURSOR-NODE-HIGHLIGHT --doc-type analysis --title "Implementation plan"`
+  - `docmgr doc add --ticket GOJA-002-CURSOR-NODE-HIGHLIGHT --doc-type reference --title "Diary"`
+- Wrote implementation blueprint:
+  - `.../analysis/01-implementation-plan.md`
+- Replaced placeholder tasks with concrete checklist:
+  - `.../tasks.md`
+
+### Why
+
+- The user explicitly requested plan-first execution and visible task progress.
+
+### What worked
+
+- Ticket scaffolding and planning docs were created successfully.
+- Task list now maps directly to implementation and validation milestones.
+
+### What didn't work
+
+- N/A.
+
+### What I learned
+
+- The current `ast-parse-editor` already has enough CST hooks to implement cursor-node highlighting without introducing a new parser dependency.
+
+### What was tricky to build
+
+- Separating GOJA-002 scope from GOJA-003 avoided premature coupling of highlight and mode features.
+
+### What warrants a second pair of eyes
+
+- Confirm expected priority when cursor overlaps both syntax color and node-range highlight (cursor should stay visually dominant).
+
+### What should be done in the future
+
+- After GOJA-003, revisit highlight layering to ensure mode-aware visual consistency.
+
+### Code review instructions
+
+- Review plan + checklist:
+  - `go-go-goja/ttmp/2026/02/13/GOJA-002-CURSOR-NODE-HIGHLIGHT--cursor-node-highlighting-in-ast-parse-editor/analysis/01-implementation-plan.md`
+  - `go-go-goja/ttmp/2026/02/13/GOJA-002-CURSOR-NODE-HIGHLIGHT--cursor-node-highlighting-in-ast-parse-editor/tasks.md`
+
+### Technical details
+
+- Ticket path:
+  - `go-go-goja/ttmp/2026/02/13/GOJA-002-CURSOR-NODE-HIGHLIGHT--cursor-node-highlighting-in-ast-parse-editor`
+
+## Step 2: Implement Cursor-Node Highlight and Regression Tests
+
+I implemented the full GOJA-002 feature in `ast-parse-editor`: the source pane now highlights the CST node at the cursor, and the status line reports node kind/range. The highlight is recomputed on cursor movement and after CST reparse on edits.
+
+I added focused tests for initial highlight state, cursor-driven highlight updates, and empty-source safety, then validated in tmux before committing.
+
+### Prompt Context
+
+**User prompt (verbatim):** (same as Step 1)
+
+**Assistant interpretation:** Execute GOJA-002 implementation with tests and commit discipline.
+
+**Inferred user intent:** Land a usable cursor-node highlight behavior with regression coverage.
+
+**Commit (code):** `8aed063` — "ast-parse-editor: highlight cursor node in source pane"
+
+### What I did
+
+- Updated implementation:
+  - `go-go-goja/cmd/ast-parse-editor/app/model.go`
+    - added highlight range state
+    - added `updateCursorNodeHighlight` and `clearCursorNodeHighlight`
+    - wired highlight refresh into cursor movement and CST reparses
+    - applied editor-pane range style rendering
+    - added status metadata for highlighted node
+- Added tests:
+  - `go-go-goja/cmd/ast-parse-editor/app/model_test.go`
+    - `TestCursorNodeHighlightInitialized`
+    - `TestCursorNodeHighlightMovesWithCursor`
+    - `TestCursorNodeHighlightEmptySourceIsSafe`
+- Ran tmux validation:
+  - `tmux new-session -d -s goja002_tests "cd ... && GOWORK=off go test ./cmd/ast-parse-editor/... ./pkg/jsparse -count=1; echo __EXIT_CODE__$?; exec zsh"`
+  - Captured pass:
+    - `ok .../cmd/ast-parse-editor`
+    - `ok .../cmd/ast-parse-editor/app`
+    - `ok .../pkg/jsparse`
+    - `__EXIT_CODE__0`
+
+### Why
+
+- The ticket requires visible, parser-grounded node highlighting at cursor position while editing live.
+
+### What worked
+
+- Highlight state updates correctly from CST node lookup.
+- Cursor movement and edits keep highlight synchronized.
+- Regression tests passed in tmux and pre-commit full test hook.
+
+### What didn't work
+
+- Pre-commit `go generate` Dagger path timed out on Docker Hub DNS lookup:
+  - `dial tcp: lookup registry-1.docker.io: i/o timeout`
+- Hook fallback to local npm build succeeded; subsequent `go test ./...` passed.
+
+### What I learned
+
+- Reusing inspector-style line/column range checks keeps highlight rendering deterministic and readable.
+
+### What was tricky to build
+
+- Correct boundary handling at cursor end-of-token required probing both `(row,col)` and `(row,col-1)` in CST lookup.
+
+### What warrants a second pair of eyes
+
+- Confirm highlight colors still read well once GOJA-003 syntax coloring is layered in.
+
+### What should be done in the future
+
+- Consider extracting shared range-highlighting helper logic if both editor modes use the same renderer paths.
+
+### Code review instructions
+
+- Review:
+  - `go-go-goja/cmd/ast-parse-editor/app/model.go`
+  - `go-go-goja/cmd/ast-parse-editor/app/model_test.go`
+- Validate:
+  - `cd go-go-goja && GOWORK=off go test ./cmd/ast-parse-editor/... ./pkg/jsparse -count=1`
+
+### Technical details
+
+- Commit hash: `8aed063`
+- tmux session used: `goja002_tests`

--- a/ttmp/2026/02/13/GOJA-002-CURSOR-NODE-HIGHLIGHT--cursor-node-highlighting-in-ast-parse-editor/tasks.md
+++ b/ttmp/2026/02/13/GOJA-002-CURSOR-NODE-HIGHLIGHT--cursor-node-highlighting-in-ast-parse-editor/tasks.md
@@ -1,0 +1,13 @@
+# Tasks
+
+## TODO
+
+- [x] Create analysis + diary docs for GOJA-002
+- [x] Write detailed implementation plan for cursor-node highlighting
+- [x] Implement cursor-node highlight state in `cmd/ast-parse-editor/app/model.go`
+- [x] Render editor range highlight for the current cursor node
+- [x] Add status metadata for highlighted node
+- [x] Add/adjust model tests for cursor-node highlighting
+- [x] Run `GOWORK=off go test ./cmd/ast-parse-editor/... ./pkg/jsparse -count=1` in tmux
+- [x] Commit code changes for GOJA-002
+- [x] Update GOJA-002 diary/changelog and check off completed tasks

--- a/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/README.md
+++ b/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/README.md
@@ -1,0 +1,21 @@
+# Syntax highlighting modes and AST selection mode in AST parse editor
+
+This is the document workspace for ticket GOJA-003-SYNTAX-MODES-AST-SELECTION.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr doc add --ticket GOJA-003-SYNTAX-MODES-AST-SELECTION --doc-type design-doc --title "My Design"`
+- Import sources: `docmgr import file --ticket GOJA-003-SYNTAX-MODES-AST-SELECTION --file /path/to/doc.md`
+- Update metadata: `docmgr meta update --ticket GOJA-003-SYNTAX-MODES-AST-SELECTION --field Status --value review`

--- a/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/analysis/01-implementation-plan.md
+++ b/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/analysis/01-implementation-plan.md
@@ -1,0 +1,129 @@
+---
+Title: Implementation plan
+Ticket: GOJA-003-SYNTAX-MODES-AST-SELECTION
+Status: active
+Topics:
+    - goja
+    - tooling
+    - ui
+DocType: analysis
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: go-go-goja/cmd/ast-parse-editor/app/model.go
+      Note: Target file for mode switching, syntax highlighting, and AST-selection behavior
+    - Path: go-go-goja/cmd/ast-parse-editor/app/model_test.go
+      Note: Existing model tests to extend for mode and selection transitions
+    - Path: go-go-goja/pkg/jsparse/index.go
+      Note: NodeAtOffset and ancestor/sibling navigation primitives for AST selection
+    - Path: go-go-goja/cmd/inspector/app/model.go
+      Note: Existing AST selection/sync behavior to reuse conceptually
+ExternalSources: []
+Summary: Plan for syntax coloring plus interactive mode switching with AST parser selection in ast-parse-editor.
+LastUpdated: 2026-02-13T16:30:00-05:00
+WhatFor: Define implementation details for GOJA-003 UI interaction upgrades.
+WhenToUse: Use when implementing or reviewing syntax/mode/AST-selection changes.
+---
+
+# GOJA-003 Implementation Plan
+
+## Goal
+
+Add color syntax highlighting and mode switching so we can reuse AST-parser node selection behavior in `ast-parse-editor`.
+
+## Current Baseline
+
+- Editor supports direct text editing with cursor movement.
+- AST parse runs asynchronously and currently emits only S-expression text.
+- No mode state exists besides focused pane cycling.
+
+## Scope
+
+In scope:
+
+- Syntax coloring in editor pane from CST leaf tokens.
+- Mode switching (edit vs AST-select).
+- AST-select mode using `jsparse.Index.NodeAtOffset` and parent/child/sibling traversal.
+- Status/help updates for discoverability.
+
+Out of scope:
+
+- Full tree pane like `inspector`.
+- Go-to-definition/usages workflows.
+
+## Design
+
+### 1. Editor Modes
+
+Add mode enum in `Model`:
+
+- `editorModeInsert` (default typing)
+- `editorModeASTSelect` (navigation-select mode)
+
+Keybinding:
+
+- `m` cycles between insert and AST-select modes.
+
+### 2. AST Parse Message Enrichment
+
+Extend async AST parse result to include index:
+
+- Build `idx := jsparse.BuildIndex(program, source)` when parse-valid.
+- Store `m.astIndex`.
+
+### 3. AST Selection State
+
+Add state:
+
+- `selectedASTNodeID jsparse.NodeID`
+
+Behaviors:
+
+- Entering AST-select mode seeds selection from cursor offset using `NodeAtOffset`.
+- In AST-select mode:
+  - `h` parent
+  - `l` first child
+  - `j` next sibling
+  - `k` previous sibling
+- After AST selection changes, source cursor jumps to node start and node highlight updates.
+
+### 4. Syntax Highlighting
+
+Implement CST-driven token map:
+
+- Walk leaf nodes and map spans to token classes.
+- Style basic classes: keyword, string, number, comment, identifier/property, operator/punctuation.
+- Add toggle key `s` for syntax color on/off.
+
+### 5. View/Status/Help
+
+- Show `mode: INSERT` or `mode: AST-SELECT` in status/header.
+- Show selected AST node kind/span in status when available.
+- Update help text with `m`, `s`, and AST-select navigation keys.
+
+## Test Plan
+
+Add tests in `cmd/ast-parse-editor/app/model_test.go`:
+
+1. Mode toggle changes behavior/state.
+2. AST-select mode seeds selection from cursor on valid AST.
+3. AST-select navigation keys move selected node and sync cursor.
+4. Syntax highlight toggle switches flag without breaking edits.
+
+Run:
+
+- `GOWORK=off go test ./cmd/ast-parse-editor/... ./pkg/jsparse -count=1`
+
+## Risks and Mitigations
+
+- Large-file per-render coloring cost:
+  - Keep tokenization simple and bounded by visible lines.
+- AST async staleness:
+  - Reuse `pendingSeq` guard and ignore stale `astParsedMsg`.
+
+## Delivery Steps
+
+1. Add mode/AST state fields and parse message index wiring.
+2. Implement AST-select navigation and source-sync hooks.
+3. Implement syntax coloring and toggle.
+4. Extend tests, run tmux suite, commit.

--- a/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/changelog.md
+++ b/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/changelog.md
@@ -4,3 +4,14 @@
 
 - Initial workspace created
 
+
+## 2026-02-13
+
+Implemented syntax highlighting toggle and AST-select mode with parser-index navigation in ast-parse-editor, plus regression tests and tmux validation (commit 1d1a88e).
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/cmd/ast-parse-editor/app/model.go — Added mode switching
+- /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/cmd/ast-parse-editor/app/model_test.go — Added mode toggle
+- /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/reference/01-diary.md — Step 2 execution diary and verification output
+

--- a/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/changelog.md
+++ b/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/changelog.md
@@ -37,3 +37,13 @@ Follow-up: added go-to-definition (ctrl+d), find-usages toggle (ctrl+g), usage h
 - /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/cmd/ast-parse-editor/app/model_test.go — Regression tests for go-to-definition and find-usages
 - /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/reference/01-diary.md — Step 4 follow-up implementation diary
 
+
+## 2026-02-13
+
+Step 5: cursor-synced TS/AST SEXP pane highlighting with line auto-scroll and regression tests (commit 90ca11a).
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/cmd/ast-parse-editor/app/model.go — SEXP selected-line tracking and pane rendering
+- /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/cmd/ast-parse-editor/app/model_test.go — SEXP tracking tests
+- /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/reference/01-diary.md — Step 5 diary details

--- a/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/changelog.md
+++ b/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/changelog.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 2026-02-13
+
+- Initial workspace created
+

--- a/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/changelog.md
+++ b/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/changelog.md
@@ -26,3 +26,14 @@ Follow-up: switched global toggles to ctrl bindings and added inspector-style ex
 - /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/cmd/ast-parse-editor/app/model_test.go — Tests for m/s literal insertion and AST tree expand toggle
 - /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/reference/01-diary.md — Step 3 follow-up diary
 
+
+## 2026-02-13
+
+Follow-up: added go-to-definition (ctrl+d), find-usages toggle (ctrl+g), usage highlighting, and dual tree-sitter/AST cursor highlights in insert mode; added regression tests and tmux validation (commit 9c6489b).
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/cmd/ast-parse-editor/app/model.go — Symbol navigation
+- /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/cmd/ast-parse-editor/app/model_test.go — Regression tests for go-to-definition and find-usages
+- /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/reference/01-diary.md — Step 4 follow-up implementation diary
+

--- a/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/changelog.md
+++ b/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/changelog.md
@@ -15,3 +15,14 @@ Implemented syntax highlighting toggle and AST-select mode with parser-index nav
 - /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/cmd/ast-parse-editor/app/model_test.go — Added mode toggle
 - /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/reference/01-diary.md — Step 2 execution diary and verification output
 
+
+## 2026-02-13
+
+Follow-up: switched global toggles to ctrl bindings and added inspector-style expandable AST tree widget in AST-select mode, including pane navigation controls and regression tests (commit e162ccf).
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/cmd/ast-parse-editor/app/model.go — Ctrl keybindings and AST tree-pane rendering/navigation
+- /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/cmd/ast-parse-editor/app/model_test.go — Tests for m/s literal insertion and AST tree expand toggle
+- /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/reference/01-diary.md — Step 3 follow-up diary
+

--- a/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/index.md
+++ b/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/index.md
@@ -1,0 +1,56 @@
+---
+Title: Syntax highlighting modes and AST selection mode in AST parse editor
+Ticket: GOJA-003-SYNTAX-MODES-AST-SELECTION
+Status: active
+Topics:
+    - goja
+    - tooling
+    - ui
+DocType: index
+Intent: long-term
+Owners: []
+RelatedFiles: []
+ExternalSources: []
+Summary: ""
+LastUpdated: 2026-02-13T16:25:48.834704166-05:00
+WhatFor: ""
+WhenToUse: ""
+---
+
+# Syntax highlighting modes and AST selection mode in AST parse editor
+
+## Overview
+
+<!-- Provide a brief overview of the ticket, its goals, and current status -->
+
+## Key Links
+
+- **Related Files**: See frontmatter RelatedFiles field
+- **External Sources**: See frontmatter ExternalSources field
+
+## Status
+
+Current status: **active**
+
+## Topics
+
+- goja
+- tooling
+- ui
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/reference/01-diary.md
+++ b/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/reference/01-diary.md
@@ -1,0 +1,111 @@
+---
+Title: Diary
+Ticket: GOJA-003-SYNTAX-MODES-AST-SELECTION
+Status: active
+Topics:
+    - goja
+    - tooling
+    - ui
+DocType: reference
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: go-go-goja/cmd/ast-parse-editor/app/model.go
+      Note: Target model for mode switching, syntax coloring, and AST selection behavior
+    - Path: go-go-goja/cmd/ast-parse-editor/app/model_test.go
+      Note: Tests for mode and selection transitions
+    - Path: go-go-goja/pkg/jsparse/index.go
+      Note: AST node selection and navigation primitives
+    - Path: go-go-goja/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/analysis/01-implementation-plan.md
+      Note: Detailed implementation blueprint for this ticket
+    - Path: go-go-goja/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/tasks.md
+      Note: Execution checklist for the ticket
+ExternalSources: []
+Summary: Detailed execution diary for syntax highlighting and AST-selection mode implementation work.
+LastUpdated: 2026-02-13T16:31:00-05:00
+WhatFor: Preserve concrete implementation and validation history for GOJA-003.
+WhenToUse: Use when reviewing or continuing GOJA-003 development.
+---
+
+# Diary
+
+## Goal
+
+Capture a complete, step-by-step log for GOJA-003 implementation decisions, command outputs, and verification.
+
+## Step 1: Ticket Setup and Plan Definition
+
+I created the GOJA-003 workspace and documentation scaffolding, then wrote a detailed plan and execution checklist before coding. This sets a strict implementation contract for syntax coloring and mode/AST-selection behavior.
+
+The scope is intentionally constrained to `ast-parse-editor` and reuses existing `jsparse.Index` node-selection primitives to keep behavior consistent with the prior inspector workflow.
+
+### Prompt Context
+
+**User prompt (verbatim):**
+
+"Add new ticket for :
+
+- Add highlighting of the node where the cursor is. 
+
+Add new ticket for: 
+- Add color syntax highlighting, allow me to switch modes and use the ast-parser selection thing from before. 
+
+Create a detailed implementation plan for each ticket, and add tasks, and then work on them, commit, check task off, keep a detailed diary."
+
+**Assistant interpretation:** Prepare and execute a dedicated implementation ticket for syntax highlighting and AST-selection mode behavior.
+
+**Inferred user intent:** Deliver richer interactive editing ergonomics while preserving parser-driven accuracy.
+
+**Commit (code):** N/A (planning step)
+
+### What I did
+
+- Created ticket:
+  - `docmgr ticket create-ticket --ticket GOJA-003-SYNTAX-MODES-AST-SELECTION ...`
+- Added docs:
+  - `docmgr doc add --ticket GOJA-003-SYNTAX-MODES-AST-SELECTION --doc-type analysis --title "Implementation plan"`
+  - `docmgr doc add --ticket GOJA-003-SYNTAX-MODES-AST-SELECTION --doc-type reference --title "Diary"`
+- Wrote implementation plan:
+  - `.../analysis/01-implementation-plan.md`
+- Replaced placeholder tasks:
+  - `.../tasks.md`
+
+### Why
+
+- The user requested detailed plan-first execution with explicit task checkoffs and diary traceability.
+
+### What worked
+
+- Ticket and document scaffold were created cleanly.
+- Plan and tasks now explicitly define coding and test phases.
+
+### What didn't work
+
+- N/A.
+
+### What I learned
+
+- AST-selection mode can be implemented with current index APIs (`NodeAtOffset`, parent/child relationships) without introducing new parser passes.
+
+### What was tricky to build
+
+- Balancing feature scope so GOJA-003 does not absorb GOJA-002 responsibilities.
+
+### What warrants a second pair of eyes
+
+- Confirm final keybinding choices (`m`, `s`, `h/j/k/l`) do not conflict with expected editor ergonomics.
+
+### What should be done in the future
+
+- If mode count grows, introduce a small mode legend widget in header instead of status-only text.
+
+### Code review instructions
+
+- Review:
+  - `go-go-goja/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/analysis/01-implementation-plan.md`
+  - `go-go-goja/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/tasks.md`
+
+### Technical details
+
+- Ticket path:
+  - `go-go-goja/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor`

--- a/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/reference/01-diary.md
+++ b/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/reference/01-diary.md
@@ -10,22 +10,31 @@ DocType: reference
 Intent: long-term
 Owners: []
 RelatedFiles:
-    - Path: go-go-goja/cmd/ast-parse-editor/app/model.go
-      Note: Target model for mode switching, syntax coloring, and AST selection behavior
-    - Path: go-go-goja/cmd/ast-parse-editor/app/model_test.go
-      Note: Tests for mode and selection transitions
-    - Path: go-go-goja/pkg/jsparse/index.go
+    - Path: cmd/ast-parse-editor/app/model.go
+      Note: |-
+        Target model for mode switching, syntax coloring, and AST selection behavior
+        GOJA-003 implementation source
+    - Path: cmd/ast-parse-editor/app/model_test.go
+      Note: |-
+        Tests for mode and selection transitions
+        GOJA-003 regression tests
+    - Path: pkg/jsparse/index.go
       Note: AST node selection and navigation primitives
-    - Path: go-go-goja/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/analysis/01-implementation-plan.md
+    - Path: ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/analysis/01-implementation-plan.md
       Note: Detailed implementation blueprint for this ticket
-    - Path: go-go-goja/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/tasks.md
-      Note: Execution checklist for the ticket
+    - Path: ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/changelog.md
+      Note: GOJA-003 changelog entry for commit 1d1a88e
+    - Path: ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/tasks.md
+      Note: |-
+        Execution checklist for the ticket
+        GOJA-003 completed task checklist
 ExternalSources: []
 Summary: Detailed execution diary for syntax highlighting and AST-selection mode implementation work.
-LastUpdated: 2026-02-13T16:31:00-05:00
+LastUpdated: 2026-02-13T16:35:03-05:00
 WhatFor: Preserve concrete implementation and validation history for GOJA-003.
 WhenToUse: Use when reviewing or continuing GOJA-003 development.
 ---
+
 
 # Diary
 
@@ -109,3 +118,88 @@ Create a detailed implementation plan for each ticket, and add tasks, and then w
 
 - Ticket path:
   - `go-go-goja/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor`
+
+## Step 2: Implement Syntax Coloring, Mode Switching, and AST Selection
+
+I implemented GOJA-003 in `ast-parse-editor` with two major behaviors: syntax coloring from tree-sitter leaf tokens and a dedicated AST-select mode driven by `jsparse.Index` node selection. This includes mode toggling, AST navigation keys, status/help updates, and new regression tests.
+
+The implementation keeps insert mode and AST-select mode intentionally separate: insert mode edits source and tracks CST highlight at cursor, while AST-select mode reuses parser-index selection logic and moves selection across parent/child/sibling nodes.
+
+### Prompt Context
+
+**User prompt (verbatim):** (same as Step 1)
+
+**Assistant interpretation:** Implement GOJA-003 features with test coverage and task/diary tracking.
+
+**Inferred user intent:** Make the editor more usable for parser-aware exploration while preserving live editing behavior.
+
+**Commit (code):** `1d1a88e` — "ast-parse-editor: add syntax highlighting and AST select mode"
+
+### What I did
+
+- Updated model implementation:
+  - `go-go-goja/cmd/ast-parse-editor/app/model.go`
+    - added editor modes (`INSERT`, `AST-SELECT`)
+    - added `m` mode toggle and `s` syntax toggle
+    - extended AST parse message with `ASTIndex`
+    - added AST selection state + navigation (`h/j/k/l`, `g`)
+    - added syntax span extraction/classification from CST leaves
+    - applied syntax-aware editor rendering and mode/status/help updates
+- Added tests:
+  - `go-go-goja/cmd/ast-parse-editor/app/model_test.go`
+    - `TestModeToggleASTSelectAndBack`
+    - `TestASTSelectNavigationMovesSelection`
+    - `TestSyntaxHighlightToggle`
+    - `TestASTSelectModeBlocksTextInsertion`
+- Ran tmux tests:
+  - `tmux new-session -d -s goja003_tests "cd ... && GOWORK=off go test ./cmd/ast-parse-editor/... ./pkg/jsparse -count=1; echo __EXIT_CODE__$?; exec zsh"`
+  - Captured pass with `__EXIT_CODE__0`.
+
+### Why
+
+- The ticket requires both visual syntax feedback and parser-index-driven selection mode changes.
+
+### What worked
+
+- Mode toggling and AST navigation logic are active and covered by tests.
+- Syntax coloring toggle is functional and defaults to enabled.
+- Focused tmux regression run passed.
+- Pre-commit full suite passed.
+
+### What didn't work
+
+- First commit attempt failed lint:
+  - `cmd/ast-parse-editor/app/model.go:845:2: missing cases in switch of type app.syntaxClass: app.syntaxClassNone (exhaustive)`
+- Fix: added explicit `case syntaxClassNone:` in `renderSyntaxChar`.
+- Pre-commit `go generate` Dagger step again failed Docker Hub DNS lookup:
+  - `dial tcp: lookup registry-1.docker.io: i/o timeout`
+- Hook fallback succeeded (local npm build), and tests still passed.
+
+### What I learned
+
+- Keeping mode-specific intent explicit (`INSERT` vs `AST-SELECT`) prevents accidental edits during parser-navigation workflows.
+
+### What was tricky to build
+
+- Highlight layering had to remain predictable across cursor state, AST selection state, and syntax styling; cursor precedence remained highest to preserve editability.
+
+### What warrants a second pair of eyes
+
+- Confirm token color palette choices for readability in your terminal theme.
+
+### What should be done in the future
+
+- Consider adding a compact per-mode legend for keybindings if more modes are introduced.
+
+### Code review instructions
+
+- Review:
+  - `go-go-goja/cmd/ast-parse-editor/app/model.go`
+  - `go-go-goja/cmd/ast-parse-editor/app/model_test.go`
+- Validate:
+  - `cd go-go-goja && GOWORK=off go test ./cmd/ast-parse-editor/... ./pkg/jsparse -count=1`
+
+### Technical details
+
+- Commit hash: `1d1a88e`
+- tmux session: `goja003_tests`

--- a/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/tasks.md
+++ b/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/tasks.md
@@ -4,12 +4,12 @@
 
 - [x] Create analysis + diary docs for GOJA-003
 - [x] Write detailed implementation plan for syntax highlighting + AST-selection mode
-- [ ] Add editor mode state and keybindings (`m` mode toggle)
-- [ ] Add AST index storage + selection state synced from cursor offset
-- [ ] Implement AST-select navigation (`h/j/k/l`) and source cursor sync
-- [ ] Add syntax highlighting toggle (`s`) and CST token coloring
-- [ ] Update header/status/help for mode + selection visibility
-- [ ] Add/adjust model tests for mode/selection/syntax toggles
-- [ ] Run `GOWORK=off go test ./cmd/ast-parse-editor/... ./pkg/jsparse -count=1` in tmux
-- [ ] Commit code changes for GOJA-003
-- [ ] Update GOJA-003 diary/changelog and check off completed tasks
+- [x] Add editor mode state and keybindings (`m` mode toggle)
+- [x] Add AST index storage + selection state synced from cursor offset
+- [x] Implement AST-select navigation (`h/j/k/l`) and source cursor sync
+- [x] Add syntax highlighting toggle (`s`) and CST token coloring
+- [x] Update header/status/help for mode + selection visibility
+- [x] Add/adjust model tests for mode/selection/syntax toggles
+- [x] Run `GOWORK=off go test ./cmd/ast-parse-editor/... ./pkg/jsparse -count=1` in tmux
+- [x] Commit code changes for GOJA-003
+- [x] Update GOJA-003 diary/changelog and check off completed tasks

--- a/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/tasks.md
+++ b/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/tasks.md
@@ -13,3 +13,12 @@
 - [x] Run `GOWORK=off go test ./cmd/ast-parse-editor/... ./pkg/jsparse -count=1` in tmux
 - [x] Commit code changes for GOJA-003
 - [x] Update GOJA-003 diary/changelog and check off completed tasks
+
+## Follow-up: Key Conflicts and Tree Widget
+
+- [x] Move global mode/syntax toggles to `ctrl+` bindings to avoid insert-mode key capture
+- [x] Show inspector-style expandable AST tree widget in right pane while in AST-select mode
+- [x] Add tree pane controls (`space` toggle, `h/l` collapse/expand, `j/k` move) when AST pane focused
+- [x] Add regression tests for literal `m/s` insertion and tree expand toggle
+- [x] Run `GOWORK=off go test ./cmd/ast-parse-editor/... ./pkg/jsparse -count=1` in tmux
+- [x] Commit follow-up code and update diary/changelog

--- a/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/tasks.md
+++ b/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/tasks.md
@@ -22,3 +22,13 @@
 - [x] Add regression tests for literal `m/s` insertion and tree expand toggle
 - [x] Run `GOWORK=off go test ./cmd/ast-parse-editor/... ./pkg/jsparse -count=1` in tmux
 - [x] Commit follow-up code and update diary/changelog
+
+## Follow-up: Definition/Usages and Dual Cursor Highlights
+
+- [x] Add `ctrl+d` go-to-definition using AST resolution bindings
+- [x] Add `ctrl+g` find-usages toggle and `esc` clear behavior
+- [x] Highlight usage nodes in source and AST tree panes
+- [x] Keep both tree-sitter cursor node and AST cursor node highlights active in insert mode
+- [x] Add regression tests for go-to-definition and usages toggling
+- [x] Run `GOWORK=off go test ./cmd/ast-parse-editor/... ./pkg/jsparse -count=1` in tmux
+- [x] Commit follow-up code and update diary/changelog

--- a/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/tasks.md
+++ b/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/tasks.md
@@ -32,3 +32,12 @@
 - [x] Add regression tests for go-to-definition and usages toggling
 - [x] Run `GOWORK=off go test ./cmd/ast-parse-editor/... ./pkg/jsparse -count=1` in tmux
 - [x] Commit follow-up code and update diary/changelog
+
+## Follow-up: Cursor-Synced SEXP Pane Highlighting
+
+- [x] Track selected TS SEXP line from cursor node range metadata
+- [x] Track selected AST SEXP line from AST cursor node span metadata
+- [x] Highlight selected SEXP line in TS/AST SEXP panes and auto-scroll it into view
+- [x] Add regression tests for SEXP line tracking and invalid-parse clearing
+- [x] Run `GOWORK=off go test ./cmd/ast-parse-editor/... ./pkg/jsparse -count=1` in tmux
+- [x] Commit follow-up code and update diary/changelog

--- a/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/tasks.md
+++ b/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/tasks.md
@@ -1,0 +1,15 @@
+# Tasks
+
+## TODO
+
+- [x] Create analysis + diary docs for GOJA-003
+- [x] Write detailed implementation plan for syntax highlighting + AST-selection mode
+- [ ] Add editor mode state and keybindings (`m` mode toggle)
+- [ ] Add AST index storage + selection state synced from cursor offset
+- [ ] Implement AST-select navigation (`h/j/k/l`) and source cursor sync
+- [ ] Add syntax highlighting toggle (`s`) and CST token coloring
+- [ ] Update header/status/help for mode + selection visibility
+- [ ] Add/adjust model tests for mode/selection/syntax toggles
+- [ ] Run `GOWORK=off go test ./cmd/ast-parse-editor/... ./pkg/jsparse -count=1` in tmux
+- [ ] Commit code changes for GOJA-003
+- [ ] Update GOJA-003 diary/changelog and check off completed tasks


### PR DESCRIPTION
This commit introduces `ast-parse-editor`, a new terminal-based tool for live
inspection of JavaScript source code using Tree-sitter and the Goja parser.

The tool features a three-pane layout providing real-time feedback as you type:
- **Editor Pane:** A text editor for modifying JavaScript source code.
- **CST Pane:** A view of the Tree-sitter Concrete Syntax Tree (CST)
  rendered as an S-expression, which updates on every keystroke.
- **AST Pane:** A view of the Goja Abstract Syntax Tree (AST), which updates
  via a debounced parse whenever the code is syntactically valid.

Key Features:
- **Dual Editing Modes:**
  - `Insert Mode`: For standard text editing.
  - `AST-Select Mode`: For navigating the code based on its AST structure.
    The AST pane switches to an interactive, expandable tree view in this mode.
- **Code Intelligence:**
  - Go-to-definition (`Ctrl+d`) and find-usages (`Ctrl+g`) powered by scope
    analysis.
  - Multi-layered source highlighting for syntax, active CST/AST nodes, and
    symbol usages.
- **Cross-Pane Synchronization:**
  - The cursor position in the editor highlights the corresponding node in the
    source and the relevant line in the S-expression panes.
- **Reusable S-Expression Library:**
  - Adds new S-expression renderers for CST and AST to the `jsparse` package.
- **Flexible Startup:**
  - The editor can be launched with an existing file, a path to a new file,
    or no arguments for a blank scratchpad.