### PR TITLE
feat(inspector): Add Smalltalk inspector and reusable analysis framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ dist/
 cmd/bun-demo/js/node_modules/
 cmd/bun-demo/js/dist/
 cmd/bun-demo/js/dist-split/
+sinspect.log

--- a/README.md
+++ b/README.md
@@ -1,205 +1,114 @@
-# go-go-goja – Native-Module Playground for goja
+# go-go-goja
 
-**go-go-goja** is a tiny sandbox project that shows how to wire Go-implemented "native" modules into a [dop251/goja] JavaScript runtime using the [goja_nodejs/require] subsystem.
+`go-go-goja` is a Go + JavaScript tooling workspace centered on:
+- goja native module execution (`cmd/repl`, `modules/*`, `engine`)
+- JavaScript parsing/indexing/completion (`pkg/jsparse`)
+- inspector domain primitives (`pkg/inspector/*`)
+- user-facing inspector orchestration (`pkg/inspectorapi`)
+- terminal inspector adapters (`cmd/inspector`, `cmd/smalltalk-inspector`)
 
-The goal is to have a place where you can:
+## Quick Start
 
-* add your own Go files under `modules/` and immediately use them from JS via `require("your-module")`
-* experiment with goja + Node-style `require()` without having to set up a whole application
-* run JS files non-interactively or open an interactive prompt (`go run ./cmd/repl`)
-
----
-
-## Folder layout
-
-```text
- go-go-goja/
- ├── cmd/
- │   └── repl/            # standalone runner / interactive prompt
- ├── engine/              # one helper: engine.New() → (*goja.Runtime, *require.RequireModule)
- ├── modules/             # ← add your Go-backed modules here
- │   ├── common.go        # registry plumbing (NativeModule, Register, …)
- │   ├── fs/              # example module 1: basic file-system helpers
- │   └── exec/            # example module 2: thin wrapper around os/exec
- ├── testdata/            # demo JS scripts used by Go tests
- ├── repl_test.go         # Go test that runs a JS script through the runner
- └── go.mod
-```
-
-`engine.New()` does the heavy lifting:
-
-1. creates a fresh `goja.Runtime`
-2. enables Node-style `require()`
-3. calls `modules.EnableAll(reg)` so every module that called `modules.Register()` during `init()` becomes available to JS
-4. exposes a global `console` object so that `console.log()` works out-of-the-box
-
----
-
-## Quick start
+From repo root:
 
 ```bash
-# from the project root
-cd go-go-goja
-
-# run a script once
-❯ go run ./cmd/repl testdata/hello.js
-OK
-
-# or open the prompt (type JS, :quit to exit)
-❯ go run ./cmd/repl -debug
-js> const fs = require("fs");
-js> fs.writeFileSync("/tmp/demo.txt", "hi");
-js> console.log(fs.readFileSync("/tmp/demo.txt"));
-hi
+go run ./cmd/repl testdata/hello.js
+go run ./cmd/inspector ../goja/testdata/sample.js
+go run ./cmd/smalltalk-inspector ../goja/testdata/sample.js
 ```
 
-The `-debug` flag prints extra logs such as which modules were registered.
+## Project Layout
 
----
+```text
+go-go-goja/
+├── cmd/
+│   ├── repl/                  # goja runtime REPL + script runner
+│   ├── inspector/             # jsparse-oriented AST inspector example
+│   └── smalltalk-inspector/   # Smalltalk-style object inspector UI
+├── engine/                    # runtime bootstrap helpers (goja + require)
+├── modules/                   # native modules exposed through require()
+├── pkg/
+│   ├── jsparse/               # low-level parser/index/resolution/completion
+│   ├── inspector/             # reusable inspector core/runtime/navigation/tree
+│   ├── inspectorapi/          # high-level service facade for adapters
+│   └── doc/                   # glazed help pages
+├── testdata/
+└── ttmp/                      # ticket docs, plans, diaries, reviews
+```
 
-## Adding **your** native module
+## Architecture Boundaries
 
-Say we want to expose a simplistic `uuid` module that exports a single `v4()` function.
+Use `pkg/jsparse` when you need parser-level control:
+- AST indexing and source mapping
+- lexical binding resolution
+- completion context extraction and candidate resolution
 
-1. **Create a sub-folder** under `modules/`:
-   ```bash
-   mkdir modules/uuid && touch modules/uuid/uuid.go
-   ```
-2. **Implement the module** – only ~40 lines:
-   ```go
-   // modules/uuid/uuid.go
-   package uuidmod
+Use `pkg/inspectorapi` when you need adapter-facing workflows:
+- document/session lifecycle
+- globals/members/jump orchestration
+- runtime merge helpers
+- tree/source sync wrappers
 
-   import (
-       "github.com/dop251/goja"
-       "github.com/go-go-golems/go-go-goja/modules" // registry helpers
-       "github.com/google/uuid"
-   )
+Command adapters (`cmd/*`) should stay focused on input, key handling, and rendering. Business orchestration should live in `pkg/inspectorapi` and lower packages.
 
-   type m struct{}
+## Native Module Authoring
 
-   // compile-time check – keeps the linter happy and guarantees the interface is satisfied
-   var _ modules.NativeModule = (*m)(nil)
+Add a module under `modules/<name>/` and register it during `init()`:
 
-   func (m) Name() string { return "uuid" }
+```go
+package uuidmod
 
-   func (m) Loader(vm *goja.Runtime, moduleObj *goja.Object) {
-       exports := moduleObj.Get("exports").(*goja.Object)
-       exports.Set("v4", func() string { return uuid.NewString() })
-   }
+import (
+    "github.com/dop251/goja"
+    "github.com/go-go-golems/go-go-goja/modules"
+    "github.com/google/uuid"
+)
 
-   func init() { modules.Register(&m{}) }
-   ```
-3. **Make sure the package is imported somewhere** so that its `init()` runs. The simplest is to add a blank-import in `engine/runtime.go` (or in `cmd/repl/main.go` if you prefer):
-   ```go
-   import (
-       _ "github.com/go-go-golems/go-go-goja/modules/uuid" // ← new module here
-   )
-   ```
-   The blank import is only required once – after that every call to `engine.New()` automatically enables the module.
-4. **Profit**
-   ```js
-   const { v4 } = require("uuid");
-   console.log(v4());
-   ```
+type Module struct{}
 
-### Tips & conventions
+var _ modules.NativeModule = (*Module)(nil)
 
-* Always keep your module self-contained inside `modules/<name>/<name>.go` – easier to copy around.
-* Return only **plain Go types** (string, number, bool, maps, slices) or `goja.Value`s. The runtime converts between Go & JS automatically.
-* If your module allocates goroutines, honour `context.Context` and consider `errgroup` for clean cancellation.
-* Use `var _ modules.NativeModule = (*yourType)(nil)` for compile-time checks (see [Go guidelines in the repo rules]).
+func (m *Module) Name() string { return "uuid" }
 
----
+func (m *Module) Loader(vm *goja.Runtime, moduleObj *goja.Object) {
+    exports := moduleObj.Get("exports").(*goja.Object)
+    exports.Set("v4", func() string { return uuid.NewString() })
+}
+
+func init() { modules.Register(&Module{}) }
+```
+
+Ensure the package is imported once (usually in `engine/runtime.go`) so the registration `init()` runs.
 
 ## Testing
 
-`repl_test.go` shows how to execute a JS file from a Go test:
+Run the full suite:
 
-```go
-cmd := exec.Command("go", "run", "./cmd/repl", "testdata/hello.js")
-cmd.Dir = "./go-go-goja" // run from module root
+```bash
+go test ./... -count=1
 ```
 
-The JS script lives in `testdata/hello.js` and prints `OK` on success. Add new test scripts the same way and extend the test function.
+Focused checks:
 
----
+```bash
+go test ./pkg/jsparse/... -count=1
+go test ./pkg/inspectorapi/... -count=1
+go test ./cmd/smalltalk-inspector/... -count=1
+```
+
+## Documentation
+
+Glazed help pages live in `pkg/doc`. Useful entry points:
+
+```bash
+glaze help jsparse-framework-reference
+glaze help inspectorapi-hybrid-service-guide
+glaze help inspector-example-user-guide
+```
 
 ## License
 
-MIT (see LICENSE file).
+MIT (see `LICENSE`).
 
-[dop251/goja]:   https://github.com/dop251/goja
+[dop251/goja]: https://github.com/dop251/goja
 [goja_nodejs/require]: https://pkg.go.dev/github.com/dop251/goja_nodejs/require
-
----
-
-## Asynchronous APIs (Promises & Callbacks)
-
-`goja` lets Go code create real JavaScript `Promise`s, or call back into JS functions at a later time.  
-The trick is that *all interactions with the VM must happen on the same goroutine that owns it.*  
-
-Two common patterns – both visible in the main codebase (`geppetto/pkg/js/embeddings-js.go`, `runtime-engine.go`):
-
-1. **`runtime.NewPromise()`**
-   ```go
-   promise, resolve, reject := vm.NewPromise()
-   go func() {
-       // expensive stuff …
-       if err != nil {
-           // bounce back into the VM goroutine to reject
-           loop.RunOnLoop(func(*goja.Runtime) { reject(vm.ToValue(err.Error())) })
-           return
-       }
-       loop.RunOnLoop(func(*goja.Runtime) { resolve(vm.ToValue(result)) })
-   }()
-   return vm.ToValue(promise)
-   ```
-   * Wrap the work in a goroutine.
-   * When done, schedule `resolve`/`reject` back on the event-loop with `RunOnLoop` (from `goja_nodejs/eventloop`).
-
-2. **Explicit callbacks** *(old-school Node style)*
-   ```go
-   func (m) Loader(vm *goja.Runtime, mod *goja.Object) {
-       exports := mod.Get("exports").(*goja.Object)
-       exports.Set("doStuff", func(call goja.FunctionCall) goja.Value {
-           input := call.Arguments[0].String()
-           callbacks := call.Arguments[1].ToObject(vm)
-           onSuccess, _ := goja.AssertFunction(callbacks.Get("onSuccess"))
-           onError,   _ := goja.AssertFunction(callbacks.Get("onError"))
-           go func() {
-               res, err := reallySlow(input)
-               loop.RunOnLoop(func(*goja.Runtime) {
-                   if err != nil { onError(goja.Undefined(), vm.ToValue(err.Error())); return }
-                   onSuccess(goja.Undefined(), vm.ToValue(res))
-               })
-           }()
-           return goja.Undefined()
-       })
-   }
-   ```
-
-### Demo: `timer` module
-
-Included in `modules/timer/timer.go` is a minimal example:
-
-```js
-const { sleep } = require("timer");
-await sleep(1000);   // returns a Promise that resolves after 1 s
-console.log("done");
-```
-
-The Go side (simplified):
-
-```go
-exports.Set("sleep", func(ms int64) goja.Value {
-    p, resolve, _ := vm.NewPromise()
-    go func() {
-        time.Sleep(time.Duration(ms) * time.Millisecond)
-        loop.RunOnLoop(func(*goja.Runtime) { resolve(goja.Undefined()) })
-    }()
-    return vm.ToValue(p)
-})
-```
-
-Use it as a template for any async binding you need (HTTP fetchers, database calls, …).

--- a/cmd/inspector/app/jsparse_bridge.go
+++ b/cmd/inspector/app/jsparse_bridge.go
@@ -10,6 +10,7 @@ type NodeRecord = jsparse.NodeRecord
 type Index = jsparse.Index
 type Resolution = jsparse.Resolution
 type BindingRecord = jsparse.BindingRecord
+type ScopeID = jsparse.ScopeID
 
 type CompletionContext = jsparse.CompletionContext
 type CompletionKind = jsparse.CompletionKind

--- a/cmd/inspector/app/keymap.go
+++ b/cmd/inspector/app/keymap.go
@@ -9,6 +9,7 @@ type KeyMap struct {
 
 	NextPane   key.Binding `keymap-mode:"*"`
 	OpenDrawer key.Binding `keymap-mode:"source,tree"`
+	Command    key.Binding `keymap-mode:"source,tree"`
 	Close      key.Binding `keymap-mode:"*"`
 
 	Yank key.Binding `keymap-mode:"source,tree"`
@@ -44,6 +45,10 @@ func newKeyMap() KeyMap {
 		OpenDrawer: key.NewBinding(
 			key.WithKeys("i"),
 			key.WithHelp("i", "drawer"),
+		),
+		Command: key.NewBinding(
+			key.WithKeys(":"),
+			key.WithHelp(":", "command"),
 		),
 		Close: key.NewBinding(
 			key.WithKeys("esc"),
@@ -117,12 +122,12 @@ func newKeyMap() KeyMap {
 }
 
 func (k KeyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.NextPane, k.OpenDrawer, k.GoToDef, k.FindUsage, k.Close, k.Quit}
+	return []key.Binding{k.NextPane, k.OpenDrawer, k.Command, k.GoToDef, k.Close, k.Quit}
 }
 
 func (k KeyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
-		{k.NextPane, k.OpenDrawer, k.Close, k.Quit},
+		{k.NextPane, k.OpenDrawer, k.Command, k.Close, k.Quit},
 		{k.Up, k.Down, k.Left, k.Right, k.Top, k.Bottom, k.HalfUp, k.HalfDown},
 		{k.Toggle, k.Apply, k.Yank, k.GoToDef, k.FindUsage, k.Complete},
 		{k.DrawGrow, k.DrawShrink},

--- a/cmd/inspector/app/keymap.go
+++ b/cmd/inspector/app/keymap.go
@@ -1,0 +1,130 @@
+package app
+
+import "github.com/charmbracelet/bubbles/key"
+
+// KeyMap defines key bindings for the inspector model.
+// keymap-mode tags are consumed by bobatea's mode-keymap helper.
+type KeyMap struct {
+	Quit key.Binding `keymap-mode:"*"`
+
+	NextPane   key.Binding `keymap-mode:"*"`
+	OpenDrawer key.Binding `keymap-mode:"source,tree"`
+	Close      key.Binding `keymap-mode:"*"`
+
+	Yank key.Binding `keymap-mode:"source,tree"`
+
+	Up        key.Binding `keymap-mode:"source,tree,drawer"`
+	Down      key.Binding `keymap-mode:"source,tree,drawer"`
+	Left      key.Binding `keymap-mode:"source,tree,drawer"`
+	Right     key.Binding `keymap-mode:"source,tree,drawer"`
+	Top       key.Binding `keymap-mode:"source,tree"`
+	Bottom    key.Binding `keymap-mode:"source,tree"`
+	HalfDown  key.Binding `keymap-mode:"source,tree"`
+	HalfUp    key.Binding `keymap-mode:"source,tree"`
+	Toggle    key.Binding `keymap-mode:"tree"`
+	Apply     key.Binding `keymap-mode:"tree"`
+	GoToDef   key.Binding `keymap-mode:"source,tree,drawer"`
+	FindUsage key.Binding `keymap-mode:"source,tree,drawer"`
+
+	Complete   key.Binding `keymap-mode:"drawer"`
+	DrawGrow   key.Binding `keymap-mode:"drawer"`
+	DrawShrink key.Binding `keymap-mode:"drawer"`
+}
+
+func newKeyMap() KeyMap {
+	return KeyMap{
+		Quit: key.NewBinding(
+			key.WithKeys("q", "ctrl+c"),
+			key.WithHelp("q/ctrl+c", "quit"),
+		),
+		NextPane: key.NewBinding(
+			key.WithKeys("tab"),
+			key.WithHelp("tab", "next pane"),
+		),
+		OpenDrawer: key.NewBinding(
+			key.WithKeys("i"),
+			key.WithHelp("i", "drawer"),
+		),
+		Close: key.NewBinding(
+			key.WithKeys("esc"),
+			key.WithHelp("esc", "close/clear"),
+		),
+		Yank: key.NewBinding(
+			key.WithKeys("y"),
+			key.WithHelp("y", "yank to drawer"),
+		),
+		Up: key.NewBinding(
+			key.WithKeys("up", "k"),
+			key.WithHelp("↑/k", "up"),
+		),
+		Down: key.NewBinding(
+			key.WithKeys("down", "j"),
+			key.WithHelp("↓/j", "down"),
+		),
+		Left: key.NewBinding(
+			key.WithKeys("left", "h"),
+			key.WithHelp("←/h", "left"),
+		),
+		Right: key.NewBinding(
+			key.WithKeys("right", "l"),
+			key.WithHelp("→/l", "right"),
+		),
+		Top: key.NewBinding(
+			key.WithKeys("g"),
+			key.WithHelp("g", "top"),
+		),
+		Bottom: key.NewBinding(
+			key.WithKeys("G"),
+			key.WithHelp("G", "bottom"),
+		),
+		HalfDown: key.NewBinding(
+			key.WithKeys("ctrl+d"),
+			key.WithHelp("ctrl+d", "half-page down"),
+		),
+		HalfUp: key.NewBinding(
+			key.WithKeys("ctrl+u"),
+			key.WithHelp("ctrl+u", "half-page up"),
+		),
+		Toggle: key.NewBinding(
+			key.WithKeys(" "),
+			key.WithHelp("space", "toggle node"),
+		),
+		Apply: key.NewBinding(
+			key.WithKeys("enter"),
+			key.WithHelp("enter", "jump/apply"),
+		),
+		GoToDef: key.NewBinding(
+			key.WithKeys("d", "ctrl+d"),
+			key.WithHelp("d/ctrl+d", "go to def"),
+		),
+		FindUsage: key.NewBinding(
+			key.WithKeys("*", "ctrl+g"),
+			key.WithHelp("*/ctrl+g", "usages"),
+		),
+		Complete: key.NewBinding(
+			key.WithKeys("ctrl+space", "ctrl+@", "ctrl+n"),
+			key.WithHelp("ctrl+n", "complete"),
+		),
+		DrawGrow: key.NewBinding(
+			key.WithKeys("ctrl+up"),
+			key.WithHelp("ctrl+↑", "grow drawer"),
+		),
+		DrawShrink: key.NewBinding(
+			key.WithKeys("ctrl+down"),
+			key.WithHelp("ctrl+↓", "shrink drawer"),
+		),
+	}
+}
+
+func (k KeyMap) ShortHelp() []key.Binding {
+	return []key.Binding{k.NextPane, k.OpenDrawer, k.GoToDef, k.FindUsage, k.Close, k.Quit}
+}
+
+func (k KeyMap) FullHelp() [][]key.Binding {
+	return [][]key.Binding{
+		{k.NextPane, k.OpenDrawer, k.Close, k.Quit},
+		{k.Up, k.Down, k.Left, k.Right, k.Top, k.Bottom, k.HalfUp, k.HalfDown},
+		{k.Toggle, k.Apply, k.Yank, k.GoToDef, k.FindUsage, k.Complete},
+		{k.DrawGrow, k.DrawShrink},
+	}
+}

--- a/cmd/inspector/app/model_test.go
+++ b/cmd/inspector/app/model_test.go
@@ -173,6 +173,36 @@ const doubled = value + value;
 	}
 }
 
+func TestModelTreeListItemIncludesUsageHint(t *testing.T) {
+	src := `const value = 1;
+const doubled = value + value;
+`
+	m := newTestModel(t, src)
+
+	usageID := nodeAtOccurrence(t, m.index, src, "value", 2)
+	m.selectedNodeID = usageID
+	m.index.ExpandTo(usageID)
+	m.refreshTreeVisible()
+	m.toggleHighlightUsages()
+	m.rebuildTreeListItems()
+
+	found := false
+	for _, item := range m.treeList.Items() {
+		row, ok := item.(treeListItem)
+		if !ok || row.id != usageID {
+			continue
+		}
+		if !strings.Contains(row.description, "★usage") {
+			t.Fatalf("expected usage hint in tree row, got %q", row.description)
+		}
+		found = true
+		break
+	}
+	if !found {
+		t.Fatalf("usage node %d not found in visible tree rows", usageID)
+	}
+}
+
 func TestModelDrawerCompletion(t *testing.T) {
 	src := `const greeting = "hello";
 console.log(greeting);

--- a/cmd/inspector/app/model_test.go
+++ b/cmd/inspector/app/model_test.go
@@ -290,3 +290,29 @@ console.log(known);
 		t.Fatalf("expected unresolved lookup to clear usage highlights, got %d", len(m.usageHighlights))
 	}
 }
+
+func TestTreePaneWidthKeepsTreeCompact(t *testing.T) {
+	m := Model{width: 100}
+	if got := m.treePaneWidth(); got != 40 {
+		t.Fatalf("treePaneWidth(100) = %d, want 40", got)
+	}
+
+	m.width = 60
+	if got := m.treePaneWidth(); got != 28 {
+		t.Fatalf("treePaneWidth(60) = %d, want 28", got)
+	}
+}
+
+func TestBuildTreeListItemClampsTitle(t *testing.T) {
+	node := &NodeRecord{
+		ID:       1,
+		Kind:     "Identifier",
+		Label:    "veryLongBindingNameThatShouldBeClampedInTreeRows",
+		Depth:    0,
+		Expanded: false,
+	}
+	item := buildTreeListItem(node, nil, nil, 16)
+	if len([]rune(item.title)) > 16 {
+		t.Fatalf("expected title to be clamped to 16 runes, got %q", item.title)
+	}
+}

--- a/cmd/inspector/app/tree_list.go
+++ b/cmd/inspector/app/tree_list.go
@@ -1,0 +1,84 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/list"
+)
+
+type treeListItem struct {
+	id          NodeID
+	title       string
+	description string
+}
+
+func (i treeListItem) Title() string       { return i.title }
+func (i treeListItem) Description() string { return i.description }
+func (i treeListItem) FilterValue() string { return i.title + " " + i.description }
+
+func newTreeListModel() list.Model {
+	delegate := list.NewDefaultDelegate()
+	delegate.SetHeight(1)
+	delegate.ShowDescription = true
+
+	l := list.New([]list.Item{}, delegate, 0, 0)
+	l.SetFilteringEnabled(false)
+	l.SetShowTitle(false)
+	l.SetShowStatusBar(false)
+	l.SetShowHelp(false)
+	l.SetShowPagination(false)
+	l.DisableQuitKeybindings()
+	l.KeyMap.Filter.SetEnabled(false)
+	l.KeyMap.ClearFilter.SetEnabled(false)
+	l.KeyMap.AcceptWhileFiltering.SetEnabled(false)
+	l.Styles.NoItems = l.Styles.NoItems.UnsetPadding()
+	return l
+}
+
+func buildTreeListItem(node *NodeRecord, usageHighlights []NodeID, res *Resolution) treeListItem {
+	if node == nil {
+		return treeListItem{}
+	}
+
+	indent := strings.Repeat("  ", node.Depth)
+	expandMarker := " "
+	if node.HasChildren() {
+		if node.Expanded {
+			expandMarker = "▼"
+		} else {
+			expandMarker = "▶"
+		}
+	}
+
+	scopeHint := ""
+	if res != nil && node.Kind == "Identifier" {
+		if res.IsDeclaration(node.ID) {
+			if b := res.BindingForNode(node.ID); b != nil {
+				scopeHint = fmt.Sprintf(" [%s decl]", b.Kind)
+			}
+		} else if res.IsReference(node.ID) {
+			scopeHint = " [ref]"
+		} else if res.IsUnresolved(node.ID) {
+			scopeHint = " [global]"
+		}
+	}
+
+	isUsage := false
+	for _, id := range usageHighlights {
+		if id == node.ID {
+			isUsage = true
+			break
+		}
+	}
+	usageHint := ""
+	if isUsage {
+		usageHint = " ★usage"
+	}
+
+	return treeListItem{
+		id:          node.ID,
+		title:       indent + expandMarker + " " + node.DisplayLabel(),
+		description: fmt.Sprintf("[%d..%d]%s%s", node.Start, node.End, scopeHint, usageHint),
+	}
+}

--- a/cmd/inspector/app/tree_list.go
+++ b/cmd/inspector/app/tree_list.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"unicode/utf8"
+
 	"github.com/charmbracelet/bubbles/list"
 	inspectortree "github.com/go-go-golems/go-go-goja/pkg/inspector/tree"
 )
@@ -18,7 +20,7 @@ func (i treeListItem) FilterValue() string { return i.title + " " + i.descriptio
 func newTreeListModel() list.Model {
 	delegate := list.NewDefaultDelegate()
 	delegate.SetHeight(1)
-	delegate.ShowDescription = true
+	delegate.ShowDescription = false
 
 	l := list.New([]list.Item{}, delegate, 0, 0)
 	l.SetFilteringEnabled(false)
@@ -34,11 +36,26 @@ func newTreeListModel() list.Model {
 	return l
 }
 
-func buildTreeListItem(node *NodeRecord, usageHighlights []NodeID, res *Resolution) treeListItem {
+func buildTreeListItem(node *NodeRecord, usageHighlights []NodeID, res *Resolution, maxTitleWidth int) treeListItem {
 	row := inspectortree.BuildRow(node, usageHighlights, res)
+	title := clampTreeTitle(row.Title, maxTitleWidth)
 	return treeListItem{
 		id:          row.NodeID,
-		title:       row.Title,
+		title:       title,
 		description: row.Description,
 	}
+}
+
+func clampTreeTitle(s string, maxWidth int) string {
+	if maxWidth < 8 {
+		maxWidth = 8
+	}
+	if utf8.RuneCountInString(s) <= maxWidth {
+		return s
+	}
+	runes := []rune(s)
+	if len(runes) <= maxWidth {
+		return s
+	}
+	return string(runes[:maxWidth-1]) + "…"
 }

--- a/cmd/inspector/app/tree_list.go
+++ b/cmd/inspector/app/tree_list.go
@@ -1,10 +1,8 @@
 package app
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/charmbracelet/bubbles/list"
+	inspectortree "github.com/go-go-golems/go-go-goja/pkg/inspector/tree"
 )
 
 type treeListItem struct {
@@ -37,48 +35,10 @@ func newTreeListModel() list.Model {
 }
 
 func buildTreeListItem(node *NodeRecord, usageHighlights []NodeID, res *Resolution) treeListItem {
-	if node == nil {
-		return treeListItem{}
-	}
-
-	indent := strings.Repeat("  ", node.Depth)
-	expandMarker := " "
-	if node.HasChildren() {
-		if node.Expanded {
-			expandMarker = "▼"
-		} else {
-			expandMarker = "▶"
-		}
-	}
-
-	scopeHint := ""
-	if res != nil && node.Kind == "Identifier" {
-		if res.IsDeclaration(node.ID) {
-			if b := res.BindingForNode(node.ID); b != nil {
-				scopeHint = fmt.Sprintf(" [%s decl]", b.Kind)
-			}
-		} else if res.IsReference(node.ID) {
-			scopeHint = " [ref]"
-		} else if res.IsUnresolved(node.ID) {
-			scopeHint = " [global]"
-		}
-	}
-
-	isUsage := false
-	for _, id := range usageHighlights {
-		if id == node.ID {
-			isUsage = true
-			break
-		}
-	}
-	usageHint := ""
-	if isUsage {
-		usageHint = " ★usage"
-	}
-
+	row := inspectortree.BuildRow(node, usageHighlights, res)
 	return treeListItem{
-		id:          node.ID,
-		title:       indent + expandMarker + " " + node.DisplayLabel(),
-		description: fmt.Sprintf("[%d..%d]%s%s", node.Start, node.End, scopeHint, usageHint),
+		id:          row.NodeID,
+		title:       row.Title,
+		description: row.Description,
 	}
 }

--- a/cmd/inspector/app/tree_list.go
+++ b/cmd/inspector/app/tree_list.go
@@ -20,6 +20,7 @@ func (i treeListItem) FilterValue() string { return i.title + " " + i.descriptio
 func newTreeListModel() list.Model {
 	delegate := list.NewDefaultDelegate()
 	delegate.SetHeight(1)
+	delegate.SetSpacing(0)
 	delegate.ShowDescription = false
 
 	l := list.New([]list.Item{}, delegate, 0, 0)

--- a/cmd/smalltalk-inspector/app/keymap.go
+++ b/cmd/smalltalk-inspector/app/keymap.go
@@ -1,0 +1,108 @@
+package app
+
+import (
+	"github.com/charmbracelet/bubbles/key"
+)
+
+// FocusPane indicates which pane has focus.
+type FocusPane int
+
+const (
+	FocusGlobals FocusPane = iota
+	FocusMembers
+	FocusSource
+	FocusRepl
+)
+
+// Mode names for mode-keymap integration.
+const (
+	modeEmpty   = "empty"
+	modeGlobals = "globals"
+	modeMembers = "members"
+	modeSource  = "source"
+	modeRepl    = "repl"
+)
+
+// KeyMap defines key bindings for the smalltalk inspector.
+type KeyMap struct {
+	Quit    key.Binding
+	Command key.Binding
+
+	NextPane key.Binding
+	PrevPane key.Binding
+
+	Up       key.Binding
+	Down     key.Binding
+	Top      key.Binding
+	Bottom   key.Binding
+	HalfDown key.Binding
+	HalfUp   key.Binding
+
+	Select key.Binding
+	Back   key.Binding
+}
+
+func newKeyMap() KeyMap {
+	return KeyMap{
+		Quit: key.NewBinding(
+			key.WithKeys("ctrl+c"),
+			key.WithHelp("ctrl+c", "quit"),
+		),
+		Command: key.NewBinding(
+			key.WithKeys(":"),
+			key.WithHelp(":", "command"),
+		),
+		NextPane: key.NewBinding(
+			key.WithKeys("tab"),
+			key.WithHelp("tab", "next pane"),
+		),
+		PrevPane: key.NewBinding(
+			key.WithKeys("shift+tab"),
+			key.WithHelp("shift+tab", "prev pane"),
+		),
+		Up: key.NewBinding(
+			key.WithKeys("up", "k"),
+			key.WithHelp("↑/k", "up"),
+		),
+		Down: key.NewBinding(
+			key.WithKeys("down", "j"),
+			key.WithHelp("↓/j", "down"),
+		),
+		Top: key.NewBinding(
+			key.WithKeys("g"),
+			key.WithHelp("g", "top"),
+		),
+		Bottom: key.NewBinding(
+			key.WithKeys("G"),
+			key.WithHelp("G", "bottom"),
+		),
+		HalfDown: key.NewBinding(
+			key.WithKeys("ctrl+d"),
+			key.WithHelp("ctrl+d", "½pg down"),
+		),
+		HalfUp: key.NewBinding(
+			key.WithKeys("ctrl+u"),
+			key.WithHelp("ctrl+u", "½pg up"),
+		),
+		Select: key.NewBinding(
+			key.WithKeys("enter"),
+			key.WithHelp("enter", "select/inspect"),
+		),
+		Back: key.NewBinding(
+			key.WithKeys("esc"),
+			key.WithHelp("esc", "back/close"),
+		),
+	}
+}
+
+func (k KeyMap) ShortHelp() []key.Binding {
+	return []key.Binding{k.NextPane, k.Command, k.Select, k.Back, k.Quit}
+}
+
+func (k KeyMap) FullHelp() [][]key.Binding {
+	return [][]key.Binding{
+		{k.NextPane, k.PrevPane, k.Command, k.Back, k.Quit},
+		{k.Up, k.Down, k.Top, k.Bottom, k.HalfUp, k.HalfDown},
+		{k.Select},
+	}
+}

--- a/cmd/smalltalk-inspector/app/keymap.go
+++ b/cmd/smalltalk-inspector/app/keymap.go
@@ -21,25 +21,27 @@ const (
 	modeMembers = "members"
 	modeSource  = "source"
 	modeRepl    = "repl"
+	modeInspect = "inspect"
+	modeStack   = "stack"
 )
 
 // KeyMap defines key bindings for the smalltalk inspector.
 type KeyMap struct {
-	Quit    key.Binding
-	Command key.Binding
+	Quit    key.Binding `keymap-mode:"*"`
+	Command key.Binding `keymap-mode:"*"`
 
-	NextPane key.Binding
-	PrevPane key.Binding
+	NextPane key.Binding `keymap-mode:"*"`
+	PrevPane key.Binding `keymap-mode:"*"`
 
-	Up       key.Binding
-	Down     key.Binding
-	Top      key.Binding
-	Bottom   key.Binding
-	HalfDown key.Binding
-	HalfUp   key.Binding
+	Up       key.Binding `keymap-mode:"globals,members,source,repl,inspect,stack"`
+	Down     key.Binding `keymap-mode:"globals,members,source,repl,inspect,stack"`
+	Top      key.Binding `keymap-mode:"globals,members,source,repl,inspect,stack"`
+	Bottom   key.Binding `keymap-mode:"globals,members,source,repl,inspect,stack"`
+	HalfDown key.Binding `keymap-mode:"globals,members,source,repl,inspect,stack"`
+	HalfUp   key.Binding `keymap-mode:"globals,members,source,repl,inspect,stack"`
 
-	Select key.Binding
-	Back   key.Binding
+	Select key.Binding `keymap-mode:"globals,members,repl,inspect"`
+	Back   key.Binding `keymap-mode:"*"`
 }
 
 func newKeyMap() KeyMap {

--- a/cmd/smalltalk-inspector/app/messages.go
+++ b/cmd/smalltalk-inspector/app/messages.go
@@ -1,0 +1,33 @@
+package app
+
+import "github.com/go-go-golems/go-go-goja/pkg/jsparse"
+
+// MsgFileLoaded is sent after a successful :load command.
+type MsgFileLoaded struct {
+	Filename string
+	Source   string
+	Analysis *jsparse.AnalysisResult
+}
+
+// MsgFileLoadError is sent when :load fails.
+type MsgFileLoadError struct {
+	Filename string
+	Err      error
+}
+
+// MsgGlobalSelected is sent when the user selects a global binding.
+type MsgGlobalSelected struct {
+	Name       string
+	BindingIdx int
+}
+
+// MsgMemberSelected is sent when the user selects a member of the current target.
+type MsgMemberSelected struct {
+	Name      string
+	MemberIdx int
+}
+
+// MsgStatusNotice is a transient status message.
+type MsgStatusNotice struct {
+	Text string
+}

--- a/cmd/smalltalk-inspector/app/messages.go
+++ b/cmd/smalltalk-inspector/app/messages.go
@@ -1,6 +1,9 @@
 package app
 
-import "github.com/go-go-golems/go-go-goja/pkg/jsparse"
+import (
+	"github.com/go-go-golems/go-go-goja/pkg/inspector/runtime"
+	"github.com/go-go-golems/go-go-goja/pkg/jsparse"
+)
 
 // MsgFileLoaded is sent after a successful :load command.
 type MsgFileLoaded struct {
@@ -25,6 +28,11 @@ type MsgGlobalSelected struct {
 type MsgMemberSelected struct {
 	Name      string
 	MemberIdx int
+}
+
+// MsgEvalResult is sent after a successful REPL eval.
+type MsgEvalResult struct {
+	Result runtime.EvalResult
 }
 
 // MsgStatusNotice is a transient status message.

--- a/cmd/smalltalk-inspector/app/messages.go
+++ b/cmd/smalltalk-inspector/app/messages.go
@@ -35,6 +35,14 @@ type MsgEvalResult struct {
 	Result runtime.EvalResult
 }
 
+// NavFrame stores the state of one level of object inspection for breadcrumb navigation.
+type NavFrame struct {
+	Label string
+	Props []runtime.PropertyInfo
+	Obj   interface{} // the goja.Object at this level
+	Idx   int         // selected property index
+}
+
 // MsgStatusNotice is a transient status message.
 type MsgStatusNotice struct {
 	Text string

--- a/cmd/smalltalk-inspector/app/model.go
+++ b/cmd/smalltalk-inspector/app/model.go
@@ -1,0 +1,586 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/help"
+	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/dop251/goja/ast"
+	"github.com/go-go-golems/go-go-goja/pkg/jsparse"
+)
+
+// GlobalItem represents a top-level binding in the globals list.
+type GlobalItem struct {
+	Name    string
+	Kind    jsparse.BindingKind
+	Extends string // for classes that extend another
+}
+
+// MemberItem represents a member of a selected class/object.
+type MemberItem struct {
+	Name      string
+	Kind      string // "function", "value", "param"
+	Preview   string // short value/signature preview
+	Inherited bool
+	Source    string // from which prototype level
+}
+
+// Model is the top-level bubbletea model for the Smalltalk inspector.
+type Model struct {
+	// Data
+	filename string
+	source   string
+	analysis *jsparse.AnalysisResult
+
+	// Global scope items
+	globals      []GlobalItem
+	globalIdx    int
+	globalScroll int
+
+	// Members for selected global
+	members      []MemberItem
+	memberIdx    int
+	memberScroll int
+
+	// Source pane
+	sourceLines  []string
+	sourceScroll int
+	sourceTarget int // target line to highlight (0-based), -1 = none
+
+	// UI state
+	focus     FocusPane
+	mode      string
+	width     int
+	height    int
+	loaded    bool
+	statusMsg string
+
+	// Components
+	keyMap    KeyMap
+	help      help.Model
+	spinner   spinner.Model
+	command   textinput.Model
+	cmdActive bool
+}
+
+// NewModel creates a new Smalltalk inspector model.
+func NewModel(filename string) Model {
+	m := Model{
+		filename:     filename,
+		focus:        FocusGlobals,
+		mode:         modeEmpty,
+		globalIdx:    0,
+		memberIdx:    0,
+		sourceTarget: -1,
+		keyMap:       newKeyMap(),
+	}
+	m.help = help.New()
+	m.help.ShowAll = false
+	m.spinner = spinner.New(spinner.WithSpinner(spinner.Line))
+	m.command = textinput.New()
+	m.command.Prompt = ": "
+	m.command.Placeholder = "load <file.js> | help | quit"
+	m.command.CharLimit = 256
+	m.command.Width = 60
+	m.command.Blur()
+
+	return m
+}
+
+// Init implements tea.Model.
+func (m Model) Init() tea.Cmd {
+	var cmds []tea.Cmd
+	cmds = append(cmds, m.spinner.Tick)
+
+	// If filename was provided on CLI, load it immediately
+	if m.filename != "" {
+		cmds = append(cmds, func() tea.Msg {
+			return loadFile(m.filename)
+		})
+	}
+
+	return tea.Batch(cmds...)
+}
+
+// loadFile reads and analyzes a JavaScript file, returning the appropriate message.
+func loadFile(filename string) tea.Msg {
+	filename = filepath.Clean(filename)
+	// #nosec G304 -- inspector intentionally reads user-selected source files.
+	src, err := os.ReadFile(filename)
+	if err != nil {
+		return MsgFileLoadError{Filename: filename, Err: err}
+	}
+
+	sourceText := string(src)
+	analysis := jsparse.Analyze(filename, sourceText, nil)
+
+	return MsgFileLoaded{
+		Filename: filename,
+		Source:   sourceText,
+		Analysis: analysis,
+	}
+}
+
+// buildGlobals extracts global bindings from the analysis result.
+func (m *Model) buildGlobals() {
+	m.globals = nil
+	if m.analysis == nil || m.analysis.Resolution == nil {
+		return
+	}
+
+	rootScope := m.analysis.Resolution.Scopes[m.analysis.Resolution.RootScopeID]
+	if rootScope == nil {
+		return
+	}
+
+	// Collect entries
+	type entry struct {
+		name    string
+		binding *jsparse.BindingRecord
+	}
+	var entries []entry
+	for name, b := range rootScope.Bindings {
+		entries = append(entries, entry{name, b})
+	}
+	// Sort: classes first, then functions, then values; within each, alphabetical
+	sortOrder := func(k jsparse.BindingKind) int {
+		//exhaustive:ignore
+		switch k {
+		case jsparse.BindingClass:
+			return 0
+		case jsparse.BindingFunction:
+			return 1
+		default:
+			return 2
+		}
+	}
+	for i := 0; i < len(entries); i++ {
+		for j := i + 1; j < len(entries); j++ {
+			oi, oj := sortOrder(entries[i].binding.Kind), sortOrder(entries[j].binding.Kind)
+			if oi > oj || (oi == oj && entries[i].name > entries[j].name) {
+				entries[i], entries[j] = entries[j], entries[i]
+			}
+		}
+	}
+
+	for _, e := range entries {
+		gi := GlobalItem{
+			Name: e.name,
+			Kind: e.binding.Kind,
+		}
+
+		// Try to find extends info for classes
+		if e.binding.Kind == jsparse.BindingClass {
+			gi.Extends = m.findClassExtends(e.name)
+		}
+
+		m.globals = append(m.globals, gi)
+	}
+
+	m.globalIdx = 0
+	m.globalScroll = 0
+}
+
+// findClassExtends tries to find the "extends" name for a class declaration.
+func (m *Model) findClassExtends(className string) string {
+	if m.analysis == nil || m.analysis.Program == nil {
+		return ""
+	}
+	for _, stmt := range m.analysis.Program.Body {
+		cd, ok := stmt.(*ast.ClassDeclaration)
+		if !ok || cd.Class == nil || cd.Class.Name == nil {
+			continue
+		}
+		if string(cd.Class.Name.Name) != className {
+			continue
+		}
+		if cd.Class.SuperClass != nil {
+			if ident, ok := cd.Class.SuperClass.(*ast.Identifier); ok {
+				return string(ident.Name)
+			}
+		}
+		break
+	}
+	return ""
+}
+
+// buildMembers builds the member list for the currently selected global.
+func (m *Model) buildMembers() {
+	m.members = nil
+	m.memberIdx = 0
+	m.memberScroll = 0
+
+	if len(m.globals) == 0 || m.globalIdx >= len(m.globals) {
+		return
+	}
+
+	selected := m.globals[m.globalIdx]
+
+	if m.analysis == nil || m.analysis.Resolution == nil || m.analysis.Index == nil {
+		return
+	}
+
+	//exhaustive:ignore
+	switch selected.Kind {
+	case jsparse.BindingClass:
+		m.buildClassMembers(selected.Name)
+	case jsparse.BindingFunction:
+		m.buildFunctionMembers(selected.Name)
+	}
+}
+
+// buildClassMembers extracts methods and properties from a class declaration.
+func (m *Model) buildClassMembers(className string) {
+	if m.analysis.Program == nil {
+		return
+	}
+
+	for _, stmt := range m.analysis.Program.Body {
+		cd, ok := stmt.(*ast.ClassDeclaration)
+		if !ok || cd.Class == nil || cd.Class.Name == nil {
+			continue
+		}
+		if string(cd.Class.Name.Name) != className {
+			continue
+		}
+
+		for _, elem := range cd.Class.Body {
+			switch e := elem.(type) {
+			case *ast.MethodDefinition:
+				name := astMethodName(e)
+				kind := "function"
+				preview := "()"
+				if e.Body != nil && e.Body.ParameterList != nil {
+					params := astParamNames(e.Body.ParameterList)
+					preview = "(" + strings.Join(params, ", ") + ")"
+				}
+				m.members = append(m.members, MemberItem{
+					Name:    name,
+					Kind:    kind,
+					Preview: preview,
+				})
+			case *ast.FieldDefinition:
+				name := astFieldName(e)
+				m.members = append(m.members, MemberItem{
+					Name: name,
+					Kind: "value",
+				})
+			}
+		}
+
+		// If extends another class, add inherited members
+		if cd.Class.SuperClass != nil {
+			if ident, ok := cd.Class.SuperClass.(*ast.Identifier); ok {
+				superName := string(ident.Name)
+				m.addInheritedMembers(superName, superName)
+			}
+		}
+		break
+	}
+}
+
+// addInheritedMembers adds methods from a parent class.
+func (m *Model) addInheritedMembers(className, source string) {
+	if m.analysis.Program == nil {
+		return
+	}
+
+	for _, stmt := range m.analysis.Program.Body {
+		cd, ok := stmt.(*ast.ClassDeclaration)
+		if !ok || cd.Class == nil || cd.Class.Name == nil {
+			continue
+		}
+		if string(cd.Class.Name.Name) != className {
+			continue
+		}
+
+		for _, elem := range cd.Class.Body {
+			if md, ok := elem.(*ast.MethodDefinition); ok {
+				name := astMethodName(md)
+				if name == "constructor" {
+					continue
+				}
+				if m.hasMember(name) {
+					continue
+				}
+				kind := "function"
+				preview := "()"
+				if md.Body != nil && md.Body.ParameterList != nil {
+					params := astParamNames(md.Body.ParameterList)
+					preview = "(" + strings.Join(params, ", ") + ")"
+				}
+				m.members = append(m.members, MemberItem{
+					Name:      name,
+					Kind:      kind,
+					Preview:   preview,
+					Inherited: true,
+					Source:    source,
+				})
+			}
+		}
+
+		// Recurse into grandparent
+		if cd.Class.SuperClass != nil {
+			if ident, ok := cd.Class.SuperClass.(*ast.Identifier); ok {
+				m.addInheritedMembers(string(ident.Name), string(ident.Name))
+			}
+		}
+		break
+	}
+}
+
+// buildFunctionMembers shows parameters for a selected function.
+func (m *Model) buildFunctionMembers(funcName string) {
+	if m.analysis.Program == nil {
+		return
+	}
+
+	for _, stmt := range m.analysis.Program.Body {
+		fd, ok := stmt.(*ast.FunctionDeclaration)
+		if !ok || fd.Function == nil || fd.Function.Name == nil {
+			continue
+		}
+		if string(fd.Function.Name.Name) != funcName {
+			continue
+		}
+
+		if fd.Function.ParameterList != nil {
+			params := astParamNames(fd.Function.ParameterList)
+			for _, p := range params {
+				m.members = append(m.members, MemberItem{
+					Name: p,
+					Kind: "param",
+				})
+			}
+		}
+		break
+	}
+}
+
+func (m *Model) hasMember(name string) bool {
+	for _, mem := range m.members {
+		if mem.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// jumpToSource sets the source pane to show the declaration of the selected member.
+func (m *Model) jumpToSource() {
+	m.sourceTarget = -1
+
+	if m.analysis == nil || m.analysis.Index == nil {
+		return
+	}
+
+	if m.focus == FocusGlobals && len(m.globals) > 0 {
+		m.jumpToBinding(m.globals[m.globalIdx].Name)
+	} else if m.focus == FocusMembers && len(m.members) > 0 && len(m.globals) > 0 {
+		member := m.members[m.memberIdx]
+		global := m.globals[m.globalIdx]
+		m.jumpToMember(global.Name, member)
+	}
+}
+
+func (m *Model) jumpToBinding(name string) {
+	if m.analysis.Resolution == nil {
+		return
+	}
+	rootScope := m.analysis.Resolution.Scopes[m.analysis.Resolution.RootScopeID]
+	if rootScope == nil {
+		return
+	}
+	b, ok := rootScope.Bindings[name]
+	if !ok {
+		return
+	}
+	declNode := m.analysis.Index.Nodes[b.DeclNodeID]
+	if declNode == nil {
+		return
+	}
+	m.sourceTarget = declNode.StartLine - 1
+	m.ensureSourceVisible(m.sourceTarget)
+}
+
+func (m *Model) jumpToMember(className string, member MemberItem) {
+	if m.analysis.Program == nil {
+		return
+	}
+
+	searchClass := className
+	if member.Inherited && member.Source != "" {
+		searchClass = member.Source
+	}
+
+	for _, stmt := range m.analysis.Program.Body {
+		cd, ok := stmt.(*ast.ClassDeclaration)
+		if !ok || cd.Class == nil || cd.Class.Name == nil {
+			continue
+		}
+		if string(cd.Class.Name.Name) != searchClass {
+			continue
+		}
+
+		for _, elem := range cd.Class.Body {
+			if md, ok := elem.(*ast.MethodDefinition); ok {
+				if astMethodName(md) == member.Name {
+					offset := int(md.Idx0())
+					if m.analysis.Index != nil {
+						l, _ := m.analysis.Index.OffsetToLineCol(offset)
+						m.sourceTarget = l - 1
+						m.ensureSourceVisible(m.sourceTarget)
+					}
+					return
+				}
+			}
+		}
+		break
+	}
+}
+
+func (m *Model) ensureSourceVisible(targetLine int) {
+	vpHeight := m.sourceViewportHeight()
+	if vpHeight <= 0 {
+		return
+	}
+	m.sourceScroll = targetLine - vpHeight/2
+	if m.sourceScroll < 0 {
+		m.sourceScroll = 0
+	}
+	maxScroll := len(m.sourceLines) - vpHeight
+	if maxScroll < 0 {
+		maxScroll = 0
+	}
+	if m.sourceScroll > maxScroll {
+		m.sourceScroll = maxScroll
+	}
+}
+
+func (m *Model) sourceViewportHeight() int {
+	h := m.contentHeight() - 1
+	if h < 1 {
+		h = 1
+	}
+	return h
+}
+
+func (m *Model) contentHeight() int {
+	overhead := 3 // header + status + help
+	if m.cmdActive {
+		overhead++
+	}
+	overhead += 3 // REPL area
+	h := m.height - overhead
+	if h < 3 {
+		h = 3
+	}
+	return h
+}
+
+func (m *Model) listViewportHeight() int {
+	h := m.contentHeight() - 2 // pane header + footer
+	if h < 1 {
+		h = 1
+	}
+	return h
+}
+
+// AST helper functions
+
+func astMethodName(md *ast.MethodDefinition) string {
+	if md == nil {
+		return "<unknown>"
+	}
+	switch k := md.Key.(type) {
+	case *ast.Identifier:
+		return string(k.Name)
+	case *ast.StringLiteral:
+		return k.Literal
+	}
+	return "<computed>"
+}
+
+func astFieldName(fd *ast.FieldDefinition) string {
+	if fd == nil {
+		return "<unknown>"
+	}
+	switch k := fd.Key.(type) {
+	case *ast.Identifier:
+		return string(k.Name)
+	case *ast.StringLiteral:
+		return k.Literal
+	}
+	return "<computed>"
+}
+
+func astParamNames(pl *ast.ParameterList) []string {
+	var names []string
+	if pl == nil {
+		return names
+	}
+	for _, p := range pl.List {
+		if p == nil || p.Target == nil {
+			continue
+		}
+		if ident, ok := p.Target.(*ast.Identifier); ok {
+			names = append(names, string(ident.Name))
+		}
+	}
+	return names
+}
+
+// kindIcon returns a display icon for binding kinds.
+func kindIcon(k jsparse.BindingKind) string {
+	//exhaustive:ignore
+	switch k {
+	case jsparse.BindingClass:
+		return "C"
+	case jsparse.BindingFunction:
+		return "ƒ"
+	default:
+		return "●"
+	}
+}
+
+// memberKindIcon returns a display icon for member kinds.
+func memberKindIcon(k string) string {
+	switch k {
+	case "function":
+		return "ƒ"
+	case "value":
+		return "●"
+	case "param":
+		return "→"
+	default:
+		return "·"
+	}
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func formatStatus(parts ...string) string {
+	var nonEmpty []string
+	for _, p := range parts {
+		if p != "" {
+			nonEmpty = append(nonEmpty, p)
+		}
+	}
+	return strings.Join(nonEmpty, " │ ")
+}

--- a/cmd/smalltalk-inspector/app/model.go
+++ b/cmd/smalltalk-inspector/app/model.go
@@ -642,20 +642,6 @@ func memberKindIcon(k string) string {
 	}
 }
 
-func maxInt(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}
-
-func minInt(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 // refreshRuntimeGlobals merges newly-defined runtime globals into the globals list.
 func (m *Model) refreshRuntimeGlobals() {
 	if m.rtSession == nil {
@@ -783,14 +769,4 @@ func isBuiltinGlobal(name string) bool {
 		"SharedArrayBuffer": true, "Atomics": true, "WeakRef": true, "FinalizationRegistry": true,
 	}
 	return builtins[name]
-}
-
-func formatStatus(parts ...string) string {
-	var nonEmpty []string
-	for _, p := range parts {
-		if p != "" {
-			nonEmpty = append(nonEmpty, p)
-		}
-	}
-	return strings.Join(nonEmpty, " │ ")
 }

--- a/cmd/smalltalk-inspector/app/model.go
+++ b/cmd/smalltalk-inspector/app/model.go
@@ -9,6 +9,7 @@ import (
 	"github.com/charmbracelet/bubbles/help"
 	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/bubbles/textinput"
+	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/dop251/goja"
 	"github.com/dop251/goja/ast"
@@ -98,11 +99,13 @@ type Model struct {
 	statusMsg string
 
 	// Components
-	keyMap    KeyMap
-	help      help.Model
-	spinner   spinner.Model
-	command   textinput.Model
-	cmdActive bool
+	keyMap          KeyMap
+	help            help.Model
+	spinner         spinner.Model
+	command         textinput.Model
+	inspectViewport viewport.Model
+	stackViewport   viewport.Model
+	cmdActive       bool
 }
 
 // NewModel creates a new Smalltalk inspector model.
@@ -125,6 +128,8 @@ func NewModel(filename string) Model {
 	m.command.CharLimit = 256
 	m.command.Width = 60
 	m.command.Blur()
+	m.inspectViewport = viewport.New(0, 0)
+	m.stackViewport = viewport.New(0, 0)
 
 	m.replInput = textinput.New()
 	m.replInput.Prompt = "» "
@@ -455,6 +460,27 @@ func (m *Model) ensureSourceVisible(targetLine int) {
 
 func (m *Model) sourceViewportHeight() int {
 	h := m.contentHeight() - 1
+	if h < 1 {
+		h = 1
+	}
+	return h
+}
+
+func (m *Model) inspectPaneViewportHeight() int {
+	h := m.contentHeight()
+	if len(m.navStack) > 0 {
+		h-- // breadcrumb line
+	}
+	h-- // pane header
+	if h < 1 {
+		h = 1
+	}
+	return h
+}
+
+func (m *Model) stackPaneViewportHeight() int {
+	h := m.contentHeight() - 1 // error banner line
+	h--                        // pane header
 	if h < 1 {
 		h = 1
 	}

--- a/cmd/smalltalk-inspector/app/model.go
+++ b/cmd/smalltalk-inspector/app/model.go
@@ -66,6 +66,9 @@ type Model struct {
 	inspectIdx   int
 	inspectLabel string
 
+	// Navigation stack for drill-in inspection
+	navStack []NavFrame
+
 	// UI state
 	focus     FocusPane
 	mode      string

--- a/cmd/smalltalk-inspector/app/model.go
+++ b/cmd/smalltalk-inspector/app/model.go
@@ -19,12 +19,8 @@ import (
 	"github.com/go-go-golems/go-go-goja/pkg/jsparse"
 )
 
-// GlobalItem represents a top-level binding in the globals list.
-type GlobalItem struct {
-	Name    string
-	Kind    jsparse.BindingKind
-	Extends string // for classes that extend another
-}
+// GlobalItem is the app-facing alias for reusable inspector global binding data.
+type GlobalItem = inspectoranalysis.GlobalBinding
 
 // MemberItem represents a member of a selected class/object.
 type MemberItem struct {
@@ -69,12 +65,12 @@ type Model struct {
 	showingReplSrc  bool // true when source pane shows REPL source instead of file
 
 	// Runtime
-	rtSession        *runtime.Session
-	replInput        textinput.Model
-	replHistory      []string
-	replResult       string
-	replError        string
-	replDefinedNames []string // names defined via REPL (const/let/class not on globalObject)
+	rtSession    *runtime.Session
+	replInput    textinput.Model
+	replHistory  []string
+	replResult   string
+	replError    string
+	replDeclared []inspectoranalysis.DeclaredBinding
 
 	// Object browser (for REPL results and inspect targets)
 	inspectObj   *goja.Object
@@ -198,14 +194,7 @@ func (m *Model) buildGlobals() {
 		return
 	}
 
-	for _, g := range m.session.Globals() {
-		gi := GlobalItem{
-			Name:    g.Name,
-			Kind:    g.Kind,
-			Extends: g.Extends,
-		}
-		m.globals = append(m.globals, gi)
-	}
+	m.globals = append(m.globals, m.session.Globals()...)
 
 	m.globalIdx = 0
 	m.globalScroll = 0
@@ -496,6 +485,7 @@ func (m *Model) showReplFunctionSource(name, fnSrc string) {
 	m.replSourceLines = append(m.replSourceLines, strings.Split(fnSrc, "\n")...)
 	m.replSourceLines = append(m.replSourceLines, "")
 	m.sourceTarget = startLine + 1
+	m.rebuildReplSyntaxSpans()
 	m.ensureReplSourceVisible(m.sourceTarget)
 }
 
@@ -545,125 +535,11 @@ func (m *Model) refreshRuntimeGlobals() {
 		return
 	}
 
-	// Build a set of already-known names
-	known := make(map[string]bool)
-	for _, g := range m.globals {
-		known[g.Name] = true
-	}
-
-	added := false
-
-	// 1. Scan GlobalObject for new var/function names
-	global := m.rtSession.VM.GlobalObject()
-	for _, key := range global.Keys() {
-		if known[key] || isBuiltinGlobal(key) {
-			continue
-		}
-		val := global.Get(key)
-		kind := jsparse.BindingVar
-		if _, ok := goja.AssertFunction(val); ok {
-			kind = jsparse.BindingFunction
-		}
-		m.globals = append(m.globals, GlobalItem{
-			Name: key,
-			Kind: kind,
-		})
-		known[key] = true
-		added = true
-	}
-
-	// 2. Check tracked REPL names (const/let/class from REPL input)
-	for _, name := range m.replDefinedNames {
-		if known[name] {
-			continue
-		}
-		// Verify it actually exists in the runtime
+	runtimeKinds := runtime.RuntimeGlobalKinds(m.rtSession.VM)
+	hasRuntimeValue := func(name string) bool {
 		val := m.rtSession.GlobalValue(name)
-		if val == nil || goja.IsUndefined(val) {
-			continue
-		}
-		m.globals = append(m.globals, GlobalItem{
-			Name: name,
-			Kind: jsparse.BindingConst,
-		})
-		known[name] = true
-		added = true
+		return val != nil && !goja.IsUndefined(val)
 	}
 
-	if added {
-		m.sortGlobals()
-	}
-}
-
-// sortGlobals re-sorts the globals list (classes, functions, values; alphabetical within).
-func (m *Model) sortGlobals() {
-	sortOrder := func(k jsparse.BindingKind) int {
-		//exhaustive:ignore
-		switch k {
-		case jsparse.BindingClass:
-			return 0
-		case jsparse.BindingFunction:
-			return 1
-		default:
-			return 2
-		}
-	}
-	for i := 0; i < len(m.globals); i++ {
-		for j := i + 1; j < len(m.globals); j++ {
-			oi, oj := sortOrder(m.globals[i].Kind), sortOrder(m.globals[j].Kind)
-			if oi > oj || (oi == oj && m.globals[i].Name > m.globals[j].Name) {
-				m.globals[i], m.globals[j] = m.globals[j], m.globals[i]
-			}
-		}
-	}
-}
-
-// extractDeclaredNames parses REPL input for const/let/var/class/function declarations.
-func extractDeclaredNames(expr string) []string {
-	var names []string
-	// Simple pattern matching for common REPL declarations
-	words := strings.Fields(expr)
-	for i := 0; i < len(words)-1; i++ {
-		switch words[i] {
-		case "const", "let", "var":
-			name := strings.TrimRight(words[i+1], "=;,")
-			if name != "" && name != "{" && name != "[" {
-				names = append(names, name)
-			}
-		case "class":
-			name := strings.TrimRight(words[i+1], "{")
-			if name != "" {
-				names = append(names, name)
-			}
-		case "function":
-			name := strings.TrimRight(words[i+1], "(")
-			if name != "" {
-				names = append(names, name)
-			}
-		}
-	}
-	return names
-}
-
-// isBuiltinGlobal returns true if the name is a standard JavaScript/goja builtin.
-func isBuiltinGlobal(name string) bool {
-	builtins := map[string]bool{
-		"Object": true, "Array": true, "Math": true, "JSON": true,
-		"String": true, "Number": true, "Boolean": true, "RegExp": true,
-		"Date": true, "Error": true, "TypeError": true, "RangeError": true,
-		"ReferenceError": true, "SyntaxError": true, "URIError": true, "EvalError": true,
-		"Symbol": true, "Map": true, "Set": true, "WeakMap": true, "WeakSet": true,
-		"Promise": true, "Proxy": true, "Reflect": true, "ArrayBuffer": true,
-		"DataView": true, "Float32Array": true, "Float64Array": true,
-		"Int8Array": true, "Int16Array": true, "Int32Array": true,
-		"Uint8Array": true, "Uint16Array": true, "Uint32Array": true, "Uint8ClampedArray": true,
-		"parseInt": true, "parseFloat": true, "isNaN": true, "isFinite": true,
-		"undefined": true, "NaN": true, "Infinity": true, "eval": true,
-		"encodeURI": true, "encodeURIComponent": true, "decodeURI": true, "decodeURIComponent": true,
-		"escape": true, "unescape": true,
-		"console": true, "globalThis": true, "require": true,
-		"Function": true, "Iterator": true, "AggregateError": true,
-		"SharedArrayBuffer": true, "Atomics": true, "WeakRef": true, "FinalizationRegistry": true,
-	}
-	return builtins[name]
+	m.globals = inspectoranalysis.MergeGlobals(m.globals, runtimeKinds, m.replDeclared, hasRuntimeValue)
 }

--- a/cmd/smalltalk-inspector/app/model.go
+++ b/cmd/smalltalk-inspector/app/model.go
@@ -9,7 +9,9 @@ import (
 	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/dop251/goja"
 	"github.com/dop251/goja/ast"
+	"github.com/go-go-golems/go-go-goja/pkg/inspector/runtime"
 	"github.com/go-go-golems/go-go-goja/pkg/jsparse"
 )
 
@@ -51,6 +53,19 @@ type Model struct {
 	sourceScroll int
 	sourceTarget int // target line to highlight (0-based), -1 = none
 
+	// Runtime
+	rtSession   *runtime.Session
+	replInput   textinput.Model
+	replHistory []string
+	replResult  string
+	replError   string
+
+	// Object browser (for REPL results and inspect targets)
+	inspectObj   *goja.Object
+	inspectProps []runtime.PropertyInfo
+	inspectIdx   int
+	inspectLabel string
+
 	// UI state
 	focus     FocusPane
 	mode      string
@@ -87,6 +102,13 @@ func NewModel(filename string) Model {
 	m.command.CharLimit = 256
 	m.command.Width = 60
 	m.command.Blur()
+
+	m.replInput = textinput.New()
+	m.replInput.Prompt = "» "
+	m.replInput.Placeholder = "evaluate expression..."
+	m.replInput.CharLimit = 512
+	m.replInput.Width = 60
+	m.replInput.Blur()
 
 	return m
 }

--- a/cmd/smalltalk-inspector/app/model.go
+++ b/cmd/smalltalk-inspector/app/model.go
@@ -12,6 +12,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/dop251/goja"
 	"github.com/dop251/goja/ast"
+	mode_keymap "github.com/go-go-golems/bobatea/pkg/mode-keymap"
 	inspectorcore "github.com/go-go-golems/go-go-goja/pkg/inspector/core"
 	"github.com/go-go-golems/go-go-goja/pkg/inspector/runtime"
 	"github.com/go-go-golems/go-go-goja/pkg/jsparse"
@@ -136,6 +137,7 @@ func NewModel(filename string) Model {
 	if parser, err := jsparse.NewTSParser(); err == nil {
 		m.tsParser = parser
 	}
+	mode_keymap.EnableMode(&m.keyMap, m.mode)
 
 	return m
 }

--- a/cmd/smalltalk-inspector/app/model.go
+++ b/cmd/smalltalk-inspector/app/model.go
@@ -69,6 +69,11 @@ type Model struct {
 	// Navigation stack for drill-in inspection
 	navStack []NavFrame
 
+	// Error/stack trace state
+	errorInfo    *runtime.ErrorInfo
+	stackIdx     int
+	showingError bool
+
 	// UI state
 	focus     FocusPane
 	mode      string

--- a/cmd/smalltalk-inspector/app/model_members_test.go
+++ b/cmd/smalltalk-inspector/app/model_members_test.go
@@ -3,8 +3,8 @@ package app
 import (
 	"testing"
 
-	inspectoranalysis "github.com/go-go-golems/go-go-goja/pkg/inspector/analysis"
 	inspectorruntime "github.com/go-go-golems/go-go-goja/pkg/inspector/runtime"
+	"github.com/go-go-golems/go-go-goja/pkg/inspectorapi"
 	"github.com/go-go-golems/go-go-goja/pkg/jsparse"
 )
 
@@ -128,7 +128,15 @@ func modelFromSource(t *testing.T, source string) Model {
 		t.Fatalf("parse error: %v", a.ParseErr)
 	}
 	m.analysis = a
-	m.session = inspectoranalysis.NewSessionFromResult(a)
+	resp, err := m.inspectorService.OpenDocumentFromAnalysis(inspectorapi.OpenDocumentFromAnalysisRequest{
+		Filename: "test.js",
+		Source:   source,
+		Analysis: a,
+	})
+	if err != nil {
+		t.Fatalf("open document: %v", err)
+	}
+	m.documentID = resp.DocumentID
 	m.buildGlobals()
 	return m
 }

--- a/cmd/smalltalk-inspector/app/model_members_test.go
+++ b/cmd/smalltalk-inspector/app/model_members_test.go
@@ -1,0 +1,71 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/go-go-golems/go-go-goja/pkg/jsparse"
+)
+
+func TestBuildMembersSelfExtendsNoPanic(t *testing.T) {
+	src := `
+class A extends A {
+  foo(x) { return x; }
+}
+`
+	m := modelFromSource(t, src)
+	selectGlobalByName(t, &m, "A")
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("buildMembers panicked: %v", r)
+		}
+	}()
+
+	m.buildMembers()
+	if len(m.members) == 0 {
+		t.Fatal("expected class members for A")
+	}
+}
+
+func TestBuildMembersIndirectCycleNoPanic(t *testing.T) {
+	src := `
+class A extends B { a() {} }
+class B extends A { b() {} }
+`
+	m := modelFromSource(t, src)
+	selectGlobalByName(t, &m, "A")
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("buildMembers panicked: %v", r)
+		}
+	}()
+
+	m.buildMembers()
+	if len(m.members) == 0 {
+		t.Fatal("expected class members for A")
+	}
+}
+
+func modelFromSource(t *testing.T, source string) Model {
+	t.Helper()
+	m := NewModel("")
+	a := jsparse.Analyze("test.js", source, nil)
+	if a.ParseErr != nil {
+		t.Fatalf("parse error: %v", a.ParseErr)
+	}
+	m.analysis = a
+	m.buildGlobals()
+	return m
+}
+
+func selectGlobalByName(t *testing.T, m *Model, name string) {
+	t.Helper()
+	for i, g := range m.globals {
+		if g.Name == name {
+			m.globalIdx = i
+			return
+		}
+	}
+	t.Fatalf("global %q not found in %+v", name, m.globals)
+}

--- a/cmd/smalltalk-inspector/app/model_members_test.go
+++ b/cmd/smalltalk-inspector/app/model_members_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"testing"
 
+	inspectoranalysis "github.com/go-go-golems/go-go-goja/pkg/inspector/analysis"
 	"github.com/go-go-golems/go-go-goja/pkg/jsparse"
 )
 
@@ -55,6 +56,7 @@ func modelFromSource(t *testing.T, source string) Model {
 		t.Fatalf("parse error: %v", a.ParseErr)
 	}
 	m.analysis = a
+	m.session = inspectoranalysis.NewSessionFromResult(a)
 	m.buildGlobals()
 	return m
 }

--- a/cmd/smalltalk-inspector/app/navigation_mode_test.go
+++ b/cmd/smalltalk-inspector/app/navigation_mode_test.go
@@ -170,6 +170,25 @@ func TestGlobalsHalfPageNavigationNoopWhenEmpty(t *testing.T) {
 	}
 }
 
+func TestMembersHalfPageNavigationNoopWhenEmpty(t *testing.T) {
+	m := NewModel("")
+	m.loaded = true
+	m.width = 120
+	m.height = 16
+	m.focus = FocusMembers
+	m.updateMode()
+
+	m = updateWithKey(t, m, keyType(tea.KeyCtrlD))
+	if m.memberIdx != 0 {
+		t.Fatalf("memberIdx after half-down on empty members = %d, want 0", m.memberIdx)
+	}
+
+	m = updateWithKey(t, m, keyType(tea.KeyCtrlU))
+	if m.memberIdx != 0 {
+		t.Fatalf("memberIdx after half-up on empty members = %d, want 0", m.memberIdx)
+	}
+}
+
 func updateWithKey(t *testing.T, m Model, msg tea.KeyMsg) Model {
 	t.Helper()
 	next, _ := m.Update(msg)

--- a/cmd/smalltalk-inspector/app/navigation_mode_test.go
+++ b/cmd/smalltalk-inspector/app/navigation_mode_test.go
@@ -151,6 +151,25 @@ func TestUpdateModePrecedenceAndReplOverride(t *testing.T) {
 	}
 }
 
+func TestGlobalsHalfPageNavigationNoopWhenEmpty(t *testing.T) {
+	m := NewModel("")
+	m.loaded = true
+	m.width = 120
+	m.height = 16
+	m.focus = FocusGlobals
+	m.updateMode()
+
+	m = updateWithKey(t, m, keyType(tea.KeyCtrlD))
+	if m.globalIdx != 0 {
+		t.Fatalf("globalIdx after half-down on empty globals = %d, want 0", m.globalIdx)
+	}
+
+	m = updateWithKey(t, m, keyType(tea.KeyCtrlU))
+	if m.globalIdx != 0 {
+		t.Fatalf("globalIdx after half-up on empty globals = %d, want 0", m.globalIdx)
+	}
+}
+
 func updateWithKey(t *testing.T, m Model, msg tea.KeyMsg) Model {
 	t.Helper()
 	next, _ := m.Update(msg)

--- a/cmd/smalltalk-inspector/app/navigation_mode_test.go
+++ b/cmd/smalltalk-inspector/app/navigation_mode_test.go
@@ -1,0 +1,181 @@
+package app
+
+import (
+	"fmt"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/dop251/goja"
+	"github.com/go-go-golems/go-go-goja/pkg/inspector/runtime"
+)
+
+func TestInspectNavigationKeepsSelectedRowVisible(t *testing.T) {
+	m := NewModel("")
+	m.loaded = true
+	m.width = 120
+	m.height = 16
+	m.inspectObj = goja.New().NewObject()
+	m.inspectProps = make([]runtime.PropertyInfo, 40)
+	for i := range m.inspectProps {
+		m.inspectProps[i] = runtime.PropertyInfo{
+			Name:    fmt.Sprintf("p%d", i),
+			Kind:    "value",
+			Preview: "x",
+		}
+	}
+	m.focus = FocusGlobals
+	m.updateMode()
+
+	for i := 0; i < 20; i++ {
+		m = updateWithKey(t, m, runeKey('j'))
+	}
+
+	if m.inspectIdx != 20 {
+		t.Fatalf("inspectIdx = %d, want 20", m.inspectIdx)
+	}
+	if m.inspectViewport.YOffset <= 0 {
+		t.Fatalf("inspect viewport should have scrolled, got offset %d", m.inspectViewport.YOffset)
+	}
+	vpHeight := m.inspectPaneViewportHeight()
+	if m.inspectIdx < m.inspectViewport.YOffset || m.inspectIdx >= m.inspectViewport.YOffset+vpHeight {
+		t.Fatalf("selected row %d not visible in [%d,%d)", m.inspectIdx, m.inspectViewport.YOffset, m.inspectViewport.YOffset+vpHeight)
+	}
+}
+
+func TestStackNavigationUsesStackModeAndMaintainsVisibility(t *testing.T) {
+	m := NewModel("")
+	m.loaded = true
+	m.width = 120
+	m.height = 16
+	m.globalIdx = 3
+	m.sourceLines = makeLines(200)
+	frames := make([]runtime.StackFrame, 30)
+	for i := range frames {
+		frames[i] = runtime.StackFrame{
+			FunctionName: fmt.Sprintf("f%d", i),
+			FileName:     "test.js",
+			Line:         i + 1,
+			Column:       1,
+		}
+	}
+	m.errorInfo = &runtime.ErrorInfo{
+		Message: "boom",
+		Frames:  frames,
+	}
+	m.showingError = true
+	m.focus = FocusGlobals
+	m.updateMode()
+
+	for i := 0; i < 12; i++ {
+		m = updateWithKey(t, m, runeKey('j'))
+	}
+
+	if m.mode != modeStack {
+		t.Fatalf("mode = %s, want %s", m.mode, modeStack)
+	}
+	if m.globalIdx != 3 {
+		t.Fatalf("globalIdx changed in stack mode: %d", m.globalIdx)
+	}
+	if m.stackIdx != 12 {
+		t.Fatalf("stackIdx = %d, want 12", m.stackIdx)
+	}
+	if m.stackViewport.YOffset <= 0 {
+		t.Fatalf("stack viewport should have scrolled, got offset %d", m.stackViewport.YOffset)
+	}
+	if m.sourceTarget != frames[12].Line-1 {
+		t.Fatalf("sourceTarget = %d, want %d", m.sourceTarget, frames[12].Line-1)
+	}
+}
+
+func TestSourceNavigationUsesViewportOffsetAndClamps(t *testing.T) {
+	m := NewModel("")
+	m.loaded = true
+	m.width = 120
+	m.height = 16
+	m.focus = FocusSource
+	m.sourceLines = makeLines(50)
+	m.updateMode()
+
+	m = updateWithKey(t, m, runeKey('G')) // bottom
+	maxOffset := len(m.sourceLines) - m.sourceViewportHeight()
+	if maxOffset < 0 {
+		maxOffset = 0
+	}
+	if m.sourceViewport.YOffset != maxOffset {
+		t.Fatalf("source offset = %d, want %d", m.sourceViewport.YOffset, maxOffset)
+	}
+
+	m = updateWithKey(t, m, runeKey('j')) // down should stay clamped
+	if m.sourceViewport.YOffset != maxOffset {
+		t.Fatalf("source offset after extra down = %d, want %d", m.sourceViewport.YOffset, maxOffset)
+	}
+
+	m = updateWithKey(t, m, runeKey('g')) // top
+	if m.sourceViewport.YOffset != 0 {
+		t.Fatalf("source offset after top = %d, want 0", m.sourceViewport.YOffset)
+	}
+
+	m = updateWithKey(t, m, keyType(tea.KeyCtrlD)) // half down
+	want := m.sourceViewportHeight() / 2
+	if m.sourceViewport.YOffset != want {
+		t.Fatalf("source offset after half-down = %d, want %d", m.sourceViewport.YOffset, want)
+	}
+}
+
+func TestUpdateModePrecedenceAndReplOverride(t *testing.T) {
+	m := NewModel("")
+	m.loaded = true
+	m.focus = FocusSource
+	m.updateMode()
+	if m.mode != modeSource {
+		t.Fatalf("mode = %s, want %s", m.mode, modeSource)
+	}
+
+	m.inspectObj = goja.New().NewObject()
+	m.updateMode()
+	if m.mode != modeInspect {
+		t.Fatalf("mode = %s, want %s", m.mode, modeInspect)
+	}
+
+	m.errorInfo = &runtime.ErrorInfo{Frames: []runtime.StackFrame{{Line: 1}}}
+	m.showingError = true
+	m.updateMode()
+	if m.mode != modeStack {
+		t.Fatalf("mode = %s, want %s", m.mode, modeStack)
+	}
+
+	m.focus = FocusRepl
+	m.updateMode()
+	if m.mode != modeRepl {
+		t.Fatalf("mode = %s, want %s", m.mode, modeRepl)
+	}
+}
+
+func updateWithKey(t *testing.T, m Model, msg tea.KeyMsg) Model {
+	t.Helper()
+	next, _ := m.Update(msg)
+	typed, ok := next.(Model)
+	if !ok {
+		t.Fatalf("unexpected model type %T", next)
+	}
+	return typed
+}
+
+func runeKey(r rune) tea.KeyMsg {
+	return tea.KeyMsg{
+		Type:  tea.KeyRunes,
+		Runes: []rune{r},
+	}
+}
+
+func keyType(t tea.KeyType) tea.KeyMsg {
+	return tea.KeyMsg{Type: t}
+}
+
+func makeLines(n int) []string {
+	lines := make([]string, n)
+	for i := 0; i < n; i++ {
+		lines[i] = fmt.Sprintf("line %d", i+1)
+	}
+	return lines
+}

--- a/cmd/smalltalk-inspector/app/styles.go
+++ b/cmd/smalltalk-inspector/app/styles.go
@@ -1,0 +1,74 @@
+package app
+
+import "github.com/charmbracelet/lipgloss"
+
+var (
+	// Colors
+	colorSecondary   = lipgloss.Color("62")  // purple
+	colorMuted       = lipgloss.Color("240") // dim gray
+	colorBright      = lipgloss.Color("15")  // white
+	colorDim         = lipgloss.Color("244") // mid gray
+	colorSuccess     = lipgloss.Color("78")  // green
+	colorError       = lipgloss.Color("196") // red - used in REPL error display
+	colorWarning     = lipgloss.Color("226") // yellow
+	colorHighlight   = lipgloss.Color("117") // light blue
+	colorStatusBg    = lipgloss.Color("236") // dark gray
+	colorPaneFocusBg = lipgloss.Color("33")  // blue (active pane header)
+	colorPaneDimBg   = lipgloss.Color("240") // gray (inactive pane header)
+
+	// Styles
+	styleHeader = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(colorBright).
+			Background(colorSecondary).
+			Padding(0, 1)
+
+	stylePaneHeaderActive = lipgloss.NewStyle().
+				Bold(true).
+				Foreground(colorBright).
+				Background(colorPaneFocusBg)
+
+	stylePaneHeaderInactive = lipgloss.NewStyle().
+				Bold(true).
+				Foreground(colorBright).
+				Background(colorPaneDimBg)
+
+	styleStatus = lipgloss.NewStyle().
+			Foreground(colorBright).
+			Background(colorStatusBg).
+			Padding(0, 1)
+
+	styleHelp = lipgloss.NewStyle().
+			Foreground(colorDim).
+			Padding(0, 1)
+
+	styleCommandLine = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("252")).
+				Background(lipgloss.Color("235")).
+				Padding(0, 1)
+
+	styleSeparator = lipgloss.NewStyle().
+			Foreground(colorMuted)
+
+	// Pane content styles
+	styleEmptyHint = lipgloss.NewStyle().
+			Foreground(colorDim).
+			Italic(true)
+
+	styleItemClass    = lipgloss.NewStyle().Foreground(lipgloss.Color("214")) // orange
+	styleItemFunction = lipgloss.NewStyle().Foreground(lipgloss.Color("117")) // blue
+	styleItemValue    = lipgloss.NewStyle().Foreground(lipgloss.Color("150")) // green
+
+	styleGutterNormal = lipgloss.NewStyle().Foreground(colorDim)
+	styleGutterCursor = lipgloss.NewStyle().Foreground(colorWarning).Bold(true)
+	styleSourceHL     = lipgloss.NewStyle().Background(lipgloss.Color("236")).Foreground(colorHighlight)
+
+	styleSelectedMarker = lipgloss.NewStyle().Foreground(colorWarning).Bold(true)
+
+	styleInheritedHeader = lipgloss.NewStyle().Foreground(colorMuted).Italic(true)
+
+	styleProtoChain = lipgloss.NewStyle().Foreground(colorDim).Italic(true)
+
+	styleReplPrompt = lipgloss.NewStyle().Foreground(colorSuccess).Bold(true)
+	styleReplError  = lipgloss.NewStyle().Foreground(colorError)
+)

--- a/cmd/smalltalk-inspector/app/update.go
+++ b/cmd/smalltalk-inspector/app/update.go
@@ -549,23 +549,21 @@ func (m Model) executeCommand(input string) (tea.Model, tea.Cmd) {
 }
 
 func (m *Model) ensureGlobalsVisible() {
-	vpHeight := m.listViewportHeight()
-	if m.globalIdx < m.globalScroll {
-		m.globalScroll = m.globalIdx
-	}
-	if m.globalIdx >= m.globalScroll+vpHeight {
-		m.globalScroll = m.globalIdx - vpHeight + 1
-	}
+	inspectorui.EnsureSelectionVisible(
+		&m.globalScroll,
+		m.globalIdx,
+		len(m.globals),
+		m.listViewportHeight(),
+	)
 }
 
 func (m *Model) ensureMembersVisible() {
-	vpHeight := m.listViewportHeight()
-	if m.memberIdx < m.memberScroll {
-		m.memberScroll = m.memberIdx
-	}
-	if m.memberIdx >= m.memberScroll+vpHeight {
-		m.memberScroll = m.memberIdx - vpHeight + 1
-	}
+	inspectorui.EnsureSelectionVisible(
+		&m.memberScroll,
+		m.memberIdx,
+		len(m.members),
+		m.listViewportHeight(),
+	)
 }
 
 func (m *Model) ensureInspectVisible() {

--- a/cmd/smalltalk-inspector/app/update.go
+++ b/cmd/smalltalk-inspector/app/update.go
@@ -467,9 +467,9 @@ func (m Model) handleReplKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 
-		// Extract declared names for const/let tracking
-		declNames := extractDeclaredNames(expr)
-		m.replDefinedNames = append(m.replDefinedNames, declNames...)
+		// Parser-backed declaration extraction for REPL-defined bindings.
+		declared := inspectoranalysis.DeclaredBindingsFromSource(expr)
+		m.replDeclared = append(m.replDeclared, declared...)
 
 		// Evaluate synchronously (expressions should be fast)
 		result := m.rtSession.EvalWithCapture(expr)

--- a/cmd/smalltalk-inspector/app/update.go
+++ b/cmd/smalltalk-inspector/app/update.go
@@ -69,6 +69,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.replResult = ""
 			m.inspectObj = nil
 			m.inspectProps = nil
+			m.navStack = nil
 
 			// Parse exception for stack trace display
 			if ex, ok := msg.Result.Error.(*goja.Exception); ok {
@@ -91,6 +92,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.replError = ""
 			m.errorInfo = nil
 			m.showingError = false
+			m.navStack = nil
 			val := msg.Result.Value
 			m.replResult = runtime.ValuePreview(val, m.rtSession.VM, 80)
 

--- a/cmd/smalltalk-inspector/app/update.go
+++ b/cmd/smalltalk-inspector/app/update.go
@@ -141,8 +141,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.replHistory = append(m.replHistory, msg.Result.Expression)
 
-		// Track REPL expression as source
-		m.appendReplSource(msg.Result.Expression)
+		// Track REPL expression as source with parser-backed declarations.
+		m.appendReplSource(msg.Result.Expression, inspectorapi.DeclaredBindingsFromSource(msg.Result.Expression))
 
 		// Refresh globals list to pick up new REPL-defined names
 		m.refreshRuntimeGlobals()

--- a/cmd/smalltalk-inspector/app/update.go
+++ b/cmd/smalltalk-inspector/app/update.go
@@ -407,12 +407,18 @@ func (m Model) handleMembersKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	if key.Matches(msg, m.keyMap.HalfDown) {
+		if len(m.members) == 0 {
+			return m, nil
+		}
 		m.memberIdx = inspectorui.MinInt(m.memberIdx+m.listViewportHeight()/2, len(m.members)-1)
 		m.ensureMembersVisible()
 		m.jumpToSource()
 		return m, nil
 	}
 	if key.Matches(msg, m.keyMap.HalfUp) {
+		if len(m.members) == 0 {
+			return m, nil
+		}
 		m.memberIdx = inspectorui.MaxInt(m.memberIdx-m.listViewportHeight()/2, 0)
 		m.ensureMembersVisible()
 		m.jumpToSource()

--- a/cmd/smalltalk-inspector/app/update.go
+++ b/cmd/smalltalk-inspector/app/update.go
@@ -328,6 +328,9 @@ func (m Model) handleGlobalsKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	if key.Matches(msg, m.keyMap.HalfDown) {
+		if len(m.globals) == 0 {
+			return m, nil
+		}
 		m.globalIdx = inspectorui.MinInt(m.globalIdx+m.listViewportHeight()/2, len(m.globals)-1)
 		m.ensureGlobalsVisible()
 		m.buildMembers()
@@ -335,6 +338,9 @@ func (m Model) handleGlobalsKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	if key.Matches(msg, m.keyMap.HalfUp) {
+		if len(m.globals) == 0 {
+			return m, nil
+		}
 		m.globalIdx = inspectorui.MaxInt(m.globalIdx-m.listViewportHeight()/2, 0)
 		m.ensureGlobalsVisible()
 		m.buildMembers()

--- a/cmd/smalltalk-inspector/app/update.go
+++ b/cmd/smalltalk-inspector/app/update.go
@@ -1,0 +1,376 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// Update implements tea.Model.
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case spinner.TickMsg:
+		var cmd tea.Cmd
+		m.spinner, cmd = m.spinner.Update(msg)
+		return m, cmd
+
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		m.help.Width = msg.Width
+		m.command.Width = maxInt(16, msg.Width-4)
+		return m, nil
+
+	case MsgFileLoaded:
+		m.filename = msg.Filename
+		m.source = msg.Source
+		m.analysis = msg.Analysis
+		m.sourceLines = strings.Split(msg.Source, "\n")
+		m.loaded = true
+		m.mode = modeGlobals
+		m.focus = FocusGlobals
+		m.sourceTarget = -1
+		m.sourceScroll = 0
+		m.buildGlobals()
+		m.buildMembers()
+		m.statusMsg = fmt.Sprintf("✓ Loaded %s (%d lines, %d globals)",
+			msg.Filename, len(m.sourceLines), len(m.globals))
+		return m, nil
+
+	case MsgFileLoadError:
+		m.statusMsg = fmt.Sprintf("✗ Error loading %s: %v", msg.Filename, msg.Err)
+		return m, nil
+
+	case MsgStatusNotice:
+		m.statusMsg = msg.Text
+		return m, nil
+
+	case tea.KeyMsg:
+		return m.handleKey(msg)
+	}
+
+	return m, nil
+}
+
+func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	// Command input mode
+	if m.cmdActive {
+		return m.handleCommandInput(msg)
+	}
+
+	// Global bindings
+	if key.Matches(msg, m.keyMap.Quit) {
+		return m, tea.Quit
+	}
+
+	if key.Matches(msg, m.keyMap.Command) {
+		m.cmdActive = true
+		m.command.SetValue("")
+		m.command.Focus()
+		return m, nil
+	}
+
+	if key.Matches(msg, m.keyMap.Back) {
+		// Esc: clear status or go back
+		m.statusMsg = ""
+		return m, nil
+	}
+
+	if key.Matches(msg, m.keyMap.NextPane) {
+		m.cyclePane(1)
+		return m, nil
+	}
+
+	if key.Matches(msg, m.keyMap.PrevPane) {
+		m.cyclePane(-1)
+		return m, nil
+	}
+
+	// Pane-specific keys
+	if !m.loaded {
+		return m, nil
+	}
+
+	//exhaustive:ignore
+	switch m.focus {
+	case FocusGlobals:
+		return m.handleGlobalsKey(msg)
+	case FocusMembers:
+		return m.handleMembersKey(msg)
+	case FocusSource:
+		return m.handleSourceKey(msg)
+	}
+
+	return m, nil
+}
+
+func (m *Model) cyclePane(dir int) {
+	if !m.loaded {
+		return
+	}
+
+	panes := []FocusPane{FocusGlobals, FocusMembers, FocusSource}
+	current := 0
+	for i, p := range panes {
+		if p == m.focus {
+			current = i
+			break
+		}
+	}
+	next := (current + dir + len(panes)) % len(panes)
+	m.focus = panes[next]
+	m.updateMode()
+}
+
+func (m *Model) updateMode() {
+	switch m.focus {
+	case FocusGlobals:
+		m.mode = modeGlobals
+	case FocusMembers:
+		m.mode = modeMembers
+	case FocusSource:
+		m.mode = modeSource
+	case FocusRepl:
+		m.mode = modeRepl
+	default:
+		m.mode = modeEmpty
+	}
+}
+
+func (m Model) handleGlobalsKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if key.Matches(msg, m.keyMap.Down) {
+		if m.globalIdx < len(m.globals)-1 {
+			m.globalIdx++
+			m.ensureGlobalsVisible()
+			m.buildMembers()
+			m.jumpToSource()
+		}
+		return m, nil
+	}
+	if key.Matches(msg, m.keyMap.Up) {
+		if m.globalIdx > 0 {
+			m.globalIdx--
+			m.ensureGlobalsVisible()
+			m.buildMembers()
+			m.jumpToSource()
+		}
+		return m, nil
+	}
+	if key.Matches(msg, m.keyMap.Top) {
+		m.globalIdx = 0
+		m.globalScroll = 0
+		m.buildMembers()
+		m.jumpToSource()
+		return m, nil
+	}
+	if key.Matches(msg, m.keyMap.Bottom) {
+		if len(m.globals) > 0 {
+			m.globalIdx = len(m.globals) - 1
+			m.ensureGlobalsVisible()
+			m.buildMembers()
+			m.jumpToSource()
+		}
+		return m, nil
+	}
+	if key.Matches(msg, m.keyMap.HalfDown) {
+		m.globalIdx = minInt(m.globalIdx+m.listViewportHeight()/2, len(m.globals)-1)
+		m.ensureGlobalsVisible()
+		m.buildMembers()
+		m.jumpToSource()
+		return m, nil
+	}
+	if key.Matches(msg, m.keyMap.HalfUp) {
+		m.globalIdx = maxInt(m.globalIdx-m.listViewportHeight()/2, 0)
+		m.ensureGlobalsVisible()
+		m.buildMembers()
+		m.jumpToSource()
+		return m, nil
+	}
+	if key.Matches(msg, m.keyMap.Select) {
+		// Enter: move focus to members
+		if len(m.members) > 0 {
+			m.focus = FocusMembers
+			m.updateMode()
+		}
+		return m, nil
+	}
+
+	return m, nil
+}
+
+func (m Model) handleMembersKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if key.Matches(msg, m.keyMap.Down) {
+		if m.memberIdx < len(m.members)-1 {
+			m.memberIdx++
+			m.ensureMembersVisible()
+			m.jumpToSource()
+		}
+		return m, nil
+	}
+	if key.Matches(msg, m.keyMap.Up) {
+		if m.memberIdx > 0 {
+			m.memberIdx--
+			m.ensureMembersVisible()
+			m.jumpToSource()
+		}
+		return m, nil
+	}
+	if key.Matches(msg, m.keyMap.Top) {
+		m.memberIdx = 0
+		m.memberScroll = 0
+		m.jumpToSource()
+		return m, nil
+	}
+	if key.Matches(msg, m.keyMap.Bottom) {
+		if len(m.members) > 0 {
+			m.memberIdx = len(m.members) - 1
+			m.ensureMembersVisible()
+			m.jumpToSource()
+		}
+		return m, nil
+	}
+	if key.Matches(msg, m.keyMap.HalfDown) {
+		m.memberIdx = minInt(m.memberIdx+m.listViewportHeight()/2, len(m.members)-1)
+		m.ensureMembersVisible()
+		m.jumpToSource()
+		return m, nil
+	}
+	if key.Matches(msg, m.keyMap.HalfUp) {
+		m.memberIdx = maxInt(m.memberIdx-m.listViewportHeight()/2, 0)
+		m.ensureMembersVisible()
+		m.jumpToSource()
+		return m, nil
+	}
+	if key.Matches(msg, m.keyMap.Back) {
+		// Esc: go back to globals
+		m.focus = FocusGlobals
+		m.updateMode()
+		return m, nil
+	}
+
+	return m, nil
+}
+
+func (m Model) handleSourceKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if key.Matches(msg, m.keyMap.Down) {
+		m.sourceScroll++
+		maxScroll := len(m.sourceLines) - m.sourceViewportHeight()
+		if maxScroll < 0 {
+			maxScroll = 0
+		}
+		if m.sourceScroll > maxScroll {
+			m.sourceScroll = maxScroll
+		}
+		return m, nil
+	}
+	if key.Matches(msg, m.keyMap.Up) {
+		m.sourceScroll--
+		if m.sourceScroll < 0 {
+			m.sourceScroll = 0
+		}
+		return m, nil
+	}
+	if key.Matches(msg, m.keyMap.Top) {
+		m.sourceScroll = 0
+		return m, nil
+	}
+	if key.Matches(msg, m.keyMap.Bottom) {
+		maxScroll := len(m.sourceLines) - m.sourceViewportHeight()
+		if maxScroll < 0 {
+			maxScroll = 0
+		}
+		m.sourceScroll = maxScroll
+		return m, nil
+	}
+	if key.Matches(msg, m.keyMap.HalfDown) {
+		m.sourceScroll += m.sourceViewportHeight() / 2
+		maxScroll := len(m.sourceLines) - m.sourceViewportHeight()
+		if maxScroll < 0 {
+			maxScroll = 0
+		}
+		if m.sourceScroll > maxScroll {
+			m.sourceScroll = maxScroll
+		}
+		return m, nil
+	}
+	if key.Matches(msg, m.keyMap.HalfUp) {
+		m.sourceScroll -= m.sourceViewportHeight() / 2
+		if m.sourceScroll < 0 {
+			m.sourceScroll = 0
+		}
+		return m, nil
+	}
+
+	return m, nil
+}
+
+func (m Model) handleCommandInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc", "escape":
+		m.cmdActive = false
+		m.command.Blur()
+		m.command.SetValue("")
+		return m, nil
+	case "enter":
+		cmd := strings.TrimSpace(m.command.Value())
+		m.cmdActive = false
+		m.command.Blur()
+		m.command.SetValue("")
+		return m.executeCommand(cmd)
+	}
+
+	var cmd tea.Cmd
+	m.command, cmd = m.command.Update(msg)
+	return m, cmd
+}
+
+func (m Model) executeCommand(input string) (tea.Model, tea.Cmd) {
+	parts := strings.Fields(input)
+	if len(parts) == 0 {
+		return m, nil
+	}
+
+	switch parts[0] {
+	case "q", "quit":
+		return m, tea.Quit
+	case "load":
+		if len(parts) < 2 {
+			m.statusMsg = "Usage: :load <file.js>"
+			return m, nil
+		}
+		filename := parts[1]
+		m.statusMsg = fmt.Sprintf("Loading %s...", filename)
+		return m, func() tea.Msg {
+			return loadFile(filename)
+		}
+	case "help":
+		m.help.ShowAll = !m.help.ShowAll
+		return m, nil
+	default:
+		m.statusMsg = fmt.Sprintf("Unknown command: %s", parts[0])
+		return m, nil
+	}
+}
+
+func (m *Model) ensureGlobalsVisible() {
+	vpHeight := m.listViewportHeight()
+	if m.globalIdx < m.globalScroll {
+		m.globalScroll = m.globalIdx
+	}
+	if m.globalIdx >= m.globalScroll+vpHeight {
+		m.globalScroll = m.globalIdx - vpHeight + 1
+	}
+}
+
+func (m *Model) ensureMembersVisible() {
+	vpHeight := m.listViewportHeight()
+	if m.memberIdx < m.memberScroll {
+		m.memberScroll = m.memberIdx
+	}
+	if m.memberIdx >= m.memberScroll+vpHeight {
+		m.memberScroll = m.memberIdx - vpHeight + 1
+	}
+}

--- a/cmd/smalltalk-inspector/app/update.go
+++ b/cmd/smalltalk-inspector/app/update.go
@@ -115,6 +115,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 		m.replHistory = append(m.replHistory, msg.Result.Expression)
+
+		// Refresh globals list to pick up new REPL-defined names
+		m.refreshRuntimeGlobals()
 		return m, nil
 
 	case tea.KeyMsg:
@@ -443,6 +446,10 @@ func (m Model) handleReplKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.replError = "no runtime session (load a file first)"
 			return m, nil
 		}
+
+		// Extract declared names for const/let tracking
+		declNames := extractDeclaredNames(expr)
+		m.replDefinedNames = append(m.replDefinedNames, declNames...)
 
 		// Evaluate synchronously (expressions should be fast)
 		result := m.rtSession.EvalWithCapture(expr)

--- a/cmd/smalltalk-inspector/app/update.go
+++ b/cmd/smalltalk-inspector/app/update.go
@@ -10,6 +10,7 @@ import (
 	"github.com/dop251/goja"
 	mode_keymap "github.com/go-go-golems/bobatea/pkg/mode-keymap"
 	"github.com/go-go-golems/go-go-goja/internal/inspectorui"
+	inspectoranalysis "github.com/go-go-golems/go-go-goja/pkg/inspector/analysis"
 	"github.com/go-go-golems/go-go-goja/pkg/inspector/runtime"
 	"github.com/go-go-golems/go-go-goja/pkg/jsparse"
 )
@@ -33,6 +34,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.filename = msg.Filename
 		m.source = msg.Source
 		m.analysis = msg.Analysis
+		m.session = inspectoranalysis.NewSessionFromResult(msg.Analysis)
 		m.sourceLines = strings.Split(msg.Source, "\n")
 		m.rebuildFileSyntaxSpans(msg.Source)
 		m.loaded = true

--- a/cmd/smalltalk-inspector/app/update.go
+++ b/cmd/smalltalk-inspector/app/update.go
@@ -32,6 +32,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.source = msg.Source
 		m.analysis = msg.Analysis
 		m.sourceLines = strings.Split(msg.Source, "\n")
+		m.rebuildFileSyntaxSpans(msg.Source)
 		m.loaded = true
 		m.mode = modeGlobals
 		m.focus = FocusGlobals

--- a/cmd/smalltalk-inspector/app/update.go
+++ b/cmd/smalltalk-inspector/app/update.go
@@ -36,14 +36,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.focus = FocusGlobals
 		m.sourceTarget = -1
 		m.sourceScroll = 0
+
+		// Initialize runtime session BEFORE building globals/members
+		// so buildValueMembers() can use it for runtime introspection.
+		m.rtSession = runtime.NewSession()
+		rtErr := m.rtSession.Load(msg.Source)
+
 		m.buildGlobals()
 		m.buildMembers()
 
-		// Initialize runtime session
-		m.rtSession = runtime.NewSession()
-		if err := m.rtSession.Load(msg.Source); err != nil {
+		if rtErr != nil {
 			m.statusMsg = fmt.Sprintf("✓ Loaded %s (%d lines, %d globals) ⚠ runtime: %v",
-				msg.Filename, len(m.sourceLines), len(m.globals), err)
+				msg.Filename, len(m.sourceLines), len(m.globals), rtErr)
 		} else {
 			m.statusMsg = fmt.Sprintf("✓ Loaded %s (%d lines, %d globals)",
 				msg.Filename, len(m.sourceLines), len(m.globals))

--- a/cmd/smalltalk-inspector/app/update.go
+++ b/cmd/smalltalk-inspector/app/update.go
@@ -26,7 +26,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.width = msg.Width
 		m.height = msg.Height
 		m.help.Width = msg.Width
-		m.command.Width = maxInt(16, msg.Width-4)
+		m.command.Width = inspectorui.MaxInt(16, msg.Width-4)
 		return m, nil
 
 	case MsgFileLoaded:
@@ -317,14 +317,14 @@ func (m Model) handleGlobalsKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	if key.Matches(msg, m.keyMap.HalfDown) {
-		m.globalIdx = minInt(m.globalIdx+m.listViewportHeight()/2, len(m.globals)-1)
+		m.globalIdx = inspectorui.MinInt(m.globalIdx+m.listViewportHeight()/2, len(m.globals)-1)
 		m.ensureGlobalsVisible()
 		m.buildMembers()
 		m.jumpToSource()
 		return m, nil
 	}
 	if key.Matches(msg, m.keyMap.HalfUp) {
-		m.globalIdx = maxInt(m.globalIdx-m.listViewportHeight()/2, 0)
+		m.globalIdx = inspectorui.MaxInt(m.globalIdx-m.listViewportHeight()/2, 0)
 		m.ensureGlobalsVisible()
 		m.buildMembers()
 		m.jumpToSource()
@@ -390,13 +390,13 @@ func (m Model) handleMembersKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	if key.Matches(msg, m.keyMap.HalfDown) {
-		m.memberIdx = minInt(m.memberIdx+m.listViewportHeight()/2, len(m.members)-1)
+		m.memberIdx = inspectorui.MinInt(m.memberIdx+m.listViewportHeight()/2, len(m.members)-1)
 		m.ensureMembersVisible()
 		m.jumpToSource()
 		return m, nil
 	}
 	if key.Matches(msg, m.keyMap.HalfUp) {
-		m.memberIdx = maxInt(m.memberIdx-m.listViewportHeight()/2, 0)
+		m.memberIdx = inspectorui.MaxInt(m.memberIdx-m.listViewportHeight()/2, 0)
 		m.ensureMembersVisible()
 		m.jumpToSource()
 		return m, nil

--- a/cmd/smalltalk-inspector/app/update.go
+++ b/cmd/smalltalk-inspector/app/update.go
@@ -38,7 +38,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.loaded = true
 		m.focus = FocusGlobals
 		m.sourceTarget = -1
-		m.sourceScroll = 0
+		m.sourceViewport.YOffset = 0
 		m.updateMode()
 
 		// Initialize runtime session BEFORE building globals/members
@@ -412,52 +412,39 @@ func (m Model) handleMembersKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleSourceKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	vpHeight := m.sourceViewportHeight()
+	totalRows := len(m.activeSourceLines())
+	clamp := func() {
+		inspectorui.ClampYOffset(&m.sourceViewport, totalRows, vpHeight)
+	}
+
 	if key.Matches(msg, m.keyMap.Down) {
-		m.sourceScroll++
-		maxScroll := len(m.sourceLines) - m.sourceViewportHeight()
-		if maxScroll < 0 {
-			maxScroll = 0
-		}
-		if m.sourceScroll > maxScroll {
-			m.sourceScroll = maxScroll
-		}
+		m.sourceViewport.YOffset++
+		clamp()
 		return m, nil
 	}
 	if key.Matches(msg, m.keyMap.Up) {
-		m.sourceScroll--
-		if m.sourceScroll < 0 {
-			m.sourceScroll = 0
-		}
+		m.sourceViewport.YOffset--
+		clamp()
 		return m, nil
 	}
 	if key.Matches(msg, m.keyMap.Top) {
-		m.sourceScroll = 0
+		m.sourceViewport.YOffset = 0
 		return m, nil
 	}
 	if key.Matches(msg, m.keyMap.Bottom) {
-		maxScroll := len(m.sourceLines) - m.sourceViewportHeight()
-		if maxScroll < 0 {
-			maxScroll = 0
-		}
-		m.sourceScroll = maxScroll
+		m.sourceViewport.YOffset = totalRows - vpHeight
+		clamp()
 		return m, nil
 	}
 	if key.Matches(msg, m.keyMap.HalfDown) {
-		m.sourceScroll += m.sourceViewportHeight() / 2
-		maxScroll := len(m.sourceLines) - m.sourceViewportHeight()
-		if maxScroll < 0 {
-			maxScroll = 0
-		}
-		if m.sourceScroll > maxScroll {
-			m.sourceScroll = maxScroll
-		}
+		m.sourceViewport.YOffset += vpHeight / 2
+		clamp()
 		return m, nil
 	}
 	if key.Matches(msg, m.keyMap.HalfUp) {
-		m.sourceScroll -= m.sourceViewportHeight() / 2
-		if m.sourceScroll < 0 {
-			m.sourceScroll = 0
-		}
+		m.sourceViewport.YOffset -= vpHeight / 2
+		clamp()
 		return m, nil
 	}
 

--- a/cmd/smalltalk-inspector/app/view.go
+++ b/cmd/smalltalk-inspector/app/view.go
@@ -452,9 +452,17 @@ func (m Model) renderMembersPane(width, height int) string {
 func (m Model) renderSourcePane(width, height int) string {
 	var lines []string
 
+	// Determine which source to display
+	srcLines := m.sourceLines
+	headerSuffix := ""
+	if m.showingReplSrc && len(m.replSourceLines) > 0 {
+		srcLines = m.replSourceLines
+		headerSuffix = " (REPL)"
+	}
+
 	// Header
-	label := " Source "
-	if m.focus == FocusMembers && len(m.members) > 0 && m.memberIdx < len(m.members) {
+	label := " Source" + headerSuffix + " "
+	if !m.showingReplSrc && m.focus == FocusMembers && len(m.members) > 0 && m.memberIdx < len(m.members) {
 		label = fmt.Sprintf(" Source: %s ", m.members[m.memberIdx].Name)
 	}
 	hStyle := stylePaneHeaderInactive
@@ -469,7 +477,7 @@ func (m Model) renderSourcePane(width, height int) string {
 		contentHeight = 1
 	}
 
-	if len(m.sourceLines) == 0 {
+	if len(srcLines) == 0 {
 		lines = append(lines, padRight(styleEmptyHint.Render(" (no source)"), width))
 		for len(lines) < height {
 			lines = append(lines, strings.Repeat(" ", width))
@@ -477,12 +485,12 @@ func (m Model) renderSourcePane(width, height int) string {
 		return lipgloss.NewStyle().Width(width).MaxWidth(width).Render(strings.Join(lines, "\n"))
 	}
 
-	gutterWidth := len(fmt.Sprintf("%d", len(m.sourceLines))) + 1
+	gutterWidth := len(fmt.Sprintf("%d", len(srcLines))) + 1
 
-	endIdx := minInt(m.sourceScroll+contentHeight, len(m.sourceLines))
+	endIdx := minInt(m.sourceScroll+contentHeight, len(srcLines))
 	for lineIdx := m.sourceScroll; lineIdx < endIdx; lineIdx++ {
 		lineNum := fmt.Sprintf("%*d ", gutterWidth, lineIdx+1)
-		content := m.sourceLines[lineIdx]
+		content := srcLines[lineIdx]
 
 		isTarget := lineIdx == m.sourceTarget
 		gs := styleGutterNormal

--- a/cmd/smalltalk-inspector/app/view.go
+++ b/cmd/smalltalk-inspector/app/view.go
@@ -583,7 +583,7 @@ func (m Model) renderStatusBar() string {
 	var parts []string
 
 	if m.loaded {
-		if m.analysis != nil && m.analysis.ParseErr != nil {
+		if m.session != nil && m.session.ParseError() != nil {
 			parts = append(parts, styleReplError.Render("⚠ parse error"))
 		} else {
 			parts = append(parts, "✓ parse ok")

--- a/cmd/smalltalk-inspector/app/view.go
+++ b/cmd/smalltalk-inspector/app/view.go
@@ -583,7 +583,7 @@ func (m Model) renderStatusBar() string {
 	var parts []string
 
 	if m.loaded {
-		if m.session != nil && m.session.ParseError() != nil {
+		if m.analysis != nil && m.analysis.ParseErr != nil {
 			parts = append(parts, styleReplError.Render("⚠ parse error"))
 		} else {
 			parts = append(parts, "✓ parse ok")

--- a/cmd/smalltalk-inspector/app/view.go
+++ b/cmd/smalltalk-inspector/app/view.go
@@ -54,7 +54,7 @@ func (m Model) renderEmptyView() string {
 		lines = append(lines, "")
 	}
 
-	body := strings.Join(lines[:minInt(len(lines), bodyHeight)], "\n")
+	body := strings.Join(lines[:inspectorui.MinInt(len(lines), bodyHeight)], "\n")
 
 	parts := []string{header, body, repl, status, helpView}
 	if m.cmdActive {
@@ -137,7 +137,7 @@ func (m Model) renderErrorView(header, status, helpView, repl string, contentHei
 
 	// Error banner
 	errorBanner := styleReplError.Render(" ✗ " + m.errorInfo.Message + " ")
-	bannerLine := errorBanner + styleSeparator.Render(strings.Repeat("─", maxInt(0, m.width-ansi.StringWidth(errorBanner))))
+	bannerLine := errorBanner + styleSeparator.Render(strings.Repeat("─", inspectorui.MaxInt(0, m.width-ansi.StringWidth(errorBanner))))
 	contentHeight-- // banner takes one line
 
 	stackPane := m.renderStackPane(stackWidth, contentHeight)
@@ -145,7 +145,7 @@ func (m Model) renderErrorView(header, status, helpView, repl string, contentHei
 
 	content := lipgloss.JoinHorizontal(lipgloss.Top, stackPane, sourcePane)
 
-	parts := []string{header, padRight(bannerLine, m.width), content, repl, status, helpView}
+	parts := []string{header, inspectorui.PadRight(bannerLine, m.width), content, repl, status, helpView}
 	if m.cmdActive {
 		parts = append(parts, m.renderCommandLine())
 	}
@@ -155,7 +155,7 @@ func (m Model) renderErrorView(header, status, helpView, repl string, contentHei
 func (m Model) renderStackPane(width, height int) string {
 	label := " Call Stack "
 	headerLine := stylePaneHeaderActive.Render(label) +
-		styleSeparator.Render(strings.Repeat("─", maxInt(0, width-ansi.StringWidth(label))))
+		styleSeparator.Render(strings.Repeat("─", inspectorui.MaxInt(0, width-ansi.StringWidth(label))))
 
 	contentHeight := height - 1
 	if contentHeight < 1 {
@@ -164,7 +164,7 @@ func (m Model) renderStackPane(width, height int) string {
 
 	var rows []string
 	if m.errorInfo == nil || len(m.errorInfo.Frames) == 0 {
-		rows = append(rows, padRight(styleEmptyHint.Render(" (no stack frames)"), width))
+		rows = append(rows, inspectorui.PadRight(styleEmptyHint.Render(" (no stack frames)"), width))
 	} else {
 		for i, frame := range m.errorInfo.Frames {
 			marker := "  "
@@ -174,7 +174,7 @@ func (m Model) renderStackPane(width, height int) string {
 
 			line := fmt.Sprintf("%s#%d  %-16s  %s:%d:%d",
 				marker, i, frame.FunctionName, frame.FileName, frame.Line, frame.Column)
-			rows = append(rows, padRight(line, width))
+			rows = append(rows, inspectorui.PadRight(line, width))
 		}
 	}
 
@@ -186,7 +186,7 @@ func (m Model) renderStackPane(width, height int) string {
 	body := lipgloss.NewStyle().Width(width).Height(contentHeight).Render(vp.View())
 	pane := lipgloss.JoinVertical(
 		lipgloss.Left,
-		padRight(headerLine, width),
+		inspectorui.PadRight(headerLine, width),
 		body,
 	)
 	return lipgloss.NewStyle().Width(width).MaxWidth(width).Render(pane)
@@ -211,7 +211,7 @@ func (m Model) renderInspectView(header, status, helpView, repl string, contentH
 		}
 		crumbs = append(crumbs, m.inspectLabel)
 		breadcrumb = stylePaneHeaderActive.Render(" Breadcrumb: "+strings.Join(crumbs, " → ")+" ") +
-			styleSeparator.Render(strings.Repeat("─", maxInt(0, m.width-20)))
+			styleSeparator.Render(strings.Repeat("─", inspectorui.MaxInt(0, m.width-20)))
 		contentHeight-- // breadcrumb takes one line
 	}
 
@@ -223,7 +223,7 @@ func (m Model) renderInspectView(header, status, helpView, repl string, contentH
 	var parts []string
 	parts = append(parts, header)
 	if breadcrumb != "" {
-		parts = append(parts, padRight(breadcrumb, m.width))
+		parts = append(parts, inspectorui.PadRight(breadcrumb, m.width))
 	}
 	parts = append(parts, content, repl, status, helpView)
 	if m.cmdActive {
@@ -239,7 +239,7 @@ func (m Model) renderInspectPane(width, height int) string {
 		label = label[:width-2]
 	}
 	headerLine := stylePaneHeaderActive.Render(label) +
-		styleSeparator.Render(strings.Repeat("─", maxInt(0, width-ansi.StringWidth(label))))
+		styleSeparator.Render(strings.Repeat("─", inspectorui.MaxInt(0, width-ansi.StringWidth(label))))
 
 	contentHeight := height - 1
 	if contentHeight < 1 {
@@ -270,11 +270,11 @@ func (m Model) renderInspectPane(width, height int) string {
 		}
 
 		line := marker + iconStyled + "  " + name + " : " + prop.Preview + kindLabel
-		rows = append(rows, padRight(line, width))
+		rows = append(rows, inspectorui.PadRight(line, width))
 	}
 
 	if len(rows) == 0 {
-		rows = append(rows, padRight(styleEmptyHint.Render(" (no properties)"), width))
+		rows = append(rows, inspectorui.PadRight(styleEmptyHint.Render(" (no properties)"), width))
 	}
 
 	vp := m.inspectViewport
@@ -285,7 +285,7 @@ func (m Model) renderInspectPane(width, height int) string {
 	body := lipgloss.NewStyle().Width(width).Height(contentHeight).Render(vp.View())
 	pane := lipgloss.JoinVertical(
 		lipgloss.Left,
-		padRight(headerLine, width),
+		inspectorui.PadRight(headerLine, width),
 		body,
 	)
 	return lipgloss.NewStyle().Width(width).MaxWidth(width).Render(pane)
@@ -300,8 +300,8 @@ func (m Model) renderGlobalsPane(width, height int) string {
 	if m.focus == FocusGlobals {
 		hStyle = stylePaneHeaderActive
 	}
-	headerLine := hStyle.Render(label) + styleSeparator.Render(strings.Repeat("─", maxInt(0, width-ansi.StringWidth(label))))
-	lines = append(lines, padRight(headerLine, width))
+	headerLine := hStyle.Render(label) + styleSeparator.Render(strings.Repeat("─", inspectorui.MaxInt(0, width-ansi.StringWidth(label))))
+	lines = append(lines, inspectorui.PadRight(headerLine, width))
 
 	contentHeight := height - 2 // header + footer
 	if contentHeight < 1 {
@@ -309,7 +309,7 @@ func (m Model) renderGlobalsPane(width, height int) string {
 	}
 
 	if len(m.globals) == 0 {
-		lines = append(lines, padRight(styleEmptyHint.Render(" (no globals)"), width))
+		lines = append(lines, inspectorui.PadRight(styleEmptyHint.Render(" (no globals)"), width))
 		for len(lines) < height-1 {
 			lines = append(lines, strings.Repeat(" ", width))
 		}
@@ -341,7 +341,7 @@ func (m Model) renderGlobalsPane(width, height int) string {
 			}
 
 			line := marker + iconStyled + "  " + name + ext
-			lines = append(lines, padRight(line, width))
+			lines = append(lines, inspectorui.PadRight(line, width))
 		}
 		for len(lines) < height-1 {
 			lines = append(lines, strings.Repeat(" ", width))
@@ -349,7 +349,7 @@ func (m Model) renderGlobalsPane(width, height int) string {
 	}
 
 	footer := fmt.Sprintf(" %d bindings", len(m.globals))
-	lines = append(lines, padRight(styleGutterNormal.Render(footer), width))
+	lines = append(lines, inspectorui.PadRight(styleGutterNormal.Render(footer), width))
 
 	return lipgloss.NewStyle().Width(width).MaxWidth(width).Render(strings.Join(lines, "\n"))
 }
@@ -366,8 +366,8 @@ func (m Model) renderMembersPane(width, height int) string {
 	if m.focus == FocusMembers {
 		hStyle = stylePaneHeaderActive
 	}
-	headerLine := hStyle.Render(label) + styleSeparator.Render(strings.Repeat("─", maxInt(0, width-ansi.StringWidth(label))))
-	lines = append(lines, padRight(headerLine, width))
+	headerLine := hStyle.Render(label) + styleSeparator.Render(strings.Repeat("─", inspectorui.MaxInt(0, width-ansi.StringWidth(label))))
+	lines = append(lines, inspectorui.PadRight(headerLine, width))
 
 	contentHeight := height - 2
 	if contentHeight < 1 {
@@ -379,7 +379,7 @@ func (m Model) renderMembersPane(width, height int) string {
 		if len(m.globals) > 0 {
 			hint = " (no members)"
 		}
-		lines = append(lines, padRight(styleEmptyHint.Render(hint), width))
+		lines = append(lines, inspectorui.PadRight(styleEmptyHint.Render(hint), width))
 		for len(lines) < height-1 {
 			lines = append(lines, strings.Repeat(" ", width))
 		}
@@ -396,7 +396,7 @@ func (m Model) renderMembersPane(width, height int) string {
 			if mem.Inherited && !lastInherited && rendered < contentHeight {
 				if rendered > 0 {
 					inhHeader := styleInheritedHeader.Render(fmt.Sprintf(" ── inherited (%s) ", mem.Source))
-					lines = append(lines, padRight(inhHeader, width))
+					lines = append(lines, inspectorui.PadRight(inhHeader, width))
 					rendered++
 					if rendered >= contentHeight {
 						break
@@ -420,7 +420,7 @@ func (m Model) renderMembersPane(width, height int) string {
 			}
 
 			line := marker + iconStyled + "  " + mem.Name + mem.Preview
-			lines = append(lines, padRight(line, width))
+			lines = append(lines, inspectorui.PadRight(line, width))
 			rendered++
 		}
 
@@ -449,7 +449,7 @@ func (m Model) renderMembersPane(width, height int) string {
 		}
 	}
 	footer := styleProtoChain.Render(" " + protoInfo)
-	lines = append(lines, padRight(footer, width))
+	lines = append(lines, inspectorui.PadRight(footer, width))
 
 	return lipgloss.NewStyle().Width(width).MaxWidth(width).Render(strings.Join(lines, "\n"))
 }
@@ -471,7 +471,7 @@ func (m Model) renderSourcePane(width, height int) string {
 	if m.focus == FocusSource {
 		hStyle = stylePaneHeaderActive
 	}
-	headerLine := hStyle.Render(label) + styleSeparator.Render(strings.Repeat("─", maxInt(0, width-ansi.StringWidth(label))))
+	headerLine := hStyle.Render(label) + styleSeparator.Render(strings.Repeat("─", inspectorui.MaxInt(0, width-ansi.StringWidth(label))))
 
 	contentHeight := height - 1
 	if contentHeight < 1 {
@@ -481,7 +481,7 @@ func (m Model) renderSourcePane(width, height int) string {
 	var rows []string
 
 	if len(srcLines) == 0 {
-		rows = append(rows, padRight(styleEmptyHint.Render(" (no source)"), width))
+		rows = append(rows, inspectorui.PadRight(styleEmptyHint.Render(" (no source)"), width))
 	} else {
 		// Select the right syntax spans
 		var syntaxSpans []jsparse.SyntaxSpan
@@ -511,7 +511,7 @@ func (m Model) renderSourcePane(width, height int) string {
 			}
 
 			line := gutter + content
-			rows = append(rows, padRight(line, width))
+			rows = append(rows, inspectorui.PadRight(line, width))
 		}
 	}
 
@@ -523,7 +523,7 @@ func (m Model) renderSourcePane(width, height int) string {
 	body := lipgloss.NewStyle().Width(width).Height(contentHeight).Render(vp.View())
 	pane := lipgloss.JoinVertical(
 		lipgloss.Left,
-		padRight(headerLine, width),
+		inspectorui.PadRight(headerLine, width),
 		body,
 	)
 	return lipgloss.NewStyle().Width(width).MaxWidth(width).Render(pane)
@@ -550,7 +550,7 @@ func (m Model) renderReplArea() string {
 	if m.focus == FocusRepl {
 		hStyle = stylePaneHeaderActive
 	}
-	separator := hStyle.Render(label) + styleSeparator.Render(strings.Repeat("─", maxInt(0, m.width-len(label))))
+	separator := hStyle.Render(label) + styleSeparator.Render(strings.Repeat("─", inspectorui.MaxInt(0, m.width-len(label))))
 
 	// Result/error line
 	var resultLine string
@@ -573,9 +573,9 @@ func (m Model) renderReplArea() string {
 	}
 
 	return lipgloss.JoinVertical(lipgloss.Left,
-		padRight(separator, m.width),
-		padRight(resultLine, m.width),
-		padRight(promptLine, m.width),
+		inspectorui.PadRight(separator, m.width),
+		inspectorui.PadRight(resultLine, m.width),
+		inspectorui.PadRight(promptLine, m.width),
 	)
 }
 
@@ -598,7 +598,7 @@ func (m Model) renderStatusBar() string {
 		parts = append(parts, m.statusMsg)
 	}
 
-	return styleStatus.Width(m.width).Render(formatStatus(parts...))
+	return styleStatus.Width(m.width).Render(inspectorui.FormatStatus(parts...))
 }
 
 func (m Model) renderHelp() string {
@@ -607,13 +607,4 @@ func (m Model) renderHelp() string {
 
 func (m Model) renderCommandLine() string {
 	return styleCommandLine.Width(m.width).Render(m.command.View())
-}
-
-// padRight pads a (possibly ANSI-styled) string to exactly the given visible width.
-func padRight(s string, width int) string {
-	w := ansi.StringWidth(s)
-	if w >= width {
-		return ansi.Truncate(s, width, "")
-	}
-	return s + strings.Repeat(" ", width-w)
 }

--- a/cmd/smalltalk-inspector/app/view.go
+++ b/cmd/smalltalk-inspector/app/view.go
@@ -126,12 +126,30 @@ func (m Model) renderInspectView(header, status, helpView, repl string, contentH
 		sourceWidth = 20
 	}
 
+	// Breadcrumb bar
+	breadcrumb := ""
+	if len(m.navStack) > 0 {
+		var crumbs []string
+		for _, frame := range m.navStack {
+			crumbs = append(crumbs, frame.Label)
+		}
+		crumbs = append(crumbs, m.inspectLabel)
+		breadcrumb = stylePaneHeaderActive.Render(" Breadcrumb: "+strings.Join(crumbs, " → ")+" ") +
+			styleSeparator.Render(strings.Repeat("─", maxInt(0, m.width-20)))
+		contentHeight-- // breadcrumb takes one line
+	}
+
 	inspectPane := m.renderInspectPane(inspectWidth, contentHeight)
 	sourcePane := m.renderSourcePane(sourceWidth, contentHeight)
 
 	content := lipgloss.JoinHorizontal(lipgloss.Top, inspectPane, sourcePane)
 
-	parts := []string{header, content, repl, status, helpView}
+	var parts []string
+	parts = append(parts, header)
+	if breadcrumb != "" {
+		parts = append(parts, padRight(breadcrumb, m.width))
+	}
+	parts = append(parts, content, repl, status, helpView)
 	if m.cmdActive {
 		parts = append(parts, m.renderCommandLine())
 	}

--- a/cmd/smalltalk-inspector/app/view.go
+++ b/cmd/smalltalk-inspector/app/view.go
@@ -1,0 +1,374 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// View implements tea.Model.
+func (m Model) View() string {
+	if m.width == 0 || m.height == 0 {
+		return "Initializing..."
+	}
+
+	if !m.loaded {
+		return m.renderEmptyView()
+	}
+
+	return m.renderLoadedView()
+}
+
+func (m Model) renderEmptyView() string {
+	header := m.renderHeader()
+	status := m.renderStatusBar()
+	helpView := m.renderHelp()
+	repl := m.renderReplArea()
+
+	// Empty body with hints
+	bodyHeight := m.height - 4 // header + status + help + repl separator
+	if m.cmdActive {
+		bodyHeight--
+	}
+	bodyHeight -= 3 // REPL
+	if bodyHeight < 1 {
+		bodyHeight = 1
+	}
+
+	var lines []string
+	lines = append(lines, "")
+	lines = append(lines, "")
+	lines = append(lines, styleEmptyHint.Render("          No program loaded."))
+	lines = append(lines, "")
+	lines = append(lines, styleEmptyHint.Render("  :load <file.js>    Load a JavaScript file"))
+	lines = append(lines, styleEmptyHint.Render("  :help              Show all commands"))
+	lines = append(lines, styleEmptyHint.Render("  :quit              Exit"))
+
+	for len(lines) < bodyHeight {
+		lines = append(lines, "")
+	}
+
+	body := strings.Join(lines[:minInt(len(lines), bodyHeight)], "\n")
+
+	parts := []string{header, body, repl, status, helpView}
+	if m.cmdActive {
+		parts = append(parts, m.renderCommandLine())
+	}
+	return lipgloss.JoinVertical(lipgloss.Left, parts...)
+}
+
+func (m Model) renderLoadedView() string {
+	header := m.renderHeader()
+	status := m.renderStatusBar()
+	helpView := m.renderHelp()
+	repl := m.renderReplArea()
+
+	contentHeight := m.contentHeight()
+
+	// Three-pane layout: globals | members | source
+	globalsWidth := m.width / 4
+	membersWidth := m.width / 4
+	sourceWidth := m.width - globalsWidth - membersWidth
+	if globalsWidth < 10 {
+		globalsWidth = 10
+	}
+	if membersWidth < 10 {
+		membersWidth = 10
+	}
+	if sourceWidth < 10 {
+		sourceWidth = 10
+	}
+
+	globalsPane := m.renderGlobalsPane(globalsWidth, contentHeight)
+	membersPane := m.renderMembersPane(membersWidth, contentHeight)
+	sourcePane := m.renderSourcePane(sourceWidth, contentHeight)
+
+	content := lipgloss.JoinHorizontal(lipgloss.Top, globalsPane, membersPane, sourcePane)
+
+	parts := []string{header, content, repl, status, helpView}
+	if m.cmdActive {
+		parts = append(parts, m.renderCommandLine())
+	}
+	return lipgloss.JoinVertical(lipgloss.Left, parts...)
+}
+
+func (m Model) renderHeader() string {
+	title := "goja-inspector"
+	if m.filename != "" {
+		title += " ─── " + m.filename
+	}
+
+	focusLabel := strings.ToUpper(m.mode)
+	gap := m.width - len(title) - len(focusLabel) - 4
+	if gap < 1 {
+		gap = 1
+	}
+
+	return styleHeader.Width(m.width).Render(
+		title + strings.Repeat(" ", gap) + "[" + focusLabel + "]",
+	)
+}
+
+func (m Model) renderGlobalsPane(width, height int) string {
+	var lines []string
+
+	// Header
+	label := " Globals "
+	hStyle := stylePaneHeaderInactive
+	if m.focus == FocusGlobals {
+		hStyle = stylePaneHeaderActive
+	}
+	headerLine := hStyle.Render(label) + styleSeparator.Render(strings.Repeat("─", maxInt(0, width-ansi.StringWidth(label))))
+	lines = append(lines, padRight(headerLine, width))
+
+	contentHeight := height - 2 // header + footer
+	if contentHeight < 1 {
+		contentHeight = 1
+	}
+
+	if len(m.globals) == 0 {
+		lines = append(lines, padRight(styleEmptyHint.Render(" (no globals)"), width))
+		for len(lines) < height-1 {
+			lines = append(lines, strings.Repeat(" ", width))
+		}
+	} else {
+		endIdx := minInt(m.globalScroll+contentHeight, len(m.globals))
+		for i := m.globalScroll; i < endIdx; i++ {
+			g := m.globals[i]
+			marker := "  "
+			if i == m.globalIdx {
+				marker = styleSelectedMarker.Render("▸ ")
+			}
+
+			icon := kindIcon(g.Kind)
+			var iconStyled string
+			//exhaustive:ignore
+			switch g.Kind {
+			case 4: // BindingClass
+				iconStyled = styleItemClass.Render(icon)
+			case 3: // BindingFunction
+				iconStyled = styleItemFunction.Render(icon)
+			default:
+				iconStyled = styleItemValue.Render(icon)
+			}
+
+			name := g.Name
+			ext := ""
+			if g.Extends != "" {
+				ext = stylePaneHeaderInactive.Render(" ← " + g.Extends)
+			}
+
+			line := marker + iconStyled + "  " + name + ext
+			lines = append(lines, padRight(line, width))
+		}
+		for len(lines) < height-1 {
+			lines = append(lines, strings.Repeat(" ", width))
+		}
+	}
+
+	footer := fmt.Sprintf(" %d bindings", len(m.globals))
+	lines = append(lines, padRight(styleGutterNormal.Render(footer), width))
+
+	return lipgloss.NewStyle().Width(width).MaxWidth(width).Render(strings.Join(lines, "\n"))
+}
+
+func (m Model) renderMembersPane(width, height int) string {
+	var lines []string
+
+	// Header
+	label := " Members "
+	if len(m.globals) > 0 && m.globalIdx < len(m.globals) {
+		label = fmt.Sprintf(" %s: Members ", m.globals[m.globalIdx].Name)
+	}
+	hStyle := stylePaneHeaderInactive
+	if m.focus == FocusMembers {
+		hStyle = stylePaneHeaderActive
+	}
+	headerLine := hStyle.Render(label) + styleSeparator.Render(strings.Repeat("─", maxInt(0, width-ansi.StringWidth(label))))
+	lines = append(lines, padRight(headerLine, width))
+
+	contentHeight := height - 2
+	if contentHeight < 1 {
+		contentHeight = 1
+	}
+
+	if len(m.members) == 0 {
+		hint := " (select a global)"
+		if len(m.globals) > 0 {
+			hint = " (no members)"
+		}
+		lines = append(lines, padRight(styleEmptyHint.Render(hint), width))
+		for len(lines) < height-1 {
+			lines = append(lines, strings.Repeat(" ", width))
+		}
+	} else {
+		// Show members with own/inherited separation
+		lastInherited := false
+		rendered := 0
+		endIdx := minInt(m.memberScroll+contentHeight, len(m.members))
+
+		for i := m.memberScroll; i < endIdx; i++ {
+			mem := m.members[i]
+
+			// Insert inherited section header
+			if mem.Inherited && !lastInherited && rendered < contentHeight {
+				if rendered > 0 {
+					inhHeader := styleInheritedHeader.Render(fmt.Sprintf(" ── inherited (%s) ", mem.Source))
+					lines = append(lines, padRight(inhHeader, width))
+					rendered++
+					if rendered >= contentHeight {
+						break
+					}
+				}
+				lastInherited = true
+			}
+
+			marker := "  "
+			if i == m.memberIdx {
+				marker = styleSelectedMarker.Render("▸ ")
+			}
+
+			icon := memberKindIcon(mem.Kind)
+			var iconStyled string
+			switch mem.Kind {
+			case "function":
+				iconStyled = styleItemFunction.Render(icon)
+			default:
+				iconStyled = styleItemValue.Render(icon)
+			}
+
+			line := marker + iconStyled + "  " + mem.Name + mem.Preview
+			lines = append(lines, padRight(line, width))
+			rendered++
+		}
+
+		for len(lines) < height-1 {
+			lines = append(lines, strings.Repeat(" ", width))
+		}
+	}
+
+	// Proto chain footer
+	protoInfo := ""
+	if len(m.globals) > 0 && m.globalIdx < len(m.globals) {
+		g := m.globals[m.globalIdx]
+		if g.Extends != "" {
+			protoInfo = fmt.Sprintf("proto: %s → Object", g.Extends)
+		}
+	}
+	footer := styleProtoChain.Render(" " + protoInfo)
+	lines = append(lines, padRight(footer, width))
+
+	return lipgloss.NewStyle().Width(width).MaxWidth(width).Render(strings.Join(lines, "\n"))
+}
+
+func (m Model) renderSourcePane(width, height int) string {
+	var lines []string
+
+	// Header
+	label := " Source "
+	if m.focus == FocusMembers && len(m.members) > 0 && m.memberIdx < len(m.members) {
+		label = fmt.Sprintf(" Source: %s ", m.members[m.memberIdx].Name)
+	}
+	hStyle := stylePaneHeaderInactive
+	if m.focus == FocusSource {
+		hStyle = stylePaneHeaderActive
+	}
+	headerLine := hStyle.Render(label) + styleSeparator.Render(strings.Repeat("─", maxInt(0, width-ansi.StringWidth(label))))
+	lines = append(lines, padRight(headerLine, width))
+
+	contentHeight := height - 1
+	if contentHeight < 1 {
+		contentHeight = 1
+	}
+
+	if len(m.sourceLines) == 0 {
+		lines = append(lines, padRight(styleEmptyHint.Render(" (no source)"), width))
+		for len(lines) < height {
+			lines = append(lines, strings.Repeat(" ", width))
+		}
+		return lipgloss.NewStyle().Width(width).MaxWidth(width).Render(strings.Join(lines, "\n"))
+	}
+
+	gutterWidth := len(fmt.Sprintf("%d", len(m.sourceLines))) + 1
+
+	endIdx := minInt(m.sourceScroll+contentHeight, len(m.sourceLines))
+	for lineIdx := m.sourceScroll; lineIdx < endIdx; lineIdx++ {
+		lineNum := fmt.Sprintf("%*d ", gutterWidth, lineIdx+1)
+		content := m.sourceLines[lineIdx]
+
+		isTarget := lineIdx == m.sourceTarget
+		gs := styleGutterNormal
+		if isTarget {
+			gs = styleGutterCursor
+		}
+		gutter := gs.Render(lineNum)
+
+		if isTarget {
+			content = styleSourceHL.Render(content)
+		}
+
+		line := gutter + content
+		lines = append(lines, padRight(line, width))
+	}
+
+	for len(lines) < height {
+		lines = append(lines, strings.Repeat(" ", width))
+	}
+
+	return lipgloss.NewStyle().Width(width).MaxWidth(width).Render(strings.Join(lines, "\n"))
+}
+
+func (m Model) renderReplArea() string {
+	sepStyle := styleSeparator
+	separator := sepStyle.Render("─── REPL " + strings.Repeat("─", maxInt(0, m.width-9)))
+
+	prompt := styleReplPrompt.Render("» ") + styleEmptyHint.Render("(press : to enter commands)")
+	result := ""
+
+	return lipgloss.JoinVertical(lipgloss.Left,
+		padRight(separator, m.width),
+		padRight(prompt, m.width),
+		padRight(result, m.width),
+	)
+}
+
+func (m Model) renderStatusBar() string {
+	var parts []string
+
+	if m.loaded {
+		if m.analysis != nil && m.analysis.ParseErr != nil {
+			parts = append(parts, styleReplError.Render("⚠ parse error"))
+		} else {
+			parts = append(parts, "✓ parse ok")
+		}
+		parts = append(parts, fmt.Sprintf("globals: %d", len(m.globals)))
+		if len(m.globals) > 0 {
+			parts = append(parts, fmt.Sprintf("selected: %s", m.globals[m.globalIdx].Name))
+		}
+	}
+
+	if m.statusMsg != "" {
+		parts = append(parts, m.statusMsg)
+	}
+
+	return styleStatus.Width(m.width).Render(formatStatus(parts...))
+}
+
+func (m Model) renderHelp() string {
+	return styleHelp.Width(m.width).Render(m.help.View(m.keyMap))
+}
+
+func (m Model) renderCommandLine() string {
+	return styleCommandLine.Width(m.width).Render(m.command.View())
+}
+
+// padRight pads a (possibly ANSI-styled) string to exactly the given visible width.
+func padRight(s string, width int) string {
+	w := ansi.StringWidth(s)
+	if w >= width {
+		return ansi.Truncate(s, width, "")
+	}
+	return s + strings.Repeat(" ", width-w)
+}

--- a/cmd/smalltalk-inspector/app/view.go
+++ b/cmd/smalltalk-inspector/app/view.go
@@ -7,6 +7,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/dop251/goja"
+	"github.com/go-go-golems/go-go-goja/internal/inspectorui"
 	"github.com/go-go-golems/go-go-goja/pkg/inspector/runtime"
 	"github.com/go-go-golems/go-go-goja/pkg/jsparse"
 )
@@ -313,8 +314,8 @@ func (m Model) renderGlobalsPane(width, height int) string {
 			lines = append(lines, strings.Repeat(" ", width))
 		}
 	} else {
-		endIdx := minInt(m.globalScroll+contentHeight, len(m.globals))
-		for i := m.globalScroll; i < endIdx; i++ {
+		start, end := inspectorui.VisibleRange(m.globalScroll, len(m.globals), contentHeight)
+		for i := start; i < end; i++ {
 			g := m.globals[i]
 			marker := "  "
 			if i == m.globalIdx {
@@ -386,9 +387,9 @@ func (m Model) renderMembersPane(width, height int) string {
 		// Show members with own/inherited separation
 		lastInherited := false
 		rendered := 0
-		endIdx := minInt(m.memberScroll+contentHeight, len(m.members))
+		start, end := inspectorui.VisibleRange(m.memberScroll, len(m.members), contentHeight)
 
-		for i := m.memberScroll; i < endIdx; i++ {
+		for i := start; i < end; i++ {
 			mem := m.members[i]
 
 			// Insert inherited section header

--- a/cmd/smalltalk-inspector/main.go
+++ b/cmd/smalltalk-inspector/main.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/go-go-golems/go-go-goja/cmd/smalltalk-inspector/app"
+)
+
+func main() {
+	var filename string
+	if len(os.Args) > 1 {
+		filename = os.Args[1]
+	}
+
+	model := app.NewModel(filename)
+
+	p := tea.NewProgram(model, tea.WithAltScreen())
+	if _, err := p.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,13 @@ go 1.25.7
 
 require (
 	dagger.io/dagger v0.19.9
-	github.com/dop251/goja v0.0.0-20250309171923-bcd7cc6bf64c
+	github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7
+	github.com/charmbracelet/bubbletea v1.3.10
+	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
+	github.com/charmbracelet/x/ansi v0.11.3
+	github.com/dop251/goja v0.0.0-20250630131328-58d95d85e994
 	github.com/dop251/goja_nodejs v0.0.0-20240728170619-29b559befffc
+	github.com/go-go-golems/bobatea v0.0.29
 	github.com/go-go-golems/glazed v0.7.13
 	github.com/mattn/go-sqlite3 v1.14.32
 	github.com/pkg/errors v0.9.1
@@ -33,12 +38,8 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.9.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
-	github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7 // indirect
-	github.com/charmbracelet/bubbletea v1.3.10 // indirect
 	github.com/charmbracelet/colorprofile v0.3.3 // indirect
 	github.com/charmbracelet/glamour v0.10.0 // indirect
-	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834 // indirect
-	github.com/charmbracelet/x/ansi v0.11.3 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.14 // indirect
 	github.com/charmbracelet/x/exp/slice v0.0.0-20250327172914-2fdc97757edf // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -78,8 +78,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
 github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/dop251/goja v0.0.0-20250309171923-bcd7cc6bf64c h1:mxWGS0YyquJ/ikZOjSrRjjFIbUqIP9ojyYQ+QZTU3Rg=
-github.com/dop251/goja v0.0.0-20250309171923-bcd7cc6bf64c/go.mod h1:MxLav0peU43GgvwVgNbLAj1s/bSGboKkhuULvq/7hx4=
+github.com/dop251/goja v0.0.0-20250630131328-58d95d85e994 h1:aQYWswi+hRL2zJqGacdCZx32XjKYV8ApXFGntw79XAM=
+github.com/dop251/goja v0.0.0-20250630131328-58d95d85e994/go.mod h1:MxLav0peU43GgvwVgNbLAj1s/bSGboKkhuULvq/7hx4=
 github.com/dop251/goja_nodejs v0.0.0-20240728170619-29b559befffc h1:MKYt39yZJi0Z9xEeRmDX2L4ocE0ETKcHKw6MVL3R+co=
 github.com/dop251/goja_nodejs v0.0.0-20240728170619-29b559befffc/go.mod h1:VULptt4Q/fNzQUJlqY/GP3qHyU7ZH46mFkBZe0ZTokU=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
@@ -88,6 +88,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
+github.com/go-go-golems/bobatea v0.0.29 h1:eWyFZ1O78bimpkUOMUZxu6qAf/FyeTz8VzRweWHYlI0=
+github.com/go-go-golems/bobatea v0.0.29/go.mod h1:c88SEAaVVa+i6OfCWRvYLAgbZ2SXHWDIS0i+nKL2Fpg=
 github.com/go-go-golems/glazed v0.7.13 h1:8qa04AbpxqNR9CqwM8YsHEvwYxFYwS7QZUxmjmF67BA=
 github.com/go-go-golems/glazed v0.7.13/go.mod h1:cXsGNGxBFjzoRjMQcJqiMQyC0GCOKeVuOWSPDmOlLEA=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/internal/inspectorui/listpane.go
+++ b/internal/inspectorui/listpane.go
@@ -1,0 +1,66 @@
+package inspectorui
+
+// EnsureSelectionVisible adjusts a list scroll offset so the selected row stays visible.
+func EnsureSelectionVisible(scroll *int, selected, totalRows, viewportHeight int) {
+	if scroll == nil {
+		return
+	}
+	if viewportHeight < 1 {
+		viewportHeight = 1
+	}
+	if totalRows <= 0 {
+		*scroll = 0
+		return
+	}
+	if selected < 0 {
+		selected = 0
+	}
+	if selected >= totalRows {
+		selected = totalRows - 1
+	}
+	if *scroll < 0 {
+		*scroll = 0
+	}
+
+	if selected < *scroll {
+		*scroll = selected
+	}
+	if selected >= *scroll+viewportHeight {
+		*scroll = selected - viewportHeight + 1
+	}
+
+	maxScroll := totalRows - viewportHeight
+	if maxScroll < 0 {
+		maxScroll = 0
+	}
+	if *scroll > maxScroll {
+		*scroll = maxScroll
+	}
+}
+
+// VisibleRange returns the half-open [start,end) window for rendering rows.
+func VisibleRange(scroll, totalRows, viewportHeight int) (int, int) {
+	if viewportHeight < 1 {
+		viewportHeight = 1
+	}
+	if totalRows <= 0 {
+		return 0, 0
+	}
+	if scroll < 0 {
+		scroll = 0
+	}
+	maxScroll := totalRows - viewportHeight
+	if maxScroll < 0 {
+		maxScroll = 0
+	}
+	if scroll > maxScroll {
+		scroll = maxScroll
+	}
+
+	start := scroll
+	end := start + viewportHeight
+	if end > totalRows {
+		end = totalRows
+	}
+	return start, end
+}

--- a/internal/inspectorui/listpane_test.go
+++ b/internal/inspectorui/listpane_test.go
@@ -1,0 +1,98 @@
+package inspectorui
+
+import "testing"
+
+func TestEnsureSelectionVisible(t *testing.T) {
+	t.Run("resets scroll for empty lists", func(t *testing.T) {
+		scroll := 7
+		EnsureSelectionVisible(&scroll, 3, 0, 5)
+		if scroll != 0 {
+			t.Fatalf("expected scroll=0, got %d", scroll)
+		}
+	})
+
+	t.Run("moves scroll up when selection is above window", func(t *testing.T) {
+		scroll := 5
+		EnsureSelectionVisible(&scroll, 2, 20, 4)
+		if scroll != 2 {
+			t.Fatalf("expected scroll=2, got %d", scroll)
+		}
+	})
+
+	t.Run("moves scroll down when selection is below window", func(t *testing.T) {
+		scroll := 2
+		EnsureSelectionVisible(&scroll, 9, 20, 4)
+		if scroll != 6 {
+			t.Fatalf("expected scroll=6, got %d", scroll)
+		}
+	})
+
+	t.Run("clamps scroll to max", func(t *testing.T) {
+		scroll := 100
+		EnsureSelectionVisible(&scroll, 99, 10, 3)
+		if scroll != 7 {
+			t.Fatalf("expected scroll=7, got %d", scroll)
+		}
+	})
+}
+
+func TestVisibleRange(t *testing.T) {
+	tests := []struct {
+		name           string
+		scroll         int
+		totalRows      int
+		viewportHeight int
+		wantStart      int
+		wantEnd        int
+	}{
+		{
+			name:           "empty",
+			scroll:         0,
+			totalRows:      0,
+			viewportHeight: 5,
+			wantStart:      0,
+			wantEnd:        0,
+		},
+		{
+			name:           "simple window",
+			scroll:         3,
+			totalRows:      20,
+			viewportHeight: 5,
+			wantStart:      3,
+			wantEnd:        8,
+		},
+		{
+			name:           "clamps negative scroll",
+			scroll:         -5,
+			totalRows:      7,
+			viewportHeight: 3,
+			wantStart:      0,
+			wantEnd:        3,
+		},
+		{
+			name:           "clamps past end",
+			scroll:         50,
+			totalRows:      7,
+			viewportHeight: 3,
+			wantStart:      4,
+			wantEnd:        7,
+		},
+		{
+			name:           "viewport taller than rows",
+			scroll:         2,
+			totalRows:      3,
+			viewportHeight: 10,
+			wantStart:      0,
+			wantEnd:        3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			start, end := VisibleRange(tt.scroll, tt.totalRows, tt.viewportHeight)
+			if start != tt.wantStart || end != tt.wantEnd {
+				t.Fatalf("got (%d,%d), want (%d,%d)", start, end, tt.wantStart, tt.wantEnd)
+			}
+		})
+	}
+}

--- a/internal/inspectorui/util.go
+++ b/internal/inspectorui/util.go
@@ -1,0 +1,40 @@
+package inspectorui
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+func MaxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func MinInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// PadRight pads a (possibly ANSI-styled) string to exactly the given visible width.
+func PadRight(s string, width int) string {
+	w := ansi.StringWidth(s)
+	if w >= width {
+		return ansi.Truncate(s, width, "")
+	}
+	return s + strings.Repeat(" ", width-w)
+}
+
+func FormatStatus(parts ...string) string {
+	var nonEmpty []string
+	for _, p := range parts {
+		if p != "" {
+			nonEmpty = append(nonEmpty, p)
+		}
+	}
+	return strings.Join(nonEmpty, " │ ")
+}

--- a/internal/inspectorui/util_test.go
+++ b/internal/inspectorui/util_test.go
@@ -1,0 +1,35 @@
+package inspectorui
+
+import "testing"
+
+func TestMaxMinInt(t *testing.T) {
+	if MaxInt(2, 5) != 5 {
+		t.Fatalf("MaxInt(2,5) should be 5")
+	}
+	if MaxInt(9, 1) != 9 {
+		t.Fatalf("MaxInt(9,1) should be 9")
+	}
+	if MinInt(2, 5) != 2 {
+		t.Fatalf("MinInt(2,5) should be 2")
+	}
+	if MinInt(9, 1) != 1 {
+		t.Fatalf("MinInt(9,1) should be 1")
+	}
+}
+
+func TestFormatStatus(t *testing.T) {
+	got := FormatStatus("a", "", "b", "", "c")
+	want := "a │ b │ c"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestPadRight(t *testing.T) {
+	if got := PadRight("abc", 5); got != "abc  " {
+		t.Fatalf("got %q, want %q", got, "abc  ")
+	}
+	if got := PadRight("abcdef", 4); got != "abcd" {
+		t.Fatalf("got %q, want %q", got, "abcd")
+	}
+}

--- a/internal/inspectorui/viewportpane.go
+++ b/internal/inspectorui/viewportpane.go
@@ -2,6 +2,32 @@ package inspectorui
 
 import "github.com/charmbracelet/bubbles/viewport"
 
+// ClampYOffset keeps viewport offset in bounds for totalRows and height.
+func ClampYOffset(vp *viewport.Model, totalRows, viewportHeight int) {
+	if vp == nil {
+		return
+	}
+	if viewportHeight < 1 {
+		viewportHeight = 1
+	}
+	vp.Height = viewportHeight
+
+	if totalRows <= 0 {
+		vp.YOffset = 0
+		return
+	}
+	if vp.YOffset < 0 {
+		vp.YOffset = 0
+	}
+	maxOffset := totalRows - vp.Height
+	if maxOffset < 0 {
+		maxOffset = 0
+	}
+	if vp.YOffset > maxOffset {
+		vp.YOffset = maxOffset
+	}
+}
+
 // EnsureRowVisible keeps the selected row within viewport bounds.
 // It only adjusts Y offset and does not alter content.
 func EnsureRowVisible(vp *viewport.Model, selected, totalRows, viewportHeight int) {
@@ -31,14 +57,5 @@ func EnsureRowVisible(vp *viewport.Model, selected, totalRows, viewportHeight in
 		vp.YOffset = selected - vp.Height + 1
 	}
 
-	if vp.YOffset < 0 {
-		vp.YOffset = 0
-	}
-	maxOffset := totalRows - vp.Height
-	if maxOffset < 0 {
-		maxOffset = 0
-	}
-	if vp.YOffset > maxOffset {
-		vp.YOffset = maxOffset
-	}
+	ClampYOffset(vp, totalRows, viewportHeight)
 }

--- a/internal/inspectorui/viewportpane.go
+++ b/internal/inspectorui/viewportpane.go
@@ -1,0 +1,44 @@
+package inspectorui
+
+import "github.com/charmbracelet/bubbles/viewport"
+
+// EnsureRowVisible keeps the selected row within viewport bounds.
+// It only adjusts Y offset and does not alter content.
+func EnsureRowVisible(vp *viewport.Model, selected, totalRows, viewportHeight int) {
+	if vp == nil {
+		return
+	}
+	if viewportHeight < 1 {
+		viewportHeight = 1
+	}
+	vp.Height = viewportHeight
+
+	if totalRows <= 0 {
+		vp.YOffset = 0
+		return
+	}
+	if selected < 0 {
+		selected = 0
+	}
+	if selected >= totalRows {
+		selected = totalRows - 1
+	}
+
+	if selected < vp.YOffset {
+		vp.YOffset = selected
+	}
+	if selected >= vp.YOffset+vp.Height {
+		vp.YOffset = selected - vp.Height + 1
+	}
+
+	if vp.YOffset < 0 {
+		vp.YOffset = 0
+	}
+	maxOffset := totalRows - vp.Height
+	if maxOffset < 0 {
+		maxOffset = 0
+	}
+	if vp.YOffset > maxOffset {
+		vp.YOffset = maxOffset
+	}
+}

--- a/pkg/doc/05-jsparse-framework-reference.md
+++ b/pkg/doc/05-jsparse-framework-reference.md
@@ -17,7 +17,7 @@ ShowPerDefault: true
 SectionType: GeneralTopic
 ---
 
-`pkg/jsparse` is the reusable analysis framework extracted from the inspector prototype. It provides parser-facing data structures and helper APIs that other tools can build on: static diagnostics, dev tooling, completion endpoints, and source-to-AST mapping workflows.
+`pkg/jsparse` is the reusable low-level analysis framework extracted from the inspector prototype. It provides parser-facing data structures and helper APIs that other tools can build on: static diagnostics, dev tooling, completion endpoints, and source-to-AST mapping workflows.
 
 ## Import Path
 
@@ -42,7 +42,21 @@ Tool-specific (`cmd/inspector/app`):
 - pane synchronization UX
 - interactive drawer controls
 
-This boundary is the key contract: new tools should depend on `pkg/jsparse`, not inspector internals.
+This boundary is the key contract: parser-centric features should depend on `pkg/jsparse`, not inspector command internals.
+
+For user-facing workflow orchestration (document lifecycle, runtime merge, tree sync wrappers), prefer `pkg/inspectorapi` on top of `pkg/jsparse`.
+
+## When to Use `pkg/jsparse` vs `pkg/inspectorapi`
+
+Use `pkg/jsparse` when you need:
+- low-level parser/index/resolution primitives
+- custom completion heuristics and CST traversal logic
+- direct control over parse and index lifecycle
+
+Use `pkg/inspectorapi` when you need:
+- adapter-facing workflows for CLI/REST/LSP surfaces
+- session/document lifecycle and typed request/response contracts
+- a stable high-level facade that already composes `pkg/jsparse` + inspector packages
 
 ## Why Two Parsers
 
@@ -274,6 +288,7 @@ if errList, ok := res.ParseErr.(parser.ErrorList); ok && len(errList) > 0 {
 
 ## See Also
 
-- `inspector-example-user-guide` (`./06-inspector-example-user-guide.md`)
-- `repl-usage` (`./04-repl-usage.md`)
-- `async-patterns` (`./03-async-patterns.md`)
+- `glaze help inspectorapi-hybrid-service-guide`
+- `glaze help inspector-example-user-guide`
+- `glaze help repl-usage`
+- `glaze help async-patterns`

--- a/pkg/doc/06-inspector-example-user-guide.md
+++ b/pkg/doc/06-inspector-example-user-guide.md
@@ -1,7 +1,7 @@
 ---
 Title: Inspector Example User Guide
 Slug: inspector-example-user-guide
-Short: How to use cmd/inspector as an example consumer of pkg/jsparse
+Short: How to use cmd/inspector as an example consumer of pkg/jsparse and when to prefer pkg/inspectorapi
 Topics:
 - inspector
 - javascript
@@ -17,6 +17,8 @@ SectionType: Tutorial
 ---
 
 `cmd/inspector` is an example application that demonstrates how to consume the public `pkg/jsparse` APIs in a real terminal UX. Treat this command as a reference implementation, not as the reusable API layer itself.
+
+For production adapters and multi-surface integrations (CLI + REST + LSP), prefer orchestrating through `pkg/inspectorapi` and keep `pkg/jsparse` for lower-level parser/index operations.
 
 ## When to Use This Guide
 
@@ -45,6 +47,7 @@ go run ./cmd/inspector ../goja/testdata/sample.js
 - `cmd/inspector/main.go`: parses input file, builds `jsparse` analysis, launches TUI model
 - `cmd/inspector/app/`: UI and interaction logic only
 - `pkg/jsparse`: parser/index/resolution/completion framework
+- `pkg/inspectorapi`: user-facing orchestration layer for adapter-ready workflows
 
 This split makes it straightforward to replace the TUI while keeping analysis behavior stable.
 
@@ -75,7 +78,7 @@ root := ts.Parse([]byte(source))
 candidates := res.CompleteAt(root, row, col)
 ```
 
-From there, choose your own output surface (CLI JSON, HTTP API, LSP, logs).
+From there, choose your own output surface (CLI JSON, HTTP API, LSP, logs). If you are building a full adapter rather than a focused parser experiment, route the workflow through `pkg/inspectorapi`.
 
 ## Validation Checklist
 
@@ -102,6 +105,7 @@ GOWORK=off go test ./... -count=1
 
 ## See Also
 
-- `jsparse-framework-reference`
-- `repl-usage`
-- `creating-modules`
+- `glaze help jsparse-framework-reference`
+- `glaze help inspectorapi-hybrid-service-guide`
+- `glaze help repl-usage`
+- `glaze help creating-modules`

--- a/pkg/doc/07-inspectorapi-hybrid-service-guide.md
+++ b/pkg/doc/07-inspectorapi-hybrid-service-guide.md
@@ -1,0 +1,230 @@
+---
+Title: Inspector API Hybrid Service Guide
+Slug: inspectorapi-hybrid-service-guide
+Short: Build inspector workflows with the new pkg/inspectorapi facade and cleanly separate UI adapters from analysis/runtime logic.
+Topics:
+- inspector
+- api
+- architecture
+- goja
+- tooling
+Commands:
+- smalltalk-inspector
+- inspector
+- repl
+IsTopLevel: true
+IsTemplate: false
+ShowPerDefault: true
+SectionType: GeneralTopic
+---
+
+`pkg/inspectorapi` is the user-facing facade for inspector workflows. It wraps reusable analysis, runtime, navigation, and tree helpers into task-oriented methods so adapters can stay thin and deterministic.
+
+## Why This Layer Exists
+
+The hybrid layer exists to stop UI models from owning business orchestration. Before `pkg/inspectorapi`, command models were directly composing `pkg/jsparse`, `pkg/inspector/analysis`, and `pkg/inspector/runtime` calls. That worked, but the same workflow logic was duplicated in adapter code and was difficult to reuse for REST or LSP endpoints.
+
+The facade solves this by centralizing use cases:
+
+- document session lifecycle (open, update, close)
+- global/member listing and declaration jumps
+- runtime global merge and REPL declaration extraction
+- source/tree sync and tree row generation
+
+This keeps adapter responsibilities focused on interaction and rendering.
+
+## Package Overview
+
+The package is intentionally small and explicit. `contracts.go` defines user-facing request/response DTOs and service errors. `service.go` implements use cases over the existing extracted packages.
+
+Import path:
+
+```go
+import "github.com/go-go-golems/go-go-goja/pkg/inspectorapi"
+```
+
+Core constructor:
+
+```go
+svc := inspectorapi.NewService()
+```
+
+The service stores document sessions in-memory and exposes methods keyed by `DocumentID`.
+
+## Core Workflow
+
+Most integrations follow a simple lifecycle: open a document, run static/rich queries, optionally merge runtime data, then close the document session. This keeps stateful context explicit and makes adapter behavior testable.
+
+### 1) Open a document
+
+```go
+resp, err := svc.OpenDocument(inspectorapi.OpenDocumentRequest{
+    Filename: "sample.js",
+    Source:   source,
+})
+if err != nil {
+    return err
+}
+
+docID := resp.DocumentID
+if len(resp.Diagnostics) > 0 {
+    // parse diagnostics are still available even if analysis exists
+}
+```
+
+### 2) List globals and members
+
+```go
+globalsResp, err := svc.ListGlobals(inspectorapi.ListGlobalsRequest{DocumentID: docID})
+if err != nil {
+    return err
+}
+
+for _, g := range globalsResp.Globals {
+    fmt.Printf("%s (%s)\n", g.Name, g.Kind.String())
+}
+
+membersResp, err := svc.ListMembers(inspectorapi.ListMembersRequest{
+    DocumentID: docID,
+    GlobalName: "Foo",
+}, nil)
+if err != nil {
+    return err
+}
+```
+
+### 3) Jump to declarations
+
+```go
+bindingDecl, err := svc.BindingDeclarationLine(inspectorapi.BindingDeclarationRequest{
+    DocumentID: docID,
+    Name:       "Foo",
+})
+if err != nil {
+    return err
+}
+if bindingDecl.Found {
+    fmt.Printf("Foo declared at line %d\n", bindingDecl.Line)
+}
+```
+
+### 4) Merge runtime globals
+
+```go
+rt := inspectorruntime.NewSession()
+_ = rt.Load(source)
+
+declared := inspectorapi.DeclaredBindingsFromSource(`const fromRepl = 1`)
+merged, err := svc.MergeRuntimeGlobals(inspectorapi.MergeRuntimeGlobalsRequest{
+    DocumentID: docID,
+    Declared:   declared,
+}, rt)
+if err != nil {
+    return err
+}
+
+_ = merged
+```
+
+### 5) Close document
+
+```go
+_ = svc.CloseDocument(inspectorapi.CloseDocumentRequest{DocumentID: docID})
+```
+
+## API Surface Reference
+
+The service API is designed around use cases rather than parser internals. Each method takes a typed request struct and returns a typed response struct.
+
+Document lifecycle:
+
+- `OpenDocument`
+- `OpenDocumentFromAnalysis`
+- `UpdateDocument`
+- `CloseDocument`
+- `Analysis`
+
+Static analysis use cases:
+
+- `ListGlobals`
+- `ListMembers`
+- `BindingDeclarationLine`
+- `MemberDeclarationLine`
+
+Runtime-aware helpers:
+
+- `DeclaredBindingsFromSource` (package-level helper)
+- `MergeRuntimeGlobals`
+
+Navigation/tree wrappers:
+
+- `BuildTreeRows`
+- `SyncSourceToTree`
+- `SyncTreeToSource`
+
+## Coordinate and State Conventions
+
+A reliable integration depends on understanding coordinate and state expectations. The facade follows existing inspector conventions and keeps them explicit in request/response contracts.
+
+- `SyncSourceToTreeRequest.CursorLine` and `CursorCol` are **0-based**.
+- `BindingDeclarationLine` and `MemberDeclarationLine` return **1-based** source lines.
+- Tree sync methods operate over current `Index.VisibleNodes()` ordering.
+- `SyncSourceToTree` may expand index ancestors (`ExpandTo`) to maintain visibility semantics.
+
+When building adapters, avoid ad hoc conversion logic in key handlers. Keep conversions in one boundary function.
+
+## Adapter Integration Pattern
+
+The preferred adapter design is: state model calls service methods, then maps DTOs to view state. The model should not re-implement analysis orchestration.
+
+Recommended split:
+
+- **Adapter model**: focus mode, key routing, view composition, and component state.
+- **Service calls**: globals/members/jumps/merge/sync operations.
+- **View rendering**: consume model state, not low-level analysis packages directly.
+
+This is the same pattern used in the current `cmd/smalltalk-inspector` cutover.
+
+## Testing Strategy
+
+`pkg/inspectorapi` has focused service tests in `pkg/inspectorapi/service_test.go`. These validate end-to-end behavior for the new facade, including runtime merge and sync wrappers.
+
+For changes to this package, run:
+
+```bash
+go test ./pkg/inspectorapi/... -count=1
+go test ./cmd/smalltalk-inspector/... -count=1
+go test ./... -count=1
+```
+
+If you change contracts, update both service tests and adapter tests in the same commit.
+
+## Troubleshooting
+
+| Problem | Cause | Solution |
+| --- | --- | --- |
+| `ErrDocumentNotFound` from service calls | Document was never opened or already closed | Store returned `DocumentID` from `OpenDocument` and close only when done |
+| `ListMembers` returns empty on value globals | Runtime session not provided for runtime-derived members | Pass `*runtime.Session` to `ListMembers` |
+| Jump methods return `Found=false` | Name is missing, unresolved, or runtime-only | Verify global/member name comes from `ListGlobals`/`ListMembers` output |
+| Source/tree sync not found | Cursor line/column out of range or no node at cursor | Clamp cursor in adapter and retry with current source state |
+| Runtime merge misses REPL symbols | Declarations not extracted from snippet or runtime value undefined | Use `inspectorapi.DeclaredBindingsFromSource` and ensure symbol exists in runtime |
+
+## Migration Notes (Clean Cutover)
+
+If you are migrating an older adapter, remove direct usage of `inspector/analysis.Session` orchestration from the UI model and replace it with service calls. Do not add temporary compatibility wrappers unless explicitly required by a ticket.
+
+Clean-cutover checklist:
+
+1. Add `inspectorapi.Service` to model state.
+2. Register/open document on file-load.
+3. Replace global/member/jump orchestration with service methods.
+4. Replace REPL declaration extraction with `inspectorapi.DeclaredBindingsFromSource`.
+5. Replace runtime merge call with `MergeRuntimeGlobals`.
+6. Update tests to construct/open document sessions via service.
+
+## See Also
+
+- `glaze help jsparse-framework-reference`
+- `glaze help inspector-example-user-guide`
+- `glaze help repl-usage`
+- `glaze help creating-modules`

--- a/pkg/inspector/analysis/globals_merge.go
+++ b/pkg/inspector/analysis/globals_merge.go
@@ -1,0 +1,64 @@
+package analysis
+
+import (
+	"sort"
+
+	"github.com/go-go-golems/go-go-goja/pkg/jsparse"
+)
+
+// SortGlobals sorts globals by kind-group then name.
+func SortGlobals(globals []GlobalBinding) {
+	sort.Slice(globals, func(i, j int) bool {
+		oi := bindingSortOrder(globals[i].Kind)
+		oj := bindingSortOrder(globals[j].Kind)
+		if oi != oj {
+			return oi < oj
+		}
+		return globals[i].Name < globals[j].Name
+	})
+}
+
+// MergeGlobals appends runtime/discovered bindings to an existing global list.
+// It keeps existing entries, de-duplicates by name, and returns a sorted list.
+func MergeGlobals(
+	existing []GlobalBinding,
+	runtimeKinds map[string]jsparse.BindingKind,
+	declared []DeclaredBinding,
+	hasRuntimeValue func(name string) bool,
+) []GlobalBinding {
+	out := make([]GlobalBinding, 0, len(existing)+len(runtimeKinds)+len(declared))
+	out = append(out, existing...)
+
+	known := make(map[string]bool, len(out))
+	for _, g := range out {
+		known[g.Name] = true
+	}
+
+	for name, kind := range runtimeKinds {
+		if known[name] {
+			continue
+		}
+		out = append(out, GlobalBinding{
+			Name: name,
+			Kind: kind,
+		})
+		known[name] = true
+	}
+
+	for _, decl := range declared {
+		if decl.Name == "" || known[decl.Name] {
+			continue
+		}
+		if hasRuntimeValue != nil && !hasRuntimeValue(decl.Name) {
+			continue
+		}
+		out = append(out, GlobalBinding{
+			Name: decl.Name,
+			Kind: decl.Kind,
+		})
+		known[decl.Name] = true
+	}
+
+	SortGlobals(out)
+	return out
+}

--- a/pkg/inspector/analysis/globals_merge_test.go
+++ b/pkg/inspector/analysis/globals_merge_test.go
@@ -1,0 +1,50 @@
+package analysis
+
+import (
+	"testing"
+
+	"github.com/go-go-golems/go-go-goja/pkg/jsparse"
+)
+
+func TestMergeGlobals(t *testing.T) {
+	existing := []GlobalBinding{
+		{Name: "A", Kind: jsparse.BindingClass},
+		{Name: "f", Kind: jsparse.BindingFunction},
+	}
+	runtimeKinds := map[string]jsparse.BindingKind{
+		"x": jsparse.BindingVar,
+		"f": jsparse.BindingFunction, // duplicate
+	}
+	declared := []DeclaredBinding{
+		{Name: "K", Kind: jsparse.BindingClass},
+		{Name: "x", Kind: jsparse.BindingLet}, // duplicate (already runtime)
+		{Name: "missing", Kind: jsparse.BindingConst},
+	}
+	hasValue := func(name string) bool {
+		return name != "missing"
+	}
+
+	got := MergeGlobals(existing, runtimeKinds, declared, hasValue)
+	if len(got) != 4 {
+		t.Fatalf("expected 4 globals, got=%d (%+v)", len(got), got)
+	}
+	seen := map[string]jsparse.BindingKind{}
+	for _, g := range got {
+		seen[g.Name] = g.Kind
+	}
+	if seen["A"] != jsparse.BindingClass {
+		t.Fatalf("missing class A")
+	}
+	if seen["f"] != jsparse.BindingFunction {
+		t.Fatalf("missing function f")
+	}
+	if seen["x"] != jsparse.BindingVar {
+		t.Fatalf("runtime kind for x should be var")
+	}
+	if seen["K"] != jsparse.BindingClass {
+		t.Fatalf("declared class K should be present")
+	}
+	if _, ok := seen["missing"]; ok {
+		t.Fatalf("missing should not be added when runtime value is absent")
+	}
+}

--- a/pkg/inspector/analysis/method_symbols.go
+++ b/pkg/inspector/analysis/method_symbols.go
@@ -1,0 +1,58 @@
+package analysis
+
+import (
+	"github.com/go-go-golems/go-go-goja/pkg/jsparse"
+)
+
+// MethodSymbol represents a local binding within a method scope.
+type MethodSymbol struct {
+	Name       string
+	Kind       jsparse.BindingKind
+	DefineLine int // 1-based line
+	UsageCount int // total usages within method scope
+}
+
+// MethodSymbols extracts local symbols for a method/function body.
+// It finds bindings defined in scopes that fall within the given source span.
+func MethodSymbols(res *jsparse.Resolution, idx *jsparse.Index, startOffset, endOffset int) []MethodSymbol {
+	if res == nil || idx == nil {
+		return nil
+	}
+
+	var symbols []MethodSymbol
+	for _, scope := range res.Scopes {
+		// Skip global scope and scopes outside the method
+		if scope.Kind == jsparse.ScopeGlobal {
+			continue
+		}
+		if scope.Start < startOffset || scope.End > endOffset {
+			continue
+		}
+
+		for _, b := range scope.Bindings {
+			// Count usages within the method span
+			usageCount := 0
+			for _, refID := range b.AllUsages() {
+				node := idx.Nodes[refID]
+				if node != nil && node.Start >= startOffset && node.End <= endOffset {
+					usageCount++
+				}
+			}
+
+			declNode := idx.Nodes[b.DeclNodeID]
+			defLine := 0
+			if declNode != nil {
+				defLine = declNode.StartLine
+			}
+
+			symbols = append(symbols, MethodSymbol{
+				Name:       b.Name,
+				Kind:       b.Kind,
+				DefineLine: defLine,
+				UsageCount: usageCount,
+			})
+		}
+	}
+
+	return symbols
+}

--- a/pkg/inspector/analysis/repl_declarations.go
+++ b/pkg/inspector/analysis/repl_declarations.go
@@ -1,0 +1,43 @@
+package analysis
+
+import (
+	"sort"
+
+	"github.com/go-go-golems/go-go-goja/pkg/jsparse"
+)
+
+// DeclaredBinding describes a binding declared by a REPL/source snippet.
+type DeclaredBinding struct {
+	Name string
+	Kind jsparse.BindingKind
+}
+
+// DeclaredBindingsFromSource parses a snippet and returns top-level declared bindings.
+// It is parser-backed (jsparse) and therefore safer than token/word heuristics.
+func DeclaredBindingsFromSource(source string) []DeclaredBinding {
+	result := jsparse.Analyze("<repl>", source, nil)
+	if result == nil || result.Resolution == nil {
+		return nil
+	}
+	root := result.Resolution.Scopes[result.Resolution.RootScopeID]
+	if root == nil || len(root.Bindings) == 0 {
+		return nil
+	}
+
+	out := make([]DeclaredBinding, 0, len(root.Bindings))
+	for name, b := range root.Bindings {
+		if name == "" || b == nil {
+			continue
+		}
+		out = append(out, DeclaredBinding{Name: name, Kind: b.Kind})
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Kind != out[j].Kind {
+			return bindingSortOrder(out[i].Kind) < bindingSortOrder(out[j].Kind)
+		}
+		return out[i].Name < out[j].Name
+	})
+
+	return out
+}

--- a/pkg/inspector/analysis/repl_declarations_test.go
+++ b/pkg/inspector/analysis/repl_declarations_test.go
@@ -1,0 +1,46 @@
+package analysis
+
+import (
+	"testing"
+
+	"github.com/go-go-golems/go-go-goja/pkg/jsparse"
+)
+
+func TestDeclaredBindingsFromSource(t *testing.T) {
+	src := `
+const c = 1;
+let l = 2;
+var v = 3;
+function f(x) { return x; }
+class K {}
+`
+	bindings := DeclaredBindingsFromSource(src)
+	got := map[string]jsparse.BindingKind{}
+	for _, b := range bindings {
+		got[b.Name] = b.Kind
+	}
+
+	tests := map[string]jsparse.BindingKind{
+		"c": jsparse.BindingConst,
+		"l": jsparse.BindingLet,
+		"v": jsparse.BindingVar,
+		"f": jsparse.BindingFunction,
+		"K": jsparse.BindingClass,
+	}
+	for name, want := range tests {
+		kind, ok := got[name]
+		if !ok {
+			t.Fatalf("missing binding %q", name)
+		}
+		if kind != want {
+			t.Fatalf("binding %q: got=%v want=%v", name, kind, want)
+		}
+	}
+}
+
+func TestDeclaredBindingsFromSourceInvalid(t *testing.T) {
+	bindings := DeclaredBindingsFromSource("const")
+	if len(bindings) != 0 {
+		t.Fatalf("expected no bindings for invalid snippet, got=%d", len(bindings))
+	}
+}

--- a/pkg/inspector/analysis/session.go
+++ b/pkg/inspector/analysis/session.go
@@ -24,12 +24,16 @@ func NewSessionFromResult(result *jsparse.AnalysisResult) *Session {
 
 // GlobalBindings returns the top-level bindings from the root scope.
 func (s *Session) GlobalBindings() map[string]*jsparse.BindingRecord {
-	if s.Result == nil || s.Result.Resolution == nil {
-		return nil
-	}
-	rootScope := s.Result.Resolution.Scopes[s.Result.Resolution.RootScopeID]
+	rootScope := s.rootScope()
 	if rootScope == nil {
 		return nil
 	}
 	return rootScope.Bindings
+}
+
+func (s *Session) rootScope() *jsparse.ScopeRecord {
+	if s == nil || s.Result == nil || s.Result.Resolution == nil {
+		return nil
+	}
+	return s.Result.Resolution.Scopes[s.Result.Resolution.RootScopeID]
 }

--- a/pkg/inspector/analysis/session.go
+++ b/pkg/inspector/analysis/session.go
@@ -1,0 +1,35 @@
+// Package analysis provides reusable helpers for working with jsparse analysis results
+// in the context of an inspector-style UI.
+package analysis
+
+import (
+	"github.com/go-go-golems/go-go-goja/pkg/jsparse"
+)
+
+// Session wraps an AnalysisResult with inspector-specific convenience methods.
+type Session struct {
+	Result *jsparse.AnalysisResult
+}
+
+// NewSession creates a new analysis session from a filename and source string.
+func NewSession(filename, source string) *Session {
+	result := jsparse.Analyze(filename, source, nil)
+	return &Session{Result: result}
+}
+
+// NewSessionFromResult wraps an existing analysis result.
+func NewSessionFromResult(result *jsparse.AnalysisResult) *Session {
+	return &Session{Result: result}
+}
+
+// GlobalBindings returns the top-level bindings from the root scope.
+func (s *Session) GlobalBindings() map[string]*jsparse.BindingRecord {
+	if s.Result == nil || s.Result.Resolution == nil {
+		return nil
+	}
+	rootScope := s.Result.Resolution.Scopes[s.Result.Resolution.RootScopeID]
+	if rootScope == nil {
+		return nil
+	}
+	return rootScope.Bindings
+}

--- a/pkg/inspector/analysis/session_test.go
+++ b/pkg/inspector/analysis/session_test.go
@@ -1,0 +1,75 @@
+package analysis
+
+import (
+	"testing"
+)
+
+const testSource = `
+class Animal {
+  constructor(name) {
+    this.name = name;
+  }
+  eat(food) {
+    return food;
+  }
+}
+
+class Dog extends Animal {
+  bark() {
+    const sound = "woof";
+    return sound;
+  }
+}
+
+function greet(name) {
+  return "Hello, " + name;
+}
+
+const version = 3;
+`
+
+func TestGlobalBindings(t *testing.T) {
+	s := NewSession("test.js", testSource)
+	if s.Result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if s.Result.ParseErr != nil {
+		t.Fatalf("unexpected parse error: %v", s.Result.ParseErr)
+	}
+
+	bindings := s.GlobalBindings()
+	if bindings == nil {
+		t.Fatal("expected non-nil bindings")
+	}
+
+	expectedNames := []string{"Animal", "Dog", "greet", "version"}
+	for _, name := range expectedNames {
+		if _, ok := bindings[name]; !ok {
+			t.Errorf("expected binding %q not found", name)
+		}
+	}
+}
+
+func TestMethodSymbols(t *testing.T) {
+	s := NewSession("test.js", testSource)
+	if s.Result == nil || s.Result.Resolution == nil || s.Result.Index == nil {
+		t.Fatal("expected analysis to succeed")
+	}
+
+	// Find the bark method scope range
+	// bark is in the Dog class, it contains "const sound"
+	symbols := MethodSymbols(s.Result.Resolution, s.Result.Index, 1, len(testSource)+1)
+
+	// Should find at least "sound" and "name" and "food" as local bindings
+	found := make(map[string]bool)
+	for _, sym := range symbols {
+		found[sym.Name] = true
+	}
+
+	if !found["sound"] {
+		t.Error("expected to find 'sound' in method symbols")
+	}
+	if !found["name"] {
+		t.Error("expected to find 'name' (parameter) in method symbols")
+	}
+}

--- a/pkg/inspector/analysis/smalltalk_session.go
+++ b/pkg/inspector/analysis/smalltalk_session.go
@@ -1,0 +1,180 @@
+package analysis
+
+import (
+	"sort"
+
+	"github.com/dop251/goja/ast"
+	inspectorcore "github.com/go-go-golems/go-go-goja/pkg/inspector/core"
+	"github.com/go-go-golems/go-go-goja/pkg/jsparse"
+)
+
+// GlobalBinding describes one top-level binding for inspector list rendering.
+type GlobalBinding struct {
+	Name    string
+	Kind    jsparse.BindingKind
+	Extends string
+}
+
+// ParseError returns the parse error for the current analysis result, if any.
+func (s *Session) ParseError() error {
+	if s == nil || s.Result == nil {
+		return nil
+	}
+	return s.Result.ParseErr
+}
+
+// Program exposes the parsed program from the session result.
+func (s *Session) Program() *ast.Program {
+	if s == nil || s.Result == nil {
+		return nil
+	}
+	return s.Result.Program
+}
+
+// Index exposes the node index from the session result.
+func (s *Session) Index() *jsparse.Index {
+	if s == nil || s.Result == nil {
+		return nil
+	}
+	return s.Result.Index
+}
+
+// Globals returns sorted top-level bindings with optional class extends info.
+func (s *Session) Globals() []GlobalBinding {
+	bindings := s.GlobalBindings()
+	if len(bindings) == 0 {
+		return nil
+	}
+
+	globals := make([]GlobalBinding, 0, len(bindings))
+	program := s.Program()
+	for name, b := range bindings {
+		g := GlobalBinding{
+			Name: name,
+			Kind: b.Kind,
+		}
+		if program != nil && b.Kind == jsparse.BindingClass {
+			g.Extends = inspectorcore.ClassExtends(program, name)
+		}
+		globals = append(globals, g)
+	}
+
+	sort.Slice(globals, func(i, j int) bool {
+		oi := bindingSortOrder(globals[i].Kind)
+		oj := bindingSortOrder(globals[j].Kind)
+		if oi != oj {
+			return oi < oj
+		}
+		return globals[i].Name < globals[j].Name
+	})
+
+	return globals
+}
+
+// ClassMembers returns own + inherited class members for className.
+func (s *Session) ClassMembers(className string) []inspectorcore.Member {
+	if className == "" {
+		return nil
+	}
+	return inspectorcore.BuildClassMembers(s.Program(), className)
+}
+
+// FunctionMembers returns function parameter members for funcName.
+func (s *Session) FunctionMembers(funcName string) []inspectorcore.Member {
+	if funcName == "" {
+		return nil
+	}
+	return inspectorcore.BuildFunctionMembers(s.Program(), funcName)
+}
+
+// BindingDeclLine returns the declaration line (1-based) for a global binding.
+func (s *Session) BindingDeclLine(name string) (int, bool) {
+	if name == "" {
+		return 0, false
+	}
+	root := s.rootScope()
+	idx := s.Index()
+	if root == nil || idx == nil {
+		return 0, false
+	}
+	b, ok := root.Bindings[name]
+	if !ok || b == nil {
+		return 0, false
+	}
+	declNode := idx.Nodes[b.DeclNodeID]
+	if declNode == nil || declNode.StartLine <= 0 {
+		return 0, false
+	}
+	return declNode.StartLine, true
+}
+
+// MemberDeclLine returns the declaration line (1-based) for memberName in className.
+// sourceClass is optional and can be used for inherited members.
+func (s *Session) MemberDeclLine(className, sourceClass, memberName string) (int, bool) {
+	if className == "" || memberName == "" {
+		return 0, false
+	}
+	program := s.Program()
+	idx := s.Index()
+	if program == nil || idx == nil {
+		return 0, false
+	}
+
+	targetClass := className
+	if sourceClass != "" {
+		targetClass = sourceClass
+	}
+
+	for _, stmt := range program.Body {
+		cd, ok := stmt.(*ast.ClassDeclaration)
+		if !ok || cd.Class == nil || cd.Class.Name == nil {
+			continue
+		}
+		if string(cd.Class.Name.Name) != targetClass {
+			continue
+		}
+
+		for _, elem := range cd.Class.Body {
+			md, ok := elem.(*ast.MethodDefinition)
+			if !ok {
+				continue
+			}
+			if methodName(md) != memberName {
+				continue
+			}
+			line, _ := idx.OffsetToLineCol(int(md.Idx0()))
+			if line <= 0 {
+				return 0, false
+			}
+			return line, true
+		}
+		break
+	}
+
+	return 0, false
+}
+
+func bindingSortOrder(k jsparse.BindingKind) int {
+	//exhaustive:ignore
+	switch k {
+	case jsparse.BindingClass:
+		return 0
+	case jsparse.BindingFunction:
+		return 1
+	default:
+		return 2
+	}
+}
+
+func methodName(md *ast.MethodDefinition) string {
+	if md == nil {
+		return "<unknown>"
+	}
+	switch k := md.Key.(type) {
+	case *ast.Identifier:
+		return string(k.Name)
+	case *ast.StringLiteral:
+		return k.Literal
+	}
+	return "<computed>"
+}

--- a/pkg/inspector/analysis/smalltalk_session_test.go
+++ b/pkg/inspector/analysis/smalltalk_session_test.go
@@ -1,0 +1,86 @@
+package analysis
+
+import "testing"
+
+func TestGlobalsSortedAndExtends(t *testing.T) {
+	s := NewSession("test.js", testSource)
+	globals := s.Globals()
+	if len(globals) != 4 {
+		t.Fatalf("expected 4 globals, got %d", len(globals))
+	}
+
+	got := []string{globals[0].Name, globals[1].Name, globals[2].Name, globals[3].Name}
+	want := []string{"Animal", "Dog", "greet", "version"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("globals[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+
+	if globals[1].Extends != "Animal" {
+		t.Fatalf("Dog extends = %q, want %q", globals[1].Extends, "Animal")
+	}
+}
+
+func TestBindingDeclLine(t *testing.T) {
+	s := NewSession("test.js", testSource)
+
+	line, ok := s.BindingDeclLine("greet")
+	if !ok || line <= 0 {
+		t.Fatalf("expected declaration line for greet, got (%d,%v)", line, ok)
+	}
+
+	if _, ok := s.BindingDeclLine("missing"); ok {
+		t.Fatal("expected missing binding lookup to fail")
+	}
+}
+
+func TestMemberDeclLine(t *testing.T) {
+	s := NewSession("test.js", testSource)
+
+	line, ok := s.MemberDeclLine("Dog", "", "bark")
+	if !ok || line <= 0 {
+		t.Fatalf("expected declaration line for Dog.bark, got (%d,%v)", line, ok)
+	}
+
+	inhLine, ok := s.MemberDeclLine("Dog", "Animal", "eat")
+	if !ok || inhLine <= 0 {
+		t.Fatalf("expected declaration line for inherited Animal.eat, got (%d,%v)", inhLine, ok)
+	}
+
+	if _, ok := s.MemberDeclLine("Dog", "", "missing"); ok {
+		t.Fatal("expected missing member lookup to fail")
+	}
+}
+
+func TestSessionMembersAccessors(t *testing.T) {
+	s := NewSession("test.js", testSource)
+
+	classMembers := s.ClassMembers("Dog")
+	if len(classMembers) == 0 {
+		t.Fatal("expected class members for Dog")
+	}
+
+	var sawBark bool
+	for _, m := range classMembers {
+		if m.Name == "bark" {
+			sawBark = true
+			break
+		}
+	}
+	if !sawBark {
+		t.Fatalf("expected bark in class members, got %+v", classMembers)
+	}
+
+	funcMembers := s.FunctionMembers("greet")
+	if len(funcMembers) != 1 || funcMembers[0].Name != "name" {
+		t.Fatalf("unexpected function members: %+v", funcMembers)
+	}
+}
+
+func TestParseErrorAccessor(t *testing.T) {
+	s := NewSession("broken.js", "function () {")
+	if s.ParseError() == nil {
+		t.Fatal("expected parse error")
+	}
+}

--- a/pkg/inspector/analysis/xref.go
+++ b/pkg/inspector/analysis/xref.go
@@ -1,0 +1,85 @@
+package analysis
+
+import (
+	"github.com/go-go-golems/go-go-goja/pkg/jsparse"
+)
+
+// XRefEntry represents a single cross-reference usage of a binding.
+type XRefEntry struct {
+	Line    int // 1-based source line
+	Col     int // 1-based source column
+	NodeID  jsparse.NodeID
+	Context string // enclosing function/class name if available
+}
+
+// CrossReferences finds all usages of a named binding in the analysis result.
+func CrossReferences(res *jsparse.Resolution, idx *jsparse.Index, bindingName string) []XRefEntry {
+	if res == nil || idx == nil {
+		return nil
+	}
+
+	// Find binding in any scope
+	var binding *jsparse.BindingRecord
+	for _, scope := range res.Scopes {
+		if b, ok := scope.Bindings[bindingName]; ok {
+			binding = b
+			break
+		}
+	}
+	if binding == nil {
+		return nil
+	}
+
+	return CrossReferencesForBinding(binding, idx)
+}
+
+// CrossReferencesForBinding returns xref entries for a specific binding record.
+func CrossReferencesForBinding(binding *jsparse.BindingRecord, idx *jsparse.Index) []XRefEntry {
+	if binding == nil || idx == nil {
+		return nil
+	}
+
+	var entries []XRefEntry
+	for _, nodeID := range binding.AllUsages() {
+		node := idx.Nodes[nodeID]
+		if node == nil {
+			continue
+		}
+
+		// Find enclosing context
+		context := findEnclosingContext(idx, nodeID)
+
+		entries = append(entries, XRefEntry{
+			Line:    node.StartLine,
+			Col:     node.StartCol,
+			NodeID:  nodeID,
+			Context: context,
+		})
+	}
+
+	return entries
+}
+
+// findEnclosingContext finds the name of the nearest enclosing function or class.
+func findEnclosingContext(idx *jsparse.Index, nodeID jsparse.NodeID) string {
+	path := idx.AncestorPath(nodeID)
+	// Walk from node toward root, find first named function/class
+	for i := len(path) - 1; i >= 0; i-- {
+		ancestor := idx.Nodes[path[i]]
+		if ancestor == nil {
+			continue
+		}
+		//exhaustive:ignore
+		switch ancestor.Kind {
+		case "FunctionDeclaration", "FunctionLiteral", "MethodDefinition":
+			if ancestor.Label != "" {
+				return ancestor.Label
+			}
+		case "ClassDeclaration", "ClassLiteral":
+			if ancestor.Label != "" {
+				return ancestor.Label
+			}
+		}
+	}
+	return "(global)"
+}

--- a/pkg/inspector/analysis/xref_test.go
+++ b/pkg/inspector/analysis/xref_test.go
@@ -1,0 +1,48 @@
+package analysis
+
+import (
+	"testing"
+)
+
+func TestCrossReferences(t *testing.T) {
+	src := `
+function greet(name) {
+  return "Hello, " + name;
+}
+
+function main() {
+  greet("world");
+  greet("test");
+}
+`
+	s := NewSession("test.js", src)
+	if s.Result == nil || s.Result.Resolution == nil {
+		t.Fatal("expected analysis to succeed")
+	}
+
+	refs := CrossReferences(s.Result.Resolution, s.Result.Index, "greet")
+	if len(refs) == 0 {
+		t.Fatal("expected cross-references for 'greet'")
+	}
+
+	// Should have at least 3 usages: declaration + 2 calls
+	if len(refs) < 3 {
+		t.Errorf("expected at least 3 xrefs for 'greet', got %d", len(refs))
+	}
+
+	// Each entry should have a valid line number
+	for _, ref := range refs {
+		if ref.Line <= 0 {
+			t.Errorf("expected positive line number, got %d", ref.Line)
+		}
+	}
+}
+
+func TestCrossReferencesNotFound(t *testing.T) {
+	src := `const x = 1;`
+	s := NewSession("test.js", src)
+	refs := CrossReferences(s.Result.Resolution, s.Result.Index, "nonexistent")
+	if len(refs) != 0 {
+		t.Errorf("expected 0 xrefs for nonexistent binding, got %d", len(refs))
+	}
+}

--- a/pkg/inspector/core/members.go
+++ b/pkg/inspector/core/members.go
@@ -8,6 +8,8 @@ import (
 	"github.com/dop251/goja/ast"
 )
 
+const maxInheritanceDepth = 128
+
 // Member describes one member entry returned by AST-based analysis.
 type Member struct {
 	Name      string
@@ -84,7 +86,7 @@ func BuildClassMembers(program *ast.Program, className string) []Member {
 	}
 
 	visited := map[string]bool{className: true}
-	addInheritedMethods(classes, superClassName(root), &members, seenNames, visited)
+	addInheritedMethods(classes, superClassName(root), &members, seenNames, visited, 0)
 
 	return members
 }
@@ -122,8 +124,9 @@ func addInheritedMethods(
 	out *[]Member,
 	seenNames map[string]bool,
 	visited map[string]bool,
+	depth int,
 ) {
-	if className == "" || visited[className] {
+	if className == "" || visited[className] || depth >= maxInheritanceDepth {
 		return
 	}
 	visited[className] = true
@@ -157,7 +160,7 @@ func addInheritedMethods(
 		seenNames[name] = true
 	}
 
-	addInheritedMethods(classes, superClassName(cd), out, seenNames, visited)
+	addInheritedMethods(classes, superClassName(cd), out, seenNames, visited, depth+1)
 }
 
 func indexClasses(program *ast.Program) map[string]*ast.ClassDeclaration {

--- a/pkg/inspector/core/members.go
+++ b/pkg/inspector/core/members.go
@@ -1,0 +1,225 @@
+// Package core provides UI-independent inspector logic that can be reused
+// by Bubble Tea, CLI, or REST frontends.
+package core
+
+import (
+	"strings"
+
+	"github.com/dop251/goja/ast"
+)
+
+// Member describes one member entry returned by AST-based analysis.
+type Member struct {
+	Name      string
+	Kind      string
+	Preview   string
+	Inherited bool
+	Source    string
+}
+
+// ClassExtends returns the direct superclass identifier name, if any.
+func ClassExtends(program *ast.Program, className string) string {
+	if program == nil {
+		return ""
+	}
+	for _, stmt := range program.Body {
+		cd, ok := stmt.(*ast.ClassDeclaration)
+		if !ok || cd.Class == nil || cd.Class.Name == nil {
+			continue
+		}
+		if string(cd.Class.Name.Name) != className {
+			continue
+		}
+		if cd.Class.SuperClass != nil {
+			if ident, ok := cd.Class.SuperClass.(*ast.Identifier); ok {
+				return string(ident.Name)
+			}
+		}
+		return ""
+	}
+	return ""
+}
+
+// BuildClassMembers returns own + inherited members for a class declaration.
+// Inherited members include methods only (constructor excluded), matching
+// existing smalltalk-inspector semantics.
+func BuildClassMembers(program *ast.Program, className string) []Member {
+	if program == nil {
+		return nil
+	}
+
+	classes := indexClasses(program)
+	root := classes[className]
+	if root == nil || root.Class == nil {
+		return nil
+	}
+
+	var members []Member
+	seenNames := map[string]bool{}
+
+	// Own members first.
+	for _, elem := range root.Class.Body {
+		switch e := elem.(type) {
+		case *ast.MethodDefinition:
+			name := methodName(e)
+			preview := "()"
+			if e.Body != nil && e.Body.ParameterList != nil {
+				params := paramNames(e.Body.ParameterList)
+				preview = "(" + strings.Join(params, ", ") + ")"
+			}
+			members = append(members, Member{
+				Name:    name,
+				Kind:    "function",
+				Preview: preview,
+			})
+			seenNames[name] = true
+		case *ast.FieldDefinition:
+			name := fieldName(e)
+			members = append(members, Member{
+				Name: name,
+				Kind: "value",
+			})
+			seenNames[name] = true
+		}
+	}
+
+	visited := map[string]bool{className: true}
+	addInheritedMethods(classes, superClassName(root), &members, seenNames, visited)
+
+	return members
+}
+
+// BuildFunctionMembers returns function parameter members for a top-level function.
+func BuildFunctionMembers(program *ast.Program, funcName string) []Member {
+	if program == nil {
+		return nil
+	}
+	for _, stmt := range program.Body {
+		fd, ok := stmt.(*ast.FunctionDeclaration)
+		if !ok || fd.Function == nil || fd.Function.Name == nil {
+			continue
+		}
+		if string(fd.Function.Name.Name) != funcName {
+			continue
+		}
+		var members []Member
+		if fd.Function.ParameterList != nil {
+			for _, p := range paramNames(fd.Function.ParameterList) {
+				members = append(members, Member{
+					Name: p,
+					Kind: "param",
+				})
+			}
+		}
+		return members
+	}
+	return nil
+}
+
+func addInheritedMethods(
+	classes map[string]*ast.ClassDeclaration,
+	className string,
+	out *[]Member,
+	seenNames map[string]bool,
+	visited map[string]bool,
+) {
+	if className == "" || visited[className] {
+		return
+	}
+	visited[className] = true
+
+	cd := classes[className]
+	if cd == nil || cd.Class == nil {
+		return
+	}
+
+	for _, elem := range cd.Class.Body {
+		md, ok := elem.(*ast.MethodDefinition)
+		if !ok {
+			continue
+		}
+		name := methodName(md)
+		if name == "constructor" || seenNames[name] {
+			continue
+		}
+		preview := "()"
+		if md.Body != nil && md.Body.ParameterList != nil {
+			params := paramNames(md.Body.ParameterList)
+			preview = "(" + strings.Join(params, ", ") + ")"
+		}
+		*out = append(*out, Member{
+			Name:      name,
+			Kind:      "function",
+			Preview:   preview,
+			Inherited: true,
+			Source:    className,
+		})
+		seenNames[name] = true
+	}
+
+	addInheritedMethods(classes, superClassName(cd), out, seenNames, visited)
+}
+
+func indexClasses(program *ast.Program) map[string]*ast.ClassDeclaration {
+	classes := map[string]*ast.ClassDeclaration{}
+	for _, stmt := range program.Body {
+		cd, ok := stmt.(*ast.ClassDeclaration)
+		if !ok || cd.Class == nil || cd.Class.Name == nil {
+			continue
+		}
+		classes[string(cd.Class.Name.Name)] = cd
+	}
+	return classes
+}
+
+func superClassName(cd *ast.ClassDeclaration) string {
+	if cd == nil || cd.Class == nil || cd.Class.SuperClass == nil {
+		return ""
+	}
+	if ident, ok := cd.Class.SuperClass.(*ast.Identifier); ok {
+		return string(ident.Name)
+	}
+	return ""
+}
+
+func methodName(md *ast.MethodDefinition) string {
+	if md == nil {
+		return "<unknown>"
+	}
+	switch k := md.Key.(type) {
+	case *ast.Identifier:
+		return string(k.Name)
+	case *ast.StringLiteral:
+		return k.Literal
+	}
+	return "<computed>"
+}
+
+func fieldName(fd *ast.FieldDefinition) string {
+	if fd == nil {
+		return "<unknown>"
+	}
+	switch k := fd.Key.(type) {
+	case *ast.Identifier:
+		return string(k.Name)
+	case *ast.StringLiteral:
+		return k.Literal
+	}
+	return "<computed>"
+}
+
+func paramNames(pl *ast.ParameterList) []string {
+	var names []string
+	if pl == nil {
+		return names
+	}
+	for _, p := range pl.List {
+		if p == nil || p.Target == nil {
+			continue
+		}
+		if ident, ok := p.Target.(*ast.Identifier); ok {
+			names = append(names, string(ident.Name))
+		}
+	}
+	return names
+}

--- a/pkg/inspector/core/members_test.go
+++ b/pkg/inspector/core/members_test.go
@@ -1,0 +1,95 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/dop251/goja/ast"
+	"github.com/go-go-golems/go-go-goja/pkg/jsparse"
+)
+
+func TestBuildClassMembersSelfCycle(t *testing.T) {
+	src := `
+class A extends A {
+  foo(x) { return x; }
+}
+`
+	program := mustProgram(t, src)
+	members := BuildClassMembers(program, "A")
+	if len(members) == 0 {
+		t.Fatal("expected members for class A")
+	}
+	fooCount := 0
+	for _, m := range members {
+		if m.Name == "foo" {
+			fooCount++
+		}
+	}
+	if fooCount != 1 {
+		t.Fatalf("expected foo exactly once, got %d", fooCount)
+	}
+}
+
+func TestBuildClassMembersIndirectCycle(t *testing.T) {
+	src := `
+class A extends B {
+  a() {}
+}
+class B extends A {
+  b() {}
+}
+`
+	program := mustProgram(t, src)
+	members := BuildClassMembers(program, "A")
+	if len(members) == 0 {
+		t.Fatal("expected members for class A")
+	}
+	var sawA, sawB bool
+	for _, m := range members {
+		if m.Name == "a" {
+			sawA = true
+		}
+		if m.Name == "b" {
+			sawB = true
+		}
+	}
+	if !sawA || !sawB {
+		t.Fatalf("expected both a and b members, got %+v", members)
+	}
+}
+
+func TestBuildFunctionMembers(t *testing.T) {
+	src := `
+function greet(name, times) {
+  return name + times;
+}
+`
+	program := mustProgram(t, src)
+	members := BuildFunctionMembers(program, "greet")
+	if len(members) != 2 {
+		t.Fatalf("expected 2 params, got %d", len(members))
+	}
+	if members[0].Name != "name" || members[1].Name != "times" {
+		t.Fatalf("unexpected params: %+v", members)
+	}
+}
+
+func TestClassExtends(t *testing.T) {
+	src := `
+class Base {}
+class Child extends Base {}
+`
+	program := mustProgram(t, src)
+	got := ClassExtends(program, "Child")
+	if got != "Base" {
+		t.Fatalf("expected Base, got %q", got)
+	}
+}
+
+func mustProgram(t *testing.T, source string) *ast.Program {
+	t.Helper()
+	a := jsparse.Analyze("test.js", source, nil)
+	if a.ParseErr != nil {
+		t.Fatalf("parse error: %v", a.ParseErr)
+	}
+	return a.Program
+}

--- a/pkg/inspector/navigation/sync.go
+++ b/pkg/inspector/navigation/sync.go
@@ -1,0 +1,98 @@
+// Package navigation provides UI-agnostic source/tree synchronization helpers.
+package navigation
+
+import "github.com/go-go-golems/go-go-goja/pkg/jsparse"
+
+// SourceSelection captures the node selected from a source cursor position.
+type SourceSelection struct {
+	NodeID         jsparse.NodeID
+	HighlightStart int
+	HighlightEnd   int
+}
+
+// TreeSelection captures source cursor/highlight for a selected tree row.
+type TreeSelection struct {
+	NodeID         jsparse.NodeID
+	HighlightStart int
+	HighlightEnd   int
+	CursorLine     int // 0-based
+	CursorCol      int // 0-based
+}
+
+// SourceOffset returns a 1-based byte offset from a 0-based (line,col) cursor.
+func SourceOffset(sourceLines []string, cursorLine, cursorCol int) int {
+	if cursorLine < 0 {
+		cursorLine = 0
+	}
+	offset := 0
+	for i := 0; i < cursorLine && i < len(sourceLines); i++ {
+		offset += len(sourceLines[i]) + 1 // include '\n'
+	}
+	if cursorLine >= 0 && cursorLine < len(sourceLines) {
+		if cursorCol < 0 {
+			cursorCol = 0
+		}
+		if cursorCol > len(sourceLines[cursorLine]) {
+			cursorCol = len(sourceLines[cursorLine])
+		}
+		offset += cursorCol
+	}
+	return offset + 1
+}
+
+// SelectionAtSourceCursor resolves source cursor -> best node + highlight span.
+func SelectionAtSourceCursor(
+	idx *jsparse.Index,
+	sourceLines []string,
+	cursorLine, cursorCol int,
+) (SourceSelection, bool) {
+	if idx == nil {
+		return SourceSelection{}, false
+	}
+	off := SourceOffset(sourceLines, cursorLine, cursorCol)
+	n := idx.NodeAtOffset(off)
+	if n == nil {
+		return SourceSelection{}, false
+	}
+	return SourceSelection{
+		NodeID:         n.ID,
+		HighlightStart: n.Start,
+		HighlightEnd:   n.End,
+	}, true
+}
+
+// FindVisibleNodeIndex returns the index of target in visibleIDs, or -1 if absent.
+func FindVisibleNodeIndex(visibleIDs []jsparse.NodeID, target jsparse.NodeID) int {
+	for i, id := range visibleIDs {
+		if id == target {
+			return i
+		}
+	}
+	return -1
+}
+
+// SelectionFromVisibleTree resolves selected visible tree row -> source cursor/highlight.
+func SelectionFromVisibleTree(
+	idx *jsparse.Index,
+	visibleIDs []jsparse.NodeID,
+	selectedIdx int,
+) (TreeSelection, bool) {
+	if idx == nil || len(visibleIDs) == 0 {
+		return TreeSelection{}, false
+	}
+	if selectedIdx < 0 || selectedIdx >= len(visibleIDs) {
+		return TreeSelection{}, false
+	}
+	id := visibleIDs[selectedIdx]
+	n := idx.Nodes[id]
+	if n == nil {
+		return TreeSelection{}, false
+	}
+	return TreeSelection{
+		NodeID:         id,
+		HighlightStart: n.Start,
+		HighlightEnd:   n.End,
+		CursorLine:     n.StartLine - 1,
+		CursorCol:      n.StartCol - 1,
+	}, true
+}

--- a/pkg/inspector/navigation/sync_test.go
+++ b/pkg/inspector/navigation/sync_test.go
@@ -1,0 +1,96 @@
+package navigation
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/go-go-golems/go-go-goja/pkg/jsparse"
+)
+
+func testIndexAndLines(t *testing.T, src string) (*jsparse.Index, []string) {
+	t.Helper()
+	res := jsparse.Analyze("test.js", src, nil)
+	if res == nil || res.Index == nil {
+		t.Fatalf("expected analysis with index")
+	}
+	return res.Index, strings.Split(src, "\n")
+}
+
+func TestSourceOffset(t *testing.T) {
+	lines := []string{"ab", "cde"}
+
+	if got := SourceOffset(lines, 0, 0); got != 1 {
+		t.Fatalf("expected offset 1, got %d", got)
+	}
+	if got := SourceOffset(lines, 0, 2); got != 3 {
+		t.Fatalf("expected offset 3, got %d", got)
+	}
+	if got := SourceOffset(lines, 1, 0); got != 4 {
+		t.Fatalf("expected offset 4, got %d", got)
+	}
+	if got := SourceOffset(lines, 1, 99); got != 7 {
+		t.Fatalf("expected clamped offset 7, got %d", got)
+	}
+	if got := SourceOffset(lines, -2, -5); got != 1 {
+		t.Fatalf("expected clamped negative offset 1, got %d", got)
+	}
+}
+
+func TestSelectionAtSourceCursor(t *testing.T) {
+	src := "const x = 1;\nconsole.log(x)\n"
+	idx, lines := testIndexAndLines(t, src)
+
+	col := strings.Index(lines[1], "x")
+	selection, ok := SelectionAtSourceCursor(idx, lines, 1, col)
+	if !ok {
+		t.Fatalf("expected selection at source cursor")
+	}
+	if selection.NodeID < 0 {
+		t.Fatalf("expected selected node id, got %d", selection.NodeID)
+	}
+	if selection.HighlightStart <= 0 || selection.HighlightEnd <= selection.HighlightStart {
+		t.Fatalf("expected valid highlight span, got [%d,%d)", selection.HighlightStart, selection.HighlightEnd)
+	}
+}
+
+func TestFindVisibleNodeIndex(t *testing.T) {
+	visible := []jsparse.NodeID{10, 20, 30}
+	if got := FindVisibleNodeIndex(visible, 20); got != 1 {
+		t.Fatalf("expected index 1, got %d", got)
+	}
+	if got := FindVisibleNodeIndex(visible, 99); got != -1 {
+		t.Fatalf("expected -1 for missing node, got %d", got)
+	}
+}
+
+func TestSelectionFromVisibleTree(t *testing.T) {
+	src := "const x = 1;\nconsole.log(x)\n"
+	idx, _ := testIndexAndLines(t, src)
+
+	visible := idx.VisibleNodes()
+	if len(visible) == 0 {
+		t.Fatalf("expected visible nodes")
+	}
+
+	selection, ok := SelectionFromVisibleTree(idx, visible, 0)
+	if !ok {
+		t.Fatalf("expected tree selection")
+	}
+	if selection.NodeID != visible[0] {
+		t.Fatalf("expected node %d, got %d", visible[0], selection.NodeID)
+	}
+
+	node := idx.Nodes[selection.NodeID]
+	if node == nil {
+		t.Fatalf("selected node is nil")
+	}
+	if selection.CursorLine != node.StartLine-1 || selection.CursorCol != node.StartCol-1 {
+		t.Fatalf(
+			"expected cursor (%d,%d), got (%d,%d)",
+			node.StartLine-1,
+			node.StartCol-1,
+			selection.CursorLine,
+			selection.CursorCol,
+		)
+	}
+}

--- a/pkg/inspector/runtime/errors.go
+++ b/pkg/inspector/runtime/errors.go
@@ -1,0 +1,69 @@
+package runtime
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/dop251/goja"
+)
+
+// StackFrame represents a single frame from a JS exception stack trace.
+type StackFrame struct {
+	FunctionName string
+	FileName     string
+	Line         int
+	Column       int
+}
+
+// ErrorInfo holds parsed information from a goja exception.
+type ErrorInfo struct {
+	Message string
+	Frames  []StackFrame
+	Raw     string
+}
+
+// ParseException extracts structured error info from a goja Exception.
+func ParseException(ex *goja.Exception) ErrorInfo {
+	raw := ex.String()
+	lines := strings.Split(raw, "\n")
+
+	info := ErrorInfo{Raw: raw}
+	if len(lines) > 0 {
+		info.Message = strings.TrimSpace(lines[0])
+	}
+
+	for _, line := range lines[1:] {
+		frame := parseStackLine(strings.TrimSpace(line))
+		if frame != nil {
+			info.Frames = append(info.Frames, *frame)
+		}
+	}
+
+	return info
+}
+
+// stackLineRe matches goja stack trace lines like:
+//
+//	at functionName (file:line:col(offset))
+//	at functionName (<eval>:line:col(offset))
+var stackLineRe = regexp.MustCompile(
+	`^at\s+(\S+)\s+\(([^:]+):(\d+):(\d+)`,
+)
+
+func parseStackLine(line string) *StackFrame {
+	m := stackLineRe.FindStringSubmatch(line)
+	if m == nil {
+		return nil
+	}
+
+	lineNum, _ := strconv.Atoi(m[3])
+	colNum, _ := strconv.Atoi(m[4])
+
+	return &StackFrame{
+		FunctionName: m[1],
+		FileName:     m[2],
+		Line:         lineNum,
+		Column:       colNum,
+	}
+}

--- a/pkg/inspector/runtime/function_map.go
+++ b/pkg/inspector/runtime/function_map.go
@@ -1,0 +1,104 @@
+package runtime
+
+import (
+	"github.com/dop251/goja"
+	"github.com/dop251/goja/ast"
+	"github.com/go-go-golems/go-go-goja/pkg/jsparse"
+)
+
+// FunctionSourceMapping maps a runtime function/method back to its AST source span.
+type FunctionSourceMapping struct {
+	Name      string
+	ClassName string // empty for standalone functions
+	StartLine int    // 1-based
+	StartCol  int    // 1-based
+	EndLine   int
+	EndCol    int
+	NodeID    jsparse.NodeID
+}
+
+// MapFunctionToSource attempts to find the source location of a runtime function
+// by matching its name against AST declarations.
+func MapFunctionToSource(val goja.Value, vm *goja.Runtime, analysis *jsparse.AnalysisResult) *FunctionSourceMapping {
+	if analysis == nil || analysis.Program == nil || analysis.Index == nil {
+		return nil
+	}
+
+	// Get function name from runtime
+	_, ok := goja.AssertFunction(val)
+	if !ok {
+		return nil
+	}
+	obj := val.ToObject(vm)
+	nameVal := obj.Get("name")
+	if nameVal == nil || goja.IsUndefined(nameVal) {
+		return nil
+	}
+	funcName := nameVal.String()
+	if funcName == "" {
+		return nil
+	}
+
+	// Search top-level function declarations
+	for _, stmt := range analysis.Program.Body {
+		if fd, ok := stmt.(*ast.FunctionDeclaration); ok {
+			if fd.Function != nil && fd.Function.Name != nil {
+				if string(fd.Function.Name.Name) == funcName {
+					offset := int(fd.Idx0())
+					sl, sc := analysis.Index.OffsetToLineCol(offset)
+					el, ec := analysis.Index.OffsetToLineCol(int(fd.Idx1()))
+					return &FunctionSourceMapping{
+						Name:      funcName,
+						StartLine: sl,
+						StartCol:  sc,
+						EndLine:   el,
+						EndCol:    ec,
+					}
+				}
+			}
+		}
+
+		// Search class methods
+		if cd, ok := stmt.(*ast.ClassDeclaration); ok {
+			if cd.Class != nil {
+				className := ""
+				if cd.Class.Name != nil {
+					className = string(cd.Class.Name.Name)
+				}
+				for _, elem := range cd.Class.Body {
+					if md, ok := elem.(*ast.MethodDefinition); ok {
+						name := methodKeyName(md)
+						if name == funcName {
+							offset := int(md.Idx0())
+							sl, sc := analysis.Index.OffsetToLineCol(offset)
+							el, ec := analysis.Index.OffsetToLineCol(int(md.Idx1()))
+							return &FunctionSourceMapping{
+								Name:      funcName,
+								ClassName: className,
+								StartLine: sl,
+								StartCol:  sc,
+								EndLine:   el,
+								EndCol:    ec,
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func methodKeyName(md *ast.MethodDefinition) string {
+	if md == nil {
+		return ""
+	}
+	switch k := md.Key.(type) {
+	case *ast.Identifier:
+		return string(k.Name)
+	case *ast.StringLiteral:
+		return k.Literal
+	}
+	return ""
+}

--- a/pkg/inspector/runtime/function_map.go
+++ b/pkg/inspector/runtime/function_map.go
@@ -1,6 +1,9 @@
 package runtime
 
 import (
+	"sort"
+	"strings"
+
 	"github.com/dop251/goja"
 	"github.com/dop251/goja/ast"
 	"github.com/go-go-golems/go-go-goja/pkg/jsparse"
@@ -39,26 +42,28 @@ func MapFunctionToSource(val goja.Value, vm *goja.Runtime, analysis *jsparse.Ana
 		return nil
 	}
 
-	// Search top-level function declarations
+	runtimeSource := normalizeFunctionSource(val.String())
+	sourceText := analysis.Index.Source()
+	candidates := make([]functionSourceCandidate, 0, 4)
+
+	// Search top-level function declarations.
 	for _, stmt := range analysis.Program.Body {
 		if fd, ok := stmt.(*ast.FunctionDeclaration); ok {
 			if fd.Function != nil && fd.Function.Name != nil {
 				if string(fd.Function.Name.Name) == funcName {
-					offset := int(fd.Idx0())
-					sl, sc := analysis.Index.OffsetToLineCol(offset)
-					el, ec := analysis.Index.OffsetToLineCol(int(fd.Idx1()))
-					return &FunctionSourceMapping{
-						Name:      funcName,
-						StartLine: sl,
-						StartCol:  sc,
-						EndLine:   el,
-						EndCol:    ec,
-					}
+					candidates = append(candidates, buildFunctionSourceCandidate(
+						analysis,
+						funcName,
+						"",
+						int(fd.Idx0()),
+						int(fd.Idx1()),
+						sourceText,
+					))
 				}
 			}
 		}
 
-		// Search class methods
+		// Search class methods.
 		if cd, ok := stmt.(*ast.ClassDeclaration); ok {
 			if cd.Class != nil {
 				className := ""
@@ -69,17 +74,14 @@ func MapFunctionToSource(val goja.Value, vm *goja.Runtime, analysis *jsparse.Ana
 					if md, ok := elem.(*ast.MethodDefinition); ok {
 						name := methodKeyName(md)
 						if name == funcName {
-							offset := int(md.Idx0())
-							sl, sc := analysis.Index.OffsetToLineCol(offset)
-							el, ec := analysis.Index.OffsetToLineCol(int(md.Idx1()))
-							return &FunctionSourceMapping{
-								Name:      funcName,
-								ClassName: className,
-								StartLine: sl,
-								StartCol:  sc,
-								EndLine:   el,
-								EndCol:    ec,
-							}
+							candidates = append(candidates, buildFunctionSourceCandidate(
+								analysis,
+								funcName,
+								className,
+								int(md.Idx0()),
+								int(md.Idx1()),
+								sourceText,
+							))
 						}
 					}
 				}
@@ -87,7 +89,35 @@ func MapFunctionToSource(val goja.Value, vm *goja.Runtime, analysis *jsparse.Ana
 		}
 	}
 
-	return nil
+	if len(candidates) == 0 {
+		return nil
+	}
+	if len(candidates) == 1 {
+		m := candidates[0].mapping
+		return &m
+	}
+
+	if runtimeSource != "" {
+		for _, c := range candidates {
+			if c.normalizedSource == runtimeSource {
+				m := c.mapping
+				return &m
+			}
+		}
+		for _, c := range candidates {
+			if strings.Contains(c.normalizedSource, runtimeSource) || strings.Contains(runtimeSource, c.normalizedSource) {
+				m := c.mapping
+				return &m
+			}
+		}
+	}
+
+	// Deterministic fallback: earliest source offset.
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].startOffset < candidates[j].startOffset
+	})
+	m := candidates[0].mapping
+	return &m
 }
 
 func methodKeyName(md *ast.MethodDefinition) string {
@@ -101,4 +131,71 @@ func methodKeyName(md *ast.MethodDefinition) string {
 		return k.Literal
 	}
 	return ""
+}
+
+type functionSourceCandidate struct {
+	mapping          FunctionSourceMapping
+	normalizedSource string
+	startOffset      int
+}
+
+func buildFunctionSourceCandidate(
+	analysis *jsparse.AnalysisResult,
+	funcName string,
+	className string,
+	startOffset int,
+	endOffset int,
+	sourceText string,
+) functionSourceCandidate {
+	startLine, startCol := analysis.Index.OffsetToLineCol(startOffset)
+	endLine, endCol := analysis.Index.OffsetToLineCol(endOffset)
+
+	nodeID := jsparse.NodeID(-1)
+	if node := analysis.Index.NodeAtOffset(startOffset); node != nil {
+		nodeID = node.ID
+	}
+
+	return functionSourceCandidate{
+		mapping: FunctionSourceMapping{
+			Name:      funcName,
+			ClassName: className,
+			StartLine: startLine,
+			StartCol:  startCol,
+			EndLine:   endLine,
+			EndCol:    endCol,
+			NodeID:    nodeID,
+		},
+		normalizedSource: normalizedSourceSnippet(sourceText, startOffset, endOffset),
+		startOffset:      startOffset,
+	}
+}
+
+func normalizedSourceSnippet(source string, startOffset, endOffset int) string {
+	if source == "" {
+		return ""
+	}
+	start := startOffset - 1 // 1-based -> 0-based
+	end := endOffset - 1
+
+	if start < 0 {
+		start = 0
+	}
+	if start > len(source) {
+		start = len(source)
+	}
+	if end < start {
+		end = start
+	}
+	if end > len(source) {
+		end = len(source)
+	}
+	return normalizeFunctionSource(source[start:end])
+}
+
+func normalizeFunctionSource(src string) string {
+	src = strings.TrimSpace(src)
+	if src == "" {
+		return ""
+	}
+	return strings.Join(strings.Fields(src), " ")
 }

--- a/pkg/inspector/runtime/function_map_test.go
+++ b/pkg/inspector/runtime/function_map_test.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"testing"
 
+	"github.com/dop251/goja"
 	"github.com/go-go-golems/go-go-goja/pkg/jsparse"
 )
 
@@ -44,5 +45,58 @@ const b = new B();
 	}
 	if mapping.ClassName != "B" {
 		t.Fatalf("expected class B mapping, got class %q (line %d)", mapping.ClassName, mapping.StartLine)
+	}
+}
+
+func TestMapFunctionToSourceTopLevelFunction(t *testing.T) {
+	source := `
+function greet(name) {
+  return "hi " + name;
+}
+class A {
+  greet(name) {
+    return "A " + name;
+  }
+}
+`
+
+	analysis := jsparse.Analyze("test.js", source, nil)
+	if analysis == nil || analysis.Program == nil || analysis.Index == nil {
+		t.Fatal("expected analysis with program and index")
+	}
+
+	s := NewSession()
+	if err := s.Load(source); err != nil {
+		t.Fatalf("runtime load failed: %v", err)
+	}
+
+	greetVal := s.VM.Get("greet")
+	if greetVal == nil {
+		t.Fatal("expected runtime value for greet")
+	}
+
+	mapping := MapFunctionToSource(greetVal, s.VM, analysis)
+	if mapping == nil {
+		t.Fatal("expected non-nil function source mapping")
+	}
+	if mapping.Name != "greet" {
+		t.Fatalf("expected mapping for greet, got %q", mapping.Name)
+	}
+	if mapping.ClassName != "" {
+		t.Fatalf("expected top-level function mapping with empty class name, got %q", mapping.ClassName)
+	}
+}
+
+func TestMapFunctionToSourceReturnsNilForNonFunction(t *testing.T) {
+	source := `const answer = 42;`
+	analysis := jsparse.Analyze("test.js", source, nil)
+	if analysis == nil || analysis.Program == nil || analysis.Index == nil {
+		t.Fatal("expected analysis with program and index")
+	}
+
+	vm := goja.New()
+	val := vm.ToValue(42)
+	if mapping := MapFunctionToSource(val, vm, analysis); mapping != nil {
+		t.Fatalf("expected nil mapping for non-function, got %+v", mapping)
 	}
 }

--- a/pkg/inspector/runtime/function_map_test.go
+++ b/pkg/inspector/runtime/function_map_test.go
@@ -1,0 +1,48 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/go-go-golems/go-go-goja/pkg/jsparse"
+)
+
+func TestMapFunctionToSourceDisambiguatesSameMethodNameAcrossClasses(t *testing.T) {
+	source := `
+class A {
+  foo() { return "A"; }
+}
+class B {
+  foo() { return "B"; }
+}
+const a = new A();
+const b = new B();
+`
+
+	analysis := jsparse.Analyze("test.js", source, nil)
+	if analysis == nil || analysis.Program == nil || analysis.Index == nil {
+		t.Fatal("expected analysis with program and index")
+	}
+
+	s := NewSession()
+	if err := s.Load(source); err != nil {
+		t.Fatalf("runtime load failed: %v", err)
+	}
+
+	bVal := s.VM.Get("b")
+	if bVal == nil {
+		t.Fatal("expected runtime value for b")
+	}
+	bObj := bVal.ToObject(s.VM)
+	fooVal := bObj.Get("foo")
+	if fooVal == nil {
+		t.Fatal("expected b.foo runtime value")
+	}
+
+	mapping := MapFunctionToSource(fooVal, s.VM, analysis)
+	if mapping == nil {
+		t.Fatal("expected non-nil function source mapping")
+	}
+	if mapping.ClassName != "B" {
+		t.Fatalf("expected class B mapping, got class %q (line %d)", mapping.ClassName, mapping.StartLine)
+	}
+}

--- a/pkg/inspector/runtime/globals.go
+++ b/pkg/inspector/runtime/globals.go
@@ -1,0 +1,55 @@
+package runtime
+
+import (
+	"github.com/dop251/goja"
+	"github.com/go-go-golems/go-go-goja/pkg/jsparse"
+)
+
+var builtinGlobals = map[string]bool{
+	"Object": true, "Array": true, "Math": true, "JSON": true,
+	"String": true, "Number": true, "Boolean": true, "RegExp": true,
+	"Date": true, "Error": true, "TypeError": true, "RangeError": true,
+	"ReferenceError": true, "SyntaxError": true, "URIError": true, "EvalError": true,
+	"Symbol": true, "Map": true, "Set": true, "WeakMap": true, "WeakSet": true,
+	"Promise": true, "Proxy": true, "Reflect": true, "ArrayBuffer": true,
+	"DataView": true, "Float32Array": true, "Float64Array": true,
+	"Int8Array": true, "Int16Array": true, "Int32Array": true,
+	"Uint8Array": true, "Uint16Array": true, "Uint32Array": true, "Uint8ClampedArray": true,
+	"parseInt": true, "parseFloat": true, "isNaN": true, "isFinite": true,
+	"undefined": true, "NaN": true, "Infinity": true, "eval": true,
+	"encodeURI": true, "encodeURIComponent": true, "decodeURI": true, "decodeURIComponent": true,
+	"escape": true, "unescape": true,
+	"console": true, "globalThis": true, "require": true,
+	"Function": true, "Iterator": true, "AggregateError": true,
+	"SharedArrayBuffer": true, "Atomics": true, "WeakRef": true, "FinalizationRegistry": true,
+}
+
+// IsBuiltinGlobal reports whether a name is a standard JavaScript/goja builtin.
+func IsBuiltinGlobal(name string) bool {
+	return builtinGlobals[name]
+}
+
+// BindingKindFromValue infers a binding kind from a runtime value.
+// Runtime-discovered values can only be inferred as function or variable here.
+func BindingKindFromValue(val goja.Value) jsparse.BindingKind {
+	if _, ok := goja.AssertFunction(val); ok {
+		return jsparse.BindingFunction
+	}
+	return jsparse.BindingVar
+}
+
+// RuntimeGlobalKinds returns non-builtin global names mapped to inferred kinds.
+func RuntimeGlobalKinds(vm *goja.Runtime) map[string]jsparse.BindingKind {
+	if vm == nil {
+		return nil
+	}
+	out := map[string]jsparse.BindingKind{}
+	global := vm.GlobalObject()
+	for _, key := range global.Keys() {
+		if IsBuiltinGlobal(key) {
+			continue
+		}
+		out[key] = BindingKindFromValue(global.Get(key))
+	}
+	return out
+}

--- a/pkg/inspector/runtime/globals_test.go
+++ b/pkg/inspector/runtime/globals_test.go
@@ -1,0 +1,30 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/dop251/goja"
+	"github.com/go-go-golems/go-go-goja/pkg/jsparse"
+)
+
+func TestRuntimeGlobalKinds(t *testing.T) {
+	vm := goja.New()
+	_, err := vm.RunString(`
+var x = 1;
+function fn() {}
+`)
+	if err != nil {
+		t.Fatalf("RunString failed: %v", err)
+	}
+
+	kinds := RuntimeGlobalKinds(vm)
+	if kinds["fn"] != jsparse.BindingFunction {
+		t.Fatalf("expected fn to be function, got=%v", kinds["fn"])
+	}
+	if kinds["x"] != jsparse.BindingVar {
+		t.Fatalf("expected x to be var, got=%v", kinds["x"])
+	}
+	if _, ok := kinds["Object"]; ok {
+		t.Fatalf("builtin Object should be filtered out")
+	}
+}

--- a/pkg/inspector/runtime/introspect.go
+++ b/pkg/inspector/runtime/introspect.go
@@ -1,0 +1,160 @@
+package runtime
+
+import (
+	"fmt"
+
+	"github.com/dop251/goja"
+)
+
+// PropertyInfo describes a single property of an object.
+type PropertyInfo struct {
+	Name     string
+	Value    goja.Value
+	Kind     string // "function", "string", "number", "boolean", "object", "undefined", "null", "symbol"
+	Preview  string // short value preview
+	IsSymbol bool   // true if this is a symbol-keyed property
+}
+
+// PrototypeLevel represents one level of the prototype chain.
+type PrototypeLevel struct {
+	Name       string // constructor name or "<anonymous>"
+	Properties []PropertyInfo
+}
+
+// InspectObject returns all own properties of an object, grouped by string and symbol keys.
+func InspectObject(obj *goja.Object, vm *goja.Runtime) []PropertyInfo {
+	if obj == nil {
+		return nil
+	}
+
+	var props []PropertyInfo
+
+	// String-keyed properties
+	for _, key := range obj.GetOwnPropertyNames() {
+		val := obj.Get(key)
+		props = append(props, PropertyInfo{
+			Name:    key,
+			Value:   val,
+			Kind:    valueKind(val, vm),
+			Preview: ValuePreview(val, vm, 30),
+		})
+	}
+
+	// Symbol-keyed properties
+	for _, sym := range obj.Symbols() {
+		val := obj.GetSymbol(sym)
+		props = append(props, PropertyInfo{
+			Name:     sym.String(),
+			Value:    val,
+			Kind:     valueKind(val, vm),
+			Preview:  ValuePreview(val, vm, 30),
+			IsSymbol: true,
+		})
+	}
+
+	return props
+}
+
+// WalkPrototypeChain returns the full prototype chain for an object.
+func WalkPrototypeChain(obj *goja.Object, vm *goja.Runtime) []PrototypeLevel {
+	if obj == nil {
+		return nil
+	}
+
+	var chain []PrototypeLevel
+	for p := obj.Prototype(); p != nil; p = p.Prototype() {
+		name := protoName(p, vm)
+		level := PrototypeLevel{
+			Name:       name,
+			Properties: InspectObject(p, vm),
+		}
+		chain = append(chain, level)
+	}
+	return chain
+}
+
+// Descriptor holds property descriptor information.
+type Descriptor struct {
+	Writable     bool
+	Enumerable   bool
+	Configurable bool
+	HasGetter    bool
+	HasSetter    bool
+}
+
+// GetDescriptor retrieves the property descriptor for a string-keyed property.
+func GetDescriptor(obj *goja.Object, vm *goja.Runtime, key string) (*Descriptor, error) {
+	script := fmt.Sprintf(
+		`(function() { var d = Object.getOwnPropertyDescriptor(this, %q); if (!d) return null; return {w: !!d.writable, e: !!d.enumerable, c: !!d.configurable, g: !!d.get, s: !!d.set}; })`,
+		key,
+	)
+	fn, err := vm.RunString(script)
+	if err != nil {
+		return nil, err
+	}
+	callable, ok := goja.AssertFunction(fn)
+	if !ok {
+		return nil, fmt.Errorf("descriptor helper is not callable")
+	}
+	result, err := callable(obj)
+	if err != nil {
+		return nil, err
+	}
+	if goja.IsNull(result) || goja.IsUndefined(result) {
+		return nil, nil
+	}
+	dObj := result.ToObject(vm)
+	return &Descriptor{
+		Writable:     dObj.Get("w").ToBoolean(),
+		Enumerable:   dObj.Get("e").ToBoolean(),
+		Configurable: dObj.Get("c").ToBoolean(),
+		HasGetter:    dObj.Get("g").ToBoolean(),
+		HasSetter:    dObj.Get("s").ToBoolean(),
+	}, nil
+}
+
+func valueKind(val goja.Value, vm *goja.Runtime) string {
+	if val == nil || goja.IsUndefined(val) {
+		return "undefined"
+	}
+	if goja.IsNull(val) {
+		return "null"
+	}
+	if _, ok := goja.AssertFunction(val); ok {
+		return "function"
+	}
+	exported := val.Export()
+	switch exported.(type) {
+	case string:
+		return "string"
+	case bool:
+		return "boolean"
+	case int64, float64:
+		return "number"
+	default:
+		if _, ok := val.(*goja.Object); ok {
+			return "object"
+		}
+		return "unknown"
+	}
+}
+
+func protoName(obj *goja.Object, vm *goja.Runtime) string {
+	ctor := obj.Get("constructor")
+	if ctor == nil || goja.IsUndefined(ctor) {
+		return "<anonymous>"
+	}
+	ctorObj, ok := ctor.(*goja.Object)
+	if !ok {
+		return "<anonymous>"
+	}
+	name := ctorObj.Get("name")
+	if name == nil || goja.IsUndefined(name) {
+		return "<anonymous>"
+	}
+	s := name.String()
+	if s == "" {
+		return "<anonymous>"
+	}
+	return s
+}

--- a/pkg/inspector/runtime/session.go
+++ b/pkg/inspector/runtime/session.go
@@ -1,0 +1,129 @@
+// Package runtime provides helpers for introspecting goja runtime values
+// in the context of the Smalltalk-style inspector.
+package runtime
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/dop251/goja"
+)
+
+// Session owns a goja.Runtime and provides load/eval/inspect helpers.
+type Session struct {
+	VM *goja.Runtime
+}
+
+// NewSession creates a new runtime session with a fresh VM.
+func NewSession() *Session {
+	return &Session{VM: goja.New()}
+}
+
+// Load executes source code in the VM.
+func (s *Session) Load(source string) error {
+	_, err := s.VM.RunString(source)
+	return err
+}
+
+// Eval evaluates an expression and returns the result value.
+func (s *Session) Eval(expr string) (goja.Value, error) {
+	return s.VM.RunString(expr)
+}
+
+// EvalResult holds the outcome of an eval operation.
+type EvalResult struct {
+	Expression string
+	Value      goja.Value
+	Error      error
+	ErrorStack string // parsed exception stack if available
+}
+
+// EvalWithCapture evaluates an expression and captures result or error details.
+func (s *Session) EvalWithCapture(expr string) EvalResult {
+	val, err := s.VM.RunString(expr)
+	result := EvalResult{
+		Expression: expr,
+		Value:      val,
+		Error:      err,
+	}
+	if err != nil {
+		if ex, ok := err.(*goja.Exception); ok {
+			result.ErrorStack = ex.String()
+		}
+	}
+	return result
+}
+
+// GlobalValue returns the value of a global variable by name.
+func (s *Session) GlobalValue(name string) goja.Value {
+	return s.VM.Get(name)
+}
+
+// ValuePreview returns a short string representation of a value.
+func ValuePreview(val goja.Value, vm *goja.Runtime, maxLen int) string {
+	if val == nil || goja.IsUndefined(val) {
+		return "undefined"
+	}
+	if goja.IsNull(val) {
+		return "null"
+	}
+
+	exportVal := val.Export()
+	switch v := exportVal.(type) {
+	case string:
+		s := fmt.Sprintf("%q", v)
+		if len(s) > maxLen {
+			return s[:maxLen-1] + "…\""
+		}
+		return s
+	case bool:
+		return fmt.Sprintf("%v", v)
+	case int64:
+		return fmt.Sprintf("%d", v)
+	case float64:
+		return fmt.Sprintf("%g", v)
+	}
+
+	// Check if it's a function
+	if _, ok := goja.AssertFunction(val); ok {
+		obj := val.ToObject(vm)
+		name := ""
+		if n := obj.Get("name"); n != nil && !goja.IsUndefined(n) {
+			name = n.String()
+		}
+		if name != "" {
+			return fmt.Sprintf("ƒ %s()", name)
+		}
+		return "ƒ ()"
+	}
+
+	// Object
+	if obj, ok := val.(*goja.Object); ok {
+		keys := obj.Keys()
+		if len(keys) == 0 {
+			return "{}"
+		}
+		preview := "{" + strings.Join(keys[:minInt(len(keys), 3)], ", ")
+		if len(keys) > 3 {
+			preview += ", …"
+		}
+		preview += "}"
+		if len(preview) > maxLen {
+			return preview[:maxLen-1] + "…"
+		}
+		return preview
+	}
+
+	s := val.String()
+	if len(s) > maxLen {
+		return s[:maxLen-1] + "…"
+	}
+	return s
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/pkg/inspector/runtime/session_test.go
+++ b/pkg/inspector/runtime/session_test.go
@@ -1,0 +1,180 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/dop251/goja"
+)
+
+func TestSessionLoadAndEval(t *testing.T) {
+	s := NewSession()
+
+	err := s.Load(`
+		class Dog {
+			constructor(name) {
+				this.name = name;
+			}
+			bark() { return "woof"; }
+		}
+	`)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	val, err := s.Eval(`new Dog("Rex").bark()`)
+	if err != nil {
+		t.Fatalf("Eval failed: %v", err)
+	}
+	if val.String() != "woof" {
+		t.Errorf("expected 'woof', got %q", val.String())
+	}
+}
+
+func TestEvalWithCapture(t *testing.T) {
+	s := NewSession()
+	_ = s.Load(`function boom() { throw new TypeError("oops"); }`)
+
+	result := s.EvalWithCapture(`boom()`)
+	if result.Error == nil {
+		t.Fatal("expected error from boom()")
+	}
+	if result.ErrorStack == "" {
+		t.Error("expected non-empty error stack")
+	}
+}
+
+func TestValuePreview(t *testing.T) {
+	s := NewSession()
+	vm := s.VM
+
+	tests := []struct {
+		expr     string
+		contains string
+	}{
+		{`"hello"`, `"hello"`},
+		{`42`, `42`},
+		{`true`, `true`},
+		{`null`, `null`},
+		{`undefined`, `undefined`},
+		{`({a:1, b:2})`, `{a, b}`},
+	}
+
+	for _, tt := range tests {
+		val, err := vm.RunString(tt.expr)
+		if err != nil {
+			t.Fatalf("RunString(%q) error: %v", tt.expr, err)
+		}
+		preview := ValuePreview(val, vm, 50)
+		if preview == "" {
+			t.Errorf("ValuePreview(%q) returned empty string", tt.expr)
+		}
+	}
+}
+
+func TestInspectObject(t *testing.T) {
+	s := NewSession()
+	vm := s.VM
+
+	_ = s.Load(`var obj = {x: 1, y: "hello", z: function() {}};`)
+	val := vm.Get("obj")
+	obj := val.ToObject(vm)
+
+	props := InspectObject(obj, vm)
+	if len(props) == 0 {
+		t.Fatal("expected properties from object")
+	}
+
+	found := make(map[string]string)
+	for _, p := range props {
+		found[p.Name] = p.Kind
+	}
+
+	if found["x"] != "number" {
+		t.Errorf("expected x to be 'number', got %q", found["x"])
+	}
+	if found["y"] != "string" {
+		t.Errorf("expected y to be 'string', got %q", found["y"])
+	}
+	if found["z"] != "function" {
+		t.Errorf("expected z to be 'function', got %q", found["z"])
+	}
+}
+
+func TestWalkPrototypeChain(t *testing.T) {
+	s := NewSession()
+	vm := s.VM
+
+	_ = s.Load(`
+		class Animal { eat() {} }
+		class Dog extends Animal { bark() {} }
+		var d = new Dog();
+	`)
+
+	val := vm.Get("d")
+	obj := val.ToObject(vm)
+
+	chain := WalkPrototypeChain(obj, vm)
+	if len(chain) < 2 {
+		t.Fatalf("expected at least 2 prototype levels, got %d", len(chain))
+	}
+
+	// First prototype should be Dog.prototype
+	if chain[0].Name != "Dog" {
+		t.Errorf("expected first proto to be Dog, got %q", chain[0].Name)
+	}
+}
+
+func TestGetDescriptor(t *testing.T) {
+	s := NewSession()
+	vm := s.VM
+
+	_ = s.Load(`var obj = {x: 42};`)
+	val := vm.Get("obj")
+	obj := val.ToObject(vm)
+
+	desc, err := GetDescriptor(obj, vm, "x")
+	if err != nil {
+		t.Fatalf("GetDescriptor failed: %v", err)
+	}
+	if desc == nil {
+		t.Fatal("expected non-nil descriptor")
+	}
+	if !desc.Writable {
+		t.Error("expected x to be writable")
+	}
+	if !desc.Enumerable {
+		t.Error("expected x to be enumerable")
+	}
+}
+
+func TestParseException(t *testing.T) {
+	s := NewSession()
+
+	_ = s.Load(`
+		function inner() { throw new TypeError("bad value"); }
+		function outer() { inner(); }
+	`)
+
+	result := s.EvalWithCapture(`outer()`)
+	if result.Error == nil {
+		t.Fatal("expected error")
+	}
+
+	ex, ok := result.Error.(*goja.Exception)
+	if !ok {
+		t.Fatalf("expected *goja.Exception, got %T", result.Error)
+	}
+
+	info := ParseException(ex)
+	if info.Message == "" {
+		t.Error("expected non-empty error message")
+	}
+	if len(info.Frames) == 0 {
+		t.Error("expected at least one stack frame")
+	}
+
+	// First frame should be "inner"
+	if len(info.Frames) > 0 && info.Frames[0].FunctionName != "inner" {
+		t.Errorf("expected first frame to be 'inner', got %q", info.Frames[0].FunctionName)
+	}
+}

--- a/pkg/inspector/tree/rows.go
+++ b/pkg/inspector/tree/rows.go
@@ -1,0 +1,81 @@
+// Package tree provides UI-agnostic tree row shaping for inspector views.
+package tree
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/go-go-golems/go-go-goja/pkg/jsparse"
+)
+
+// Row is a render-ready, UI-framework-agnostic view model for one tree node row.
+type Row struct {
+	NodeID      jsparse.NodeID
+	Title       string
+	Description string
+}
+
+// BuildRowsFromIndex builds rows for currently visible nodes in index order.
+func BuildRowsFromIndex(idx *jsparse.Index, usageHighlights []jsparse.NodeID) []Row {
+	if idx == nil {
+		return nil
+	}
+	visible := idx.VisibleNodes()
+	rows := make([]Row, 0, len(visible))
+	for _, id := range visible {
+		n := idx.Nodes[id]
+		if n == nil {
+			continue
+		}
+		rows = append(rows, BuildRow(n, usageHighlights, idx.Resolution))
+	}
+	return rows
+}
+
+// BuildRow converts a node into a display row.
+func BuildRow(node *jsparse.NodeRecord, usageHighlights []jsparse.NodeID, res *jsparse.Resolution) Row {
+	if node == nil {
+		return Row{}
+	}
+
+	indent := strings.Repeat("  ", node.Depth)
+	expandMarker := " "
+	if node.HasChildren() {
+		if node.Expanded {
+			expandMarker = "▼"
+		} else {
+			expandMarker = "▶"
+		}
+	}
+
+	scopeHint := ""
+	if res != nil && node.Kind == "Identifier" {
+		if res.IsDeclaration(node.ID) {
+			if b := res.BindingForNode(node.ID); b != nil {
+				scopeHint = fmt.Sprintf(" [%s decl]", b.Kind)
+			}
+		} else if res.IsReference(node.ID) {
+			scopeHint = " [ref]"
+		} else if res.IsUnresolved(node.ID) {
+			scopeHint = " [global]"
+		}
+	}
+
+	isUsage := false
+	for _, id := range usageHighlights {
+		if id == node.ID {
+			isUsage = true
+			break
+		}
+	}
+	usageHint := ""
+	if isUsage {
+		usageHint = " ★usage"
+	}
+
+	return Row{
+		NodeID:      node.ID,
+		Title:       indent + expandMarker + " " + node.DisplayLabel(),
+		Description: fmt.Sprintf("[%d..%d]%s%s", node.Start, node.End, scopeHint, usageHint),
+	}
+}

--- a/pkg/inspector/tree/rows_test.go
+++ b/pkg/inspector/tree/rows_test.go
@@ -1,0 +1,77 @@
+package tree
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/go-go-golems/go-go-goja/pkg/jsparse"
+)
+
+func TestBuildRowsFromIndex(t *testing.T) {
+	src := "const x = 1;\nfunction f(y){return x+y}\n"
+	res := jsparse.Analyze("test.js", src, nil)
+	if res == nil || res.Index == nil {
+		t.Fatalf("expected analysis with index")
+	}
+
+	rows := BuildRowsFromIndex(res.Index, nil)
+	if len(rows) == 0 {
+		t.Fatalf("expected non-empty rows")
+	}
+	if rows[0].Title == "" || rows[0].Description == "" {
+		t.Fatalf("expected title/description, got %+v", rows[0])
+	}
+}
+
+func TestBuildRowUsageHint(t *testing.T) {
+	src := "const x = 1;\nconsole.log(x)\n"
+	res := jsparse.Analyze("test.js", src, nil)
+	if res == nil || res.Index == nil {
+		t.Fatalf("expected analysis with index")
+	}
+
+	var target jsparse.NodeID = -1
+	for id, n := range res.Index.Nodes {
+		if n != nil && n.Kind == "Identifier" && strings.Contains(n.DisplayLabel(), "x") {
+			target = id
+			break
+		}
+	}
+	if target < 0 {
+		t.Fatalf("failed to find identifier node")
+	}
+
+	row := BuildRow(res.Index.Nodes[target], []jsparse.NodeID{target}, res.Resolution)
+	if !strings.Contains(row.Description, "★usage") {
+		t.Fatalf("expected usage hint in description: %q", row.Description)
+	}
+}
+
+func TestBuildRowScopeHints(t *testing.T) {
+	src := "const x = 1;\nconsole.log(x)\n"
+	res := jsparse.Analyze("test.js", src, nil)
+	if res == nil || res.Index == nil || res.Resolution == nil {
+		t.Fatalf("expected analysis with resolution")
+	}
+
+	foundDecl := false
+	foundRef := false
+	for _, n := range res.Index.Nodes {
+		if n == nil || n.Kind != "Identifier" || !strings.Contains(n.DisplayLabel(), "x") {
+			continue
+		}
+		row := BuildRow(n, nil, res.Resolution)
+		if strings.Contains(row.Description, "decl") {
+			foundDecl = true
+		}
+		if strings.Contains(row.Description, "[ref]") {
+			foundRef = true
+		}
+	}
+	if !foundDecl {
+		t.Fatalf("expected declaration hint for x")
+	}
+	if !foundRef {
+		t.Fatalf("expected reference hint for x")
+	}
+}

--- a/pkg/inspectorapi/contracts.go
+++ b/pkg/inspectorapi/contracts.go
@@ -1,0 +1,174 @@
+package inspectorapi
+
+import (
+	"errors"
+
+	inspectornavigation "github.com/go-go-golems/go-go-goja/pkg/inspector/navigation"
+	inspectortree "github.com/go-go-golems/go-go-goja/pkg/inspector/tree"
+	"github.com/go-go-golems/go-go-goja/pkg/jsparse"
+)
+
+// DocumentID identifies one analysis document session in the service.
+type DocumentID string
+
+var (
+	ErrDocumentNotFound = errors.New("inspectorapi: document not found")
+	ErrGlobalNotFound   = errors.New("inspectorapi: global not found")
+)
+
+// Global is the user-facing global binding DTO.
+type Global struct {
+	Name    string
+	Kind    jsparse.BindingKind
+	Extends string
+}
+
+// Member is the user-facing member DTO.
+type Member struct {
+	Name           string
+	Kind           string
+	Preview        string
+	Inherited      bool
+	Source         string
+	RuntimeDerived bool
+}
+
+// DeclaredBinding is the user-facing declaration DTO for REPL snippets.
+type DeclaredBinding struct {
+	Name string
+	Kind jsparse.BindingKind
+}
+
+// OpenDocumentRequest opens/analyzes source into a service document session.
+type OpenDocumentRequest struct {
+	Filename string
+	Source   string
+}
+
+// OpenDocumentFromAnalysisRequest registers an existing analysis result.
+type OpenDocumentFromAnalysisRequest struct {
+	Filename string
+	Source   string
+	Analysis *jsparse.AnalysisResult
+}
+
+// OpenDocumentResponse describes one opened document session.
+type OpenDocumentResponse struct {
+	DocumentID  DocumentID
+	Analysis    *jsparse.AnalysisResult
+	Diagnostics []jsparse.Diagnostic
+}
+
+// UpdateDocumentRequest reparses and refreshes an existing document session.
+type UpdateDocumentRequest struct {
+	DocumentID DocumentID
+	Source     string
+}
+
+// UpdateDocumentResponse includes the updated analysis and diagnostics.
+type UpdateDocumentResponse struct {
+	Analysis    *jsparse.AnalysisResult
+	Diagnostics []jsparse.Diagnostic
+}
+
+// CloseDocumentRequest closes and removes a document session.
+type CloseDocumentRequest struct {
+	DocumentID DocumentID
+}
+
+// ListGlobalsRequest requests globals for one document.
+type ListGlobalsRequest struct {
+	DocumentID DocumentID
+}
+
+// ListGlobalsResponse includes all global bindings for a document.
+type ListGlobalsResponse struct {
+	Globals []Global
+}
+
+// ListMembersRequest requests members for one selected global.
+type ListMembersRequest struct {
+	DocumentID DocumentID
+	GlobalName string
+}
+
+// ListMembersResponse includes all members for the selected global.
+type ListMembersResponse struct {
+	Members []Member
+}
+
+// BindingDeclarationRequest requests declaration line lookup for a global binding.
+type BindingDeclarationRequest struct {
+	DocumentID DocumentID
+	Name       string
+}
+
+// BindingDeclarationResponse returns a 1-based declaration line when found.
+type BindingDeclarationResponse struct {
+	Line  int
+	Found bool
+}
+
+// MemberDeclarationRequest requests declaration line lookup for a member.
+type MemberDeclarationRequest struct {
+	DocumentID  DocumentID
+	ClassName   string
+	SourceClass string
+	MemberName  string
+}
+
+// MemberDeclarationResponse returns a 1-based declaration line when found.
+type MemberDeclarationResponse struct {
+	Line  int
+	Found bool
+}
+
+// MergeRuntimeGlobalsRequest merges static globals with runtime and REPL declarations.
+type MergeRuntimeGlobalsRequest struct {
+	DocumentID DocumentID
+	Existing   []Global
+	Declared   []DeclaredBinding
+}
+
+// MergeRuntimeGlobalsResponse returns merged/sorted globals.
+type MergeRuntimeGlobalsResponse struct {
+	Globals []Global
+}
+
+// BuildTreeRowsRequest builds tree row DTOs for a document index.
+type BuildTreeRowsRequest struct {
+	DocumentID      DocumentID
+	UsageHighlights []jsparse.NodeID
+}
+
+// BuildTreeRowsResponse includes UI-agnostic tree rows.
+type BuildTreeRowsResponse struct {
+	Rows []inspectortree.Row
+}
+
+// SyncSourceToTreeRequest maps a source cursor to tree selection.
+// CursorLine/CursorCol are 0-based, mirroring Bubble Tea cursor conventions.
+type SyncSourceToTreeRequest struct {
+	DocumentID DocumentID
+	CursorLine int
+	CursorCol  int
+}
+
+// SyncSourceToTreeResponse includes selected node and visible-tree index.
+type SyncSourceToTreeResponse struct {
+	Selection    inspectornavigation.SourceSelection
+	VisibleIndex int
+	Found        bool
+}
+
+// SyncTreeToSourceRequest maps selected tree row index to source cursor.
+type SyncTreeToSourceRequest struct {
+	DocumentID    DocumentID
+	SelectedIndex int
+}
+
+// SyncTreeToSourceResponse includes source cursor/highlight selection.
+type SyncTreeToSourceResponse struct {
+	Selection inspectornavigation.TreeSelection
+	Found     bool
+}

--- a/pkg/inspectorapi/service.go
+++ b/pkg/inspectorapi/service.go
@@ -1,0 +1,373 @@
+package inspectorapi
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/dop251/goja"
+	inspectoranalysis "github.com/go-go-golems/go-go-goja/pkg/inspector/analysis"
+	inspectorcore "github.com/go-go-golems/go-go-goja/pkg/inspector/core"
+	inspectornavigation "github.com/go-go-golems/go-go-goja/pkg/inspector/navigation"
+	inspectorruntime "github.com/go-go-golems/go-go-goja/pkg/inspector/runtime"
+	inspectortree "github.com/go-go-golems/go-go-goja/pkg/inspector/tree"
+	"github.com/go-go-golems/go-go-goja/pkg/jsparse"
+)
+
+type documentSession struct {
+	id       DocumentID
+	filename string
+	source   string
+	lines    []string
+	analysis *jsparse.AnalysisResult
+	session  *inspectoranalysis.Session
+}
+
+// Service exposes task-oriented inspector operations over extracted analysis/runtime packages.
+type Service struct {
+	mu     sync.RWMutex
+	nextID int
+	docs   map[DocumentID]*documentSession
+}
+
+// NewService creates an empty inspector API service.
+func NewService() *Service {
+	return &Service{docs: map[DocumentID]*documentSession{}}
+}
+
+// OpenDocument parses source and creates a new document session.
+func (s *Service) OpenDocument(req OpenDocumentRequest) (OpenDocumentResponse, error) {
+	result := jsparse.Analyze(req.Filename, req.Source, nil)
+	return s.openFromAnalysis(OpenDocumentFromAnalysisRequest{
+		Filename: req.Filename,
+		Source:   req.Source,
+		Analysis: result,
+	})
+}
+
+// OpenDocumentFromAnalysis registers an existing analysis result as a new document session.
+func (s *Service) OpenDocumentFromAnalysis(req OpenDocumentFromAnalysisRequest) (OpenDocumentResponse, error) {
+	return s.openFromAnalysis(req)
+}
+
+func (s *Service) openFromAnalysis(req OpenDocumentFromAnalysisRequest) (OpenDocumentResponse, error) {
+	result := req.Analysis
+	if result == nil {
+		result = jsparse.Analyze(req.Filename, req.Source, nil)
+	}
+
+	doc := &documentSession{
+		filename: req.Filename,
+		source:   req.Source,
+		lines:    strings.Split(req.Source, "\n"),
+		analysis: result,
+		session:  inspectoranalysis.NewSessionFromResult(result),
+	}
+
+	s.mu.Lock()
+	s.nextID++
+	doc.id = DocumentID(fmt.Sprintf("doc-%d", s.nextID))
+	s.docs[doc.id] = doc
+	s.mu.Unlock()
+
+	return OpenDocumentResponse{
+		DocumentID:  doc.id,
+		Analysis:    result,
+		Diagnostics: result.Diagnostics(),
+	}, nil
+}
+
+// UpdateDocument reparses source for an existing document session.
+func (s *Service) UpdateDocument(req UpdateDocumentRequest) (UpdateDocumentResponse, error) {
+	s.mu.Lock()
+	doc, ok := s.docs[req.DocumentID]
+	if !ok {
+		s.mu.Unlock()
+		return UpdateDocumentResponse{}, ErrDocumentNotFound
+	}
+	filename := doc.filename
+	result := jsparse.Analyze(filename, req.Source, nil)
+	doc.source = req.Source
+	doc.lines = strings.Split(req.Source, "\n")
+	doc.analysis = result
+	doc.session = inspectoranalysis.NewSessionFromResult(result)
+	s.mu.Unlock()
+
+	return UpdateDocumentResponse{
+		Analysis:    result,
+		Diagnostics: result.Diagnostics(),
+	}, nil
+}
+
+// CloseDocument removes an existing document session.
+func (s *Service) CloseDocument(req CloseDocumentRequest) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.docs[req.DocumentID]; !ok {
+		return ErrDocumentNotFound
+	}
+	delete(s.docs, req.DocumentID)
+	return nil
+}
+
+// Analysis returns the analysis result for a document.
+func (s *Service) Analysis(documentID DocumentID) (*jsparse.AnalysisResult, error) {
+	doc, err := s.getDocument(documentID)
+	if err != nil {
+		return nil, err
+	}
+	return doc.analysis, nil
+}
+
+// ListGlobals returns static globals for a document.
+func (s *Service) ListGlobals(req ListGlobalsRequest) (ListGlobalsResponse, error) {
+	doc, err := s.getDocument(req.DocumentID)
+	if err != nil {
+		return ListGlobalsResponse{}, err
+	}
+	globals := doc.session.Globals()
+	return ListGlobalsResponse{Globals: mapAnalysisGlobals(globals)}, nil
+}
+
+// ListMembers returns members for the selected global. Value members are runtime-derived when runtime is provided.
+func (s *Service) ListMembers(req ListMembersRequest, rt *inspectorruntime.Session) (ListMembersResponse, error) {
+	doc, err := s.getDocument(req.DocumentID)
+	if err != nil {
+		return ListMembersResponse{}, err
+	}
+
+	globals := doc.session.Globals()
+	selected, ok := findGlobalByName(globals, req.GlobalName)
+	if !ok {
+		return ListMembersResponse{}, ErrGlobalNotFound
+	}
+
+	//exhaustive:ignore
+	switch selected.Kind {
+	case jsparse.BindingClass:
+		members := doc.session.ClassMembers(selected.Name)
+		return ListMembersResponse{Members: mapClassMembers(members)}, nil
+	case jsparse.BindingFunction:
+		members := doc.session.FunctionMembers(selected.Name)
+		return ListMembersResponse{Members: mapFunctionMembers(members)}, nil
+	default:
+		if rt == nil {
+			return ListMembersResponse{}, nil
+		}
+		return ListMembersResponse{Members: runtimeValueMembers(rt, selected.Name)}, nil
+	}
+}
+
+// BindingDeclarationLine finds the 1-based declaration line for a global binding.
+func (s *Service) BindingDeclarationLine(req BindingDeclarationRequest) (BindingDeclarationResponse, error) {
+	doc, err := s.getDocument(req.DocumentID)
+	if err != nil {
+		return BindingDeclarationResponse{}, err
+	}
+	line, ok := doc.session.BindingDeclLine(req.Name)
+	return BindingDeclarationResponse{Line: line, Found: ok}, nil
+}
+
+// MemberDeclarationLine finds the 1-based declaration line for a class member.
+func (s *Service) MemberDeclarationLine(req MemberDeclarationRequest) (MemberDeclarationResponse, error) {
+	doc, err := s.getDocument(req.DocumentID)
+	if err != nil {
+		return MemberDeclarationResponse{}, err
+	}
+	line, ok := doc.session.MemberDeclLine(req.ClassName, req.SourceClass, req.MemberName)
+	return MemberDeclarationResponse{Line: line, Found: ok}, nil
+}
+
+// DeclaredBindingsFromSource extracts top-level declarations from snippet source.
+func DeclaredBindingsFromSource(source string) []DeclaredBinding {
+	declared := inspectoranalysis.DeclaredBindingsFromSource(source)
+	out := make([]DeclaredBinding, 0, len(declared))
+	for _, d := range declared {
+		out = append(out, DeclaredBinding{Name: d.Name, Kind: d.Kind})
+	}
+	return out
+}
+
+// MergeRuntimeGlobals merges static globals with runtime globals and REPL declarations.
+func (s *Service) MergeRuntimeGlobals(req MergeRuntimeGlobalsRequest, rt *inspectorruntime.Session) (MergeRuntimeGlobalsResponse, error) {
+	doc, err := s.getDocument(req.DocumentID)
+	if err != nil {
+		return MergeRuntimeGlobalsResponse{}, err
+	}
+
+	existing := req.Existing
+	if len(existing) == 0 {
+		existing = mapAnalysisGlobals(doc.session.Globals())
+	}
+	if rt == nil {
+		return MergeRuntimeGlobalsResponse{Globals: existing}, nil
+	}
+
+	runtimeKinds := inspectorruntime.RuntimeGlobalKinds(rt.VM)
+	hasRuntimeValue := func(name string) bool {
+		val := rt.GlobalValue(name)
+		return val != nil && !goja.IsUndefined(val)
+	}
+
+	merged := inspectoranalysis.MergeGlobals(
+		toAnalysisGlobals(existing),
+		runtimeKinds,
+		toAnalysisDeclaredBindings(req.Declared),
+		hasRuntimeValue,
+	)
+	return MergeRuntimeGlobalsResponse{Globals: mapAnalysisGlobals(merged)}, nil
+}
+
+// BuildTreeRows returns current tree rows for a document index.
+func (s *Service) BuildTreeRows(req BuildTreeRowsRequest) (BuildTreeRowsResponse, error) {
+	doc, err := s.getDocument(req.DocumentID)
+	if err != nil {
+		return BuildTreeRowsResponse{}, err
+	}
+	if doc.analysis == nil || doc.analysis.Index == nil {
+		return BuildTreeRowsResponse{}, nil
+	}
+	rows := inspectortree.BuildRowsFromIndex(doc.analysis.Index, req.UsageHighlights)
+	return BuildTreeRowsResponse{Rows: rows}, nil
+}
+
+// SyncSourceToTree maps source cursor (0-based line/col) to tree selection.
+func (s *Service) SyncSourceToTree(req SyncSourceToTreeRequest) (SyncSourceToTreeResponse, error) {
+	doc, err := s.getDocument(req.DocumentID)
+	if err != nil {
+		return SyncSourceToTreeResponse{}, err
+	}
+	if doc.analysis == nil || doc.analysis.Index == nil {
+		return SyncSourceToTreeResponse{}, nil
+	}
+	selection, ok := inspectornavigation.SelectionAtSourceCursor(
+		doc.analysis.Index,
+		doc.lines,
+		req.CursorLine,
+		req.CursorCol,
+	)
+	if !ok {
+		return SyncSourceToTreeResponse{}, nil
+	}
+
+	doc.analysis.Index.ExpandTo(selection.NodeID)
+	visible := doc.analysis.Index.VisibleNodes()
+	visibleIdx := inspectornavigation.FindVisibleNodeIndex(visible, selection.NodeID)
+
+	return SyncSourceToTreeResponse{
+		Selection:    selection,
+		VisibleIndex: visibleIdx,
+		Found:        true,
+	}, nil
+}
+
+// SyncTreeToSource maps selected tree row index to source cursor/highlight.
+func (s *Service) SyncTreeToSource(req SyncTreeToSourceRequest) (SyncTreeToSourceResponse, error) {
+	doc, err := s.getDocument(req.DocumentID)
+	if err != nil {
+		return SyncTreeToSourceResponse{}, err
+	}
+	if doc.analysis == nil || doc.analysis.Index == nil {
+		return SyncTreeToSourceResponse{}, nil
+	}
+	visible := doc.analysis.Index.VisibleNodes()
+	selection, ok := inspectornavigation.SelectionFromVisibleTree(doc.analysis.Index, visible, req.SelectedIndex)
+	if !ok {
+		return SyncTreeToSourceResponse{}, nil
+	}
+	return SyncTreeToSourceResponse{Selection: selection, Found: true}, nil
+}
+
+func (s *Service) getDocument(documentID DocumentID) (*documentSession, error) {
+	s.mu.RLock()
+	doc, ok := s.docs[documentID]
+	s.mu.RUnlock()
+	if !ok {
+		return nil, ErrDocumentNotFound
+	}
+	return doc, nil
+}
+
+func mapAnalysisGlobals(globals []inspectoranalysis.GlobalBinding) []Global {
+	out := make([]Global, 0, len(globals))
+	for _, g := range globals {
+		out = append(out, Global{Name: g.Name, Kind: g.Kind, Extends: g.Extends})
+	}
+	return out
+}
+
+func toAnalysisGlobals(globals []Global) []inspectoranalysis.GlobalBinding {
+	out := make([]inspectoranalysis.GlobalBinding, 0, len(globals))
+	for _, g := range globals {
+		out = append(out, inspectoranalysis.GlobalBinding{Name: g.Name, Kind: g.Kind, Extends: g.Extends})
+	}
+	return out
+}
+
+func toAnalysisDeclaredBindings(declared []DeclaredBinding) []inspectoranalysis.DeclaredBinding {
+	out := make([]inspectoranalysis.DeclaredBinding, 0, len(declared))
+	for _, d := range declared {
+		out = append(out, inspectoranalysis.DeclaredBinding{Name: d.Name, Kind: d.Kind})
+	}
+	return out
+}
+
+func mapClassMembers(members []inspectorcore.Member) []Member {
+	out := make([]Member, 0, len(members))
+	for _, m := range members {
+		out = append(out, Member{
+			Name:      m.Name,
+			Kind:      m.Kind,
+			Preview:   m.Preview,
+			Inherited: m.Inherited,
+			Source:    m.Source,
+		})
+	}
+	return out
+}
+
+func mapFunctionMembers(members []inspectorcore.Member) []Member {
+	out := make([]Member, 0, len(members))
+	for _, m := range members {
+		out = append(out, Member{Name: m.Name, Kind: m.Kind, Preview: m.Preview})
+	}
+	return out
+}
+
+func findGlobalByName(globals []inspectoranalysis.GlobalBinding, name string) (inspectoranalysis.GlobalBinding, bool) {
+	for _, g := range globals {
+		if g.Name == name {
+			return g, true
+		}
+	}
+	return inspectoranalysis.GlobalBinding{}, false
+}
+
+func runtimeValueMembers(rt *inspectorruntime.Session, name string) []Member {
+	val := rt.GlobalValue(name)
+	if val == nil || goja.IsUndefined(val) {
+		return []Member{{Name: "(value)", Kind: "value", Preview: " : undefined", RuntimeDerived: true}}
+	}
+	if goja.IsNull(val) {
+		return []Member{{Name: "(value)", Kind: "value", Preview: " : null", RuntimeDerived: true}}
+	}
+	if obj, ok := val.(*goja.Object); ok {
+		props := inspectorruntime.InspectObject(obj, rt.VM)
+		out := make([]Member, 0, len(props))
+		for _, p := range props {
+			out = append(out, Member{
+				Name:           p.Name,
+				Kind:           p.Kind,
+				Preview:        " : " + p.Preview,
+				RuntimeDerived: true,
+			})
+		}
+		return out
+	}
+	return []Member{{
+		Name:           "(value)",
+		Kind:           "value",
+		Preview:        " : " + inspectorruntime.ValuePreview(val, rt.VM, 40),
+		RuntimeDerived: true,
+	}}
+}

--- a/pkg/inspectorapi/service_test.go
+++ b/pkg/inspectorapi/service_test.go
@@ -1,0 +1,189 @@
+package inspectorapi
+
+import (
+	"testing"
+
+	inspectorruntime "github.com/go-go-golems/go-go-goja/pkg/inspector/runtime"
+)
+
+func openDoc(t *testing.T, svc *Service, src string) DocumentID {
+	t.Helper()
+	resp, err := svc.OpenDocument(OpenDocumentRequest{Filename: "test.js", Source: src})
+	if err != nil {
+		t.Fatalf("open document: %v", err)
+	}
+	if resp.DocumentID == "" {
+		t.Fatalf("expected document id")
+	}
+	return resp.DocumentID
+}
+
+func TestListGlobalsAndMembers(t *testing.T) {
+	svc := NewService()
+	src := `
+class Foo {
+  bar(x) { return x }
+}
+function greet(name) { return name }
+const cfg = { answer: 42 }
+`
+	docID := openDoc(t, svc, src)
+
+	globals, err := svc.ListGlobals(ListGlobalsRequest{DocumentID: docID})
+	if err != nil {
+		t.Fatalf("list globals: %v", err)
+	}
+	if len(globals.Globals) < 3 {
+		t.Fatalf("expected globals, got %d", len(globals.Globals))
+	}
+
+	classMembers, err := svc.ListMembers(ListMembersRequest{DocumentID: docID, GlobalName: "Foo"}, nil)
+	if err != nil {
+		t.Fatalf("list class members: %v", err)
+	}
+	if len(classMembers.Members) == 0 {
+		t.Fatalf("expected class members")
+	}
+
+	fnMembers, err := svc.ListMembers(ListMembersRequest{DocumentID: docID, GlobalName: "greet"}, nil)
+	if err != nil {
+		t.Fatalf("list function members: %v", err)
+	}
+	if len(fnMembers.Members) == 0 {
+		t.Fatalf("expected function members")
+	}
+}
+
+func TestDeclarationLookups(t *testing.T) {
+	svc := NewService()
+	src := `
+class Foo {
+  bar(x) { return x }
+}
+`
+	docID := openDoc(t, svc, src)
+
+	binding, err := svc.BindingDeclarationLine(BindingDeclarationRequest{
+		DocumentID: docID,
+		Name:       "Foo",
+	})
+	if err != nil {
+		t.Fatalf("binding declaration line: %v", err)
+	}
+	if !binding.Found || binding.Line <= 0 {
+		t.Fatalf("expected binding declaration line, got %+v", binding)
+	}
+
+	member, err := svc.MemberDeclarationLine(MemberDeclarationRequest{
+		DocumentID: docID,
+		ClassName:  "Foo",
+		MemberName: "bar",
+	})
+	if err != nil {
+		t.Fatalf("member declaration line: %v", err)
+	}
+	if !member.Found || member.Line <= 0 {
+		t.Fatalf("expected member declaration line, got %+v", member)
+	}
+}
+
+func TestRuntimeMergeAndValueMembers(t *testing.T) {
+	svc := NewService()
+	src := `
+const cfg = { answer: 42 }
+`
+	docID := openDoc(t, svc, src)
+
+	rt := inspectorruntime.NewSession()
+	if err := rt.Load(src); err != nil {
+		t.Fatalf("runtime load: %v", err)
+	}
+	if err := rt.Load(`const replAdded = 1`); err != nil {
+		t.Fatalf("runtime load repl: %v", err)
+	}
+
+	members, err := svc.ListMembers(ListMembersRequest{DocumentID: docID, GlobalName: "cfg"}, rt)
+	if err != nil {
+		t.Fatalf("list runtime value members: %v", err)
+	}
+	if len(members.Members) == 0 {
+		t.Fatalf("expected runtime value members")
+	}
+
+	declared := DeclaredBindingsFromSource(`const replAdded = 1`)
+	merged, err := svc.MergeRuntimeGlobals(MergeRuntimeGlobalsRequest{
+		DocumentID: docID,
+		Declared:   declared,
+	}, rt)
+	if err != nil {
+		t.Fatalf("merge runtime globals: %v", err)
+	}
+
+	found := false
+	for _, g := range merged.Globals {
+		if g.Name == "replAdded" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected merged globals to include replAdded")
+	}
+}
+
+func TestTreeAndSyncFacade(t *testing.T) {
+	svc := NewService()
+	src := `
+const greeting = "hello"
+console.log(greeting)
+`
+	docID := openDoc(t, svc, src)
+
+	rows, err := svc.BuildTreeRows(BuildTreeRowsRequest{DocumentID: docID})
+	if err != nil {
+		t.Fatalf("build tree rows: %v", err)
+	}
+	if len(rows.Rows) == 0 {
+		t.Fatalf("expected tree rows")
+	}
+
+	syncFromSource, err := svc.SyncSourceToTree(SyncSourceToTreeRequest{
+		DocumentID: docID,
+		CursorLine: 2,
+		CursorCol:  13,
+	})
+	if err != nil {
+		t.Fatalf("sync source to tree: %v", err)
+	}
+	if !syncFromSource.Found {
+		t.Fatalf("expected source->tree selection")
+	}
+
+	syncFromTree, err := svc.SyncTreeToSource(SyncTreeToSourceRequest{
+		DocumentID:    docID,
+		SelectedIndex: syncFromSource.VisibleIndex,
+	})
+	if err != nil {
+		t.Fatalf("sync tree to source: %v", err)
+	}
+	if !syncFromTree.Found {
+		t.Fatalf("expected tree->source selection")
+	}
+}
+
+func TestUpdateAndCloseDocument(t *testing.T) {
+	svc := NewService()
+	docID := openDoc(t, svc, "const a = 1")
+
+	if _, err := svc.UpdateDocument(UpdateDocumentRequest{DocumentID: docID, Source: "const b = 2"}); err != nil {
+		t.Fatalf("update document: %v", err)
+	}
+
+	if err := svc.CloseDocument(CloseDocumentRequest{DocumentID: docID}); err != nil {
+		t.Fatalf("close document: %v", err)
+	}
+
+	if _, err := svc.ListGlobals(ListGlobalsRequest{DocumentID: docID}); err == nil {
+		t.Fatalf("expected document not found after close")
+	}
+}

--- a/pkg/jsparse/highlight.go
+++ b/pkg/jsparse/highlight.go
@@ -1,0 +1,147 @@
+package jsparse
+
+import (
+	"github.com/charmbracelet/lipgloss"
+)
+
+// SyntaxClass identifies the highlighting category for a syntax token.
+type SyntaxClass int
+
+const (
+	SyntaxNone        SyntaxClass = iota
+	SyntaxKeyword                 // const, let, class, function, return, ...
+	SyntaxString                  // "...", '...', `...`
+	SyntaxNumber                  // 42, 3.14
+	SyntaxComment                 // // ..., /* ... */
+	SyntaxIdentifier              // variable/property names
+	SyntaxOperator                // =, +, -, =>
+	SyntaxPunctuation             // (, ), {, }, [, ]
+)
+
+// SyntaxSpan represents a highlighted region in source code.
+type SyntaxSpan struct {
+	StartLine int // 1-based
+	StartCol  int // 1-based
+	EndLine   int // 1-based
+	EndCol    int // 1-based (exclusive)
+	Class     SyntaxClass
+}
+
+// BuildSyntaxSpans walks a TSNode tree and returns syntax spans for leaf tokens.
+func BuildSyntaxSpans(root *TSNode) []SyntaxSpan {
+	if root == nil {
+		return nil
+	}
+	var spans []SyntaxSpan
+	appendSyntaxSpans(root, &spans)
+	return spans
+}
+
+func appendSyntaxSpans(n *TSNode, spans *[]SyntaxSpan) {
+	if n == nil {
+		return
+	}
+	if len(n.Children) == 0 {
+		class := ClassifySyntaxKind(n.Kind)
+		if class != SyntaxNone {
+			*spans = append(*spans, SyntaxSpan{
+				StartLine: n.StartRow + 1,
+				StartCol:  n.StartCol + 1,
+				EndLine:   n.EndRow + 1,
+				EndCol:    n.EndCol + 1,
+				Class:     class,
+			})
+		}
+		return
+	}
+	for _, child := range n.Children {
+		appendSyntaxSpans(child, spans)
+	}
+}
+
+// ClassifySyntaxKind maps a tree-sitter node kind to a SyntaxClass.
+func ClassifySyntaxKind(kind string) SyntaxClass {
+	switch kind {
+	case "comment":
+		return SyntaxComment
+	case "string", "string_fragment", "template_string", "template_chars":
+		return SyntaxString
+	case "number":
+		return SyntaxNumber
+	case "identifier", "property_identifier", "shorthand_property_identifier",
+		"shorthand_property_identifier_pattern":
+		return SyntaxIdentifier
+	case "const", "let", "var", "function", "return", "if", "else", "for", "while", "do",
+		"switch", "case", "default", "break", "continue", "new", "class", "import", "export",
+		"from", "try", "catch", "finally", "throw", "await", "async", "extends", "this",
+		"typeof", "instanceof", "in", "of", "yield", "super", "true", "false", "null",
+		"undefined", "void", "delete", "static", "get", "set":
+		return SyntaxKeyword
+	case ".", ",", ";", ":", "=", "==", "===", "!=", "!==", "+", "-", "*", "/", "%", "=>",
+		"&&", "||", "!", ">", "<", ">=", "<=", "?", "++", "--", "+=", "-=", "*=", "/=",
+		"**", "??", "?.", "...":
+		return SyntaxOperator
+	case "(", ")", "{", "}", "[", "]":
+		return SyntaxPunctuation
+	default:
+		return SyntaxNone
+	}
+}
+
+// SyntaxClassAt returns the syntax class for a given position (1-based line/col).
+func SyntaxClassAt(spans []SyntaxSpan, lineNo, colNo int) SyntaxClass {
+	for _, span := range spans {
+		if inSyntaxRange(lineNo, colNo, span.StartLine, span.StartCol, span.EndLine, span.EndCol) {
+			return span.Class
+		}
+	}
+	return SyntaxNone
+}
+
+func inSyntaxRange(line, col, startLine, startCol, endLine, endCol int) bool {
+	if line < startLine || line > endLine {
+		return false
+	}
+	if line == startLine && col < startCol {
+		return false
+	}
+	if line == endLine && col >= endCol {
+		return false
+	}
+	return true
+}
+
+// --- Default color rendering ---
+
+var (
+	styleKeyword     = lipgloss.NewStyle().Foreground(lipgloss.Color("141")).Bold(true)
+	styleString      = lipgloss.NewStyle().Foreground(lipgloss.Color("114"))
+	styleNumber      = lipgloss.NewStyle().Foreground(lipgloss.Color("220"))
+	styleComment     = lipgloss.NewStyle().Foreground(lipgloss.Color("244")).Italic(true)
+	styleIdent       = lipgloss.NewStyle().Foreground(lipgloss.Color("81"))
+	styleOperator    = lipgloss.NewStyle().Foreground(lipgloss.Color("213"))
+	stylePunctuation = lipgloss.NewStyle().Foreground(lipgloss.Color("248"))
+)
+
+// RenderSyntaxChar renders a single character with syntax coloring.
+func RenderSyntaxChar(class SyntaxClass, ch string) string {
+	switch class {
+	case SyntaxNone:
+		return ch
+	case SyntaxKeyword:
+		return styleKeyword.Render(ch)
+	case SyntaxString:
+		return styleString.Render(ch)
+	case SyntaxNumber:
+		return styleNumber.Render(ch)
+	case SyntaxComment:
+		return styleComment.Render(ch)
+	case SyntaxIdentifier:
+		return styleIdent.Render(ch)
+	case SyntaxOperator:
+		return styleOperator.Render(ch)
+	case SyntaxPunctuation:
+		return stylePunctuation.Render(ch)
+	}
+	return ch
+}

--- a/testdata/inspector-test.js
+++ b/testdata/inspector-test.js
@@ -1,0 +1,92 @@
+// inspector-test.js — A file for testing the Smalltalk inspector TUI
+// Covers: classes, inheritance, functions, constants, symbols, closures, arrays, maps
+
+const VERSION = "1.0.0";
+const MAX_ITEMS = 100;
+
+const settings = {
+  theme: "dark",
+  fontSize: 14,
+  lineNumbers: true,
+};
+
+class Shape {
+  constructor(color) {
+    this.color = color;
+    this.visible = true;
+  }
+
+  describe() {
+    return `A ${this.color} shape`;
+  }
+
+  hide() {
+    this.visible = false;
+  }
+}
+
+class Circle extends Shape {
+  constructor(color, radius) {
+    super(color);
+    this.radius = radius;
+  }
+
+  area() {
+    return Math.PI * this.radius * this.radius;
+  }
+
+  perimeter() {
+    return 2 * Math.PI * this.radius;
+  }
+
+  describe() {
+    return `A ${this.color} circle with radius ${this.radius}`;
+  }
+}
+
+class Rectangle extends Shape {
+  constructor(color, width, height) {
+    super(color);
+    this.width = width;
+    this.height = height;
+  }
+
+  area() {
+    return this.width * this.height;
+  }
+
+  perimeter() {
+    return 2 * (this.width + this.height);
+  }
+}
+
+function createShape(type, color, ...args) {
+  switch (type) {
+    case "circle":
+      return new Circle(color, args[0] || 1);
+    case "rectangle":
+      return new Rectangle(color, args[0] || 1, args[1] || 1);
+    default:
+      return new Shape(color);
+  }
+}
+
+function totalArea(shapes) {
+  let sum = 0;
+  for (const s of shapes) {
+    if (typeof s.area === "function") {
+      sum += s.area();
+    }
+  }
+  return sum;
+}
+
+const myCircle = new Circle("red", 5);
+const myRect = new Rectangle("blue", 3, 4);
+const shapes = [myCircle, myRect];
+
+function main() {
+  const c = createShape("circle", "green", 10);
+  const r = createShape("rectangle", "yellow", 6, 8);
+  return { circle: c, rectangle: r, totalArea: totalArea([c, r]) };
+}

--- a/ttmp/2026/02/12/GOJA-001-ADD-AST-TOOLS--port-ast-inspector-tooling-from-goja-to-go-go-goja-without-upstream-patches/changelog.md
+++ b/ttmp/2026/02/12/GOJA-001-ADD-AST-TOOLS--port-ast-inspector-tooling-from-goja-to-go-go-goja-without-upstream-patches/changelog.md
@@ -28,3 +28,8 @@
 - Added inspector UX validation tests and TTY smoke coverage for sync/go-to-def/usages/drawer-completion (commit `443946b`)
 - Recorded final strategy decision to keep `cmd/inspector` standalone now and defer `repl` integration as follow-up (commit `c90c867`)
 - Added `make test-inspector` and CI `inspector-validation` job so inspector migration checks are bun-demo independent (commit `5fd439d`)
+
+## 2026-02-15
+
+Ticket closed
+

--- a/ttmp/2026/02/12/GOJA-001-ADD-AST-TOOLS--port-ast-inspector-tooling-from-goja-to-go-go-goja-without-upstream-patches/index.md
+++ b/ttmp/2026/02/12/GOJA-001-ADD-AST-TOOLS--port-ast-inspector-tooling-from-goja-to-go-go-goja-without-upstream-patches/index.md
@@ -1,7 +1,7 @@
 ---
 Title: Port AST inspector tooling from goja to go-go-goja without upstream patches
 Ticket: GOJA-001-ADD-AST-TOOLS
-Status: active
+Status: complete
 Topics:
     - goja
     - analysis
@@ -12,11 +12,12 @@ Intent: long-term
 Owners: []
 RelatedFiles: []
 ExternalSources: []
-Summary: "Analysis ticket for extracting a reusable JS parsing/completion framework plus inspector-specific tooling in go-go-goja."
-LastUpdated: 2026-02-12T16:13:54.828262977-05:00
-WhatFor: "Track analysis, decisions, and execution plan for inspector migration."
-WhenToUse: "Read this first to understand ticket status and jump to detailed docs."
+Summary: Analysis ticket for extracting a reusable JS parsing/completion framework plus inspector-specific tooling in go-go-goja.
+LastUpdated: 2026-02-15T00:21:24.834440312-05:00
+WhatFor: Track analysis, decisions, and execution plan for inspector migration.
+WhenToUse: Read this first to understand ticket status and jump to detailed docs.
 ---
+
 
 # Port AST inspector tooling from goja to go-go-goja without upstream patches
 

--- a/ttmp/2026/02/12/GOJA-002-FIX-INSPECTOR-CR-ISSUES--fix-inspector-jsparse-code-review-findings-and-similar-stability-issues/changelog.md
+++ b/ttmp/2026/02/12/GOJA-002-FIX-INSPECTOR-CR-ISSUES--fix-inspector-jsparse-code-review-findings-and-similar-stability-issues/changelog.md
@@ -13,3 +13,8 @@
 - Recorded ongoing task bookkeeping/diary updates and checked off task 10
 - Uploaded GOJA-002 analysis doc to reMarkable path `/ai/2026/02/12/GOJA-002-FIX-INSPECTOR-CR-ISSUES` and verified remote presence
 - Checked off task 11; ticket tasks now complete
+
+## 2026-02-15
+
+Ticket closed
+

--- a/ttmp/2026/02/12/GOJA-002-FIX-INSPECTOR-CR-ISSUES--fix-inspector-jsparse-code-review-findings-and-similar-stability-issues/index.md
+++ b/ttmp/2026/02/12/GOJA-002-FIX-INSPECTOR-CR-ISSUES--fix-inspector-jsparse-code-review-findings-and-similar-stability-issues/index.md
@@ -1,7 +1,7 @@
 ---
 Title: Fix inspector/jsparse code review findings and similar stability issues
 Ticket: GOJA-002-FIX-INSPECTOR-CR-ISSUES
-Status: active
+Status: complete
 Topics:
     - goja
     - analysis
@@ -13,10 +13,11 @@ Owners: []
 RelatedFiles: []
 ExternalSources: []
 Summary: ""
-LastUpdated: 2026-02-12T18:54:58.975536277-05:00
+LastUpdated: 2026-02-15T00:21:24.94648786-05:00
 WhatFor: ""
 WhenToUse: ""
 ---
+
 
 # Fix inspector/jsparse code review findings and similar stability issues
 

--- a/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/changelog.md
+++ b/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/changelog.md
@@ -91,3 +91,8 @@ Implemented Task 5 CLI startup flow: ast-parse-editor now opens an empty buffer 
 - /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/cmd/ast-parse-editor/main_test.go — Unit coverage for no-arg
 - /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/reference/01-diary.md — Step 9 records reproduction
 
+
+## 2026-02-14
+
+Ticket closed
+

--- a/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/index.md
+++ b/ttmp/2026/02/13/GOJA-001-AST-PARSE-EDITOR--live-ast-parse-editor-with-tree-sitter-and-goja-sexp-panes/index.md
@@ -1,7 +1,7 @@
 ---
 Title: Live AST parse editor with tree-sitter and goja SEXP panes
 Ticket: GOJA-001-AST-PARSE-EDITOR
-Status: active
+Status: complete
 Topics:
     - goja
     - analysis
@@ -16,10 +16,11 @@ RelatedFiles:
       Note: Detailed diary of commands
 ExternalSources: []
 Summary: Ticket index for analysis and delivery artifacts for a live tree-sitter + goja AST SEXP editor design.
-LastUpdated: 2026-02-13T15:56:00-05:00
+LastUpdated: 2026-02-14T20:00:09.291765527-05:00
 WhatFor: Central navigation for GOJA-001-AST-PARSE-EDITOR docs and outcomes.
 WhenToUse: Use to quickly locate the analysis, diary, tasks, changelog, and upload destination.
 ---
+
 
 
 # Live AST parse editor with tree-sitter and goja SEXP panes

--- a/ttmp/2026/02/13/GOJA-002-CURSOR-NODE-HIGHLIGHT--cursor-node-highlighting-in-ast-parse-editor/changelog.md
+++ b/ttmp/2026/02/13/GOJA-002-CURSOR-NODE-HIGHLIGHT--cursor-node-highlighting-in-ast-parse-editor/changelog.md
@@ -15,3 +15,8 @@ Implemented cursor-node highlight in ast-parse-editor source pane with status me
 - /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/cmd/ast-parse-editor/app/model_test.go — Added highlight initialization
 - /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/ttmp/2026/02/13/GOJA-002-CURSOR-NODE-HIGHLIGHT--cursor-node-highlighting-in-ast-parse-editor/reference/01-diary.md — Step 2 details commands
 
+
+## 2026-02-14
+
+Ticket closed
+

--- a/ttmp/2026/02/13/GOJA-002-CURSOR-NODE-HIGHLIGHT--cursor-node-highlighting-in-ast-parse-editor/index.md
+++ b/ttmp/2026/02/13/GOJA-002-CURSOR-NODE-HIGHLIGHT--cursor-node-highlighting-in-ast-parse-editor/index.md
@@ -1,7 +1,7 @@
 ---
 Title: Cursor node highlighting in AST parse editor
 Ticket: GOJA-002-CURSOR-NODE-HIGHLIGHT
-Status: active
+Status: complete
 Topics:
     - goja
     - tooling
@@ -12,10 +12,11 @@ Owners: []
 RelatedFiles: []
 ExternalSources: []
 Summary: ""
-LastUpdated: 2026-02-13T16:25:48.75092543-05:00
+LastUpdated: 2026-02-14T20:00:09.178470739-05:00
 WhatFor: ""
 WhenToUse: ""
 ---
+
 
 # Cursor node highlighting in AST parse editor
 

--- a/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/changelog.md
+++ b/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/changelog.md
@@ -58,3 +58,8 @@ Step 6: fixed byte-vs-rune column mapping for source highlights and AST cursor j
 - /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/cmd/ast-parse-editor/app/model_test.go — multibyte regression tests
 - /home/manuel/workspaces/2026-02-13/ast-parse-editor/go-go-goja/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/reference/01-diary.md — Step 6 diary details
 
+
+## 2026-02-14
+
+Ticket closed
+

--- a/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/index.md
+++ b/ttmp/2026/02/13/GOJA-003-SYNTAX-MODES-AST-SELECTION--syntax-highlighting-modes-and-ast-selection-mode-in-ast-parse-editor/index.md
@@ -1,7 +1,7 @@
 ---
 Title: Syntax highlighting modes and AST selection mode in AST parse editor
 Ticket: GOJA-003-SYNTAX-MODES-AST-SELECTION
-Status: active
+Status: complete
 Topics:
     - goja
     - tooling
@@ -12,10 +12,11 @@ Owners: []
 RelatedFiles: []
 ExternalSources: []
 Summary: ""
-LastUpdated: 2026-02-13T16:25:48.834704166-05:00
+LastUpdated: 2026-02-14T20:00:09.025181979-05:00
 WhatFor: ""
 WhenToUse: ""
 ---
+
 
 # Syntax highlighting modes and AST selection mode in AST parse editor
 

--- a/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/.meta/sources.yaml
+++ b/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/.meta/sources.yaml
@@ -1,0 +1,3 @@
+- type: local
+  path: /tmp/smalltalk-goja-inspector.md
+  lastFetched: 2026-02-14T11:22:00.522173848-05:00

--- a/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/README.md
+++ b/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/README.md
@@ -1,0 +1,21 @@
+# Smalltalk Inspector
+
+This is the document workspace for ticket GOJA-024-SMALLTALK-INSPECTOR.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr doc add --ticket GOJA-024-SMALLTALK-INSPECTOR --doc-type design-doc --title "My Design"`
+- Import sources: `docmgr import file --ticket GOJA-024-SMALLTALK-INSPECTOR --file /path/to/doc.md`
+- Update metadata: `docmgr meta update --ticket GOJA-024-SMALLTALK-INSPECTOR --field Status --value review`

--- a/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/changelog.md
+++ b/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/changelog.md
@@ -1,0 +1,96 @@
+# Changelog
+
+## 2026-02-14
+
+- Initial workspace created
+
+
+## 2026-02-14
+
+Step 1: Created ticket workspace and hit initial import failure due to missing /tmp/smalltalk-js-editor.md path.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/sources/local/smalltalk-goja-inspector.md — Imported source was eventually resolved after correcting path
+
+
+## 2026-02-14
+
+Step 2: Imported and analyzed smalltalk-goja-inspector source; extracted screen-by-screen requirements and navigation flow.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/reference/02-smalltalk-goja-inspector-interface-and-component-design.md — Main analysis document containing verbatim screens and implementation mapping
+
+
+## 2026-02-14
+
+Step 3: Added and ran runtime/static probe scripts to validate Goja symbol/prototype/stack behavior and jsparse global binding extraction.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/scripts/goja-runtime-probe.go — Runtime capability probe executed successfully
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/scripts/jsparse-index-probe.go — Static analysis capability probe executed successfully
+
+
+## 2026-02-14
+
+Step 4: Authored detailed design doc with verbatim screenshots, per-screen implementation analysis, reusable Bubble Tea component system design, and file-by-file blueprint; updated diary and related-file metadata.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/reference/01-diary.md — Detailed execution diary
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/reference/02-smalltalk-goja-inspector-interface-and-component-design.md — Primary design deliverable
+
+
+## 2026-02-14
+
+Step 5: Updated ticket index overview and key links to point to final design, diary, source, and probe scripts.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/index.md — Ticket entrypoint now links all deliverables
+
+
+## 2026-02-14
+
+Step 6: Ran docmgr validation/doctor; added missing topics vocabulary entries (go, tui) and recorded residual source-file frontmatter warning for imported raw source.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/sources/local/smalltalk-goja-inspector.md — Imported raw source intentionally lacks frontmatter
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/vocabulary.yaml — Added go and tui topic vocabulary
+
+
+## 2026-02-14
+
+Step 7: Refreshed implementation guide after reusable component cleanup (GOJA-025 baseline), added explicit reuse/refactor matrix and fast code-navigation marks, and restructured tasks into phase-based execution + handoff checklist.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/reference/02-smalltalk-goja-inspector-interface-and-component-design.md — Added reuse/refactor matrix and onboarding navigation commands
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/tasks.md — Replaced generic TODOs with phase-structured implementation tasks and handoff checklist
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/reference/01-diary.md — Added detailed diary step for this refresh
+
+## 2026-02-14
+
+Phase 1 bootstrap: created cmd/smalltalk-inspector with three-pane layout, globals/members/source browsing, :load command, key system, pane cycling (commit 1f5cfac)
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/cmd/smalltalk-inspector/app/model.go — Root model with globals/members/source state
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/cmd/smalltalk-inspector/app/view.go — Three-pane rendering
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/cmd/smalltalk-inspector/main.go — CLI entry point
+
+
+## 2026-02-14
+
+Phase 2+3 implementation: added REPL eval, object browser, breadcrumb navigation, prototype chain walking, error/stack trace inspection. Created pkg/inspector/{analysis,runtime} with 11 tests. All 8 design screens implemented.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/pkg/inspector/analysis/session.go — Analysis session wrapper
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/pkg/inspector/runtime/errors.go — Exception stack trace parsing
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/pkg/inspector/runtime/introspect.go — Object/prototype/descriptor inspection
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/pkg/inspector/runtime/session.go — Runtime session with eval/capture
+

--- a/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/index.md
+++ b/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/index.md
@@ -1,0 +1,77 @@
+---
+Title: Smalltalk Inspector
+Ticket: GOJA-024-SMALLTALK-INSPECTOR
+Status: active
+Topics:
+    - go
+    - goja
+    - tui
+DocType: index
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: go-go-goja/cmd/smalltalk-inspector/app/model.go
+      Note: Root model with all inspector state
+    - Path: go-go-goja/cmd/smalltalk-inspector/app/update.go
+      Note: Key handling and REPL eval
+    - Path: go-go-goja/pkg/inspector/runtime/session.go
+      Note: Runtime eval session
+    - Path: go-go-goja/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/reference/01-diary.md
+      Note: Detailed execution diary for this ticket
+    - Path: go-go-goja/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/reference/02-smalltalk-goja-inspector-interface-and-component-design.md
+      Note: Main implementation-oriented design analysis deliverable
+    - Path: go-go-goja/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/scripts/goja-runtime-probe.go
+      Note: Runtime capability probe for symbols, prototypes, and error stack output
+    - Path: go-go-goja/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/scripts/jsparse-index-probe.go
+      Note: Static analysis capability probe for globals/classes
+ExternalSources:
+    - local:smalltalk-goja-inspector.md
+Summary: Ticket workspace for Smalltalk-style Goja inspector analysis and implementation blueprint generation.
+LastUpdated: 2026-02-14T16:50:00Z
+WhatFor: Track source import, screen-by-screen analysis, component-system design, and supporting probe artifacts.
+WhenToUse: Use as the entry page for GOJA-024 to find the final design document, diary, scripts, and changelog.
+---
+
+
+
+# Smalltalk Inspector
+
+## Overview
+
+This ticket contains an implementation-oriented architecture package for a Smalltalk-style Goja inspector TUI. The imported source mockup is preserved, each target screen was analyzed, reusable Bubble Tea model decomposition was proposed, and supporting probe scripts were added to validate key runtime/static-analysis assumptions.
+
+## Key Links
+
+- Design doc: `reference/02-smalltalk-goja-inspector-interface-and-component-design.md`
+- Diary: `reference/01-diary.md`
+- Imported source: `sources/local/smalltalk-goja-inspector.md`
+- Runtime probe: `scripts/goja-runtime-probe.go`
+- Static probe: `scripts/jsparse-index-probe.go`
+- Changelog: `changelog.md`
+
+## Status
+
+Current status: **active**
+
+## Topics
+
+- go
+- goja
+- tui
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/reference/01-diary.md
+++ b/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/reference/01-diary.md
@@ -1,0 +1,820 @@
+---
+Title: Diary
+Ticket: GOJA-024-SMALLTALK-INSPECTOR
+Status: active
+Topics:
+    - go
+    - goja
+    - tui
+DocType: reference
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: go-go-goja/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/reference/02-smalltalk-goja-inspector-interface-and-component-design.md
+      Note: Primary analysis deliverable tracked by diary
+    - Path: go-go-goja/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/scripts/goja-runtime-probe.go
+      Note: Experiment script executed during analysis
+    - Path: go-go-goja/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/scripts/jsparse-index-probe.go
+      Note: Experiment script executed during analysis
+    - Path: go-go-goja/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/sources/local/smalltalk-goja-inspector.md
+      Note: Imported source document and screen mockup origin
+ExternalSources:
+    - local:smalltalk-goja-inspector.md
+Summary: Detailed step-by-step diary for GOJA-024 ticket creation, source import, analysis, probes, and documentation output.
+LastUpdated: 2026-02-14T18:10:00Z
+WhatFor: Preserve implementation narrative, exact commands/errors, and review instructions for this analysis-focused ticket.
+WhenToUse: Use to audit what was done, reproduce probe outputs, and review the final design document.
+---
+
+
+# Diary
+
+## Goal
+
+Capture a detailed execution trail for GOJA-024 from ticket creation through final design document production, including command-level failures, correction steps, probe experiments, and review guidance.
+
+## Step 1: Ticket Creation And Initial Import Failure
+
+I started by executing the ticket setup and import flow exactly as requested. The ticket creation succeeded immediately and produced the expected workspace structure under `go-go-goja/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector`.
+
+The first import command failed because the file path in the prompt did not exist. I treated this as a concrete blocker and moved into path discovery and prompt correction handling rather than proceeding with speculative analysis.
+
+### Prompt Context
+
+**User prompt (verbatim):** "Create a new docmgr ticket GOJA-024-SMALLTALK-INSPECTOR and import the file with `docmgr import file --file /tmp/smalltalk-js-editor.md --ticket GOJA-024-SMALLTALK-INSPECTOR` and read it.
+
+Then do an indepth analysis for each file of what the interface and code would be. Do a detailed analysis, copy the screenshots verbatim, add your own analysis to each screen, so that an implementer knows how to tackle it. Describe the different bubbletea models that would be needed (try to decompose into reusable components) and make a component system design section in your document.
+
+You can look at the current ast-parser and js-inspector tools . 
+
+Keep a frequent detailed diary as you go.
+You can run experiments and prototypes (store in scripts/ of the ticket)."
+
+**Assistant interpretation:** Create a docmgr ticket, import and read the provided source document, then produce a deep implementation design doc plus diary, using existing inspector/ast-editor code as references.
+
+**Inferred user intent:** Build an implementation-ready architecture package that an engineer can directly execute, with strong traceability of decisions.
+
+**Commit (code):** N/A (no git commit created in this session)
+
+### What I did
+
+- Ran:
+  - `docmgr status --summary-only`
+  - `docmgr ticket create-ticket --ticket GOJA-024-SMALLTALK-INSPECTOR --title "Smalltalk Inspector" --topics go,goja,tui`
+  - `docmgr import file --file /tmp/smalltalk-js-editor.md --ticket GOJA-024-SMALLTALK-INSPECTOR`
+- Attempted path discovery via `rg --files` and `find` for the missing source filename.
+
+### Why
+
+- The prompt required strict execution of the import command.
+- The import error had to be resolved before reading the source and producing accurate screen-level analysis.
+
+### What worked
+
+- Ticket workspace creation succeeded.
+- Docmgr ticket structure and index files were created correctly.
+
+### What didn't work
+
+- Import failed with exact error:
+
+```text
+Error: source file does not exist: /tmp/smalltalk-js-editor.md
+```
+
+- Path scanning in `/tmp` with `rg --files` produced permission noise for systemd private temp dirs and did not locate the requested file.
+
+### What I learned
+
+- The requested file path was stale/incorrect, but the workflow remained recoverable once the corrected filename was provided.
+- The ticket creation could proceed independently of import success, which reduced rework.
+
+### What was tricky to build
+
+- The main sharp edge was preserving forward progress while an input path was invalid.
+- Symptom: analysis could not proceed because source content was unavailable.
+- Approach: keep workspace creation done, mark import as blocked, and immediately request/use corrected path when provided.
+
+### What warrants a second pair of eyes
+
+- Confirm the ticket metadata fields (`topics`, `status`, `external source`) align with team conventions.
+
+### What should be done in the future
+
+- Add a pre-import existence check helper in docmgr workflows for `/tmp` paths used in prompts.
+
+### Code review instructions
+
+- Start at `go-go-goja/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/changelog.md` for step entry.
+- Validate by running `docmgr ticket list --ticket GOJA-024-SMALLTALK-INSPECTOR`.
+
+### Technical details
+
+- Workspace path created:
+  - `/home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector`
+
+## Step 2: Corrected Source Import And Full Source Read
+
+After the correction prompt arrived, I reran import with the updated file path and confirmed the source document was copied into ticket-local `sources/local` storage. I then read the entire imported markdown to ensure all screen specs and flow text were captured verbatim before analysis.
+
+This step converted the task from blocked state to analysis-ready state.
+
+### Prompt Context
+
+**User prompt (verbatim):** "/tmp/smalltalk-goja-inspector.md, my bad"
+
+**Assistant interpretation:** Re-run import using the corrected `/tmp/smalltalk-goja-inspector.md` source path.
+
+**Inferred user intent:** Unblock the requested design analysis with the intended source document.
+
+**Commit (code):** N/A (no git commit created in this session)
+
+### What I did
+
+- Ran:
+  - `docmgr import file --file /tmp/smalltalk-goja-inspector.md --ticket GOJA-024-SMALLTALK-INSPECTOR`
+  - `sed -n '1,260p' .../sources/local/smalltalk-goja-inspector.md`
+  - `sed -n '261,520p' .../sources/local/smalltalk-goja-inspector.md`
+- Confirmed all eight screens and flow summary existed in source.
+
+### Why
+
+- The analysis had to copy screenshots verbatim, so reading the imported source fully was mandatory.
+
+### What worked
+
+- Import succeeded and updated ticket index/external source metadata.
+- Source included complete screen and flow spec necessary for design output.
+
+### What didn't work
+
+- N/A in this step after correction.
+
+### What I learned
+
+- The screen mockups are sufficiently detailed to directly map to Bubble Tea model responsibilities.
+
+### What was tricky to build
+
+- The main care point was ensuring screenshots are copied exactly as source-of-truth text rather than reconstructed from memory.
+- Approach: treat imported markdown blocks as canonical and embed them unchanged in the final design doc.
+
+### What warrants a second pair of eyes
+
+- Verify no whitespace/icon drift exists between source mockups and copied sections in the final design doc.
+
+### What should be done in the future
+
+- Keep the imported source alongside generated docs for ongoing traceability.
+
+### Code review instructions
+
+- Compare `sources/local/smalltalk-goja-inspector.md` with `reference/02-smalltalk-goja-inspector-interface-and-component-design.md` screen blocks.
+
+### Technical details
+
+- Imported file destination:
+  - `/home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/sources/local/smalltalk-goja-inspector.md`
+
+## Step 3: Baseline Code Inspection And Capability Probes
+
+With source in place, I inspected current `ast-parse-editor`, `inspector`, and `pkg/jsparse` files to map reusable behavior and identify gaps relative to the requested Smalltalk-style experience.
+
+I also created and executed two probe scripts in the ticket `scripts/` directory to verify runtime and static-analysis capabilities with concrete output.
+
+### Prompt Context
+
+**User prompt (verbatim):** (same as Step 1)
+
+**Assistant interpretation:** Analyze existing tools deeply and use targeted experiments to ground architecture recommendations.
+
+**Inferred user intent:** Avoid speculative design by proving implementation feasibility with current codebase/runtime primitives.
+
+**Commit (code):** N/A (no git commit created in this session)
+
+### What I did
+
+- Inspected core files:
+  - `go-go-goja/cmd/ast-parse-editor/app/model.go`
+  - `go-go-goja/cmd/inspector/app/model.go`
+  - `go-go-goja/cmd/inspector/app/drawer.go`
+  - `go-go-goja/pkg/jsparse/index.go`
+  - `go-go-goja/pkg/jsparse/resolve.go`
+  - `go-go-goja/pkg/jsparse/completion.go`
+  - `go-go-goja/pkg/jsparse/analyze.go`
+- Added scripts:
+  - `scripts/goja-runtime-probe.go`
+  - `scripts/jsparse-index-probe.go`
+- Executed:
+  - `cd go-go-goja && go run ./ttmp/.../scripts/goja-runtime-probe.go`
+  - `cd go-go-goja && go run ./ttmp/.../scripts/jsparse-index-probe.go`
+
+### Why
+
+- Requested output needs file-by-file implementation guidance and Bubble Tea component decomposition based on real existing patterns.
+- Probes were needed to confirm symbol-key, prototype, and stack behavior for Screens 6-8.
+
+### What worked
+
+- Runtime probe confirmed:
+  - `Object.Symbols()` exposes symbol properties including `Symbol.iterator`, `Symbol.toPrimitive`, custom symbol.
+  - Prototype walking with `Prototype()` gives stable chain.
+  - Exception stack strings include function + location lines.
+- Static probe confirmed global binding extraction and class/function classification from `jsparse.Resolve`.
+
+### What didn't work
+
+- `CaptureCallStack` probe produced one empty filename frame (`:0:0`) due to context of invocation; direct stack capture is usable but not yet a full replacement for parsed exception stack rendering.
+
+### What I learned
+
+- Existing code already contains most required infrastructure; the main missing work is decomposition and integration into Smalltalk-style navigation models.
+- Screen 8 locals inspection is the only notable phase-2 complexity area.
+
+### What was tricky to build
+
+- Tricky point: validating stack behavior without overfitting to one capture path.
+- Symptom: raw stack frame metadata was less complete than exception string output.
+- Approach: use exception-string-based frame parsing for phase-1 and keep `CaptureCallStack` as instrumentation path for richer future support.
+
+### What warrants a second pair of eyes
+
+- Validate preferred frame source of truth for Screen 8 (`Exception.String()` parse vs explicit instrumentation).
+- Validate function-to-source mapping strategy for runtime-selected methods.
+
+### What should be done in the future
+
+- Add dedicated package-level runtime introspection helpers and tests for function-to-source mapping.
+
+### Code review instructions
+
+- Start with scripts:
+  - `go-go-goja/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/scripts/goja-runtime-probe.go`
+  - `go-go-goja/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/scripts/jsparse-index-probe.go`
+- Re-run commands from this step and verify output shape matches diary notes.
+
+### Technical details
+
+- Key runtime output excerpt:
+
+```text
+Symbols=[Symbol.iterator Symbol.toPrimitive custom]
+TypeError: Cannot read property 'calories' of undefined
+	at eat (<eval>:25:25(13))
+```
+
+- Key static output excerpt:
+
+```text
+- Animal kind=class
+- Dog kind=class
+- greet kind=function
+- main kind=function
+```
+
+## Step 4: Main Design Document Authoring
+
+I created the primary analysis deliverable with all eight screen mockups copied verbatim and implementation notes attached to each screen. I also added a dedicated component-system section that decomposes root model, reusable components, feature models, and message contracts.
+
+The document then expanded into a concrete file-by-file implementation blueprint, including both command wiring and package structure needed to realize the requested interface.
+
+### Prompt Context
+
+**User prompt (verbatim):** (same as Step 1)
+
+**Assistant interpretation:** Deliver a detailed implementation document with verbatim screens and deep model/file decomposition.
+
+**Inferred user intent:** Give implementers a concrete map from UI intent to code modules and interfaces.
+
+**Commit (code):** N/A (no git commit created in this session)
+
+### What I did
+
+- Created document:
+  - `reference/02-smalltalk-goja-inspector-interface-and-component-design.md`
+- Included:
+  - Verbatim Screen 1-8 blocks.
+  - Per-screen implementation analysis.
+  - Component system design with model decomposition and message contracts.
+  - File-by-file implementation blueprint covering `cmd/smalltalk-inspector` and `pkg/inspector/...`.
+
+### Why
+
+- The prompt explicitly requested deep per-screen analysis, reusable Bubble Tea decomposition, and component-system design section.
+
+### What worked
+
+- The screen requirements mapped cleanly to existing primitives from `cmd/inspector`, `cmd/ast-parse-editor`, `pkg/jsparse`, and Goja runtime APIs.
+
+### What didn't work
+
+- N/A (document authoring completed as expected).
+
+### What I learned
+
+- The fastest route to implementation quality is splitting current monolithic model behavior into typed models with explicit message contracts.
+
+### What was tricky to build
+
+- Main challenge: balancing completeness with implementability while avoiding speculative architecture.
+- Approach: anchor every proposed section to existing files and probe outputs.
+
+### What warrants a second pair of eyes
+
+- Confirm proposed package/file granularity matches team preferences for command vs package boundaries.
+- Confirm phase split (phase-1 vs phase-2 for deep stack locals) is acceptable.
+
+### What should be done in the future
+
+- Begin implementation from command wiring + core stores, then add feature models incrementally with snapshot tests.
+
+### Code review instructions
+
+- Review `reference/02-smalltalk-goja-inspector-interface-and-component-design.md` from top to bottom.
+- Validate each screen section against `sources/local/smalltalk-goja-inspector.md`.
+
+### Technical details
+
+- Added phase plan in doc:
+  - Phase 1: Screens 1-6 core browsing.
+  - Phase 2: Screen 7 deep descriptors and Screen 8 richer locals instrumentation.
+  - Phase 3: component reuse hardening.
+
+## Step 5: Ticket Metadata, Relationships, And Changelog Hygiene
+
+After content authoring, I linked the design and diary docs to all decision-driving files and probe scripts using `docmgr doc relate`, then added changelog entries for each major execution step.
+
+This ensures the ticket remains searchable and auditable without requiring reconstruction from terminal logs.
+
+### Prompt Context
+
+**User prompt (verbatim):** (same as Step 1)
+
+**Assistant interpretation:** Keep a detailed, durable diary trail and organize outputs in docmgr.
+
+**Inferred user intent:** Preserve full traceability from prompt to artifacts and commands.
+
+**Commit (code):** N/A (no git commit created in this session)
+
+### What I did
+
+- Related design doc to source, probe scripts, and baseline code files via `docmgr doc relate`.
+- Related diary doc to source, probes, and design doc.
+- Added changelog entries for steps 1 through 4 via `docmgr changelog update`.
+
+### Why
+
+- Required by the prompt emphasis on frequent detailed diary and practical implementer handoff.
+
+### What worked
+
+- Related file counts updated successfully for both docs.
+- Changelog updates were appended successfully.
+
+### What didn't work
+
+- N/A.
+
+### What I learned
+
+- Relating both modified files and decision-shaping files greatly improves ticket portability for future implementers.
+
+### What was tricky to build
+
+- Main care point was ensuring absolute path usage in `--file-note` fields to avoid ambiguity.
+
+### What warrants a second pair of eyes
+
+- Check whether additional file relations are desired for test files or docs under `pkg/doc`.
+
+### What should be done in the future
+
+- Keep changelog step granularity aligned with major milestones to avoid noisy entries.
+
+### Code review instructions
+
+- Run:
+
+```bash
+docmgr doc list --ticket GOJA-024-SMALLTALK-INSPECTOR
+docmgr ticket list --ticket GOJA-024-SMALLTALK-INSPECTOR
+```
+
+- Inspect:
+  - `go-go-goja/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/changelog.md`
+  - `go-go-goja/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/reference/01-diary.md`
+  - `go-go-goja/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/reference/02-smalltalk-goja-inspector-interface-and-component-design.md`
+
+### Technical details
+
+- Related-file updates reported:
+  - Design doc: added 10 related files.
+  - Diary doc: added 4 related files.
+- Changelog updated in four explicit step entries.
+
+## Step 6: Ticket Index Finalization And Validation Pass
+
+After writing the first diary version, I noticed the ticket index page still had placeholder sections. I updated `index.md` to include concrete links to the final deliverables and then performed a final validation pass on frontmatter and document listing.
+
+This step keeps handoff friction low because reviewers can now navigate the ticket from one canonical entry page.
+
+### Prompt Context
+
+**User prompt (verbatim):** (same as Step 1)
+
+**Assistant interpretation:** Ensure the ticket remains organized and easy to consume, not just technically complete.
+
+**Inferred user intent:** Receive a usable docmgr ticket workspace, not only isolated markdown files.
+
+**Commit (code):** N/A (no git commit created in this session)
+
+### What I did
+
+- Updated:
+  - `go-go-goja/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/index.md`
+- Added changelog entry:
+  - `Step 5: Updated ticket index overview and key links...`
+- Ran validation commands:
+  - `docmgr doc list --ticket GOJA-024-SMALLTALK-INSPECTOR`
+  - `docmgr validate frontmatter --doc .../reference/01-diary.md --suggest-fixes`
+  - `docmgr validate frontmatter --doc .../reference/02-smalltalk-goja-inspector-interface-and-component-design.md --suggest-fixes`
+
+### Why
+
+- The index file is the primary navigation entry for ticket consumers and needed explicit links to final outputs.
+
+### What worked
+
+- Index now links design doc, diary, imported source, and both probe scripts.
+- Frontmatter validation passed for both reference docs.
+
+### What didn't work
+
+- N/A.
+
+### What I learned
+
+- Finishing with an index-validation pass catches documentation usability gaps that pure content authoring can miss.
+
+### What was tricky to build
+
+- Minor consistency challenge: keeping changelog step numbers and diary step numbering coherent after late-stage cleanup.
+- Approach: added explicit index-finalization changelog entry and diary step.
+
+### What warrants a second pair of eyes
+
+- Confirm wording/metadata conventions in `index.md` align with docmgr style used across other tickets.
+
+### What should be done in the future
+
+- Perform index-link completeness checks before finalizing any doc-heavy ticket.
+
+### Code review instructions
+
+- Open `go-go-goja/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/index.md` first.
+- Verify links resolve to existing docs/scripts and that `docmgr doc list` shows both reference docs.
+
+### Technical details
+
+- Final validation outputs:
+  - `Frontmatter OK: .../reference/01-diary.md`
+  - `Frontmatter OK: .../reference/02-smalltalk-goja-inspector-interface-and-component-design.md`
+
+## Step 7: Doctor Pass, Vocabulary Fixes, And Residual Warning Documentation
+
+I executed a final `docmgr doctor` check to catch metadata drift and discovered topic-vocabulary warnings plus an expected source-frontmatter issue for the imported raw markdown file.
+
+I fixed the vocabulary warnings by adding `go` and `tui` topic slugs, and kept the source-frontmatter warning documented as an intentional exception because the imported source is raw reference material.
+
+### Prompt Context
+
+**User prompt (verbatim):** (same as Step 1)
+
+**Assistant interpretation:** Keep documentation quality high and explicitly capture any unresolved hygiene warnings.
+
+**Inferred user intent:** Leave a clean, transparent ticket state with known exceptions clearly explained.
+
+**Commit (code):** N/A (no git commit created in this session)
+
+### What I did
+
+- Ran:
+  - `docmgr doctor --ticket GOJA-024-SMALLTALK-INSPECTOR --stale-after 30`
+- Added vocabulary entries:
+  - `docmgr vocab add --category topics --slug go --description "Go language"`
+  - `docmgr vocab add --category topics --slug tui --description "Terminal user interfaces"`
+- Added changelog entry documenting this quality pass.
+
+### Why
+
+- Doctor output identified actionable taxonomy warnings.
+- Imported raw source warning needed explicit disposition to avoid future confusion.
+
+### What worked
+
+- Topic vocabulary warnings were resolved by adding missing slugs.
+- Changelog now records doctor and vocabulary actions.
+
+### What didn't work
+
+- Doctor still reports one imported-source frontmatter error for:
+  - `sources/local/smalltalk-goja-inspector.md`
+
+This remains intentional because the imported file is a raw source artifact, not a docmgr-managed authored doc.
+
+### What I learned
+
+- Running doctor near the end is useful for surfacing global vocabulary issues that are easy to miss during focused doc writing.
+
+### What was tricky to build
+
+- The nuanced part was deciding whether to mutate imported source to satisfy doctor.
+- Approach: preserve source verbatim and document the exception instead of rewriting source content.
+
+### What warrants a second pair of eyes
+
+- Confirm team policy on whether imported raw source files should be exempted from frontmatter checks or normalized post-import.
+
+### What should be done in the future
+
+- Consider a docmgr feature for marking raw imported source files as frontmatter-exempt.
+
+### Code review instructions
+
+- Inspect current doctor output against ticket files.
+- Confirm `vocabulary.yaml` contains `go` and `tui` topic slugs.
+
+### Technical details
+
+- Updated vocabulary file:
+  - `/home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/vocabulary.yaml`
+
+## Step 8: Implementation Guide Refresh For Reusable Components + New Developer Handoff Context
+
+I revisited the implementation guide after GOJA-025 reuse cleanup and tightened the sections that matter most for handoff execution: reusable component mapping, refactor boundaries, and "where to look first" commands. I also restructured `tasks.md` into explicit phase-based work packages with concrete file targets and a handoff checklist.
+
+### Prompt Context
+
+**User prompt (verbatim):** "update the impementation document for the smalltalk inspector if necessary, now that we have clean reusable components. Update tasks too if necessary. Add all the required context for a new developer to this code base to find their marks, explaining the bigger architecture, where to look for what, etc..."
+
+**Assistant interpretation:** Ensure GOJA-024 docs reflect the now-clean reusable Bubble Tea component baseline and make onboarding execution-ready for a new engineer.
+
+**Inferred user intent:** Remove ambiguity so an implementer can start coding immediately with clear architecture boundaries and task sequencing.
+
+**Commit (code):** N/A (no git commit created in this session)
+
+### What I did
+
+- Updated implementation document:
+  - `reference/02-smalltalk-goja-inspector-interface-and-component-design.md`
+  - Added `Reuse And Refactor Matrix (GOJA-025 Baseline)` covering `help`, `viewport`, `list`, `table`, `spinner`, `mode-keymap`, `textinput`.
+  - Added `Fast Code Navigation Commands` under onboarding runbook.
+- Reworked task list:
+  - `tasks.md`
+  - Replaced generic TODOs with phase-structured implementation tasks (Phase 1 to Phase 3) and a developer handoff checklist.
+- Updated this diary and changelog to capture the refresh.
+
+### Why
+
+- The reusable component refactor changed execution strategy for GOJA-024; docs needed to point directly at reuse points and refactor-safe boundaries.
+- New developers need exact "first files + first commands + first tasks" guidance to avoid architecture drift.
+
+### What worked
+
+- Design doc now clearly maps each required Bubble Tea primitive to existing reusable inspector code.
+- Tasks now sequence implementation logically and call out non-regression and handoff checks.
+
+### What didn't work
+
+- N/A.
+
+### What I learned
+
+- The most useful onboarding additions were not more architecture prose, but concrete navigation commands and direct file reuse mapping.
+
+### What was tricky to build
+
+- Challenge: avoid duplicating prior architecture sections while still adding actionable new context.
+- Approach: added narrowly scoped sections (reuse matrix + fast navigation commands) and left the larger blueprint intact.
+
+### What warrants a second pair of eyes
+
+- Confirm task phase boundaries align with team delivery preference (for example, whether domain extraction should begin in late Phase 1 instead of Phase 2).
+
+### What should be done in the future
+
+- As implementation starts, append command outputs and concrete PR/checkpoint references under each phase task.
+
+### Code review instructions
+
+- Review diff in:
+  - `go-go-goja/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/reference/02-smalltalk-goja-inspector-interface-and-component-design.md`
+  - `go-go-goja/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/tasks.md`
+- Verify task wording aligns with sections `Delivery Phases` and `File-By-File Implementation Blueprint`.
+
+## Step 9: Phase 1 Implementation — Three-Pane Bootstrap
+
+Implemented the complete Phase 1 bootstrap for the Smalltalk inspector TUI. Created `cmd/smalltalk-inspector/` with a working three-pane layout (Globals / Members / Source), file loading via `:load` command or CLI arg, and full keyboard navigation. The inspector correctly extracts class members including inherited methods from the AST, shows prototype chain info, and jumps to source declarations on selection.
+
+### Prompt Context
+
+**User prompt (verbatim):** "Work on docmgr ticket GOJA-024-SMALLTALK-INSPECTOR, keep a frequent diary. Go task by task, build, test, commit, check off, update the diary. You can run the TUI in tmux to check."
+
+**Assistant interpretation:** Implement the Smalltalk inspector TUI following the design doc tasks, with working code at each step.
+
+**Inferred user intent:** Get a working, tested implementation progressing through the ticket tasks with full traceability.
+
+**Commit (code):** `1f5cfac` — "smalltalk-inspector: Phase 1 bootstrap with three-pane layout"
+
+### What I did
+
+- Created 7 new files under `cmd/smalltalk-inspector/`:
+  - `main.go`: CLI entry with optional file argument
+  - `app/model.go`: Root model with globals, members, source state, AST introspection helpers
+  - `app/update.go`: Key handling, `:load`/`:help`/`:quit` commands, pane cycling
+  - `app/view.go`: Three-pane rendering with globals/members/source
+  - `app/keymap.go`: Key bindings with help integration
+  - `app/styles.go`: Lipgloss style definitions
+  - `app/messages.go`: Typed message structs
+- Created `scripts/sample.js` test file with class hierarchy
+- Verified in tmux: Dog class shows own methods + inherited Animal methods, source jumps work
+
+### Why
+
+- Tasks 2-6 (Phase 1) cover the bootstrap, key system, pane scaffolding, load flow, and static browsing
+
+### What worked
+
+- Build + lint + all tests pass (0 lint issues, existing inspector tests unaffected)
+- Three-pane layout renders correctly at 120x35
+- Class inheritance extraction from AST works (Dog shows constructor, bark, fetch as own; eat, sleep as inherited from Animal)
+- Source pane highlights target line on selection
+- `:load` command works for loading files in-app
+
+### What didn't work
+
+- First commit attempt failed with 11 lint issues (exhaustive switch, gofmt, unused vars)
+- Fixed all lint issues and committed cleanly on second attempt
+
+### What I learned
+
+- The `exhaustive` linter requires `//exhaustive:ignore` comments for intentional default-only switches over BindingKind
+- Direct AST type usage from `goja/ast` is cleaner than creating type aliases from jsparse
+
+### What was tricky to build
+
+- Member extraction from AST class declarations required walking the prototype chain statically by following `SuperClass` identifiers
+- Source jump for inherited members needs to find the method in the parent class declaration, not the child class
+- The existing inspector model is a monolith; this new implementation uses a simpler decomposition suitable for progressive enhancement
+
+### What warrants a second pair of eyes
+
+- The globals sort order (classes → functions → values) uses bubble sort — fine for small N but could be cleaner
+- Source jump accuracy for deeply nested inherited members
+
+### What should be done in the future
+
+- Add runtime introspection for Screens 5-8 (Phase 2)
+- Add symbol table panel below source (Screen 4)
+
+### Code review instructions
+
+- Start with `cmd/smalltalk-inspector/app/model.go` for data model and AST introspection
+- Run: `go run ./cmd/smalltalk-inspector ./ttmp/.../scripts/sample.js`
+- Verify: `go test ./... -count=1` and `golangci-lint run ./cmd/smalltalk-inspector/...`
+
+### Technical details
+
+- Files created: 7 files, 1575 lines total
+- Test JS file: `scripts/sample.js` with Animal/Dog class hierarchy, functions, and constants
+- Verified TUI screenshot shows all 8 bindings sorted by kind with proper icons
+
+## Step 10: Phase 2 — Domain Packages, REPL, and Object Inspection
+
+Created the `pkg/inspector` domain layer with reusable analysis and runtime packages, then integrated them into the TUI for REPL evaluation, live object browsing, and prototype chain walking.
+
+### Prompt Context
+
+**User prompt (verbatim):** (see Step 9)
+
+**Assistant interpretation:** Implement Phase 2 tasks: domain extraction, REPL eval, object inspection, breadcrumb navigation.
+
+**Inferred user intent:** Build the runtime integration layer that distinguishes this from a static-only inspector.
+
+**Commits (code):**
+- `914c4b0` — "inspector: add pkg/inspector domain packages for analysis and runtime"
+- `8f8db6a` — "smalltalk-inspector: add REPL eval and live object inspection"
+- `239827d` — "smalltalk-inspector: add breadcrumb navigation for recursive object inspection"
+- `bcd3850` — "smalltalk-inspector: add [[Proto]] entries for prototype chain walking"
+
+### What I did
+
+- Created `pkg/inspector/analysis/` with: session.go, method_symbols.go, xref.go + tests
+- Created `pkg/inspector/runtime/` with: session.go, introspect.go, errors.go, function_map.go + tests
+- Added REPL textinput to TUI with runtime eval integration
+- Added object browser that shows properties with type/preview when REPL returns objects
+- Added NavFrame-based breadcrumb stack for drill-in/back navigation
+- Added `[[Proto]]` entries for prototype chain walking (Dog → Animal → Object)
+- All 11 domain tests pass
+
+### Why
+
+- Tasks 7-10 require separating domain logic from UI and adding runtime inspection capabilities
+
+### What worked
+
+- `runtime.InspectObject` gives clean property introspection with type classification
+- Prototype chain walking via `[[Proto]]` entries matches the Smalltalk Class Browser design exactly
+- Breadcrumb navigation with lossless back restoration works for arbitrarily deep chains
+- `runtime.ParseException` successfully extracts structured stack frames from goja exceptions
+
+### What didn't work
+
+- First attempt at `j/k` key navigation in inspect mode didn't work because the keymap uses "down"/"k" but the inspect handler only matched `key.Matches(msg, m.keyMap.Down)` — this was actually correct, the issue was focus management (needed to Tab out of REPL first)
+
+### What I learned
+
+- The `buildInspectProps` pattern of adding synthetic entries (`[[Proto]]`) to the property list is a clean way to expose structural navigation without special UI paths
+- Focus management between REPL input and inspect mode needs explicit handling
+
+### What was tricky to build
+
+- Managing the interaction between three UI modes (normal globals browse, object inspect, error stack) required careful conditional routing in handleKey
+- The navStack had to store the exact property list and selection index to enable lossless back navigation
+
+### What warrants a second pair of eyes
+
+- The inspect key handler bypasses the normal pane switch — confirm this doesn't cause unexpected behavior with Tab
+- The breadcrumb label concatenation can get long for deep chains — truncation may be needed
+
+### What should be done in the future
+
+- Add locals display in stack trace view (Phase 2 stretch goal from design doc)
+- Add cross-reference panel when selecting members
+
+### Code review instructions
+
+- Start with `pkg/inspector/runtime/session_test.go` — verify all 7 runtime tests pass
+- Start with `pkg/inspector/analysis/session_test.go` — verify all 4 analysis tests pass
+- Run TUI: `go run ./cmd/smalltalk-inspector ./ttmp/.../scripts/sample.js`
+- Test: Tab to REPL → `new Dog('Rex')` → Enter → Tab → navigate → Enter on `[[Proto]]`
+
+## Step 11: Phase 3 — Error/Stack Trace Inspection
+
+Added the error view that appears when a REPL expression throws an exception, showing a parsed call stack with navigable frames that update the source pane.
+
+### Prompt Context
+
+**User prompt (verbatim):** (see Step 9)
+
+**Assistant interpretation:** Implement Screen 8 (error/stack trace inspection) from the design doc.
+
+**Inferred user intent:** Complete the core inspection loop: browse, eval, inspect success, inspect errors.
+
+**Commit (code):** `b7d7f60` — "smalltalk-inspector: add error/stack trace inspection view"
+
+### What I did
+
+- Added `errorInfo`, `stackIdx`, `showingError` state to Model
+- Parse `*goja.Exception` into structured `runtime.ErrorInfo` with frames
+- Added `renderErrorView` with error banner + call stack pane
+- Added `handleStackKey` for arrow-key frame navigation updating source
+- Source pane jumps to error line automatically on first exception display
+
+### Why
+
+- Task 11 requires error/stack trace inspection as described in Screen 8
+
+### What worked
+
+- Stack trace parsing correctly extracts `eat` at line 21 and `fetch` at line 42
+- Frame navigation updates source pane in real time
+- Error banner prominently displays the TypeError message
+
+### What didn't work
+
+- N/A — implementation was straightforward using the already-tested `runtime.ParseException`
+
+### What I learned
+
+- Reusing the existing `renderSourcePane` for both inspect and error views keeps the code DRY
+
+### What was tricky to build
+
+- Getting the conditional routing right: error mode → inspect mode → normal mode, with REPL always accessible via Tab
+- Esc in error mode must dismiss the error view rather than navigating breadcrumbs
+
+### What warrants a second pair of eyes
+
+- Confirm Esc behavior in error mode vs inspect mode doesn't overlap
+
+### What should be done in the future
+
+- Add locals display for selected stack frame
+- Enhance frame selection to allow inspect of `this` and arguments
+
+### Code review instructions
+
+- Test: Tab to REPL → `new Dog('Rex').fetch()` → Enter → see error banner + stack
+- Arrow down to `fetch` frame → source jumps to line 42
+- Esc → error view dismissed

--- a/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/reference/02-smalltalk-goja-inspector-interface-and-component-design.md
+++ b/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/reference/02-smalltalk-goja-inspector-interface-and-component-design.md
@@ -1,0 +1,816 @@
+---
+Title: Smalltalk Goja Inspector Interface And Component Design
+Ticket: GOJA-024-SMALLTALK-INSPECTOR
+Status: active
+Topics:
+    - go
+    - goja
+    - tui
+DocType: reference
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: go-go-goja/cmd/ast-parse-editor/app/model.go
+      Note: AST/CST dual-pane and async parse sequencing reference
+    - Path: go-go-goja/cmd/inspector/app/drawer.go
+      Note: Reusable drawer editor and completion popup behavior
+    - Path: go-go-goja/cmd/inspector/app/model.go
+      Note: Baseline Bubble Tea sync patterns and existing inspector behavior
+    - Path: go-go-goja/pkg/jsparse/analyze.go
+      Note: High-level analysis facade used for proposed architecture
+    - Path: go-go-goja/pkg/jsparse/completion.go
+      Note: Completion context and candidate generation model
+    - Path: go-go-goja/pkg/jsparse/index.go
+      Note: AST node index and navigation primitives
+    - Path: go-go-goja/pkg/jsparse/resolve.go
+      Note: Scope/binding resolution and usages model
+    - Path: go-go-goja/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/scripts/goja-runtime-probe.go
+      Note: Runtime behavior probe for symbols
+    - Path: go-go-goja/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/scripts/jsparse-index-probe.go
+      Note: Static index/resolution probe for global bindings and class nodes
+    - Path: go-go-goja/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/sources/local/smalltalk-goja-inspector.md
+      Note: Primary screen specification used verbatim in analysis
+ExternalSources:
+    - local:smalltalk-goja-inspector.md
+Summary: Implementation-oriented screen analysis and file/component blueprint for a Smalltalk-style Goja inspector TUI.
+LastUpdated: 2026-02-14T18:05:00Z
+WhatFor: Guide implementation of a reusable Bubble Tea Smalltalk inspector using current ast-parse-editor, inspector, jsparse, and runtime probes.
+WhenToUse: Use before and during implementation of GOJA-024 to map screens to concrete models, messages, and files.
+---
+
+
+# Smalltalk Goja Inspector Interface And Component Design
+
+## Goal
+
+Provide an implementation-ready blueprint for the Smalltalk-style inspector, including verbatim screen specs, per-screen behavior mapping, reusable Bubble Tea model decomposition, and a file-by-file code plan.
+
+## Context
+
+The ticket source was imported from `sources/local/smalltalk-goja-inspector.md` and defines eight target screens plus navigation principles.
+
+Current code baseline used for this design:
+
+- `cmd/ast-parse-editor`: strong live editing + CST/AST sync patterns and async parse sequencing.
+- `cmd/inspector`: now refactored to include reusable Bubbles components from `GOJA-025`.
+- `pkg/jsparse`: reusable index, resolution, completion context/candidate infrastructure.
+
+GOJA-025 refactor updates now available and should be treated as mandatory reuse points:
+
+- `go-go-goja/cmd/inspector/app/keymap.go`
+  - mode-aware key definitions using `bobatea/pkg/mode-keymap`.
+  - standardized `bubbles/help` integration.
+- `go-go-goja/cmd/inspector/app/tree_list.go`
+  - `bubbles/list` adapter for AST-node tree rows.
+- `go-go-goja/cmd/inspector/app/model.go` (updated)
+  - `bubbles/viewport` source rendering.
+  - `bubbles/spinner` status signaling.
+  - `bubbles/textinput` command mode (`:`).
+  - `bubbles/table` metadata panel.
+
+GOJA-025 implementation commits (for code archaeology):
+
+- `3339aa86b12bbe450ebb01e184241fe2ff47a541` — keymap/help/spinner
+- `13d7bbfcecd801d6bd75743826ac5e360f13062b` — viewport/list
+- `8e1e1ce4b5c2f4caf3e202fb521bf3b4d2919f99` — textinput/table
+
+Runtime probes were added in this ticket:
+
+- `scripts/goja-runtime-probe.go`
+- `scripts/jsparse-index-probe.go`
+
+These probes validate that Goja and jsparse already provide enough primitives for prototype walking, symbol-key listing, descriptors, global binding discovery, and stack-trace text capture.
+
+## Quick Reference
+
+### Baseline Files And What They Already Solve
+
+`go-go-goja/cmd/ast-parse-editor/main.go`
+Entry point that opens file or scratch buffer, launches Bubble Tea alt screen.
+
+`go-go-goja/cmd/ast-parse-editor/app/model.go`
+Single large model with async AST parse (`parseSeq`, `pendingSeq`), CST parse, AST select mode, go-to-def, find usages, syntax highlighting, multi-pane rendering.
+
+`go-go-goja/cmd/inspector/main.go`
+Reads JS file, parses with goja parser, builds `jsparse.Index` and `Resolve`, launches inspector model.
+
+`go-go-goja/cmd/inspector/app/model.go`
+Two-pane static inspector plus drawer. Now already includes reusable Bubbles primitives (`help`, `spinner`, `viewport`, `list`, `table`, `textinput`) and mode-gated key handling.
+
+`go-go-goja/cmd/inspector/app/keymap.go`
+Central mode-aware key bindings and help model contract.
+
+`go-go-goja/cmd/inspector/app/tree_list.go`
+List adapter for AST tree rows, selection, and scope hint formatting.
+
+`go-go-goja/cmd/inspector/app/drawer.go`
+Reusable mini editor + CST panel + completion popup logic.
+
+`go-go-goja/cmd/inspector/app/jsparse_bridge.go`
+Type aliases and thin API bridge to `pkg/jsparse`.
+
+`go-go-goja/pkg/jsparse/index.go`
+AST node index, offset mapping, tree visibility and expand/collapse primitives.
+
+`go-go-goja/pkg/jsparse/resolve.go`
+Lexical scope graph and binding/reference resolution (`BindingForNode`, `AllUsages`).
+
+`go-go-goja/pkg/jsparse/completion.go`
+Completion context extraction from tree-sitter plus candidate synthesis.
+
+`go-go-goja/pkg/jsparse/analyze.go`
+Facade returning parse/index/resolution bundle.
+
+### New Developer Architecture Map
+
+If you are new to this codebase, start with this map before writing code.
+
+Repository-level map:
+
+- `go-go-goja/`
+  - Primary project for this ticket.
+  - Contains CLI commands and reusable analysis packages.
+- `goja/`
+  - JavaScript runtime implementation details (upstream-ish engine internals).
+  - Usually not modified for GOJA-024 unless runtime API gaps are proven.
+- `bobatea/`
+  - Shared TUI primitives; GOJA-024 currently depends on `mode-keymap`.
+- `glazed/`
+  - CLI/documentation framework and tooling integration.
+
+GOJA-024 implementation zones:
+
+- Entry command:
+  - `go-go-goja/cmd/smalltalk-inspector/` (new command to create)
+- Existing reusable UI baseline:
+  - `go-go-goja/cmd/inspector/app/`
+- Static analysis engine:
+  - `go-go-goja/pkg/jsparse/`
+- New runtime/introspection domain logic (to add):
+  - `go-go-goja/pkg/inspector/runtime/`
+- New UI/domain orchestration (to add):
+  - `go-go-goja/pkg/inspector/...`
+
+Where to look for key behaviors:
+
+- Source ↔ AST sync: `go-go-goja/cmd/inspector/app/model.go`
+- AST/CST parse and async parse sequence: `go-go-goja/cmd/ast-parse-editor/app/model.go`
+- Binding/usages logic: `go-go-goja/pkg/jsparse/resolve.go`
+- Completion context/candidates: `go-go-goja/pkg/jsparse/completion.go`
+- Runtime object/prototype/symbol APIs: `goja/value.go` (`Symbols`, `Prototype`, `GetOwnPropertyNames`)
+- Stack capture and exception shape: `goja/runtime.go`
+
+### Probe Outputs (Implementation Constraints)
+
+From `scripts/goja-runtime-probe.go`:
+
+```text
+== Dog instance own keys ==
+GetOwnPropertyNames=[name alive energy breed]
+Keys=[name alive energy breed]
+Symbols=[]
+...
+== config keys and symbols ==
+GetOwnPropertyNames=[apiUrl timeout retries debug]
+Symbols=[Symbol.iterator Symbol.toPrimitive custom]
+...
+== thrown error stack string ==
+TypeError: Cannot read property 'calories' of undefined
+	at eat (<eval>:25:25(13))
+	at fetch (<eval>:46:20(4))
+	at <eval>:1:21(4)
+```
+
+From `scripts/jsparse-index-probe.go`:
+
+```text
+== Global Bindings ==
+- Animal kind=class ...
+- Dog kind=class ...
+- greet kind=function ...
+- main kind=function ...
+== Unresolved Identifiers ==
+- "Error" ...
+```
+
+Design implication:
+
+- Screen 7 symbol-key section is fully feasible with `Object.Symbols()`.
+- Screen 6 prototype walk is fully feasible with `Object.Prototype()`.
+- Screen 8 stack trace can be built from `*goja.Exception` text immediately, and upgraded later to richer frame objects.
+- Screen 2 global binding list maps directly to `Resolution` root scope bindings.
+
+## Interface And Behavior By Screen
+
+### Screen 1 — Startup / Load File
+
+The user launches the inspector and is greeted with a file loader + empty workspace. The REPL is always at the bottom.
+
+```
+┌─── goja-inspector ──────────────────────────────────────────────────────────┐
+│                                                                             │
+│                                                                             │
+│                         No program loaded.                                  │
+│                                                                             │
+│              :load <file.js>    Load a JavaScript file                      │
+│              :run  <expr>       Evaluate an expression                      │
+│              :help              Show all commands                           │
+│                                                                             │
+│                                                                             │
+│                                                                             │
+│                                                                             │
+│                                                                             │
+│                                                                             │
+│                                                                             │
+│                                                                             │
+│                                                                             │
+│                                                                             │
+├─── REPL ────────────────────────────────────────────────────────────────────┤
+│ » :load app.js                                                              │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+Implementation analysis:
+
+- Root model starts in `ModeEmpty` with only command palette + REPL enabled.
+- `:load` dispatches `LoadFileCmd(path)` that performs parse/index/resolution build and runtime bootstrap.
+- Reuse: file loading and parse bootstrap logic from `cmd/inspector/main.go`, but move into model command path so loading can happen in-app.
+- Minimal required state is `currentFile`, `source`, `analysis`, `runtimeSession`, `replHistory`, and `statusLine`.
+
+### Screen 2 — File Loaded: Global Scope Overview
+
+After loading, the left pane shows **all top-level bindings** (globals, classes, functions). The right pane is empty until something is selected. This is the "Class Browser" root.
+
+```
+┌─── goja-inspector ─── app.js ───────────────────────────────────────────────┐
+│ ┌─ Globals ──────────────┐  ┌─ Members ─────────────┐  ┌─ Source ────────┐ │
+│ │                        │  │                        │  │                 │ │
+│ │  ƒ  greet              │  │   (select a global)    │  │  (no source)    │ │
+│ │  C  Animal             │  │                        │  │                 │ │
+│ │  C  Dog  ← Animal      │  │                        │  │                 │ │
+│ │  ƒ  main               │  │                        │  │                 │ │
+│ │  ●  config      {…}    │  │                        │  │                 │ │
+│ │  ●  API_KEY     "sk-…" │  │                        │  │                 │ │
+│ │  ●  version     3      │  │                        │  │                 │ │
+│ │                        │  │                        │  │                 │ │
+│ │                        │  │                        │  │                 │ │
+│ │                        │  │                        │  │                 │ │
+│ │  8 bindings found      │  │                        │  │                 │ │
+│ └────────────────────────┘  └────────────────────────┘  └─────────────────┘ │
+├─── REPL ────────────────────────────────────────────────────────────────────┤
+│ ✓ Loaded app.js (245 lines, 8 globals)                                      │
+│ » ▌                                                                         │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+Implementation analysis:
+
+- `GlobalsModel` data comes from `analysis.Resolution.Scopes[RootScopeID].Bindings` plus runtime global object snapshots for values not statically declared.
+- For each item show kind icon (`function`, `class`, `value`) and optional extends info.
+- Selection event publishes `MsgGlobalSelected{BindingName, DeclNodeID, RuntimeValueRef}`.
+- Source pane stays empty until selected member/function maps to source span.
+
+### Screen 3 — Select a Class: Member List Populates
+
+User highlights `Dog` in the left pane. The middle pane fills with its **own members + inherited** members. Prototype chain is shown.
+
+```
+┌─── goja-inspector ─── app.js ───────────────────────────────────────────────┐
+│ ┌─ Globals ──────────────┐  ┌─ Dog: Members ────────┐  ┌─ Source ────────┐ │
+│ │                        │  │                        │  │                 │ │
+│ │   ƒ  greet             │  │ ── own ──────────────  │  │  (select a      │ │
+│ │   C  Animal            │  │  ƒ  constructor(name)  │  │   member)       │ │
+│ │ ▸ C  Dog  ← Animal     │  │  ƒ  bark()            │  │                 │ │
+│ │   ƒ  main              │  │  ƒ  fetch(item)       │  │                 │ │
+│ │   ●  config      {…}   │  │  ●  breed    "lab"     │  │                 │ │
+│ │   ●  API_KEY     "sk-… │  │                        │  │                 │ │
+│ │   ●  version     3     │  │ ── inherited (Animal)  │  │                 │ │
+│ │                        │  │  ƒ  eat(food)          │  │                 │ │
+│ │                        │  │  ƒ  sleep()            │  │                 │ │
+│ │                        │  │  ●  alive     true     │  │                 │ │
+│ │                        │  │                        │  │                 │ │
+│ │                        │  │ proto: Animal → Object │  │                 │ │
+│ └────────────────────────┘  └────────────────────────┘  └─────────────────┘ │
+├─── REPL ────────────────────────────────────────────────────────────────────┤
+│ » ▌                                                                         │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Key:** The `▸` marker shows the currently selected item. Prototype chain is rendered at the bottom of the members pane.
+
+Implementation analysis:
+
+- `MembersModel` receives selected global class/object and builds grouped rows: own, inherited, metadata.
+- Own/inherited separation requires runtime reflection walk: inspect object own properties, then walk `Prototype()` and diff by first occurrence.
+- Static method signatures come from AST class declaration in `jsparse.Index` if available; fallback to runtime property labels if no static mapping.
+- Reuse: AST span lookup patterns from `inspector` for def jumps.
+
+### Screen 4 — Select a Method: Source + Symbols Appear
+
+User selects `bark()`. The right pane shows **source code**, and a **symbols sub-panel** appears below it with local bindings.
+
+```
+┌─── goja-inspector ─── app.js ───────────────────────────────────────────────┐
+│ ┌─ Globals ──────────┐ ┌─ Dog: Members ──────┐ ┌─ Source: bark() ────────┐ │
+│ │                    │ │                      │ │                         │ │
+│ │  ƒ  greet          │ │ ── own ────────────  │ │  43│ bark() {            │ │
+│ │  C  Animal         │ │  ƒ  constructor()    │ │  44│   const sound =     │ │
+│ │▸ C  Dog ← Animal   │ │ ▸ƒ  bark()          │ │  45│     this.breed ===  │ │
+│ │  ƒ  main           │ │  ƒ  fetch(item)     │ │  46│     "husky"         │ │
+│ │  ●  config    {…}  │ │  ●  breed   "lab"   │ │  47│     ? "awoo" : "wo… │ │
+│ │  ●  API_KEY   "sk… │ │                      │ │  48│   console.log(      │ │
+│ │  ●  version   3    │ │ ── inherited ──────  │ │  49│     `${this.name}:  │ │
+│ │                    │ │  ƒ  eat(food)        │ │  50│      ${sound}`);    │ │
+│ │                    │ │  ƒ  sleep()          │ │  51│   return sound;     │ │
+│ │                    │ │  ●  alive    true    │ │  52│ }                   │ │
+│ │                    │ │                      │ ├─ Symbols ──────────────┤ │
+│ │                    │ │                      │ │ sound  const  L44  2u  │ │
+│ │                    │ │                      │ │ this   recv   —    4u  │ │
+│ └────────────────────┘ └──────────────────────┘ └─────────────────────────┘ │
+├─── REPL ────────────────────────────────────────────────────────────────────┤
+│ » ▌                                                                         │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Symbols sub-panel:** `L44` = defined on line 44, `2u` = 2 usages found. This comes from Layer B (`BuildIndex` + `Resolve`).
+
+Implementation analysis:
+
+- `SourcePanelModel` renders selected span with syntax style and optional target line marker.
+- `SymbolTableModel` computes symbols limited to selected method subtree: filter `Resolve` bindings to descendant node IDs of selected method node.
+- Usage count is direct from `BindingRecord.AllUsages()` count constrained by method span.
+- Row action `Enter` on symbol triggers highlight overlays in source pane.
+
+### Screen 5 — REPL Evaluation: Live Object Inspection
+
+User types an expression in the REPL. The result becomes an **inspectable object** that replaces or augments the Globals pane (shown here as a dedicated result panel).
+
+```
+┌─── goja-inspector ─── app.js ───────────────────────────────────────────────┐
+│ ┌─ REPL Result ──────────────────────────────┐  ┌─ Source ────────────────┐ │
+│ │                                            │  │                         │ │
+│ │  new Dog("Rex")                            │  │                         │ │
+│ │  → Dog {                                   │  │  (select member to      │ │
+│ │      name      : "Rex"           string    │  │   view source)          │ │
+│ │      breed     : "lab"           string    │  │                         │ │
+│ │    ▸ bark      : ƒ bark()        function  │  │                         │ │
+│ │      fetch     : ƒ fetch(item)   function  │  │                         │ │
+│ │      eat       : ƒ eat(food)     function  │  │                         │ │
+│ │      sleep     : ƒ sleep()       function  │  │                         │ │
+│ │      alive     : true            boolean   │  │                         │ │
+│ │      [[Proto]] : Animal.prototype          │  │                         │ │
+│ │                                            │  │                         │ │
+│ │  [Tab: expand]  [Enter: inspect]  [s: src] │  │                         │ │
+│ └────────────────────────────────────────────┘  └─────────────────────────┘ │
+├─── REPL ────────────────────────────────────────────────────────────────────┤
+│   new Dog("Rex")                                                            │
+│ » ▌                                                                         │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Flow:** The REPL result is a **live runtime object**. Selecting `bark` here would show the same source as Screen 4. Selecting `[[Proto]]` would drill into `Animal.prototype`.
+
+Implementation analysis:
+
+- `ReplModel` owns input buffer, history, eval command parsing, and emits `MsgEvalResult` or `MsgEvalError`.
+- `ObjectBrowserModel` renders exported preview rows for objects and functions.
+- Source jump for runtime function rows requires function-to-AST mapping strategy.
+- Mapping strategy v1 should be name-based + class context and then span fallback via declaration lookup.
+
+### Screen 6 — Drill Into Prototype / Deep Inspect
+
+User selects `[[Proto]]` to walk the prototype chain. The inspector now shows `Animal.prototype` as the inspected target.
+
+```
+┌─── goja-inspector ─── app.js ───────────────────────────────────────────────┐
+│ ┌─ Breadcrumb: Dog instance → [[Proto]] ─────────────────────────────────┐  │
+│ └────────────────────────────────────────────────────────────────────────┘  │
+│ ┌─ Animal.prototype ─────────────────────────┐  ┌─ Source: eat(food) ────┐ │
+│ │                                            │  │                        │ │
+│ │   constructor : ƒ Animal(name)   function  │  │ 12│ eat(food) {        │ │
+│ │ ▸ eat         : ƒ eat(food)      function  │  │ 13│   if (!this.alive) │ │
+│ │   sleep       : ƒ sleep()        function  │  │ 14│     throw new      │ │
+│ │   alive       : true             boolean   │  │ 15│       Error("…");  │ │
+│ │   [[Proto]]   : Object.prototype           │  │ 16│   this.energy +=   │ │
+│ │                                            │  │ 17│     food.calories; │ │
+│ │                                            │  │ 18│   return this;     │ │
+│ │                                            │  │ 19│ }                  │ │
+│ │                                            │  ├─ Symbols ─────────────┤ │
+│ │                                            │  │ food    param L12  3u │ │
+│ │                                            │  │ this    recv  —    2u │ │
+│ │  [Esc: back to Dog]  [Enter: inspect]      │  │                      │ │
+│ └────────────────────────────────────────────┘  └────────────────────────┘ │
+├─── REPL ────────────────────────────────────────────────────────────────────┤
+│ » ▌                                                                         │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Key:** The **breadcrumb bar** at the top tracks navigation history. `Esc` goes back. This is the "continue exploring forever" Smalltalk behavior.
+
+Implementation analysis:
+
+- `NavigationStackModel` stores `InspectTarget` frames and supports push/pop/replace.
+- Each frame carries enough identity to restore selection and scroll state.
+- `InspectTarget` union must support runtime object refs, AST node refs, stack frame locals, and cross-reference rows.
+- Back navigation must be lossless, including previous source highlight and selected member row.
+
+### Screen 7 — Symbol-Keyed Properties & Cross-References
+
+User inspects an object with Symbol keys (Layer A: `obj.Symbols()`). Also shows the cross-reference / usages panel.
+
+```
+┌─── goja-inspector ─── app.js ───────────────────────────────────────────────┐
+│ ┌─ Breadcrumb: config ───────────────────────────────────────────────────┐  │
+│ └────────────────────────────────────────────────────────────────────────┘  │
+│ ┌─ config: Members ──────────────────────────┐  ┌─ Cross-References ────┐ │
+│ │                                            │  │                        │ │
+│ │ ── string keys ──────────────────────────  │  │ config.apiUrl          │ │
+│ │   apiUrl    : "https://…"        string    │  │ ── usages (4 found) ── │ │
+│ │   timeout   : 3000               number    │  │                        │ │
+│ │   retries   : 5                  number    │  │  L67  main()           │ │
+│ │   debug     : false              boolean   │  │  L89  Animal.eat()     │ │
+│ │                                            │  │  L134 fetchData()      │ │
+│ │ ── symbol keys ──────────────────────────  │  │  L201 init()           │ │
+│ │   [Symbol.iterator]  : ƒ        function   │  │                        │ │
+│ │   [Symbol.toPrim…]   : ƒ        function   │  │ [Enter: jump to usage] │ │
+│ │   [Symbol(custom)]   : "meta"   string     │  │                        │ │
+│ │                                            │  │                        │ │
+│ │ ── descriptors ──────────────────────────  │  │                        │ │
+│ │   apiUrl: {writable:T enum:T config:T}     │  │                        │ │
+│ └────────────────────────────────────────────┘  └────────────────────────┘ │
+├─── REPL ────────────────────────────────────────────────────────────────────┤
+│ » config.apiUrl                                                             │
+│ → "https://api.example.com/v3"                                              │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+Implementation analysis:
+
+- String keys from `GetOwnPropertyNames()`, symbols from `Symbols()`.
+- Descriptor details should be read through JS helper call `Object.getOwnPropertyDescriptor` for both string and symbol keys.
+- `CrossRefModel` should consume `jsparse.Resolve` references when object maps to static binding.
+- For runtime-only values with no static anchor, cross-ref panel should explicitly render `no static references available`.
+
+### Screen 8 — Error / Stack Trace Inspection
+
+When an expression throws, the REPL catches it and shows the **call stack** as an inspectable entity (Layer A: `CaptureCallStack`).
+
+```
+┌─── goja-inspector ─── app.js ───────────────────────────────────────────────┐
+│ ┌─ Error ────────────────────────────────────────────────────────────────┐  │
+│ │  TypeError: Cannot read property 'calories' of undefined               │  │
+│ └────────────────────────────────────────────────────────────────────────┘  │
+│ ┌─ Call Stack ───────────────────────────────┐  ┌─ Source: eat() ────────┐ │
+│ │                                            │  │                        │ │
+│ │ ▸ #0  Animal.eat        app.js:17:5        │  │  15│     Error("…");   │ │
+│ │   #1  Dog.fetch         app.js:56:12       │  │  16│   this.energy +=  │ │
+│ │   #2  main              app.js:72:3        │  │ →17│     food.calories │ │
+│ │   #3  (global)          app.js:80:1        │  │  18│   return this;    │ │
+│ │                                            │  │  19│ }                 │ │
+│ │                                            │  │                        │ │
+│ │ ── locals at #0 ───────────────────────    │  │  → marks error line    │ │
+│ │   this   : Dog { name: "Rex" }             │  │                        │ │
+│ │   food   : undefined                       │  │                        │ │
+│ │                                            │  │                        │ │
+│ │  [Enter: inspect value]  [↑↓: walk stack]  │  │                        │ │
+│ └────────────────────────────────────────────┘  └────────────────────────┘ │
+├─── REPL ────────────────────────────────────────────────────────────────────┤
+│ ✗ new Dog("Rex").fetch()                                                    │
+│ » ▌                                                                         │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Flow:** Arrow keys walk the stack frames. Selecting `this` or `food` in the locals section opens them as inspectable objects (back to Screen 5 style). Selecting a different stack frame updates the source pane.
+
+Implementation analysis:
+
+- Immediate implementation uses `*goja.Exception` string parse to extract message and frame locations.
+- Upgrade path uses runtime-side helper wrappers around `CaptureCallStack` where possible during function calls.
+- Frame selection publishes `MsgStackFrameSelected` to source panel.
+- Locals inspection requires runtime instrumentation wrappers. This should be marked `phase-2` with graceful placeholder in phase-1.
+
+## Component System Design
+
+### Model Decomposition
+
+`RootModel`
+Orchestrates focus, layout, active mode, shared stores, and command routing.
+
+`GlobalsModel`
+Shows static root bindings and global runtime values.
+
+`MembersModel`
+Shows selected target members grouped into own/inherited/symbol/descriptors.
+
+`SourcePanelModel`
+Displays source slice, current highlight range, error line, and optional symbol table subsection.
+
+`SymbolTableModel`
+Displays local symbols for selected method with kind and usage counts.
+
+`CrossRefModel`
+Displays usages and supports jump-to-usage.
+
+`ReplModel`
+Maintains input/history/result/error and emits eval messages.
+
+`ObjectBrowserModel`
+Renders inspectable values and member rows.
+
+`NavigationStackModel`
+Maintains breadcrumb frames and `Esc` back behavior.
+
+`StackTraceModel`
+Renders error stack entries and selected frame.
+
+`StatusModel`
+Renders contextual status + transient notices.
+
+### Reusable UI Components
+
+`PaneFrame`
+Title bar, focused border style, body clipping.
+
+`SelectableList`
+Keyboard selection, scroll windowing, optional sections.
+
+`CodeView`
+Gutter, line highlight, char-range highlight.
+
+`InlineTable`
+Two-to-four column compact row display for symbols/descriptors.
+
+`BreadcrumbBar`
+Truncated path segments with active item styling.
+
+`CommandLine`
+REPL input with prompt, history, transient result line.
+
+### Reuse And Refactor Matrix (GOJA-025 Baseline)
+
+`mode-keymap` + `help`
+Reuse `cmd/inspector/app/keymap.go` patterns directly for mode-scoped bindings (`global`, `members`, `source`, `repl`, `stack`) and keep a single help footer contract.
+
+`list`
+Reuse the approach in `cmd/inspector/app/tree_list.go`: domain row -> `list.Item` adapter, centralized `FilterValue`, and single owner for selected-row mapping.
+
+`viewport`
+Reuse source-pane behavior from `cmd/inspector/app/model.go` (`viewport.Model` ownership in panel model, not in root). Refactor only line-highlight handling into `pkg/inspector/ui/components/code_view.go`.
+
+`table`
+Reuse metadata panel/table shape from `cmd/inspector/app/model.go` for descriptors, locals, and symbol-key rows. Refactor column factories into one shared helper to avoid per-pane column drift.
+
+`spinner`
+Reuse spinner lifecycle/status messaging from `cmd/inspector/app/model.go` for async load/eval states (`loading file`, `rebuilding analysis`, `evaluating`).
+
+`textinput`
+Reuse command-mode input patterns from `cmd/inspector/app/model.go` for `:load`/`:run`, and keep REPL input as a separate model that shares history/edit key behavior.
+
+Refactor scope to avoid overcoupling:
+- Do not copy the existing inspector root model wholesale.
+- Extract tiny reusable constructors/helpers first, then compose them in `cmd/smalltalk-inspector/app`.
+- Keep `pkg/inspector/*` UI-agnostic where possible (especially runtime and analysis packages).
+
+### Message Contracts
+
+`MsgFileLoaded`
+Carries filename, source, analysis bundle, runtime session state.
+
+`MsgGlobalSelected`
+Carries selected root binding and optional runtime reference.
+
+`MsgMemberSelected`
+Carries member identity and optional source span.
+
+`MsgInspectTargetPushed`
+Carries new inspect target frame.
+
+`MsgInspectBack`
+Pops one breadcrumb frame.
+
+`MsgEvalResult`
+Carries expression text and runtime value reference.
+
+`MsgEvalError`
+Carries expression text and parsed stack metadata.
+
+`MsgJumpToSource`
+Carries filename + line/column/span.
+
+`MsgHighlightBinding`
+Carries binding id and usage ids for source overlay.
+
+### State Stores
+
+`AnalysisStore`
+`jsparse` result cache for current file.
+
+`RuntimeStore`
+Goja runtime and reference registry for inspectable values.
+
+`NavigationStore`
+Breadcrumb frames and per-frame UI snapshot.
+
+`SelectionStore`
+Current global/member/symbol/xref/stack selections.
+
+## Developer Onboarding Runbook
+
+### First 30 Minutes (Find Your Marks)
+
+1. Read this document end-to-end once.
+2. Open and skim:
+   - `go-go-goja/cmd/inspector/app/model.go`
+   - `go-go-goja/cmd/inspector/app/keymap.go`
+   - `go-go-goja/cmd/inspector/app/tree_list.go`
+   - `go-go-goja/pkg/jsparse/index.go`
+   - `go-go-goja/pkg/jsparse/resolve.go`
+3. Run baseline tests:
+   - `cd go-go-goja && go test ./cmd/inspector/... -count=1`
+   - `cd go-go-goja && go test ./pkg/jsparse -count=1`
+4. Run existing inspector to understand interaction baseline:
+   - `cd go-go-goja && go run ./cmd/inspector ../path/to/file.js`
+
+### Fast Code Navigation Commands
+
+Run these from `go-go-goja/` to find key implementation marks quickly:
+
+- `rg -n "type keyMap|ShortHelp|FullHelp" cmd/inspector/app`
+- `rg -n "spinner|textinput|viewport|table|list" cmd/inspector/app/model.go`
+- `rg -n "BindingForNode|AllUsages|WalkScopeChain" pkg/jsparse`
+- `rg -n "Symbols\\(|Prototype\\(|GetOwnPropertyNames\\(" ../goja`
+- `rg -n "TODO|FIXME|GOJA-024|smalltalk-inspector" cmd pkg`
+
+### Architectural Boundaries (Do Not Blur)
+
+- `cmd/*` directories:
+  - CLI glue and high-level wiring only.
+  - Avoid putting deep business logic here.
+- `pkg/jsparse`:
+  - Static parse/index/resolve/completion logic.
+  - Keep this reusable and UI-agnostic.
+- `pkg/inspector` (new):
+  - Smalltalk-inspector domain and UI orchestration.
+  - Prefer this over adding more monolith logic into `cmd/inspector/app`.
+- `goja/` runtime internals:
+  - Modify only if unavoidable and justified by missing API capability.
+
+### New Developer Checklist Before Opening First PR
+
+- Confirm your changes do not regress existing `cmd/inspector` behavior.
+- Keep new Smalltalk features behind the new command path.
+- Add/update tests in the same directory as changed logic.
+- Update GOJA-024 `tasks.md`, `changelog.md`, and `reference/01-diary.md` at each meaningful milestone.
+
+## File-By-File Implementation Blueprint
+
+### Command Entry And Wiring
+
+`cmd/smalltalk-inspector/main.go`
+CLI args, startup config, launches root model with alt screen.
+
+`cmd/smalltalk-inspector/app/model.go`
+Root model struct fields for all child models and shared stores.
+
+`cmd/smalltalk-inspector/app/update.go`
+Main message routing and command chaining logic.
+
+`cmd/smalltalk-inspector/app/view.go`
+Top-level layout assembly and pane switching by mode.
+
+`cmd/smalltalk-inspector/app/keymap.go`
+Canonical key definitions and help text per mode.
+
+`cmd/smalltalk-inspector/app/messages.go`
+Shared typed message structs used across components.
+
+`cmd/smalltalk-inspector/app/styles.go`
+Central lipgloss style definitions.
+
+`cmd/smalltalk-inspector/app/reuse_inspector_components.go` (or equivalent wiring module)
+Imports/adapts reusable logic from `cmd/inspector/app` where practical (keymap patterns, list/view/table setup, viewport behaviors).
+
+### Domain Layer
+
+`pkg/inspector/analysis/session.go`
+Build/refresh analysis from source using `jsparse.Analyze`.
+
+`pkg/inspector/analysis/method_symbols.go`
+Resolve method-local symbol rows and usage counts.
+
+`pkg/inspector/analysis/xref.go`
+Binding-to-usage row mapping with jump targets.
+
+`pkg/inspector/runtime/session.go`
+Owns `goja.Runtime`, load/run/eval helpers, and value registry.
+
+`pkg/inspector/runtime/introspect.go`
+Property, symbol, descriptor, and prototype helpers.
+
+`pkg/inspector/runtime/errors.go`
+Normalize `*goja.Exception` into UI stack/error rows.
+
+`pkg/inspector/runtime/function_map.go`
+Map runtime function/method selections to static source spans.
+
+`pkg/inspector/navigation/targets.go`
+Defines `InspectTarget` union and breadcrumb frame payloads.
+
+### Component Layer
+
+`pkg/inspector/ui/components/selectable_list.go`
+Optional thin wrapper around `bubbles/list` for inspector-specific sections and icons.
+
+`pkg/inspector/ui/components/code_view.go`
+Reusable source rendering with line/char highlights built on `bubbles/viewport`.
+
+`pkg/inspector/ui/components/pane_frame.go`
+Pane wrapper and focus border rendering.
+
+`pkg/inspector/ui/components/breadcrumb.go`
+Breadcrumb row rendering and truncation.
+
+`pkg/inspector/ui/components/repl_line.go`
+Prompt line, input editing, and history behavior built on `bubbles/textinput`.
+
+### Feature Models
+
+`pkg/inspector/ui/models/globals_model.go`
+Build/render/update root binding list.
+
+`pkg/inspector/ui/models/members_model.go`
+Build/render/update selected target members.
+
+`pkg/inspector/ui/models/source_model.go`
+Render source and manage jump/highlight.
+
+`pkg/inspector/ui/models/symbols_model.go`
+Render method-local symbol rows.
+
+`pkg/inspector/ui/models/xref_model.go`
+Render xref rows and jump selection.
+
+`pkg/inspector/ui/models/object_model.go`
+Render runtime object member table.
+
+`pkg/inspector/ui/models/repl_model.go`
+Input/history/eval dispatch/result presentation.
+
+`pkg/inspector/ui/models/stack_model.go`
+Error stack list and frame selection.
+
+`pkg/inspector/ui/models/status_model.go`
+Status and transient notices.
+
+## Delivery Phases
+
+Phase 0 (completed in GOJA-025)
+Reusable inspector component baseline in `cmd/inspector/app`:
+- mode-aware keymap (`mode-keymap`)
+- `bubbles/help`, `bubbles/spinner`
+- `bubbles/viewport`, `bubbles/list`
+- `bubbles/textinput`, `bubbles/table`
+
+Phase 1
+Implement Smalltalk command skeleton and Screens 1 to 4 on top of the Phase-0 baseline.
+
+Phase 2
+Implement Screens 5 to 7 with runtime object browsing, prototype navigation, and descriptor/symbol-key panes.
+
+Phase 3
+Implement Screen 8 stack trace browsing, then harden tests/docs and extract stable `pkg/inspector` shared packages.
+
+## Usage Examples
+
+Example implementation loop:
+
+```bash
+cd go-go-goja
+
+go test ./cmd/inspector/... -count=1
+
+go test ./pkg/jsparse -count=1
+
+go run ./ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/scripts/goja-runtime-probe.go
+
+go run ./ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/scripts/jsparse-index-probe.go
+```
+
+Example design-to-code mapping:
+
+- Screen 2 globals list -> `globals_model.go` + `analysis/session.go`
+- Screen 5 REPL object inspect -> `repl_model.go` + `runtime/session.go` + `object_model.go`
+- Screen 8 stack trace -> `runtime/errors.go` + `stack_model.go` + `source_model.go`
+
+## Related
+
+- `sources/local/smalltalk-goja-inspector.md`
+- `reference/01-diary.md`
+- `go-go-goja/cmd/inspector/app/model.go`
+- `go-go-goja/cmd/inspector/app/keymap.go`
+- `go-go-goja/cmd/inspector/app/tree_list.go`
+- `go-go-goja/cmd/ast-parse-editor/app/model.go`
+- `go-go-goja/pkg/jsparse/index.go`
+- `go-go-goja/pkg/jsparse/resolve.go`
+- `go-go-goja/pkg/jsparse/completion.go`
+- `go-go-goja/ttmp/2026/02/14/GOJA-025-INSPECTOR-BUBBLES-REFACTOR--inspector-bubbles-component-refactor/reference/01-inspector-refactor-design-guide.md`

--- a/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/scripts/goja-runtime-probe.go
+++ b/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/scripts/goja-runtime-probe.go
@@ -1,0 +1,157 @@
+//go:build ignore
+// +build ignore
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/dop251/goja"
+)
+
+func main() {
+	vm := goja.New()
+
+	vm.Set("captureStack", func(call goja.FunctionCall) goja.Value {
+		frames := vm.CaptureCallStack(0, nil)
+		fmt.Println("== CaptureCallStack (inside JS call) ==")
+		for i, f := range frames {
+			pos := f.Position()
+			fmt.Printf("#%d %s:%d:%d\n", i, pos.Filename, pos.Line, pos.Column)
+		}
+		return goja.Undefined()
+	})
+
+	src := `
+const symCustom = Symbol("custom");
+
+const config = {
+  apiUrl: "https://api.example.com/v3",
+  timeout: 3000,
+  retries: 5,
+  debug: false,
+  [Symbol.iterator]: function* iterator() { yield 1; },
+  [Symbol.toPrimitive]: function() { return "cfg"; },
+  [symCustom]: "meta"
+};
+
+class Animal {
+  constructor(name) {
+    this.name = name;
+    this.alive = true;
+    this.energy = 0;
+  }
+
+  eat(food) {
+    if (!this.alive) {
+      throw new Error("dead");
+    }
+    this.energy += food.calories;
+    return this;
+  }
+
+  sleep() {
+    return "zzz";
+  }
+}
+
+class Dog extends Animal {
+  constructor(name) {
+    super(name);
+    this.breed = "lab";
+  }
+
+  bark() {
+    const sound = this.breed === "husky" ? "awoo" : "woof";
+    return sound;
+  }
+
+  fetch(item) {
+    return this.eat(item);
+  }
+}
+
+function main() {
+  const rex = new Dog("Rex");
+  captureStack();
+  return rex;
+}
+
+globalThis.main = main;
+globalThis.config = config;
+globalThis.Dog = Dog;
+globalThis.Animal = Animal;
+globalThis.symCustom = symCustom;
+`
+
+	if _, err := vm.RunString(src); err != nil {
+		panic(err)
+	}
+
+	mainFn, ok := goja.AssertFunction(vm.Get("main"))
+	if !ok {
+		panic("main is not callable")
+	}
+
+	v, err := mainFn(goja.Undefined())
+	if err != nil {
+		panic(err)
+	}
+
+	rex := v.ToObject(vm)
+	fmt.Println("== Dog instance own keys ==")
+	fmt.Printf("GetOwnPropertyNames=%v\n", rex.GetOwnPropertyNames())
+	fmt.Printf("Keys=%v\n", rex.Keys())
+	fmt.Printf("Symbols=%v\n", symbolStrings(rex.Symbols()))
+
+	fmt.Println("== Dog instance prototype chain ==")
+	for i, p := 0, rex.Prototype(); p != nil; i, p = i+1, p.Prototype() {
+		ctor := p.Get("constructor")
+		name := "<anon>"
+		if ctorObj, ok := ctor.(*goja.Object); ok {
+			if n := ctorObj.Get("name"); n != nil {
+				name = n.String()
+			}
+		}
+		fmt.Printf("level=%d ctor=%s ownNames=%v\n", i, name, p.GetOwnPropertyNames())
+	}
+
+	configObj := vm.Get("config").ToObject(vm)
+	fmt.Println("== config keys and symbols ==")
+	fmt.Printf("GetOwnPropertyNames=%v\n", configObj.GetOwnPropertyNames())
+	fmt.Printf("Symbols=%v\n", symbolStrings(configObj.Symbols()))
+
+	for _, key := range []string{"apiUrl", "timeout", "retries", "debug"} {
+		desc, err := vm.RunString(fmt.Sprintf("JSON.stringify(Object.getOwnPropertyDescriptor(config, %q))", key))
+		if err != nil {
+			panic(err)
+		}
+		fmt.Printf("descriptor[%s]=%s\n", key, desc.String())
+	}
+
+	fmt.Println("== thrown error stack string ==")
+	_, err = vm.RunString(`new Dog("Rex").fetch()`)
+	if err != nil {
+		if ex, ok := err.(*goja.Exception); ok {
+			fmt.Println(ex.String())
+			lines := strings.Split(ex.String(), "\n")
+			if len(lines) > 0 {
+				fmt.Printf("errorMessage=%s\n", lines[0])
+			}
+		} else {
+			fmt.Printf("non-exception error=%v\n", err)
+		}
+	}
+}
+
+func symbolStrings(syms []*goja.Symbol) []string {
+	ret := make([]string, 0, len(syms))
+	for _, s := range syms {
+		if s == nil {
+			continue
+		}
+		ret = append(ret, s.String())
+	}
+	return ret
+}

--- a/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/scripts/jsparse-index-probe.go
+++ b/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/scripts/jsparse-index-probe.go
@@ -1,0 +1,81 @@
+//go:build ignore
+// +build ignore
+
+package main
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/dop251/goja/parser"
+	"github.com/go-go-golems/go-go-goja/pkg/jsparse"
+)
+
+func main() {
+	source := `
+function greet(name) { return "hi " + name; }
+class Animal {
+  constructor(name) { this.name = name; this.alive = true; }
+  eat(food) { if (!this.alive) throw new Error("dead"); return food; }
+  sleep() { return "zzz"; }
+}
+class Dog extends Animal {
+  constructor(name) { super(name); this.breed = "lab"; }
+  bark() { const sound = this.breed === "husky" ? "awoo" : "woof"; return sound; }
+  fetch(item) { return this.eat(item); }
+}
+function main() {
+  const config = { apiUrl: "https://api.example.com/v3", retries: 5 };
+  return new Dog("Rex");
+}
+`
+
+	program, err := parser.ParseFile(nil, "sample.js", source, 0)
+	if err != nil {
+		fmt.Printf("parseErr=%v\n", err)
+	}
+	if program == nil {
+		panic("no program")
+	}
+
+	idx := jsparse.BuildIndex(program, source)
+	res := jsparse.Resolve(program, idx)
+	idx.Resolution = res
+
+	global := res.Scopes[res.RootScopeID]
+	fmt.Println("== Global Bindings ==")
+	names := make([]string, 0, len(global.Bindings))
+	for name := range global.Bindings {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		b := global.Bindings[name]
+		n := idx.Nodes[b.DeclNodeID]
+		if n == nil {
+			fmt.Printf("- %s kind=%s decl=<missing> refs=%d\n", name, b.Kind, len(b.References))
+			continue
+		}
+		fmt.Printf("- %s kind=%s declNode=%s span=%d..%d refs=%d\n", name, b.Kind, n.Kind, n.Start, n.End, len(b.References))
+	}
+
+	fmt.Println("== Unresolved Identifiers ==")
+	for _, nodeID := range res.Unresolved {
+		n := idx.Nodes[nodeID]
+		if n == nil {
+			continue
+		}
+		fmt.Printf("- %s span=%d..%d\n", n.Label, n.Start, n.End)
+	}
+
+	fmt.Println("== Selected Node Labels Around ClassLiteral/MethodDefinition ==")
+	for _, nodeID := range idx.OrderedByStart {
+		n := idx.Nodes[nodeID]
+		if n == nil {
+			continue
+		}
+		if n.Kind == "ClassLiteral" || n.Kind == "MethodDefinition" || n.Kind == "ClassDeclaration" {
+			fmt.Printf("- %s label=%s span=%d..%d depth=%d\n", n.Kind, n.Label, n.Start, n.End, n.Depth)
+		}
+	}
+}

--- a/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/scripts/sample.js
+++ b/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/scripts/sample.js
@@ -1,0 +1,57 @@
+const symCustom = Symbol("custom");
+
+const config = {
+  apiUrl: "https://api.example.com/v3",
+  timeout: 3000,
+  retries: 5,
+  debug: false,
+};
+
+class Animal {
+  constructor(name) {
+    this.name = name;
+    this.alive = true;
+    this.energy = 0;
+  }
+
+  eat(food) {
+    if (!this.alive) {
+      throw new Error("dead");
+    }
+    this.energy += food.calories;
+    return this;
+  }
+
+  sleep() {
+    return "zzz";
+  }
+}
+
+class Dog extends Animal {
+  constructor(name) {
+    super(name);
+    this.breed = "lab";
+  }
+
+  bark() {
+    const sound = this.breed === "husky" ? "awoo" : "woof";
+    return sound;
+  }
+
+  fetch(item) {
+    return this.eat(item);
+  }
+}
+
+function greet(name) {
+  return `Hello, ${name}!`;
+}
+
+function main() {
+  const rex = new Dog("Rex");
+  rex.bark();
+  return rex;
+}
+
+const API_KEY = "sk-abc123";
+const version = 3;

--- a/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/sources/local/smalltalk-goja-inspector.md
+++ b/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/sources/local/smalltalk-goja-inspector.md
@@ -1,0 +1,312 @@
+Let me read the task document first.Now I have a solid picture. Here's a full set of TUI mockups with flow explanations.
+
+---
+
+## Screen 1 — Startup / Load File
+
+The user launches the inspector and is greeted with a file loader + empty workspace. The REPL is always at the bottom.
+
+```
+┌─── goja-inspector ──────────────────────────────────────────────────────────┐
+│                                                                             │
+│                                                                             │
+│                         No program loaded.                                  │
+│                                                                             │
+│              :load <file.js>    Load a JavaScript file                      │
+│              :run  <expr>       Evaluate an expression                      │
+│              :help              Show all commands                           │
+│                                                                             │
+│                                                                             │
+│                                                                             │
+│                                                                             │
+│                                                                             │
+│                                                                             │
+│                                                                             │
+│                                                                             │
+│                                                                             │
+│                                                                             │
+├─── REPL ────────────────────────────────────────────────────────────────────┤
+│ » :load app.js                                                              │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Screen 2 — File Loaded: Global Scope Overview
+
+After loading, the left pane shows **all top-level bindings** (globals, classes, functions). The right pane is empty until something is selected. This is the "Class Browser" root.
+
+```
+┌─── goja-inspector ─── app.js ───────────────────────────────────────────────┐
+│ ┌─ Globals ──────────────┐  ┌─ Members ─────────────┐  ┌─ Source ────────┐ │
+│ │                        │  │                        │  │                 │ │
+│ │  ƒ  greet              │  │   (select a global)    │  │  (no source)    │ │
+│ │  C  Animal             │  │                        │  │                 │ │
+│ │  C  Dog  ← Animal      │  │                        │  │                 │ │
+│ │  ƒ  main               │  │                        │  │                 │ │
+│ │  ●  config      {…}    │  │                        │  │                 │ │
+│ │  ●  API_KEY     "sk-…" │  │                        │  │                 │ │
+│ │  ●  version     3      │  │                        │  │                 │ │
+│ │                        │  │                        │  │                 │ │
+│ │                        │  │                        │  │                 │ │
+│ │                        │  │                        │  │                 │ │
+│ │  8 bindings found      │  │                        │  │                 │ │
+│ └────────────────────────┘  └────────────────────────┘  └─────────────────┘ │
+├─── REPL ────────────────────────────────────────────────────────────────────┤
+│ ✓ Loaded app.js (245 lines, 8 globals)                                      │
+│ » ▌                                                                         │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Legend:** `ƒ` = function, `C` = class, `●` = value/object. Arrow `← Animal` shows extends.
+
+---
+
+## Screen 3 — Select a Class: Member List Populates
+
+User highlights `Dog` in the left pane. The middle pane fills with its **own members + inherited** members. Prototype chain is shown.
+
+```
+┌─── goja-inspector ─── app.js ───────────────────────────────────────────────┐
+│ ┌─ Globals ──────────────┐  ┌─ Dog: Members ────────┐  ┌─ Source ────────┐ │
+│ │                        │  │                        │  │                 │ │
+│ │   ƒ  greet             │  │ ── own ──────────────  │  │  (select a      │ │
+│ │   C  Animal            │  │  ƒ  constructor(name)  │  │   member)       │ │
+│ │ ▸ C  Dog  ← Animal     │  │  ƒ  bark()            │  │                 │ │
+│ │   ƒ  main              │  │  ƒ  fetch(item)       │  │                 │ │
+│ │   ●  config      {…}   │  │  ●  breed    "lab"     │  │                 │ │
+│ │   ●  API_KEY     "sk-… │  │                        │  │                 │ │
+│ │   ●  version     3     │  │ ── inherited (Animal)  │  │                 │ │
+│ │                        │  │  ƒ  eat(food)          │  │                 │ │
+│ │                        │  │  ƒ  sleep()            │  │                 │ │
+│ │                        │  │  ●  alive     true     │  │                 │ │
+│ │                        │  │                        │  │                 │ │
+│ │                        │  │ proto: Animal → Object │  │                 │ │
+│ └────────────────────────┘  └────────────────────────┘  └─────────────────┘ │
+├─── REPL ────────────────────────────────────────────────────────────────────┤
+│ » ▌                                                                         │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Key:** The `▸` marker shows the currently selected item. Prototype chain is rendered at the bottom of the members pane.
+
+---
+
+## Screen 4 — Select a Method: Source + Symbols Appear
+
+User selects `bark()`. The right pane shows **source code**, and a **symbols sub-panel** appears below it with local bindings.
+
+```
+┌─── goja-inspector ─── app.js ───────────────────────────────────────────────┐
+│ ┌─ Globals ──────────┐ ┌─ Dog: Members ──────┐ ┌─ Source: bark() ────────┐ │
+│ │                    │ │                      │ │                         │ │
+│ │  ƒ  greet          │ │ ── own ────────────  │ │  43│ bark() {            │ │
+│ │  C  Animal         │ │  ƒ  constructor()    │ │  44│   const sound =     │ │
+│ │▸ C  Dog ← Animal   │ │ ▸ƒ  bark()          │ │  45│     this.breed ===  │ │
+│ │  ƒ  main           │ │  ƒ  fetch(item)     │ │  46│     "husky"         │ │
+│ │  ●  config    {…}  │ │  ●  breed   "lab"   │ │  47│     ? "awoo" : "wo… │ │
+│ │  ●  API_KEY   "sk… │ │                      │ │  48│   console.log(      │ │
+│ │  ●  version   3    │ │ ── inherited ──────  │ │  49│     `${this.name}:  │ │
+│ │                    │ │  ƒ  eat(food)        │ │  50│      ${sound}`);    │ │
+│ │                    │ │  ƒ  sleep()          │ │  51│   return sound;     │ │
+│ │                    │ │  ●  alive    true    │ │  52│ }                   │ │
+│ │                    │ │                      │ ├─ Symbols ──────────────┤ │
+│ │                    │ │                      │ │ sound  const  L44  2u  │ │
+│ │                    │ │                      │ │ this   recv   —    4u  │ │
+│ └────────────────────┘ └──────────────────────┘ └─────────────────────────┘ │
+├─── REPL ────────────────────────────────────────────────────────────────────┤
+│ » ▌                                                                         │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Symbols sub-panel:** `L44` = defined on line 44, `2u` = 2 usages found. This comes from Layer B (`BuildIndex` + `Resolve`).
+
+---
+
+## Screen 5 — REPL Evaluation: Live Object Inspection
+
+User types an expression in the REPL. The result becomes an **inspectable object** that replaces or augments the Globals pane (shown here as a dedicated result panel).
+
+```
+┌─── goja-inspector ─── app.js ───────────────────────────────────────────────┐
+│ ┌─ REPL Result ──────────────────────────────┐  ┌─ Source ────────────────┐ │
+│ │                                            │  │                         │ │
+│ │  new Dog("Rex")                            │  │                         │ │
+│ │  → Dog {                                   │  │  (select member to      │ │
+│ │      name      : "Rex"           string    │  │   view source)          │ │
+│ │      breed     : "lab"           string    │  │                         │ │
+│ │    ▸ bark      : ƒ bark()        function  │  │                         │ │
+│ │      fetch     : ƒ fetch(item)   function  │  │                         │ │
+│ │      eat       : ƒ eat(food)     function  │  │                         │ │
+│ │      sleep     : ƒ sleep()       function  │  │                         │ │
+│ │      alive     : true            boolean   │  │                         │ │
+│ │      [[Proto]] : Animal.prototype          │  │                         │ │
+│ │                                            │  │                         │ │
+│ │  [Tab: expand]  [Enter: inspect]  [s: src] │  │                         │ │
+│ └────────────────────────────────────────────┘  └─────────────────────────┘ │
+├─── REPL ────────────────────────────────────────────────────────────────────┤
+│   new Dog("Rex")                                                            │
+│ » ▌                                                                         │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Flow:** The REPL result is a **live runtime object**. Selecting `bark` here would show the same source as Screen 4. Selecting `[[Proto]]` would drill into `Animal.prototype`.
+
+---
+
+## Screen 6 — Drill Into Prototype / Deep Inspect
+
+User selects `[[Proto]]` to walk the prototype chain. The inspector now shows `Animal.prototype` as the inspected target.
+
+```
+┌─── goja-inspector ─── app.js ───────────────────────────────────────────────┐
+│ ┌─ Breadcrumb: Dog instance → [[Proto]] ─────────────────────────────────┐  │
+│ └────────────────────────────────────────────────────────────────────────┘  │
+│ ┌─ Animal.prototype ─────────────────────────┐  ┌─ Source: eat(food) ────┐ │
+│ │                                            │  │                        │ │
+│ │   constructor : ƒ Animal(name)   function  │  │ 12│ eat(food) {        │ │
+│ │ ▸ eat         : ƒ eat(food)      function  │  │ 13│   if (!this.alive) │ │
+│ │   sleep       : ƒ sleep()        function  │  │ 14│     throw new      │ │
+│ │   alive       : true             boolean   │  │ 15│       Error("…");  │ │
+│ │   [[Proto]]   : Object.prototype           │  │ 16│   this.energy +=   │ │
+│ │                                            │  │ 17│     food.calories; │ │
+│ │                                            │  │ 18│   return this;     │ │
+│ │                                            │  │ 19│ }                  │ │
+│ │                                            │  ├─ Symbols ─────────────┤ │
+│ │                                            │  │ food    param L12  3u │ │
+│ │                                            │  │ this    recv  —    2u │ │
+│ │  [Esc: back to Dog]  [Enter: inspect]      │  │                      │ │
+│ └────────────────────────────────────────────┘  └────────────────────────┘ │
+├─── REPL ────────────────────────────────────────────────────────────────────┤
+│ » ▌                                                                         │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Key:** The **breadcrumb bar** at the top tracks navigation history. `Esc` goes back. This is the "continue exploring forever" Smalltalk behavior.
+
+---
+
+## Screen 7 — Symbol-Keyed Properties & Cross-References
+
+User inspects an object with Symbol keys (Layer A: `obj.Symbols()`). Also shows the cross-reference / usages panel.
+
+```
+┌─── goja-inspector ─── app.js ───────────────────────────────────────────────┐
+│ ┌─ Breadcrumb: config ───────────────────────────────────────────────────┐  │
+│ └────────────────────────────────────────────────────────────────────────┘  │
+│ ┌─ config: Members ──────────────────────────┐  ┌─ Cross-References ────┐ │
+│ │                                            │  │                        │ │
+│ │ ── string keys ──────────────────────────  │  │ config.apiUrl          │ │
+│ │   apiUrl    : "https://…"        string    │  │ ── usages (4 found) ── │ │
+│ │   timeout   : 3000               number    │  │                        │ │
+│ │   retries   : 5                  number    │  │  L67  main()           │ │
+│ │   debug     : false              boolean   │  │  L89  Animal.eat()     │ │
+│ │                                            │  │  L134 fetchData()      │ │
+│ │ ── symbol keys ──────────────────────────  │  │  L201 init()           │ │
+│ │   [Symbol.iterator]  : ƒ        function   │  │                        │ │
+│ │   [Symbol.toPrim…]   : ƒ        function   │  │ [Enter: jump to usage] │ │
+│ │   [Symbol(custom)]   : "meta"   string     │  │                        │ │
+│ │                                            │  │                        │ │
+│ │ ── descriptors ──────────────────────────  │  │                        │ │
+│ │   apiUrl: {writable:T enum:T config:T}     │  │                        │ │
+│ └────────────────────────────────────────────┘  └────────────────────────┘ │
+├─── REPL ────────────────────────────────────────────────────────────────────┤
+│ » config.apiUrl                                                             │
+│ → "https://api.example.com/v3"                                              │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Screen 8 — Error / Stack Trace Inspection
+
+When an expression throws, the REPL catches it and shows the **call stack** as an inspectable entity (Layer A: `CaptureCallStack`).
+
+```
+┌─── goja-inspector ─── app.js ───────────────────────────────────────────────┐
+│ ┌─ Error ────────────────────────────────────────────────────────────────┐  │
+│ │  TypeError: Cannot read property 'calories' of undefined               │  │
+│ └────────────────────────────────────────────────────────────────────────┘  │
+│ ┌─ Call Stack ───────────────────────────────┐  ┌─ Source: eat() ────────┐ │
+│ │                                            │  │                        │ │
+│ │ ▸ #0  Animal.eat        app.js:17:5        │  │  15│     Error("…");   │ │
+│ │   #1  Dog.fetch         app.js:56:12       │  │  16│   this.energy +=  │ │
+│ │   #2  main              app.js:72:3        │  │ →17│     food.calories │ │
+│ │   #3  (global)          app.js:80:1        │  │  18│   return this;    │ │
+│ │                                            │  │  19│ }                 │ │
+│ │                                            │  │                        │ │
+│ │ ── locals at #0 ───────────────────────    │  │  → marks error line    │ │
+│ │   this   : Dog { name: "Rex" }             │  │                        │ │
+│ │   food   : undefined                       │  │                        │ │
+│ │                                            │  │                        │ │
+│ │  [Enter: inspect value]  [↑↓: walk stack]  │  │                        │ │
+│ └────────────────────────────────────────────┘  └────────────────────────┘ │
+├─── REPL ────────────────────────────────────────────────────────────────────┤
+│ ✗ new Dog("Rex").fetch()                                                    │
+│ » ▌                                                                         │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Flow:** Arrow keys walk the stack frames. Selecting `this` or `food` in the locals section opens them as inspectable objects (back to Screen 5 style). Selecting a different stack frame updates the source pane.
+
+---
+
+## Flow Summary
+
+```
+┌──────────────┐     :load file.js     ┌──────────────────┐
+│   Startup    │ ────────────────────▸  │  Global Overview  │
+│  (Screen 1)  │                       │    (Screen 2)     │
+└──────────────┘                       └────────┬─────────┘
+                                                │
+                                     select class/object
+                                                │
+                                                ▾
+                                       ┌──────────────────┐
+                                       │  Member List +    │
+                                       │  Source + Symbols │
+                                       │  (Screens 3–4)   │
+                                       └───────┬──────────┘
+                                               │
+                              ┌────────────────┼────────────────┐
+                              │                │                │
+                     select [[Proto]]    select symbol     REPL eval
+                              │           property              │
+                              ▾                │                ▾
+                     ┌────────────────┐        ▾       ┌────────────────┐
+                     │ Prototype Walk │  ┌──────────┐  │  Live Object   │
+                     │  (Screen 6)    │  │ Sym keys │  │  Inspection    │
+                     └────────┬───────┘  │(Screen 7)│  │  (Screen 5)   │
+                              │          └──────────┘  └───────┬────────┘
+                              │                                │
+                              └──────────┬─────────────────────┘
+                                         │
+                                   error thrown?
+                                    ┌────┴─────┐
+                                    │  no  yes │
+                                    │      │   │
+                                    │      ▾   │
+                                    │ ┌──────────────┐
+                                    │ │  Stack Trace  │
+                                    │ │  (Screen 8)   │
+                                    │ └──────┬───────┘
+                                    │        │
+                                    └────────┘
+                                         │
+                                         ▾
+                              ┌─────────────────────┐
+                              │  inspect any value   │──┐
+                              │  from any context    │  │ ← recursive:
+                              │  (back to Screen 5)  │◂─┘   "explore forever"
+                              └─────────────────────┘
+```
+
+### Core Navigation Principles
+
+**Three-pane Smalltalk layout:** Globals (or breadcrumb target) → Members → Source+Symbols. This mirrors the classic Class → Method → Code browser.
+
+**REPL is always present** at the bottom. Any expression result becomes an inspectable object, bridging static browsing and live runtime exploration.
+
+**Breadcrumb navigation** tracks where you've been. `Esc` always goes back. Drilling into `[[Proto]]`, a member value, a stack local, or a cross-reference target all push onto the breadcrumb stack.
+
+**Layers are invisible to the user** — the inspector silently uses Layer A (public API) for runtime values, Layer B (inspector package) for symbols/usages/go-to-definition, and Layer C (private internals) for deep source mapping. The user just sees a unified browsing experience.

--- a/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/tasks.md
+++ b/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/tasks.md
@@ -17,11 +17,11 @@
 
 - [x] Phase 3 error inspection: implement exception capture and stack frame list (source jump + locals/object drill-in entry points)
 - [x] Phase 3 tests: add focused tests for pane sync, inspect navigation, REPL eval behavior, descriptor/symbol rendering, and stack/source jump mapping
-- [ ] Phase 3 polish/docs: update `reference/02-smalltalk-goja-inspector-interface-and-component-design.md`, `reference/01-diary.md`, and `changelog.md` with final decisions and reviewer guidance
+- [x] Phase 3 polish/docs: update `reference/02-smalltalk-goja-inspector-interface-and-component-design.md`, `reference/01-diary.md`, and `changelog.md` with final decisions and reviewer guidance
 
 ## Developer Handoff Checklist
 
 - [x] Confirm `go test ./cmd/inspector/... -count=1` still passes (no regression in existing inspector)
 - [x] Confirm new code path compiles/runs via `go run ./cmd/smalltalk-inspector <file.js>`
 - [x] Ensure reusable components are imported/adapted rather than duplicated from `cmd/inspector/app`
-- [ ] Record each meaningful milestone in diary + changelog with exact commands and outcomes
+- [x] Record each meaningful milestone in diary + changelog with exact commands and outcomes

--- a/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/tasks.md
+++ b/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/tasks.md
@@ -1,0 +1,27 @@
+# Tasks
+
+## TODO
+
+- [x] Replace placeholder task list with phase-structured implementation plan
+
+- [x] Phase 1 bootstrap: create `cmd/smalltalk-inspector/main.go` and `cmd/smalltalk-inspector/app/{model,update,view,messages,styles}.go` with alt-screen launch and root layout skeleton
+- [x] Phase 1 key system: wire `mode-keymap` and `bubbles/help` using patterns from `cmd/inspector/app/keymap.go`; include explicit modes for globals/members/source/repl/stack
+- [x] Phase 1 pane scaffolding: wire `bubbles/list` (globals/members), `bubbles/viewport` (source), `bubbles/table` (metadata), `bubbles/textinput` (command line), `bubbles/spinner` (status)
+- [x] Phase 1 load flow: implement `:load` pipeline in root update loop (read file -> `jsparse.Analyze` -> goja runtime bootstrap -> UI state refresh)
+- [x] Phase 1 static browsing: implement globals and members panes from `pkg/jsparse` bindings/resolution and render source jumps for selected class/method
+
+- [x] Phase 2 domain extraction: add `pkg/inspector/analysis/{session,method_symbols,xref}.go` and `pkg/inspector/runtime/{session,introspect,function_map,errors}.go` to keep cmd layer thin
+- [x] Phase 2 REPL/object inspect: implement eval command path and object browser model with inspect-target payloads (string keys, inherited keys, symbol keys)
+- [x] Phase 2 breadcrumb navigation: implement navigation stack model (`push`, `back`, frame restore) for recursive object/method inspection
+- [x] Phase 2 descriptor/symbol panes: add descriptor table and symbol-key section using runtime helpers for `Object.getOwnPropertyDescriptor` and `Object.Symbols()`
+
+- [x] Phase 3 error inspection: implement exception capture and stack frame list (source jump + locals/object drill-in entry points)
+- [x] Phase 3 tests: add focused tests for pane sync, inspect navigation, REPL eval behavior, descriptor/symbol rendering, and stack/source jump mapping
+- [ ] Phase 3 polish/docs: update `reference/02-smalltalk-goja-inspector-interface-and-component-design.md`, `reference/01-diary.md`, and `changelog.md` with final decisions and reviewer guidance
+
+## Developer Handoff Checklist
+
+- [x] Confirm `go test ./cmd/inspector/... -count=1` still passes (no regression in existing inspector)
+- [x] Confirm new code path compiles/runs via `go run ./cmd/smalltalk-inspector <file.js>`
+- [x] Ensure reusable components are imported/adapted rather than duplicated from `cmd/inspector/app`
+- [ ] Record each meaningful milestone in diary + changelog with exact commands and outcomes

--- a/ttmp/2026/02/14/GOJA-025-INSPECTOR-BUBBLES-REFACTOR--inspector-bubbles-component-refactor/README.md
+++ b/ttmp/2026/02/14/GOJA-025-INSPECTOR-BUBBLES-REFACTOR--inspector-bubbles-component-refactor/README.md
@@ -1,0 +1,21 @@
+# Inspector Bubbles Component Refactor
+
+This is the document workspace for ticket GOJA-025-INSPECTOR-BUBBLES-REFACTOR.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr doc add --ticket GOJA-025-INSPECTOR-BUBBLES-REFACTOR --doc-type design-doc --title "My Design"`
+- Import sources: `docmgr import file --ticket GOJA-025-INSPECTOR-BUBBLES-REFACTOR --file /path/to/doc.md`
+- Update metadata: `docmgr meta update --ticket GOJA-025-INSPECTOR-BUBBLES-REFACTOR --field Status --value review`

--- a/ttmp/2026/02/14/GOJA-025-INSPECTOR-BUBBLES-REFACTOR--inspector-bubbles-component-refactor/changelog.md
+++ b/ttmp/2026/02/14/GOJA-025-INSPECTOR-BUBBLES-REFACTOR--inspector-bubbles-component-refactor/changelog.md
@@ -55,3 +55,8 @@ Step 5: Committed finalized ticket documentation and completed task checklist (c
 - /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-025-INSPECTOR-BUBBLES-REFACTOR--inspector-bubbles-component-refactor/reference/02-diary.md — Diary updated with final docs commit
 - /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-025-INSPECTOR-BUBBLES-REFACTOR--inspector-bubbles-component-refactor/tasks.md — All tasks complete
 
+
+## 2026-02-14
+
+Ticket closed
+

--- a/ttmp/2026/02/14/GOJA-025-INSPECTOR-BUBBLES-REFACTOR--inspector-bubbles-component-refactor/changelog.md
+++ b/ttmp/2026/02/14/GOJA-025-INSPECTOR-BUBBLES-REFACTOR--inspector-bubbles-component-refactor/changelog.md
@@ -45,3 +45,13 @@ Step 4: Finalized design guide, diary, index links, and task bookkeeping for com
 - /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-025-INSPECTOR-BUBBLES-REFACTOR--inspector-bubbles-component-refactor/reference/01-inspector-refactor-design-guide.md — Detailed implementation guide
 - /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-025-INSPECTOR-BUBBLES-REFACTOR--inspector-bubbles-component-refactor/reference/02-diary.md — Per-task diary
 
+
+## 2026-02-14
+
+Step 5: Committed finalized ticket documentation and completed task checklist (commit 9725df9e5523ecb82f9d36b9ca081f11ade91573).
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-025-INSPECTOR-BUBBLES-REFACTOR--inspector-bubbles-component-refactor/reference/02-diary.md — Diary updated with final docs commit
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-025-INSPECTOR-BUBBLES-REFACTOR--inspector-bubbles-component-refactor/tasks.md — All tasks complete
+

--- a/ttmp/2026/02/14/GOJA-025-INSPECTOR-BUBBLES-REFACTOR--inspector-bubbles-component-refactor/changelog.md
+++ b/ttmp/2026/02/14/GOJA-025-INSPECTOR-BUBBLES-REFACTOR--inspector-bubbles-component-refactor/changelog.md
@@ -1,0 +1,47 @@
+# Changelog
+
+## 2026-02-14
+
+- Initial workspace created
+
+
+## 2026-02-14
+
+Step 1: Completed mode-aware keymap migration and replaced static help/footer wiring with bubbles help and spinner plumbing (commit 3339aa86b12bbe450ebb01e184241fe2ff47a541).
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/cmd/inspector/app/keymap.go — New keymap definitions with mode tags and help metadata
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/cmd/inspector/app/model.go — Help/spinner models and mode-sync plumbing
+
+
+## 2026-02-14
+
+Step 2: Refactored source/tree panes to use bubbles viewport and bubbles list with selection synchronization preserved (commit 13d7bbfcecd801d6bd75743826ac5e360f13062b).
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/cmd/inspector/app/model.go — Viewport/list integration and sync updates
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/cmd/inspector/app/tree_list.go — New tree list adapter and list model setup
+
+
+## 2026-02-14
+
+Step 3: Added textinput command mode and table-driven metadata panel for selected AST node context (commit 8e1e1ce4b5c2f4caf3e202fb521bf3b4d2919f99).
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/cmd/inspector/app/keymap.go — Added command binding for ':' mode
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/cmd/inspector/app/model.go — Command mode and metadata table implementation
+
+
+## 2026-02-14
+
+Step 4: Finalized design guide, diary, index links, and task bookkeeping for commit-level traceability.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-025-INSPECTOR-BUBBLES-REFACTOR--inspector-bubbles-component-refactor/index.md — Ticket entrypoint update
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-025-INSPECTOR-BUBBLES-REFACTOR--inspector-bubbles-component-refactor/reference/01-inspector-refactor-design-guide.md — Detailed implementation guide
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-025-INSPECTOR-BUBBLES-REFACTOR--inspector-bubbles-component-refactor/reference/02-diary.md — Per-task diary
+

--- a/ttmp/2026/02/14/GOJA-025-INSPECTOR-BUBBLES-REFACTOR--inspector-bubbles-component-refactor/index.md
+++ b/ttmp/2026/02/14/GOJA-025-INSPECTOR-BUBBLES-REFACTOR--inspector-bubbles-component-refactor/index.md
@@ -1,0 +1,71 @@
+---
+Title: Inspector Bubbles Component Refactor
+Ticket: GOJA-025-INSPECTOR-BUBBLES-REFACTOR
+Status: active
+Topics:
+    - go
+    - goja
+    - tui
+    - tooling
+DocType: index
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: cmd/inspector/app/model.go
+      Note: Primary refactor target for component adoption
+    - Path: cmd/inspector/app/keymap.go
+      Note: Mode-aware keymap and help integration
+    - Path: cmd/inspector/app/tree_list.go
+      Note: bubbles/list adapter for AST tree pane
+    - Path: ttmp/2026/02/14/GOJA-025-INSPECTOR-BUBBLES-REFACTOR--inspector-bubbles-component-refactor/reference/01-inspector-refactor-design-guide.md
+      Note: Detailed implementation guide
+    - Path: ttmp/2026/02/14/GOJA-025-INSPECTOR-BUBBLES-REFACTOR--inspector-bubbles-component-refactor/reference/02-diary.md
+      Note: Per-task execution diary
+ExternalSources: []
+Summary: "Refactor ticket to adopt reusable Bubble Tea components in cmd/inspector before Smalltalk inspector implementation." 
+LastUpdated: 2026-02-14T12:14:00Z
+WhatFor: "Track component-driven refactor tasks, commits, and documentation for inspector UI groundwork." 
+WhenToUse: "Use as entrypoint for GOJA-025 to review scope, links, and completion state." 
+---
+
+# Inspector Bubbles Component Refactor
+
+## Overview
+
+This ticket refactors existing inspector machinery to reusable Bubble Tea components before implementing new Smalltalk browser features. It introduces mode-aware key bindings and standardizes core UI surfaces around Bubbles components.
+
+## Key Links
+
+- Design guide: `reference/01-inspector-refactor-design-guide.md`
+- Diary: `reference/02-diary.md`
+- Tasks: `tasks.md`
+- Changelog: `changelog.md`
+- Main code target: `cmd/inspector/app/model.go`
+
+## Status
+
+Current status: **active**
+
+## Topics
+
+- go
+- goja
+- tui
+- tooling
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/2026/02/14/GOJA-025-INSPECTOR-BUBBLES-REFACTOR--inspector-bubbles-component-refactor/index.md
+++ b/ttmp/2026/02/14/GOJA-025-INSPECTOR-BUBBLES-REFACTOR--inspector-bubbles-component-refactor/index.md
@@ -1,7 +1,7 @@
 ---
 Title: Inspector Bubbles Component Refactor
 Ticket: GOJA-025-INSPECTOR-BUBBLES-REFACTOR
-Status: active
+Status: complete
 Topics:
     - go
     - goja
@@ -22,11 +22,12 @@ RelatedFiles:
     - Path: ttmp/2026/02/14/GOJA-025-INSPECTOR-BUBBLES-REFACTOR--inspector-bubbles-component-refactor/reference/02-diary.md
       Note: Per-task execution diary
 ExternalSources: []
-Summary: "Refactor ticket to adopt reusable Bubble Tea components in cmd/inspector before Smalltalk inspector implementation." 
-LastUpdated: 2026-02-14T12:14:00Z
-WhatFor: "Track component-driven refactor tasks, commits, and documentation for inspector UI groundwork." 
-WhenToUse: "Use as entrypoint for GOJA-025 to review scope, links, and completion state." 
+Summary: Refactor ticket to adopt reusable Bubble Tea components in cmd/inspector before Smalltalk inspector implementation.
+LastUpdated: 2026-02-14T20:00:08.906362554-05:00
+WhatFor: Track component-driven refactor tasks, commits, and documentation for inspector UI groundwork.
+WhenToUse: Use as entrypoint for GOJA-025 to review scope, links, and completion state.
 ---
+
 
 # Inspector Bubbles Component Refactor
 

--- a/ttmp/2026/02/14/GOJA-025-INSPECTOR-BUBBLES-REFACTOR--inspector-bubbles-component-refactor/reference/01-inspector-refactor-design-guide.md
+++ b/ttmp/2026/02/14/GOJA-025-INSPECTOR-BUBBLES-REFACTOR--inspector-bubbles-component-refactor/reference/01-inspector-refactor-design-guide.md
@@ -1,0 +1,130 @@
+---
+Title: Inspector Refactor Design Guide
+Ticket: GOJA-025-INSPECTOR-BUBBLES-REFACTOR
+Status: active
+Topics:
+    - go
+    - goja
+    - tui
+    - tooling
+DocType: reference
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: go-go-goja/cmd/inspector/app/drawer_test.go
+      Note: Drawer/completion baseline tests
+    - Path: go-go-goja/cmd/inspector/app/keymap.go
+      Note: Mode-aware keymap and help metadata
+    - Path: go-go-goja/cmd/inspector/app/model.go
+      Note: Primary implementation file for component integration
+    - Path: go-go-goja/cmd/inspector/app/model_test.go
+      Note: Behavior baseline tests
+    - Path: go-go-goja/cmd/inspector/app/tree_list.go
+      Note: List adapter for AST tree pane
+ExternalSources: []
+Summary: Detailed implementation guide for refactoring cmd/inspector to reusable Bubble Tea components before Smalltalk inspector implementation.
+LastUpdated: 2026-02-14T12:10:00Z
+WhatFor: Document architecture decisions, task sequence, and validation strategy for component-driven inspector refactor.
+WhenToUse: Use before extending inspector UX so new work builds on shared help/viewport/list/table/spinner/textinput/mode-keymap plumbing.
+---
+
+
+# Inspector Refactor Design Guide
+
+## Goal
+
+Refactor `cmd/inspector` to use reusable Bubble Tea/Bubbles primitives (`help`, `viewport`, `list`, `table`, `spinner`, `textinput`) and mode-aware key binding control (`bobatea/pkg/mode-keymap`) so future Smalltalk-browser features build on stable UI infrastructure instead of ad-hoc rendering/state code.
+
+## Context
+
+Pre-refactor state in `cmd/inspector/app/model.go` had:
+
+- Manual help string rendering.
+- Manual tree and source scroll state bookkeeping.
+- No standard command-input component.
+- No structured tabular metadata panel.
+- Key behavior encoded mostly as string comparisons without mode-gated binding metadata.
+
+Refactor constraints:
+
+- Keep current inspector behavior (source/tree sync, go-to-def/usages, drawer actions) working.
+- Avoid breaking existing tests in `cmd/inspector/app/model_test.go` and `cmd/inspector/app/drawer_test.go`.
+- Preserve command startup flow in `cmd/inspector/main.go`.
+
+## Quick Reference
+
+### Components Introduced
+
+- `help.Model`: unified help footer from key bindings.
+- `spinner.Model`: status activity indicator while completion popup is active.
+- `viewport.Model`: source pane scrolling/render viewport.
+- `list.Model`: AST tree pane list rendering/selection shell.
+- `textinput.Model`: command mode (`:`) input line.
+- `table.Model`: selected-node metadata panel in tree pane.
+- `mode-keymap`: enable/disable key bindings by active UI mode (`source`, `tree`, `drawer`).
+
+### Files Changed (Code)
+
+- `cmd/inspector/app/keymap.go` (new)
+- `cmd/inspector/app/tree_list.go` (new)
+- `cmd/inspector/app/model.go` (refactored)
+
+### Task/Commit Mapping
+
+1. Mode-aware keymap + help/spinner plumbing
+- Commit: `3339aa86b12bbe450ebb01e184241fe2ff47a541`
+
+2. Source/tree refactor to viewport/list
+- Commit: `13d7bbfcecd801d6bd75743826ac5e360f13062b`
+
+3. Drawer-adjacent command input + metadata table
+- Commit: `8e1e1ce4b5c2f4caf3e202fb521bf3b4d2919f99`
+
+### Implementation Notes By Task
+
+Task 1 details:
+
+- Added `KeyMap` structure with mode tags and full/short help integration.
+- Wired `help.View(m.keyMap)` in footer.
+- Wired `spinner.TickMsg` update cycle and status rendering for completion activity.
+- Added `updateInteractionMode()` and mode sync calls on focus transitions.
+
+Task 2 details:
+
+- Added `sourceViewport` and rewired source pane rendering through viewport content.
+- Added `treeList` with `treeListItem` builder for AST rows and scope hints.
+- Refactored `refreshTreeVisible` and selection sync methods to keep list index aligned.
+
+Task 3 details:
+
+- Added `textinput` command mode (`:`) with commands: `drawer`, `clear`, `help`, `quit`.
+- Added `table` metadata pane below tree list for selected node fields.
+- Added command-line render section and command status feedback string.
+
+## Usage Examples
+
+Focused validation loop:
+
+```bash
+cd go-go-goja
+go test ./cmd/inspector/... -count=1
+```
+
+Repo hook-equivalent validation performed during commits:
+
+```bash
+cd go-go-goja
+make lint
+make test
+```
+
+## Related
+
+- `cmd/inspector/app/model.go`
+- `cmd/inspector/app/keymap.go`
+- `cmd/inspector/app/tree_list.go`
+- `cmd/inspector/app/model_test.go`
+- `cmd/inspector/app/drawer_test.go`
+- `reference/02-diary.md`
+- `tasks.md`
+- `changelog.md`

--- a/ttmp/2026/02/14/GOJA-025-INSPECTOR-BUBBLES-REFACTOR--inspector-bubbles-component-refactor/reference/02-diary.md
+++ b/ttmp/2026/02/14/GOJA-025-INSPECTOR-BUBBLES-REFACTOR--inspector-bubbles-component-refactor/reference/02-diary.md
@@ -1,0 +1,266 @@
+---
+Title: Diary
+Ticket: GOJA-025-INSPECTOR-BUBBLES-REFACTOR
+Status: active
+Topics:
+    - go
+    - goja
+    - tui
+    - tooling
+DocType: reference
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: go-go-goja/cmd/inspector/app/keymap.go
+      Note: Task-level keymap changes
+    - Path: go-go-goja/cmd/inspector/app/model.go
+      Note: Main file modified across tasks
+    - Path: go-go-goja/cmd/inspector/app/tree_list.go
+      Note: Task-level tree list changes
+    - Path: go-go-goja/ttmp/2026/02/14/GOJA-025-INSPECTOR-BUBBLES-REFACTOR--inspector-bubbles-component-refactor/changelog.md
+      Note: Step log for commits/tasks
+    - Path: go-go-goja/ttmp/2026/02/14/GOJA-025-INSPECTOR-BUBBLES-REFACTOR--inspector-bubbles-component-refactor/reference/01-inspector-refactor-design-guide.md
+      Note: Design document referenced by diary
+    - Path: go-go-goja/ttmp/2026/02/14/GOJA-025-INSPECTOR-BUBBLES-REFACTOR--inspector-bubbles-component-refactor/tasks.md
+      Note: Checklist state
+ExternalSources: []
+Summary: Step-by-step execution diary for GOJA-025 inspector bubbles refactor with per-task commit tracking.
+LastUpdated: 2026-02-14T12:12:00Z
+WhatFor: Capture implementation sequence, failures, fixes, and validation for component-based inspector refactor.
+WhenToUse: Use to review what changed per task and reproduce validation for commits in GOJA-025.
+---
+
+
+# Diary
+
+## Goal
+
+Record the full implementation path for GOJA-025, including task planning, per-task code changes, commit hashes, validation outcomes, and operational blockers encountered during commit hooks.
+
+## Step 1: Ticket Setup, Design Scope, And Task Plan
+
+I created a dedicated refactor ticket and defined an explicit task sequence tied to the required component list (`help`, `viewport`, `list`, `table`, `spinner`, `mode-keymap`, `textinput`). This established a deterministic implementation order before touching inspector code.
+
+I also created the design-guide and diary documents up front so commit-by-commit notes could be attached immediately as tasks completed.
+
+### Prompt Context
+
+**User prompt (verbatim):** "use help, viewport, list, table, spinner, mode-keymap, textinput, for now. 
+
+Create a new ticket to refactor the existing go-go-goja machinery before we start implementing. Add a detailed implementation guide / design guide, then add detailed tasks to the ticket.
+
+Work them off one by one, implement, commit, check off, update your diary."
+
+**Assistant interpretation:** Create a new refactor ticket, plan concrete component migration tasks, implement each task as code with commits, then track completion and documentation in ticket artifacts.
+
+**Inferred user intent:** Build a robust pre-implementation refactor baseline so upcoming Smalltalk inspector work starts from reusable Bubble Tea components rather than bespoke UI internals.
+
+**Commit (code):** N/A
+
+### What I did
+- Created ticket `GOJA-025-INSPECTOR-BUBBLES-REFACTOR`.
+- Added docs:
+  - `reference/01-inspector-refactor-design-guide.md`
+  - `reference/02-diary.md`
+- Added detailed tasks in `tasks.md` and checked placeholder task.
+
+### Why
+- Needed a traceable task queue before code refactors.
+
+### What worked
+- Ticket + doc scaffolding created cleanly.
+
+### What didn't work
+- N/A.
+
+### What I learned
+- A strict component-to-task mapping reduces refactor drift and makes commit scope easier to keep small.
+
+### What was tricky to build
+- Choosing tasks granular enough for one-commit execution while still delivering meaningful functionality.
+
+### What warrants a second pair of eyes
+- Task wording granularity in `tasks.md` (scope per commit).
+
+### What should be done in the future
+- Keep this task-to-component pattern for subsequent GOJA tickets.
+
+### Code review instructions
+- Start with `tasks.md`, then verify ticket docs exist.
+
+### Technical details
+- Ticket path: `go-go-goja/ttmp/2026/02/14/GOJA-025-INSPECTOR-BUBBLES-REFACTOR--inspector-bubbles-component-refactor`
+
+## Step 2: Task 1 Implementation (Mode Keymap + Help + Spinner)
+
+I added a dedicated `KeyMap` type and switched inspector help rendering to `bubbles/help`, with mode-aware key enablement through `bobatea/pkg/mode-keymap`. I also added `bubbles/spinner` tick wiring and surfaced spinner state in the status bar while completion is active.
+
+This task established standardized key/help infrastructure and eliminated hard-coded help strings.
+
+### Prompt Context
+
+**User prompt (verbatim):** (see Step 1)
+
+**Assistant interpretation:** First complete the key/help/spinner refactor task and commit it in isolation.
+
+**Inferred user intent:** Ensure interaction model is explicit and reusable before deeper layout refactors.
+
+**Commit (code):** `3339aa86b12bbe450ebb01e184241fe2ff47a541` — "inspector: add mode-aware keymap with bubbles help and spinner"
+
+### What I did
+- Added `cmd/inspector/app/keymap.go`.
+- Updated `cmd/inspector/app/model.go` to include:
+  - `help.Model`
+  - `spinner.Model`
+  - mode state + `updateInteractionMode()`
+  - key matching via `key.Matches(...)` for major controls.
+- Replaced custom help footer with `m.help.View(m.keyMap)`.
+
+### Why
+- Needed mode-aware key metadata before integrating componentized panes.
+
+### What worked
+- `go test ./cmd/inspector/... -count=1` passed.
+- Pre-commit hook accepted lint and tests after formatting fixes.
+
+### What didn't work
+- Initial commit attempt failed pre-commit due unrelated script-package typecheck errors in `ttmp/.../scripts`:
+
+```text
+main redeclared in this block ...
+```
+
+### What I learned
+- Repo-wide hooks lint/test all packages, including ticket scripts; scripts need `//go:build ignore` if they define standalone `main` packages in shared dirs.
+
+### What was tricky to build
+- Hook failures were not caused by staged files, but by global package discovery.
+- I resolved this by adding ignore build tags to the conflicting script files, then reran commit.
+
+### What warrants a second pair of eyes
+- Keymap coverage across source/tree/drawer modes.
+
+### What should be done in the future
+- Add build-ignore headers by default for ticket-local Go probe scripts.
+
+### Code review instructions
+- Review `cmd/inspector/app/keymap.go` and `cmd/inspector/app/model.go`.
+- Run `go test ./cmd/inspector/... -count=1`.
+
+### Technical details
+- Formatting issue fixed before commit:
+
+```text
+cmd/inspector/app/keymap.go: File is not properly formatted (gofmt)
+```
+
+## Step 3: Task 2 Implementation (Viewport + List)
+
+I refactored source rendering to flow through `viewport.Model` and introduced a dedicated tree list adapter backed by `bubbles/list` for AST rows. Selection synchronization logic was updated to keep `selectedNodeID`, list cursor, and source highlights aligned.
+
+This reduced manual pane-window bookkeeping and made tree rendering more component-driven.
+
+### Prompt Context
+
+**User prompt (verbatim):** (see Step 1)
+
+**Assistant interpretation:** Replace manual source/tree pane internals with viewport/list while preserving inspector behavior.
+
+**Inferred user intent:** Standardize scrolling/selection mechanics on reusable components.
+
+**Commit (code):** `13d7bbfcecd801d6bd75743826ac5e360f13062b` — "inspector: refactor source/tree panes to viewport and list"
+
+### What I did
+- Added `cmd/inspector/app/tree_list.go` to define list item adapter and list model setup.
+- Updated `cmd/inspector/app/model.go`:
+  - Added `sourceViewport` and `treeList` fields.
+  - Reworked source pane rendering through viewport content.
+  - Reworked tree pane rendering through bubbles list.
+  - Synced list index with existing selection/sync flows.
+
+### Why
+- Needed to remove ad-hoc source/tree render loops before extending UI further.
+
+### What worked
+- `go test ./cmd/inspector/... -count=1` passed.
+- Full pre-commit hook (lint + tests) passed for this commit.
+
+### What didn't work
+- N/A.
+
+### What I learned
+- Existing sync logic can be preserved if list cursor/index is treated as a projection of `selectedNodeID`, not the source of truth.
+
+### What was tricky to build
+- Keeping tree selection stable after expand/collapse and sync jumps with list-backed rendering.
+- Solved by centralizing item rebuild + `Select(...)` calls in refresh paths.
+
+### What warrants a second pair of eyes
+- Tree list item formatting and behavior for very deep trees / heavy usage-highlights.
+
+### What should be done in the future
+- Add dedicated tests around list selection index after expand/collapse.
+
+### Code review instructions
+- Review `cmd/inspector/app/tree_list.go` and tree/source sections of `cmd/inspector/app/model.go`.
+
+### Technical details
+- Commit passed with hooks despite transient docker/dagger network timeout fallback in pre-commit test stage.
+
+## Step 4: Task 3 Implementation (Textinput + Table)
+
+I added a `:` command mode using `bubbles/textinput` and introduced a `bubbles/table` metadata panel under the tree list to show selected-node attributes (kind/span/lines/binding/usages). This completed the requested component set for the current refactor phase.
+
+The command mode currently supports `drawer`, `clear`, `help`, and `quit` as lightweight control commands.
+
+### Prompt Context
+
+**User prompt (verbatim):** (see Step 1)
+
+**Assistant interpretation:** Finish the component set by adding text input and table-driven metadata UI.
+
+**Inferred user intent:** Ensure command interaction and structured metadata rendering are componentized before new feature implementation.
+
+**Commit (code):** `8e1e1ce4b5c2f4caf3e202fb521bf3b4d2919f99` — "inspector: add textinput command mode and metadata table"
+
+### What I did
+- Updated `cmd/inspector/app/model.go` to include:
+  - `textinput.Model` command state (`commandOn`, `commandMsg`)
+  - command parser/handler (`drawer`, `clear`, `help`, `quit`)
+  - `table.Model` metadata pane
+  - additional command-line view section.
+- Updated `cmd/inspector/app/keymap.go` with `:` command binding.
+
+### Why
+- Needed to complete requested component adoption set in this refactor ticket.
+
+### What worked
+- `go test ./cmd/inspector/... -count=1` passed.
+- Pre-commit lint/test passed for this commit.
+
+### What didn't work
+- N/A.
+
+### What I learned
+- Adding command mode as an explicit sub-state simplifies future command palette or REPL unification work.
+
+### What was tricky to build
+- Layout balancing: fitting list + table within existing tree pane height without collapsing content.
+- Implemented adaptive split (`treeHeight` vs `metaHeight`) with minimum constraints.
+
+### What warrants a second pair of eyes
+- Table row width handling for small terminal widths.
+- Command mode interactions when drawer is opened/closed frequently.
+
+### What should be done in the future
+- Add command-mode tests (enter/escape/known command/unknown command paths).
+
+### Code review instructions
+- Review command-mode and table sections in `cmd/inspector/app/model.go`.
+- Run `go test ./cmd/inspector/... -count=1`.
+
+### Technical details
+- Final three code commits in order:
+  - `3339aa86b12bbe450ebb01e184241fe2ff47a541`
+  - `13d7bbfcecd801d6bd75743826ac5e360f13062b`
+  - `8e1e1ce4b5c2f4caf3e202fb521bf3b4d2919f99`

--- a/ttmp/2026/02/14/GOJA-025-INSPECTOR-BUBBLES-REFACTOR--inspector-bubbles-component-refactor/reference/02-diary.md
+++ b/ttmp/2026/02/14/GOJA-025-INSPECTOR-BUBBLES-REFACTOR--inspector-bubbles-component-refactor/reference/02-diary.md
@@ -264,3 +264,57 @@ The command mode currently supports `drawer`, `clear`, `help`, and `quit` as lig
   - `3339aa86b12bbe450ebb01e184241fe2ff47a541`
   - `13d7bbfcecd801d6bd75743826ac5e360f13062b`
   - `8e1e1ce4b5c2f4caf3e202fb521bf3b4d2919f99`
+
+## Step 5: Task 5 Completion (Docs/Tasks/Changelog Commit)
+
+I finalized the ticket documentation layer by updating the index, design guide, diary, changelog, and task checklist, then committed the entire GOJA-025 ticket workspace in one focused docs commit.
+
+This locks in commit-level traceability and leaves the ticket with zero open tasks.
+
+### Prompt Context
+
+**User prompt (verbatim):** (see Step 1)
+
+**Assistant interpretation:** Complete final documentation bookkeeping as a dedicated committed step.
+
+**Inferred user intent:** Ensure every task, including documentation and diary updates, is actually executed and committed.
+
+**Commit (code):** `9725df9e5523ecb82f9d36b9ca081f11ade91573` — "docs: add GOJA-025 refactor guide, diary, and completed tasks"
+
+### What I did
+- Committed ticket docs/files:
+  - `index.md`
+  - `tasks.md`
+  - `changelog.md`
+  - `reference/01-inspector-refactor-design-guide.md`
+  - `reference/02-diary.md`
+  - `README.md`
+- Verified task list now has 0 open tasks.
+
+### Why
+- Needed an explicit final commit for Task 5 and complete auditability.
+
+### What worked
+- Commit completed without lint/test hooks (docs-only staged files).
+
+### What didn't work
+- N/A.
+
+### What I learned
+- Keeping docs commit separate from code commits makes review and rollback cleaner.
+
+### What was tricky to build
+- Ensuring diary/changelog/task status remained consistent after multiple staged code commits and separate docs commit.
+
+### What warrants a second pair of eyes
+- Final consistency check between changelog entries and diary step list.
+
+### What should be done in the future
+- Keep “docs closure commit” as a standard final step for ticketed refactors.
+
+### Code review instructions
+- Open `tasks.md` and confirm all tasks checked.
+- Compare commits in diary against `git log --oneline`.
+
+### Technical details
+- Docs commit hash: `9725df9e5523ecb82f9d36b9ca081f11ade91573`

--- a/ttmp/2026/02/14/GOJA-025-INSPECTOR-BUBBLES-REFACTOR--inspector-bubbles-component-refactor/tasks.md
+++ b/ttmp/2026/02/14/GOJA-025-INSPECTOR-BUBBLES-REFACTOR--inspector-bubbles-component-refactor/tasks.md
@@ -1,0 +1,10 @@
+# Tasks
+
+## TODO
+
+- [x] Add tasks here
+
+- [x] Introduce mode-aware keymap + bubbles help/spinner plumbing in cmd/inspector/app model
+- [x] Refactor source and AST tree panes to use bubbles viewport + bubbles list
+- [x] Refactor drawer input to bubbles textinput and add bubbles table panel for selection metadata
+- [x] Update ticket design guide/diary/changelog with per-task commit-level notes

--- a/ttmp/2026/02/14/GOJA-026-INSPECTOR-BUGS--smalltalk-inspector-bug-fixes-empty-members-and-repl-definitions/README.md
+++ b/ttmp/2026/02/14/GOJA-026-INSPECTOR-BUGS--smalltalk-inspector-bug-fixes-empty-members-and-repl-definitions/README.md
@@ -1,0 +1,21 @@
+# Smalltalk Inspector Bug Fixes: Empty Members and REPL Definitions
+
+This is the document workspace for ticket GOJA-026-INSPECTOR-BUGS.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr doc add --ticket GOJA-026-INSPECTOR-BUGS --doc-type design-doc --title "My Design"`
+- Import sources: `docmgr import file --ticket GOJA-026-INSPECTOR-BUGS --file /path/to/doc.md`
+- Update metadata: `docmgr meta update --ticket GOJA-026-INSPECTOR-BUGS --field Status --value review`

--- a/ttmp/2026/02/14/GOJA-026-INSPECTOR-BUGS--smalltalk-inspector-bug-fixes-empty-members-and-repl-definitions/changelog.md
+++ b/ttmp/2026/02/14/GOJA-026-INSPECTOR-BUGS--smalltalk-inspector-bug-fixes-empty-members-and-repl-definitions/changelog.md
@@ -15,3 +15,8 @@ All 6 bugs fixed: runtime members for value globals, globals refresh after REPL 
 - /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/cmd/smalltalk-inspector/app/update.go — navStack clear
 - /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/pkg/inspector/runtime/introspect.go — safeGet
 
+
+## 2026-02-14
+
+Ticket closed
+

--- a/ttmp/2026/02/14/GOJA-026-INSPECTOR-BUGS--smalltalk-inspector-bug-fixes-empty-members-and-repl-definitions/changelog.md
+++ b/ttmp/2026/02/14/GOJA-026-INSPECTOR-BUGS--smalltalk-inspector-bug-fixes-empty-members-and-repl-definitions/changelog.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 2026-02-14
+
+- Initial workspace created
+

--- a/ttmp/2026/02/14/GOJA-026-INSPECTOR-BUGS--smalltalk-inspector-bug-fixes-empty-members-and-repl-definitions/changelog.md
+++ b/ttmp/2026/02/14/GOJA-026-INSPECTOR-BUGS--smalltalk-inspector-bug-fixes-empty-members-and-repl-definitions/changelog.md
@@ -4,3 +4,14 @@
 
 - Initial workspace created
 
+
+## 2026-02-14
+
+All 6 bugs fixed: runtime members for value globals, globals refresh after REPL eval, Enter-to-inspect, proto chain footer, navStack leak, init ordering. Also fixed strict-mode panic in InspectObject via safeGet().
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/cmd/smalltalk-inspector/app/model.go — buildValueMembers
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/cmd/smalltalk-inspector/app/update.go — navStack clear
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/pkg/inspector/runtime/introspect.go — safeGet
+

--- a/ttmp/2026/02/14/GOJA-026-INSPECTOR-BUGS--smalltalk-inspector-bug-fixes-empty-members-and-repl-definitions/design/01-fix-plan.md
+++ b/ttmp/2026/02/14/GOJA-026-INSPECTOR-BUGS--smalltalk-inspector-bug-fixes-empty-members-and-repl-definitions/design/01-fix-plan.md
@@ -1,0 +1,332 @@
+---
+title: "Fix Plan"
+doc_type: design
+status: active
+intent: long-term
+topics:
+  - smalltalk-inspector
+  - bugs
+  - debugging
+created: 2026-02-14T13:10:00-05:00
+---
+
+# Fix Plan — Smalltalk Inspector Bugs
+
+## Overview
+
+Analysis uncovered **6 bugs** (3 original + 3 found during analysis). They share a common root cause: **the globals/members layer is static-only** and doesn't leverage the runtime session. The fix strategy is to bridge runtime introspection into the existing static data structures, preserving the Smalltalk-style class browser for classes while adding runtime-aware display for everything else.
+
+## Complete Bug Inventory
+
+| # | Bug | Severity | Category |
+|---|-----|----------|----------|
+| 1 | Non-class globals show "(no members)" | Medium | Static-only members |
+| 2 | REPL definitions don't refresh globals list | Medium | No post-eval refresh |
+| 3 | Enter on value globals does nothing | Low-Medium | Missing interaction |
+| 4 | Runtime session created after buildMembers() on load | Low | Init ordering |
+| 5 | Proto chain footer only shows static `Extends` | Low | Static-only view |
+| 6 | navStack not cleared on new REPL eval | Medium | Stale state |
+
+### Bug 4 (NEW): Init ordering
+
+In `MsgFileLoaded` handler, `buildGlobals()` and `buildMembers()` run on lines 39–40, but `m.rtSession` is created on lines 43–44. Any runtime-aware `buildMembers()` would get a nil session on initial load.
+
+**Fix:** Move runtime session initialization *before* `buildGlobals()`/`buildMembers()`.
+
+### Bug 5 (NEW): Proto chain footer only uses static `Extends`
+
+The `renderMembersPane` footer shows `proto: Shape → Object` but only for classes (via `g.Extends` from jsparse). For `myCircle` it shows nothing, even though the runtime knows the full chain `Circle → Shape → Object`.
+
+**Fix:** When displaying a non-class global, query the runtime for the prototype chain and display it in the footer.
+
+### Bug 6 (NEW): navStack not cleared on new eval
+
+When a new REPL expression is evaluated, the handler replaces `inspectObj`/`inspectProps` but doesn't clear `navStack`. If you'd drilled 3 levels into a previous result and then eval something new, pressing Esc tries to restore stale old frames.
+
+**Fix:** Add `m.navStack = nil` in both success and error paths of `MsgEvalResult`.
+
+## Critical Discovery: const/let vs var in goja
+
+`goja.Runtime.GlobalObject().Keys()` only returns `var` and `function` declarations. `const` and `let` declarations are lexical — they're NOT on the global object. However, `vm.Get(name)` (used by `Session.GlobalValue()`) works for all binding types.
+
+**Implications for Bug 2 fix:**
+- Can't discover REPL-defined `const`/`let` names just by enumerating the global object
+- Must parse the REPL input to extract declared names (simple regex/AST)
+- `var`/`function` definitions CAN be discovered via `GlobalObject().Keys()`
+- Best approach: combine both strategies — scan `GlobalObject` for new `var`/`function` names, AND parse REPL input for `const`/`let`/`class` names
+
+## Fix Plan — Execution Order
+
+### Step 1: Fix Bug 6 — navStack leak (trivial, unblocks safe testing)
+
+**File:** `cmd/smalltalk-inspector/app/update.go`
+
+Add `m.navStack = nil` in both the error and success branches of `MsgEvalResult`:
+
+```go
+// In error branch (after m.inspectProps = nil):
+m.navStack = nil
+
+// In success branch (after m.inspectLabel = ...):
+m.navStack = nil
+```
+
+**Risk:** None. **Test:** Eval `settings`, drill into `[[Proto]]`, eval `myCircle` — Esc should clear cleanly, not restore stale settings proto state.
+
+### Step 2: Fix Bug 4 — Init ordering (trivial, unblocks Bug 1 fix)
+
+**File:** `cmd/smalltalk-inspector/app/update.go`
+
+Move the runtime session initialization block *before* `buildGlobals()` and `buildMembers()`:
+
+```go
+case MsgFileLoaded:
+    m.filename = msg.Filename
+    m.source = msg.Source
+    m.analysis = msg.Analysis
+    m.sourceLines = strings.Split(msg.Source, "\n")
+    m.loaded = true
+
+    // Initialize runtime session FIRST
+    m.rtSession = runtime.NewSession()
+    if err := m.rtSession.Load(msg.Source); err != nil {
+        m.statusMsg = fmt.Sprintf("... ⚠ runtime: %v", ...)
+    }
+
+    // Now build globals and members (can use runtime)
+    m.buildGlobals()
+    m.buildMembers()
+    ...
+```
+
+**Risk:** None — just reordering. **Test:** Load a file, verify globals still appear correctly.
+
+### Step 3: Fix Bug 1 — Runtime members for value globals (main fix)
+
+**File:** `cmd/smalltalk-inspector/app/model.go`
+
+Add a `default` case to `buildMembers()` and a new `buildValueMembers()` method:
+
+```go
+//exhaustive:ignore
+switch selected.Kind {
+case jsparse.BindingClass:
+    m.buildClassMembers(selected.Name)
+case jsparse.BindingFunction:
+    m.buildFunctionMembers(selected.Name)
+default:
+    m.buildValueMembers(selected.Name)
+}
+```
+
+`buildValueMembers(name string)`:
+1. Guard: `if m.rtSession == nil { return }` (handles pre-runtime state gracefully)
+2. `val := m.rtSession.GlobalValue(name)` — get the runtime value
+3. If nil/undefined: add a single member `{Name: "(value)", Kind: "value", Preview: "undefined"}`
+4. If primitive (string/number/boolean): add a single member `{Name: "(value)", Kind: "value", Preview: preview}`
+5. If object: call `runtime.InspectObject(obj, vm)` → convert each `PropertyInfo` to `MemberItem`:
+   - `Name` = prop.Name
+   - `Kind` = prop.Kind (already "function"/"string"/"number"/etc)
+   - `Preview` = " : " + prop.Preview (to match inspect view style)
+   - New field `RuntimeDerived: true` to distinguish from static members
+
+Add `RuntimeDerived bool` to `MemberItem` struct. This flag:
+- Prevents `jumpToMember()` from trying AST lookup (which would fail)
+- Can be used by view to show a subtle visual distinction if desired
+- Tells the Enter handler to open runtime inspect view instead of source-jump
+
+**jumpToSource() change:** In `jumpToSource()`, when focus is on Members and the member is `RuntimeDerived`, skip the `jumpToMember()` call (no source location exists for runtime properties).
+
+**Risk:** Low. `InspectObject` is already well-tested. **Test:** Navigate to `settings` → see `theme`, `fontSize`, `lineNumbers`. Navigate to `myCircle` → see `color`, `visible`, `radius`.
+
+### Step 4: Fix Bug 5 — Runtime proto chain in members footer
+
+**File:** `cmd/smalltalk-inspector/app/view.go`
+
+In `renderMembersPane()`, replace the static-only proto chain footer logic:
+
+```go
+// Current (static only):
+if g.Extends != "" {
+    protoInfo = fmt.Sprintf("proto: %s → Object", g.Extends)
+}
+
+// New (static + runtime fallback):
+if g.Extends != "" {
+    protoInfo = fmt.Sprintf("proto: %s → Object", g.Extends)
+} else if m.rtSession != nil {
+    val := m.rtSession.GlobalValue(g.Name)
+    if val != nil && !goja.IsUndefined(val) {
+        if obj, ok := val.(*goja.Object); ok {
+            chain := runtime.WalkPrototypeChain(obj, m.rtSession.VM)
+            if len(chain) > 0 {
+                var names []string
+                for _, level := range chain {
+                    names = append(names, level.Name)
+                }
+                protoInfo = "proto: " + strings.Join(names, " → ")
+            }
+        }
+    }
+}
+```
+
+**Risk:** Low — `WalkPrototypeChain` is tested. Might need to cache to avoid re-walking on every render. **Test:** Navigate to `myCircle` → footer shows `proto: Circle → Shape → Object`.
+
+### Step 5: Fix Bug 3 — Enter on value globals opens runtime inspect
+
+**File:** `cmd/smalltalk-inspector/app/update.go`
+
+Modify the Select handler in `handleGlobalsKey()`:
+
+```go
+if key.Matches(msg, m.keyMap.Select) {
+    if len(m.globals) == 0 || m.globalIdx >= len(m.globals) {
+        return m, nil
+    }
+    selected := m.globals[m.globalIdx]
+
+    // For value-type globals, trigger runtime inspection
+    if selected.Kind != jsparse.BindingClass && selected.Kind != jsparse.BindingFunction {
+        if m.rtSession != nil {
+            result := m.rtSession.EvalWithCapture(selected.Name)
+            return m, func() tea.Msg {
+                return MsgEvalResult{Result: result}
+            }
+        }
+        return m, nil
+    }
+
+    // For class/function, move to members pane
+    if len(m.members) > 0 {
+        m.focus = FocusMembers
+        m.updateMode()
+    }
+    return m, nil
+}
+```
+
+**Risk:** Low. **Test:** Navigate to `myCircle` → Enter → inspect view shows `{color, visible, radius}` with `[[Proto]]: Circle.prototype`.
+
+### Step 6: Fix Bug 2 — Refresh globals after REPL eval
+
+**File:** `cmd/smalltalk-inspector/app/model.go` + `update.go`
+
+This is the most nuanced fix because of the `const`/`let` vs `var` semantics.
+
+**Strategy: Two-source merge**
+
+Add a new method `refreshRuntimeGlobals()` that merges runtime-discovered names into the globals list:
+
+```go
+func (m *Model) refreshRuntimeGlobals() {
+    if m.rtSession == nil {
+        return
+    }
+
+    // Build a set of already-known names
+    known := make(map[string]bool)
+    for _, g := range m.globals {
+        known[g.Name] = true
+    }
+
+    // 1. Scan GlobalObject for new var/function names
+    global := m.rtSession.VM.GlobalObject()
+    for _, key := range global.Keys() {
+        if known[key] {
+            continue
+        }
+        // Skip goja builtins (Object, Array, Math, etc.)
+        if isBuiltinGlobal(key) {
+            continue
+        }
+        val := global.Get(key)
+        kind := jsparse.BindingVar
+        if _, ok := goja.AssertFunction(val); ok {
+            kind = jsparse.BindingFunction
+        }
+        m.globals = append(m.globals, GlobalItem{
+            Name: key,
+            Kind: kind,
+        })
+        known[key] = true
+    }
+
+    // 2. Check tracked REPL names (const/let/class from REPL input)
+    for _, name := range m.replDefinedNames {
+        if known[name] {
+            continue
+        }
+        m.globals = append(m.globals, GlobalItem{
+            Name: name,
+            Kind: jsparse.BindingConst, // approximate
+        })
+        known[name] = true
+    }
+
+    // Re-sort
+    m.sortGlobals()
+}
+```
+
+Add `replDefinedNames []string` to Model. In `handleReplKey()`, before eval, extract declared names:
+
+```go
+func extractDeclaredNames(expr string) []string {
+    // Simple regex/split for: var x, let x, const x, class X, function X
+    // Not full parsing — just enough for REPL one-liners
+}
+```
+
+Add `isBuiltinGlobal(name string) bool` helper that filters out goja builtins (`Object`, `Array`, `Math`, `JSON`, `String`, `Number`, `Boolean`, `RegExp`, `Date`, `Error`, `Symbol`, `Map`, `Set`, `WeakMap`, `WeakSet`, `Promise`, `Proxy`, `Reflect`, `parseInt`, `parseFloat`, `isNaN`, `isFinite`, `undefined`, `NaN`, `Infinity`, `eval`, `encodeURI`, `encodeURIComponent`, `decodeURI`, `decodeURIComponent`, `console`, `globalThis`, `require`).
+
+In `MsgEvalResult` success handler, add: `m.refreshRuntimeGlobals()`.
+
+**Risk:** Medium — builtin filter list needs to be comprehensive enough. REPL name extraction regex can miss complex patterns but covers the common case. **Test:** Tab to REPL → `var z = 99` → globals list updates to include `z`. Also `const w = {x:1}` → `w` appears.
+
+## Execution Order Rationale
+
+1. **Bug 6 first** — trivial one-liner, prevents stale state from confusing subsequent testing
+2. **Bug 4 second** — reorder init, prerequisite for Bug 1 fix to work on load
+3. **Bug 1 third** — core fix, highest user impact, makes value globals useful
+4. **Bug 5 fourth** — view improvement that complements Bug 1 (proto chain for value globals)
+5. **Bug 3 fifth** — interaction improvement that now works naturally (Bug 1 populated members, but Enter-to-inspect is still useful for the deep drill-down view)
+6. **Bug 2 last** — most complex, requires the name extraction + merge + filtering logic
+
+Steps 1–2 are trivial setup. Steps 3–5 are the core fixes. Step 6 is a standalone enhancement.
+
+## Testing Plan
+
+After each step, build + lint + run in tmux with `testdata/inspector-test.js`:
+
+```bash
+go build ./cmd/smalltalk-inspector/... && golangci-lint run ./cmd/smalltalk-inspector/...
+tmux new-session -d -s sinspect -x 130 -y 40 \
+  "go run ./cmd/smalltalk-inspector ./testdata/inspector-test.js; read"
+```
+
+### Test Matrix
+
+| Test | After Step | Expected |
+|------|-----------|----------|
+| Navigate to `settings` → members pane | 3 | Shows `theme`, `fontSize`, `lineNumbers` |
+| Navigate to `myCircle` → members pane | 3 | Shows `color`, `visible`, `radius` |
+| Navigate to `VERSION` → members pane | 3 | Shows `(value) : "1.0.0"` |
+| Navigate to `shapes` → members pane | 3 | Shows `0`, `1`, `length` |
+| `myCircle` footer shows proto chain | 4 | `proto: Circle → Shape → Object` |
+| Enter on `myCircle` → inspect view | 5 | Shows `{color, visible, radius}` with `[[Proto]]` |
+| Enter on `VERSION` → inspect view | 5 | Shows `→ "1.0.0"` (primitive, no inspect pane) |
+| REPL `var z = 99` → globals list | 6 | 13 bindings, `z` visible as `● z` |
+| REPL `const w = {x:1}` → globals list | 6 | 14 bindings, `w` visible as `● w` |
+| Navigate to `w` → members pane | 6+3 | Shows `x : 1  number` |
+| Eval `settings`, drill `[[Proto]]`, eval `myCircle` → Esc | 1 | Clean exit, no stale proto frames |
+
+## Files Changed Summary
+
+| File | Steps | Changes |
+|------|-------|---------|
+| `cmd/smalltalk-inspector/app/update.go` | 1,2,5,6 | navStack clear, init reorder, Enter handler, eval refresh |
+| `cmd/smalltalk-inspector/app/model.go` | 3,6 | `buildValueMembers()`, `refreshRuntimeGlobals()`, `MemberItem.RuntimeDerived` |
+| `cmd/smalltalk-inspector/app/view.go` | 4 | Runtime proto chain in members footer |
+| `pkg/inspector/runtime/session.go` | — | No changes needed (GlobalValue already exists) |
+| `pkg/inspector/runtime/introspect.go` | — | No changes needed (InspectObject already exists) |

--- a/ttmp/2026/02/14/GOJA-026-INSPECTOR-BUGS--smalltalk-inspector-bug-fixes-empty-members-and-repl-definitions/design/01-fix-plan.md
+++ b/ttmp/2026/02/14/GOJA-026-INSPECTOR-BUGS--smalltalk-inspector-bug-fixes-empty-members-and-repl-definitions/design/01-fix-plan.md
@@ -12,6 +12,12 @@ created: 2026-02-14T13:10:00-05:00
 
 # Fix Plan — Smalltalk Inspector Bugs
 
+## Historical Status (Updated 2026-02-15)
+
+This document captures the tactical fix plan used during GOJA-026. It is preserved for implementation history, but parts of the orchestration guidance are superseded by later architectural work that introduced `pkg/inspectorapi` and extracted reusable inspector packages.
+
+Use this page to understand why fixes were made, not as the primary integration guide for current code.
+
 ## Overview
 
 Analysis uncovered **6 bugs** (3 original + 3 found during analysis). They share a common root cause: **the globals/members layer is static-only** and doesn't leverage the runtime session. The fix strategy is to bridge runtime introspection into the existing static data structures, preserving the Smalltalk-style class browser for classes while adding runtime-aware display for everything else.

--- a/ttmp/2026/02/14/GOJA-026-INSPECTOR-BUGS--smalltalk-inspector-bug-fixes-empty-members-and-repl-definitions/index.md
+++ b/ttmp/2026/02/14/GOJA-026-INSPECTOR-BUGS--smalltalk-inspector-bug-fixes-empty-members-and-repl-definitions/index.md
@@ -1,0 +1,67 @@
+---
+Title: 'Smalltalk Inspector Bug Fixes: Empty Members and REPL Definitions'
+Ticket: GOJA-026-INSPECTOR-BUGS
+Status: active
+Topics:
+    - smalltalk-inspector
+    - bugs
+    - debugging
+DocType: index
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: cmd/smalltalk-inspector/app/model.go
+      Note: buildMembers() and buildGlobals() - root cause of Bug 1 and 2
+    - Path: cmd/smalltalk-inspector/app/update.go
+      Note: handleGlobalsKey() Enter handler and MsgEvalResult handler - root cause of Bug 2 and 3
+    - Path: pkg/inspector/runtime/introspect.go
+      Note: InspectObject() - existing API needed for fixes
+    - Path: pkg/inspector/runtime/session.go
+      Note: GlobalValue() - existing API needed for fixes
+    - Path: testdata/inspector-test.js
+      Note: Test fixture for reproduction
+ExternalSources: []
+Summary: ""
+LastUpdated: 2026-02-14T16:07:14.390891718-05:00
+WhatFor: ""
+WhenToUse: ""
+---
+
+
+# Smalltalk Inspector Bug Fixes: Empty Members and REPL Definitions
+
+## Overview
+
+<!-- Provide a brief overview of the ticket, its goals, and current status -->
+
+## Key Links
+
+- **Related Files**: See frontmatter RelatedFiles field
+- **External Sources**: See frontmatter ExternalSources field
+
+## Status
+
+Current status: **active**
+
+## Topics
+
+- smalltalk-inspector
+- bugs
+- debugging
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/2026/02/14/GOJA-026-INSPECTOR-BUGS--smalltalk-inspector-bug-fixes-empty-members-and-repl-definitions/index.md
+++ b/ttmp/2026/02/14/GOJA-026-INSPECTOR-BUGS--smalltalk-inspector-bug-fixes-empty-members-and-repl-definitions/index.md
@@ -1,7 +1,7 @@
 ---
 Title: 'Smalltalk Inspector Bug Fixes: Empty Members and REPL Definitions'
 Ticket: GOJA-026-INSPECTOR-BUGS
-Status: active
+Status: complete
 Topics:
     - smalltalk-inspector
     - bugs
@@ -22,10 +22,11 @@ RelatedFiles:
       Note: Test fixture for reproduction
 ExternalSources: []
 Summary: ""
-LastUpdated: 2026-02-14T16:07:14.390891718-05:00
+LastUpdated: 2026-02-14T20:00:08.62088923-05:00
 WhatFor: ""
 WhenToUse: ""
 ---
+
 
 
 # Smalltalk Inspector Bug Fixes: Empty Members and REPL Definitions

--- a/ttmp/2026/02/14/GOJA-026-INSPECTOR-BUGS--smalltalk-inspector-bug-fixes-empty-members-and-repl-definitions/reference/01-diary.md
+++ b/ttmp/2026/02/14/GOJA-026-INSPECTOR-BUGS--smalltalk-inspector-bug-fixes-empty-members-and-repl-definitions/reference/01-diary.md
@@ -1,0 +1,101 @@
+---
+title: "Diary"
+doc_type: reference
+status: active
+intent: long-term
+topics:
+  - smalltalk-inspector
+  - bugs
+  - debugging
+created: 2026-02-14T12:50:00-05:00
+---
+
+# Diary
+
+## Goal
+
+Track the reproduction, root-cause analysis, and eventual fixing of three bugs found in the Smalltalk-style JavaScript inspector TUI.
+
+## Step 1: Reproduction and Bug Report
+
+Created a dedicated test file `testdata/inspector-test.js` with a variety of global binding types (classes with inheritance, functions, constants, object literals, class instances, arrays) to exercise the inspector comprehensively.
+
+Launched the TUI in tmux and systematically tested each global type. Found three distinct bugs that share a common theme: the globals/members pane is purely static (AST-based via jsparse) and does not leverage the runtime session for introspection of non-class/non-function bindings. The REPL works fine for direct expression evaluation, but results don't flow back to refresh the globals pane.
+
+### Prompt Context
+
+**User prompt (verbatim):** "Ok, test it: :load ./testdata/inspector-test.js -> execute, then show the data, and then define some stuff in the repl: all the toplevel globals apparently have no members, and the stuff I define in the REPL doesn't work. You need to create that file first. Create a new ticket to handle bugs and keep a frequent diary as you go. Reproduce, then write a bug-report file in the ticket."
+
+**Assistant interpretation:** Create a test fixture, create a bug ticket, reproduce the reported bugs in tmux, document them formally.
+
+**Inferred user intent:** Get actionable bug reports with root causes and suggested fixes before starting repairs.
+
+### What I did
+
+1. Created `testdata/inspector-test.js` with Shape/Circle/Rectangle class hierarchy, createShape/totalArea/main functions, VERSION/MAX_ITEMS constants, settings object literal, myCircle/myRect instances, shapes array (12 globals total)
+2. Created ticket GOJA-026-INSPECTOR-BUGS with diary and bug-report documents
+3. Launched TUI in tmux session `sinspect` and tested systematically:
+   - Navigated to each global type (C, ƒ, ●) checking members pane
+   - Tested REPL eval of `settings`, `myCircle`, object literals
+   - Tested `var myVar = 42` and `var myObj = {x:1, y:2, name:'test'}` definitions
+   - Tested Enter key on value globals
+   - Verified classes work correctly (Circle shows constructor, area, perimeter, describe + inherited hide)
+4. Wrote formal bug report with severity, repro steps, expected/actual behavior, root cause analysis, suggested fixes, and files involved
+
+### Why
+
+User reported two bugs (no members for value globals, REPL definitions not reflected). Systematic testing revealed a third (Enter on value globals does nothing). All three share the same root cause: the globals/members layer is static-only.
+
+### What worked
+
+- The TUI loads correctly with all 12 globals properly sorted
+- Class member extraction with inheritance works perfectly (Circle shows Shape's hide() method)
+- REPL eval works for direct expression evaluation and object inspection
+- Prototype chain walking works (settings → Object.prototype, myCircle → Circle.prototype → Shape.prototype)
+- Source pane jumps work for classes and their methods
+
+### What didn't work
+
+- **Bug 1:** Selecting any `●` value global in the globals pane shows "(no members)" in the members pane. This includes object literals (`settings`), class instances (`myCircle`, `myRect`), arrays (`shapes`), strings (`VERSION`), and numbers (`MAX_ITEMS`).
+- **Bug 2:** `var myVar = 42` → globals list stays at 12 bindings. `myVar` exists in runtime but isn't shown. No `refreshGlobals` call after eval.
+- **Bug 3:** Pressing Enter on a value global does nothing because the handler checks `len(m.members) > 0` and value globals have no members (due to Bug 1).
+
+### What I learned
+
+- The `buildMembers()` function only handles `jsparse.BindingClass` and `jsparse.BindingFunction` — there's no default/fallback case for value bindings
+- The `buildGlobals()` function only reads from `jsparse.AnalysisResult.Resolution.Scopes`, never from the runtime
+- The runtime session (`m.rtSession`) has all the necessary APIs already: `GlobalValue()`, `InspectObject()`, `EvalWithCapture()`
+- The REPL eval path and the globals/members path are completely independent — eval results only go to the inspect view, never back to globals
+
+### What was tricky to build
+
+Nothing was built yet — this step was pure reproduction and analysis.
+
+### What warrants a second pair of eyes
+
+The bug report's suggested fixes are straightforward but need to consider:
+- How to merge static (jsparse) and runtime globals without duplicates
+- Whether runtime-derived members should look different from static ones (different icons, section headers)
+- Whether the globalIdx should be preserved or reset when globals are refreshed after REPL eval
+
+### What should be done in the future
+
+- Fix all three bugs (see bug report for suggested approaches)
+- Add tests for the runtime-aware members and globals refresh paths
+- Consider adding a "refresh globals" key binding for manual refresh
+
+### Code review instructions
+
+- Read `reference/02-bug-report.md` for full details
+- Reproduce: `go run ./cmd/smalltalk-inspector ./testdata/inspector-test.js`
+- Navigate to `settings` → confirm "(no members)" (Bug 1)
+- Tab to REPL → `var x = 1` → Enter → confirm globals count unchanged (Bug 2)
+- Navigate to `myCircle` → Enter → confirm nothing happens (Bug 3)
+
+### Technical details
+
+- Test file: `testdata/inspector-test.js` (93 lines, 12 globals: 3 classes, 3 functions, 6 values)
+- Root cause location: `cmd/smalltalk-inspector/app/model.go` lines 194-213 (`buildMembers()`)
+- Root cause location: `cmd/smalltalk-inspector/app/update.go` lines 73-104 (`MsgEvalResult`)
+- Root cause location: `cmd/smalltalk-inspector/app/update.go` lines 218-224 (`handleGlobalsKey` Enter)
+- Runtime introspection APIs available: `runtime.Session.GlobalValue()`, `runtime.InspectObject()`, `runtime.ValuePreview()`

--- a/ttmp/2026/02/14/GOJA-026-INSPECTOR-BUGS--smalltalk-inspector-bug-fixes-empty-members-and-repl-definitions/reference/02-bug-report.md
+++ b/ttmp/2026/02/14/GOJA-026-INSPECTOR-BUGS--smalltalk-inspector-bug-fixes-empty-members-and-repl-definitions/reference/02-bug-report.md
@@ -1,0 +1,214 @@
+---
+title: "Bug Report"
+doc_type: reference
+status: active
+intent: long-term
+topics:
+  - smalltalk-inspector
+  - bugs
+  - debugging
+created: 2026-02-14T12:50:00-05:00
+---
+
+# Smalltalk Inspector — Bug Report
+
+## Test File
+
+`testdata/inspector-test.js` — contains classes (Shape, Circle, Rectangle with inheritance), functions (createShape, totalArea, main), constants (VERSION, MAX_ITEMS), object literals (settings), and instantiated objects (myCircle, myRect, shapes).
+
+## Bug 1: Non-Class Globals Show "(no members)" in Members Pane
+
+### Severity
+
+Medium — degrades usability for value-type globals.
+
+### Steps to Reproduce
+
+1. `go run ./cmd/smalltalk-inspector ./testdata/inspector-test.js`
+2. Navigate globals pane with arrow keys to `settings` (object literal), `myCircle` (class instance), `myRect`, `shapes` (array), `VERSION` (string), or `MAX_ITEMS` (number)
+3. Observe members pane shows "(no members)" for all value-type globals
+
+### Expected Behavior
+
+- `settings` should show `theme`, `fontSize`, `lineNumbers` as members
+- `myCircle` should show `color`, `visible`, `radius` plus Circle/Shape methods
+- `shapes` should show `0`, `1`, `length` (array properties)
+- `VERSION` should show the string value "1.0.0"
+- `MAX_ITEMS` should show the number value 100
+
+### Actual Behavior
+
+All value globals (`●` icon) show "(no members)". Only class declarations (`C`) and function declarations (`ƒ`) populate the members pane.
+
+### Root Cause
+
+`buildMembers()` in `model.go` only handles two cases:
+
+```go
+switch selected.Kind {
+case jsparse.BindingClass:
+    m.buildClassMembers(selected.Name)
+case jsparse.BindingFunction:
+    m.buildFunctionMembers(selected.Name)
+}
+```
+
+There is no case for value-type bindings (`jsparse.BindingConst`, `jsparse.BindingLet`, `jsparse.BindingVar`). The method uses only static AST analysis (`jsparse`), not the runtime session. The runtime session is available (`m.rtSession`) and can introspect any global value via `m.rtSession.GlobalValue(name)`.
+
+### Suggested Fix
+
+Add a default case to `buildMembers()` that uses the runtime session to introspect the value:
+
+```go
+default:
+    m.buildValueMembers(selected.Name)
+```
+
+Where `buildValueMembers` does:
+1. `val := m.rtSession.GlobalValue(name)` — get the runtime value
+2. If it's an object: `runtime.InspectObject(obj, m.rtSession.VM)` — show properties
+3. If it's a primitive: show a single entry with the value preview
+4. Convert the `PropertyInfo` list to `MemberItem` entries
+
+### Files Involved
+
+- `cmd/smalltalk-inspector/app/model.go` — `buildMembers()`, lines 194-213
+- `pkg/inspector/runtime/session.go` — `GlobalValue()` already exists
+- `pkg/inspector/runtime/introspect.go` — `InspectObject()` already exists
+
+---
+
+## Bug 2: REPL Variable Definitions Don't Refresh Globals List
+
+### Severity
+
+Medium — runtime state diverges from displayed state.
+
+### Steps to Reproduce
+
+1. `go run ./cmd/smalltalk-inspector ./testdata/inspector-test.js`
+2. Tab to REPL
+3. Type `var myVar = 42` → Enter
+4. Result shows `→ undefined` (correct for `var` declaration)
+5. Globals pane still shows "12 bindings" — `myVar` is not listed
+6. Type `myVar` → Enter → shows `→ 42` (value IS in runtime)
+
+### Expected Behavior
+
+After evaluating `var myVar = 42`, the globals list should refresh to show 13 bindings including `myVar`.
+
+### Actual Behavior
+
+The globals list is never refreshed after REPL evaluation. It only changes on `:load`.
+
+### Root Cause
+
+The eval result handler in `update.go` (`case MsgEvalResult:`) updates the inspect/error state but never calls `m.buildGlobals()`. Even if it did, `buildGlobals()` only reads from `m.analysis.Resolution` (the static AST scope), not from the runtime's actual global object.
+
+Two issues compound:
+1. `buildGlobals()` is purely static — it reads `jsparse.AnalysisResult`, not `goja.Runtime`
+2. No call to refresh globals after REPL eval
+
+### Suggested Fix
+
+After successful REPL eval, enumerate the runtime's global object and merge new bindings:
+
+```go
+// In MsgEvalResult handler, after successful eval:
+m.refreshRuntimeGlobals()
+```
+
+Where `refreshRuntimeGlobals()`:
+1. Gets the runtime global object: `m.rtSession.VM.GlobalObject()`
+2. Enumerates its keys
+3. For any key not already in `m.globals`, adds it as a `●` value binding
+4. Optionally sorts the combined list
+
+Alternatively, maintain a separate "REPL-defined globals" list that appends to the static list.
+
+### Files Involved
+
+- `cmd/smalltalk-inspector/app/update.go` — `MsgEvalResult` handler, lines 73-104
+- `cmd/smalltalk-inspector/app/model.go` — `buildGlobals()`, lines 154-191
+
+---
+
+## Bug 3: Enter on Value Globals Does Nothing
+
+### Severity
+
+Low-Medium — missed interaction that would make the inspector more discoverable.
+
+### Steps to Reproduce
+
+1. Navigate to `myCircle` in globals pane
+2. Press Enter
+3. Nothing happens — no inspect view, no navigation
+
+### Expected Behavior
+
+Pressing Enter on a value global should trigger runtime inspection, equivalent to typing the name in the REPL. For `myCircle` this would show `{color, visible, radius}` with `[[Proto]]: Circle.prototype`.
+
+### Actual Behavior
+
+The Enter handler in `handleGlobalsKey()` only moves focus to the members pane if there are members:
+
+```go
+if key.Matches(msg, m.keyMap.Select) {
+    if len(m.members) > 0 {
+        m.focus = FocusMembers
+        m.updateMode()
+    }
+    return m, nil
+}
+```
+
+Since value globals have no members (Bug 1), Enter does nothing.
+
+### Suggested Fix
+
+When Enter is pressed on a global and either there are no members or the binding is a value type, trigger runtime inspection:
+
+```go
+if key.Matches(msg, m.keyMap.Select) {
+    selected := m.globals[m.globalIdx]
+    if selected.Kind != jsparse.BindingClass && selected.Kind != jsparse.BindingFunction {
+        // Trigger runtime inspection
+        result := m.rtSession.EvalWithCapture(selected.Name)
+        return m, func() tea.Msg { return MsgEvalResult{Result: result} }
+    }
+    if len(m.members) > 0 {
+        m.focus = FocusMembers
+        m.updateMode()
+    }
+    return m, nil
+}
+```
+
+### Files Involved
+
+- `cmd/smalltalk-inspector/app/update.go` — `handleGlobalsKey()`, Select handler
+
+---
+
+## Summary
+
+| # | Bug | Severity | Root Cause | Fix Complexity |
+|---|-----|----------|-----------|---------------|
+| 1 | Non-class globals show no members | Medium | `buildMembers()` only handles class/function via static AST | Small — add runtime introspection fallback |
+| 2 | REPL definitions don't refresh globals | Medium | `buildGlobals()` is static-only, no refresh after eval | Medium — need runtime global enumeration + merge |
+| 3 | Enter on value globals does nothing | Low-Medium | Enter handler requires non-empty members list | Small — add runtime eval fallback for value bindings |
+
+### Reproduction Command
+
+```bash
+go run ./cmd/smalltalk-inspector ./testdata/inspector-test.js
+```
+
+### Test Sequence
+
+1. Arrow to `settings` → members pane should show properties (Bug 1)
+2. Arrow to `myCircle` → members pane should show instance properties (Bug 1)
+3. Enter on `myCircle` → should open inspect view (Bug 3)
+4. Tab to REPL → `var x = {a:1}` → Enter → globals should show `x` (Bug 2)
+5. Type `x` → Enter → inspect view shows `{a}` (this works — REPL eval is fine)

--- a/ttmp/2026/02/14/GOJA-026-INSPECTOR-BUGS--smalltalk-inspector-bug-fixes-empty-members-and-repl-definitions/tasks.md
+++ b/ttmp/2026/02/14/GOJA-026-INSPECTOR-BUGS--smalltalk-inspector-bug-fixes-empty-members-and-repl-definitions/tasks.md
@@ -4,11 +4,11 @@
 
 - [x] Add tasks here
 
-- [ ] Reproduce and document all bugs in a formal bug report
-- [ ] Bug 1 fix: Add runtime introspection for value-type globals in buildMembers()
-- [ ] Bug 2 fix: Refresh globals list after REPL eval by merging runtime globals
-- [ ] Bug 3 fix: Enter on value globals triggers runtime inspection
-- [ ] Test all three fixes in tmux and verify no regressions
-- [ ] Bug 4 (new): Fix init ordering — move rtSession creation before buildGlobals/buildMembers
-- [ ] Bug 5 (new): Show runtime proto chain in members pane footer for non-class globals
-- [ ] Bug 6 (new): Clear navStack on new REPL eval to prevent stale drill-in state
+- [x] Reproduce and document all bugs in a formal bug report
+- [x] Bug 1 fix: Add runtime introspection for value-type globals in buildMembers()
+- [x] Bug 2 fix: Refresh globals list after REPL eval by merging runtime globals
+- [x] Bug 3 fix: Enter on value globals triggers runtime inspection
+- [x] Test all three fixes in tmux and verify no regressions
+- [x] Bug 4 (new): Fix init ordering — move rtSession creation before buildGlobals/buildMembers
+- [x] Bug 5 (new): Show runtime proto chain in members pane footer for non-class globals
+- [x] Bug 6 (new): Clear navStack on new REPL eval to prevent stale drill-in state

--- a/ttmp/2026/02/14/GOJA-026-INSPECTOR-BUGS--smalltalk-inspector-bug-fixes-empty-members-and-repl-definitions/tasks.md
+++ b/ttmp/2026/02/14/GOJA-026-INSPECTOR-BUGS--smalltalk-inspector-bug-fixes-empty-members-and-repl-definitions/tasks.md
@@ -12,3 +12,4 @@
 - [x] Bug 4 (new): Fix init ordering — move rtSession creation before buildGlobals/buildMembers
 - [x] Bug 5 (new): Show runtime proto chain in members pane footer for non-class globals
 - [x] Bug 6 (new): Clear navStack on new REPL eval to prevent stale drill-in state
+- [x] REPL source tracking: show REPL-defined function source in source pane

--- a/ttmp/2026/02/14/GOJA-026-INSPECTOR-BUGS--smalltalk-inspector-bug-fixes-empty-members-and-repl-definitions/tasks.md
+++ b/ttmp/2026/02/14/GOJA-026-INSPECTOR-BUGS--smalltalk-inspector-bug-fixes-empty-members-and-repl-definitions/tasks.md
@@ -9,3 +9,6 @@
 - [ ] Bug 2 fix: Refresh globals list after REPL eval by merging runtime globals
 - [ ] Bug 3 fix: Enter on value globals triggers runtime inspection
 - [ ] Test all three fixes in tmux and verify no regressions
+- [ ] Bug 4 (new): Fix init ordering — move rtSession creation before buildGlobals/buildMembers
+- [ ] Bug 5 (new): Show runtime proto chain in members pane footer for non-class globals
+- [ ] Bug 6 (new): Clear navStack on new REPL eval to prevent stale drill-in state

--- a/ttmp/2026/02/14/GOJA-026-INSPECTOR-BUGS--smalltalk-inspector-bug-fixes-empty-members-and-repl-definitions/tasks.md
+++ b/ttmp/2026/02/14/GOJA-026-INSPECTOR-BUGS--smalltalk-inspector-bug-fixes-empty-members-and-repl-definitions/tasks.md
@@ -1,0 +1,11 @@
+# Tasks
+
+## TODO
+
+- [x] Add tasks here
+
+- [ ] Reproduce and document all bugs in a formal bug report
+- [ ] Bug 1 fix: Add runtime introspection for value-type globals in buildMembers()
+- [ ] Bug 2 fix: Refresh globals list after REPL eval by merging runtime globals
+- [ ] Bug 3 fix: Enter on value globals triggers runtime inspection
+- [ ] Test all three fixes in tmux and verify no regressions

--- a/ttmp/2026/02/14/GOJA-027-SYNTAX-HIGHLIGHT--syntax-highlighting-for-smalltalk-inspector-source-pane/README.md
+++ b/ttmp/2026/02/14/GOJA-027-SYNTAX-HIGHLIGHT--syntax-highlighting-for-smalltalk-inspector-source-pane/README.md
@@ -1,0 +1,21 @@
+# Syntax highlighting for smalltalk-inspector source pane
+
+This is the document workspace for ticket GOJA-027-SYNTAX-HIGHLIGHT.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr doc add --ticket GOJA-027-SYNTAX-HIGHLIGHT --doc-type design-doc --title "My Design"`
+- Import sources: `docmgr import file --ticket GOJA-027-SYNTAX-HIGHLIGHT --file /path/to/doc.md`
+- Update metadata: `docmgr meta update --ticket GOJA-027-SYNTAX-HIGHLIGHT --field Status --value review`

--- a/ttmp/2026/02/14/GOJA-027-SYNTAX-HIGHLIGHT--syntax-highlighting-for-smalltalk-inspector-source-pane/changelog.md
+++ b/ttmp/2026/02/14/GOJA-027-SYNTAX-HIGHLIGHT--syntax-highlighting-for-smalltalk-inspector-source-pane/changelog.md
@@ -4,3 +4,13 @@
 
 - Initial workspace created
 
+
+## 2026-02-14
+
+Ticket closed
+
+
+## 2026-02-15
+
+Ticket closed
+

--- a/ttmp/2026/02/14/GOJA-027-SYNTAX-HIGHLIGHT--syntax-highlighting-for-smalltalk-inspector-source-pane/changelog.md
+++ b/ttmp/2026/02/14/GOJA-027-SYNTAX-HIGHLIGHT--syntax-highlighting-for-smalltalk-inspector-source-pane/changelog.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 2026-02-14
+
+- Initial workspace created
+

--- a/ttmp/2026/02/14/GOJA-027-SYNTAX-HIGHLIGHT--syntax-highlighting-for-smalltalk-inspector-source-pane/index.md
+++ b/ttmp/2026/02/14/GOJA-027-SYNTAX-HIGHLIGHT--syntax-highlighting-for-smalltalk-inspector-source-pane/index.md
@@ -1,0 +1,54 @@
+---
+Title: Syntax highlighting for smalltalk-inspector source pane
+Ticket: GOJA-027-SYNTAX-HIGHLIGHT
+Status: active
+Topics:
+    - inspector
+    - ui
+DocType: index
+Intent: long-term
+Owners: []
+RelatedFiles: []
+ExternalSources: []
+Summary: ""
+LastUpdated: 2026-02-14T17:22:13.060128481-05:00
+WhatFor: ""
+WhenToUse: ""
+---
+
+# Syntax highlighting for smalltalk-inspector source pane
+
+## Overview
+
+<!-- Provide a brief overview of the ticket, its goals, and current status -->
+
+## Key Links
+
+- **Related Files**: See frontmatter RelatedFiles field
+- **External Sources**: See frontmatter ExternalSources field
+
+## Status
+
+Current status: **active**
+
+## Topics
+
+- inspector
+- ui
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/2026/02/14/GOJA-027-SYNTAX-HIGHLIGHT--syntax-highlighting-for-smalltalk-inspector-source-pane/index.md
+++ b/ttmp/2026/02/14/GOJA-027-SYNTAX-HIGHLIGHT--syntax-highlighting-for-smalltalk-inspector-source-pane/index.md
@@ -1,7 +1,7 @@
 ---
 Title: Syntax highlighting for smalltalk-inspector source pane
 Ticket: GOJA-027-SYNTAX-HIGHLIGHT
-Status: active
+Status: complete
 Topics:
     - inspector
     - ui
@@ -11,10 +11,12 @@ Owners: []
 RelatedFiles: []
 ExternalSources: []
 Summary: ""
-LastUpdated: 2026-02-14T17:22:13.060128481-05:00
+LastUpdated: 2026-02-15T09:18:45.422997427-05:00
 WhatFor: ""
 WhenToUse: ""
 ---
+
+
 
 # Syntax highlighting for smalltalk-inspector source pane
 

--- a/ttmp/2026/02/14/GOJA-027-SYNTAX-HIGHLIGHT--syntax-highlighting-for-smalltalk-inspector-source-pane/tasks.md
+++ b/ttmp/2026/02/14/GOJA-027-SYNTAX-HIGHLIGHT--syntax-highlighting-for-smalltalk-inspector-source-pane/tasks.md
@@ -8,4 +8,4 @@
 - [x] Add TSParser to smalltalk-inspector Model, parse file source on load
 - [x] Apply syntax coloring in renderSourcePane for file source
 - [x] Parse REPL source with tree-sitter and apply highlighting
-- [ ] Build, lint, test, verify in tmux
+- [x] Build, lint, test, verify in tmux

--- a/ttmp/2026/02/14/GOJA-027-SYNTAX-HIGHLIGHT--syntax-highlighting-for-smalltalk-inspector-source-pane/tasks.md
+++ b/ttmp/2026/02/14/GOJA-027-SYNTAX-HIGHLIGHT--syntax-highlighting-for-smalltalk-inspector-source-pane/tasks.md
@@ -1,0 +1,11 @@
+# Tasks
+
+## TODO
+
+- [x] Add tasks here
+
+- [x] Extract syntax highlighting types/functions into pkg/jsparse/highlight.go
+- [x] Add TSParser to smalltalk-inspector Model, parse file source on load
+- [x] Apply syntax coloring in renderSourcePane for file source
+- [x] Parse REPL source with tree-sitter and apply highlighting
+- [ ] Build, lint, test, verify in tmux

--- a/ttmp/2026/02/14/GOJA-028-CLEANUP-INSPECTOR--cleanup-inspector/README.md
+++ b/ttmp/2026/02/14/GOJA-028-CLEANUP-INSPECTOR--cleanup-inspector/README.md
@@ -1,0 +1,21 @@
+# Cleanup Inspector
+
+This is the document workspace for ticket GOJA-028-CLEANUP-INSPECTOR.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr doc add --ticket GOJA-028-CLEANUP-INSPECTOR --doc-type design-doc --title "My Design"`
+- Import sources: `docmgr import file --ticket GOJA-028-CLEANUP-INSPECTOR --file /path/to/doc.md`
+- Update metadata: `docmgr meta update --ticket GOJA-028-CLEANUP-INSPECTOR --field Status --value review`

--- a/ttmp/2026/02/14/GOJA-028-CLEANUP-INSPECTOR--cleanup-inspector/changelog.md
+++ b/ttmp/2026/02/14/GOJA-028-CLEANUP-INSPECTOR--cleanup-inspector/changelog.md
@@ -1,0 +1,49 @@
+# Changelog
+
+## 2026-02-14
+
+- Initial workspace created
+
+
+## 2026-02-14
+
+Step 1: Inventoried GOJA-024 through GOJA-027 tickets and commit history, then mapped all implementation files changed since the pre-ticket baseline.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/index.md — Baseline design ticket context
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-025-INSPECTOR-BUBBLES-REFACTOR--inspector-bubbles-component-refactor/reference/01-inspector-refactor-design-guide.md — Reusable component baseline context
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-026-INSPECTOR-BUGS--smalltalk-inspector-bug-fixes-empty-members-and-repl-definitions/reference/02-bug-report.md — Bug-fix wave context
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-027-SYNTAX-HIGHLIGHT--syntax-highlighting-for-smalltalk-inspector-source-pane/index.md — Syntax-highlighting ticket context
+
+
+## 2026-02-14
+
+Step 2: Validated the current codebase with tests/vet and reproduced a critical stack-overflow crash for self-referential inheritance during member-building recursion.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/cmd/smalltalk-inspector/app/model.go — Recursion path (`addInheritedMembers`) responsible for stack overflow
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/cmd/smalltalk-inspector/app/update.go — Runtime behavior and state transition review
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/cmd/smalltalk-inspector/app/view.go — Rendering and scrolling behavior review
+
+
+## 2026-02-14
+
+Step 3: Authored comprehensive cleanup review document with severity-ranked findings, architecture map, reuse/refactor opportunities, and phased remediation roadmap.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-028-CLEANUP-INSPECTOR--cleanup-inspector/reference/01-inspector-cleanup-review.md — Primary review deliverable
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-028-CLEANUP-INSPECTOR--cleanup-inspector/tasks.md — Cleanup backlog derived from findings
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-028-CLEANUP-INSPECTOR--cleanup-inspector/index.md — Ticket overview and navigation links
+
+
+## 2026-02-14
+
+Step 4: Validated frontmatter and doctor checks for GOJA-028, then added missing topic vocabulary entries (`inspector`, `refactor`) so the ticket passes hygiene checks.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/vocabulary.yaml — Added topics `inspector` and `refactor`
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-028-CLEANUP-INSPECTOR--cleanup-inspector/index.md — Topic metadata validated successfully

--- a/ttmp/2026/02/14/GOJA-028-CLEANUP-INSPECTOR--cleanup-inspector/changelog.md
+++ b/ttmp/2026/02/14/GOJA-028-CLEANUP-INSPECTOR--cleanup-inspector/changelog.md
@@ -57,3 +57,14 @@ Cross-ticket update: GOJA-028 task #13 (analysis-layer integration) has been exe
 - /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/15/GOJA-032-ANALYSIS-INTEGRATION--smalltalk-inspector-analysis-session-integration/design/01-implementation-guide-integrate-pkg-inspector-analysis-into-smalltalk-inspector.md — Execution plan and architecture for the extracted task
 - /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/15/GOJA-032-ANALYSIS-INTEGRATION--smalltalk-inspector-analysis-session-integration/tasks.md — Task-level execution tracking for the extracted work
 
+
+## 2026-02-15
+
+Backlog reconciliation update: marked completed cleanup items delivered via GOJA-029/031/032 and closed GOJA-027 hygiene gap after doctor validation.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-027-SYNTAX-HIGHLIGHT--syntax-highlighting-for-smalltalk-inspector-source-pane/changelog.md — GOJA-027 closure and hygiene validation
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-027-SYNTAX-HIGHLIGHT--syntax-highlighting-for-smalltalk-inspector-source-pane/tasks.md — Final GOJA-027 task completion
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-028-CLEANUP-INSPECTOR--cleanup-inspector/tasks.md — Reconciled completed-vs-open backlog tasks
+

--- a/ttmp/2026/02/14/GOJA-028-CLEANUP-INSPECTOR--cleanup-inspector/changelog.md
+++ b/ttmp/2026/02/14/GOJA-028-CLEANUP-INSPECTOR--cleanup-inspector/changelog.md
@@ -47,3 +47,13 @@ Step 4: Validated frontmatter and doctor checks for GOJA-028, then added missing
 
 - /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/vocabulary.yaml — Added topics `inspector` and `refactor`
 - /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-028-CLEANUP-INSPECTOR--cleanup-inspector/index.md — Topic metadata validated successfully
+
+## 2026-02-15
+
+Cross-ticket update: GOJA-028 task #13 (analysis-layer integration) has been executed in GOJA-032-ANALYSIS-INTEGRATION with implementation guide, staged refactor commits, and regression validation.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/15/GOJA-032-ANALYSIS-INTEGRATION--smalltalk-inspector-analysis-session-integration/design/01-implementation-guide-integrate-pkg-inspector-analysis-into-smalltalk-inspector.md — Execution plan and architecture for the extracted task
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/15/GOJA-032-ANALYSIS-INTEGRATION--smalltalk-inspector-analysis-session-integration/tasks.md — Task-level execution tracking for the extracted work
+

--- a/ttmp/2026/02/14/GOJA-028-CLEANUP-INSPECTOR--cleanup-inspector/changelog.md
+++ b/ttmp/2026/02/14/GOJA-028-CLEANUP-INSPECTOR--cleanup-inspector/changelog.md
@@ -68,3 +68,16 @@ Backlog reconciliation update: marked completed cleanup items delivered via GOJA
 - /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-027-SYNTAX-HIGHLIGHT--syntax-highlighting-for-smalltalk-inspector-source-pane/tasks.md — Final GOJA-027 task completion
 - /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-028-CLEANUP-INSPECTOR--cleanup-inspector/tasks.md — Reconciled completed-vs-open backlog tasks
 
+
+## 2026-02-15
+
+Extracted reusable REPL/global merge logic into pkg/inspector (analysis + runtime), rewired smalltalk-inspector to consume pkg APIs, fixed REPL fallback syntax-span rebuild path, and audited cmd/inspector salvage opportunities.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/cmd/smalltalk-inspector/app/model.go — Fallback syntax span rebuild and pkg API adoption
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/cmd/smalltalk-inspector/app/update.go — Parser-backed REPL declaration tracking
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/pkg/inspector/analysis/globals_merge.go — General merge/sort policy for globals
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/pkg/inspector/analysis/repl_declarations.go — Parser-backed declaration extraction reusable by CLI/LSP
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/pkg/inspector/runtime/globals.go — Runtime global classification primitives
+

--- a/ttmp/2026/02/14/GOJA-028-CLEANUP-INSPECTOR--cleanup-inspector/index.md
+++ b/ttmp/2026/02/14/GOJA-028-CLEANUP-INSPECTOR--cleanup-inspector/index.md
@@ -1,0 +1,82 @@
+---
+Title: Cleanup Inspector
+Ticket: GOJA-028-CLEANUP-INSPECTOR
+Status: active
+Topics:
+    - go
+    - goja
+    - tui
+    - refactor
+    - inspector
+DocType: index
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: go-go-goja/ttmp/2026/02/14/GOJA-028-CLEANUP-INSPECTOR--cleanup-inspector/reference/01-inspector-cleanup-review.md
+      Note: Primary 8+ page analysis and review document
+    - Path: go-go-goja/ttmp/2026/02/14/GOJA-028-CLEANUP-INSPECTOR--cleanup-inspector/reference/02-diary.md
+      Note: Execution diary and command trace for this review cycle
+    - Path: go-go-goja/cmd/smalltalk-inspector/app/model.go
+      Note: Main state and member-building logic reviewed
+    - Path: go-go-goja/cmd/smalltalk-inspector/app/update.go
+      Note: Message handling and interaction logic reviewed
+    - Path: go-go-goja/cmd/smalltalk-inspector/app/view.go
+      Note: Render and scrolling behavior reviewed
+    - Path: go-go-goja/pkg/inspector/runtime/introspect.go
+      Note: Runtime introspection helpers reviewed
+    - Path: go-go-goja/pkg/jsparse/highlight.go
+      Note: Syntax highlighting implementation reviewed
+ExternalSources: []
+Summary: Thorough cleanup review of inspector work from GOJA-024 to GOJA-027 with severity-ranked findings, architecture mapping, and refactor plan.
+LastUpdated: 2026-02-14T18:48:00Z
+WhatFor: Capture implementation quality assessment and prioritized cleanup roadmap before additional feature expansion.
+WhenToUse: Use as the primary starting point for GOJA-028 cleanup and refactor execution.
+---
+
+# Cleanup Inspector
+
+## Overview
+
+GOJA-028 provides a deep post-implementation review of the inspector work delivered in GOJA-024 through GOJA-027. It focuses on correctness risks, architecture drift, reuse opportunities, unidiomatic patterns, and a concrete cleanup roadmap with implementation tasks.
+
+## Key Links
+
+- Review doc: `reference/01-inspector-cleanup-review.md`
+- Diary: `reference/02-diary.md`
+- Tasks: `tasks.md`
+- Changelog: `changelog.md`
+- Key code surface:
+  - `go-go-goja/cmd/smalltalk-inspector/app/model.go`
+  - `go-go-goja/cmd/smalltalk-inspector/app/update.go`
+  - `go-go-goja/cmd/smalltalk-inspector/app/view.go`
+  - `go-go-goja/pkg/inspector/runtime/introspect.go`
+  - `go-go-goja/pkg/jsparse/highlight.go`
+
+## Status
+
+Current status: **active**
+
+## Topics
+
+- go
+- goja
+- tui
+- refactor
+- inspector
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/2026/02/14/GOJA-028-CLEANUP-INSPECTOR--cleanup-inspector/reference/01-inspector-cleanup-review.md
+++ b/ttmp/2026/02/14/GOJA-028-CLEANUP-INSPECTOR--cleanup-inspector/reference/01-inspector-cleanup-review.md
@@ -44,12 +44,16 @@ RelatedFiles:
       Note: Bug-fix sequencing and rationale
 ExternalSources: []
 Summary: Deep technical review of inspector work from GOJA-024 through GOJA-027, including architecture analysis, severity-ranked findings, and cleanup/refactor roadmap.
-LastUpdated: 2026-02-14T18:45:00Z
+LastUpdated: 2026-02-15T17:10:00Z
 WhatFor: Give implementers and maintainers a concrete, evidence-backed cleanup plan and architecture guide for the smalltalk-inspector code path.
 WhenToUse: Use before further feature work on smalltalk-inspector or when planning refactors/shared component extraction.
 ---
 
 # Inspector Cleanup Review (GOJA-024 to GOJA-027)
+
+## Historical Status (Updated 2026-02-15)
+
+This review is a historical snapshot from the pre-`pkg/inspectorapi` cutover phase. Several findings were intentionally resolved by later tickets (notably GOJA-029, GOJA-030, GOJA-034) that moved adapter orchestration into `pkg/inspectorapi` and integrated extracted inspector packages.
 
 ## Findings First (Severity-Ordered)
 
@@ -122,9 +126,9 @@ WhenToUse: Use before further feature work on smalltalk-inspector or when planni
     - no removal path for deleted bindings.
     Impact: global list can drift from actual runtime semantics over long sessions.
 
-12. **`pkg/inspector/analysis` is currently not integrated into the smalltalk-inspector path**  
-    Where: `go-go-goja/pkg/inspector/analysis/*.go` (implemented), no references from `go-go-goja/cmd/smalltalk-inspector/app`  
-    Impact: new abstractions exist but no production usage; architecture intent not yet realized.
+12. **`pkg/inspector/analysis` was not integrated in the reviewed snapshot (now superseded)**  
+    Where at review time: `go-go-goja/pkg/inspector/analysis/*.go` with no references from `go-go-goja/cmd/smalltalk-inspector/app`  
+    Status at update time (2026-02-15): superseded by the `pkg/inspectorapi` cutover and subsequent integration work.
 
 ### Low Findings
 

--- a/ttmp/2026/02/14/GOJA-028-CLEANUP-INSPECTOR--cleanup-inspector/reference/01-inspector-cleanup-review.md
+++ b/ttmp/2026/02/14/GOJA-028-CLEANUP-INSPECTOR--cleanup-inspector/reference/01-inspector-cleanup-review.md
@@ -1,0 +1,507 @@
+---
+Title: Inspector Cleanup Review (GOJA-024 to GOJA-027)
+Ticket: GOJA-028-CLEANUP-INSPECTOR
+Status: active
+Topics:
+    - go
+    - goja
+    - tui
+    - inspector
+    - refactor
+DocType: reference
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: go-go-goja/cmd/smalltalk-inspector/app/model.go
+      Note: Core state, globals/members logic, runtime merge, REPL source tracking
+    - Path: go-go-goja/cmd/smalltalk-inspector/app/update.go
+      Note: Message routing, key handling, eval flow, inspect/stack navigation
+    - Path: go-go-goja/cmd/smalltalk-inspector/app/view.go
+      Note: Rendering pipeline and pane-specific UI behavior
+    - Path: go-go-goja/cmd/smalltalk-inspector/app/keymap.go
+      Note: Current keymap and help model integration constraints
+    - Path: go-go-goja/pkg/inspector/runtime/introspect.go
+      Note: Runtime object/property/prototype helpers reused by UI
+    - Path: go-go-goja/pkg/inspector/runtime/errors.go
+      Note: Stack trace parsing implementation and portability caveats
+    - Path: go-go-goja/pkg/inspector/runtime/function_map.go
+      Note: Runtime-function to static-source mapping strategy
+    - Path: go-go-goja/pkg/jsparse/highlight.go
+      Note: Syntax span model and character-class lookup path
+    - Path: go-go-goja/cmd/inspector/app/model.go
+      Note: GOJA-025 reusable component baseline for list/table/viewport/help/spinner/textinput
+    - Path: go-go-goja/cmd/inspector/app/keymap.go
+      Note: mode-keymap tags and mode-aware key binding model
+    - Path: go-go-goja/cmd/inspector/app/tree_list.go
+      Note: Existing reusable list adapter pattern
+    - Path: go-go-goja/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/reference/02-smalltalk-goja-inspector-interface-and-component-design.md
+      Note: Original implementation blueprint and intended component decomposition
+    - Path: go-go-goja/ttmp/2026/02/14/GOJA-025-INSPECTOR-BUBBLES-REFACTOR--inspector-bubbles-component-refactor/reference/01-inspector-refactor-design-guide.md
+      Note: Refactor baseline and reusable component decisions
+    - Path: go-go-goja/ttmp/2026/02/14/GOJA-026-INSPECTOR-BUGS--smalltalk-inspector-bug-fixes-empty-members-and-repl-definitions/reference/02-bug-report.md
+      Note: Bug set and intended remediation details
+    - Path: go-go-goja/ttmp/2026/02/14/GOJA-026-INSPECTOR-BUGS--smalltalk-inspector-bug-fixes-empty-members-and-repl-definitions/design/01-fix-plan.md
+      Note: Bug-fix sequencing and rationale
+ExternalSources: []
+Summary: Deep technical review of inspector work from GOJA-024 through GOJA-027, including architecture analysis, severity-ranked findings, and cleanup/refactor roadmap.
+LastUpdated: 2026-02-14T18:45:00Z
+WhatFor: Give implementers and maintainers a concrete, evidence-backed cleanup plan and architecture guide for the smalltalk-inspector code path.
+WhenToUse: Use before further feature work on smalltalk-inspector or when planning refactors/shared component extraction.
+---
+
+# Inspector Cleanup Review (GOJA-024 to GOJA-027)
+
+## Findings First (Severity-Ordered)
+
+### Critical Findings
+
+1. **Self-referential inheritance can crash the process via infinite recursion**  
+   Where: `go-go-goja/cmd/smalltalk-inspector/app/model.go:345`, `go-go-goja/cmd/smalltalk-inspector/app/model.go:385`, `go-go-goja/cmd/smalltalk-inspector/app/model.go:387`  
+   Evidence: `addInheritedMembers` recurses without cycle detection; `class A extends A {}` reproduces a stack overflow.  
+   Reproduction run during this review:
+   - `go test ./cmd/smalltalk-inspector/app -run TestTmpSelfExtends -count=1`
+   - Runtime output included `fatal error: stack overflow` and recursive stack frames in `addInheritedMembers`.  
+   Impact: any malformed/hostile input can hard-crash the inspector session.
+
+2. **The main UI command has zero package-level tests despite high complexity**  
+   Where: `go-go-goja/cmd/smalltalk-inspector/app` (no `_test.go` files), `go test` output shows `[no test files]`.  
+   Evidence: `go test ./cmd/smalltalk-inspector/... -count=1` reports no tests in command/app packages.  
+   Impact: regressions in navigation, rendering, and cross-pane state transitions are currently caught only manually.
+
+### High Findings
+
+3. **Inspect and stack views do not support scrolling windows; selection can move off-screen**  
+   Where: `go-go-goja/cmd/smalltalk-inspector/app/view.go:175`, `go-go-goja/cmd/smalltalk-inspector/app/view.go:253`, `go-go-goja/cmd/smalltalk-inspector/app/update.go:547`, `go-go-goja/cmd/smalltalk-inspector/app/update.go:639`  
+   Evidence: render loops always start at index `0`; `inspectIdx`/`stackIdx` can exceed visible rows, but no scroll offset exists.  
+   Impact: for large objects/stacks, users can navigate to items they cannot see.
+
+4. **Syntax highlighting path is asymptotically expensive and likely to degrade on larger files**  
+   Where: `go-go-goja/cmd/smalltalk-inspector/app/view.go:530`, `go-go-goja/pkg/jsparse/highlight.go:92`  
+   Evidence: `renderSyntaxLine` iterates characters, and each character performs a full linear scan of all spans via `SyntaxClassAt`.  
+   Complexity: roughly `O(chars_per_line * spans)` per line render.  
+   Impact: scroll/render latency growth with file size and REPL history size.
+
+5. **GOJA-025 reusable component baseline was not reused in GOJA-024/026/027 implementation path**  
+   Where intended: `go-go-goja/cmd/inspector/app/keymap.go`, `go-go-goja/cmd/inspector/app/tree_list.go`, `go-go-goja/cmd/inspector/app/model.go`  
+   Where implemented: `go-go-goja/cmd/smalltalk-inspector/app/{model,update,view,keymap}.go`  
+   Evidence: no imports of `bubbles/list`, `bubbles/table`, `bubbles/viewport`, or `mode-keymap` in smalltalk-inspector app code (except a comment in keymap).  
+   Impact: significant divergence, duplicate state/render logic, and reduced maintainability.
+
+### Medium Findings
+
+6. **Source scrolling logic uses file source length even when REPL source is active**  
+   Where: `go-go-goja/cmd/smalltalk-inspector/app/update.go:391`, `go-go-goja/cmd/smalltalk-inspector/app/update.go:412`, `go-go-goja/cmd/smalltalk-inspector/app/model.go:727`  
+   Evidence: `handleSourceKey` bounds to `len(m.sourceLines)`; REPL mode displays `replSourceLines`.  
+   Impact: inconsistent scroll behavior when browsing REPL-rendered source.
+
+7. **Command parsing for `:load` is not path-safe for filenames with spaces**  
+   Where: `go-go-goja/cmd/smalltalk-inspector/app/update.go:498` to `go-go-goja/cmd/smalltalk-inspector/app/update.go:513`  
+   Evidence: `strings.Fields` splits path tokens; no quoted path handling.  
+   Impact: common filesystem paths can fail unexpectedly.
+
+8. **Stack parser is brittle and non-portable for colon-bearing filenames (e.g., Windows paths)**  
+   Where: `go-go-goja/pkg/inspector/runtime/errors.go:50`, `go-go-goja/pkg/inspector/runtime/errors.go:51`  
+   Evidence: regex uses `([^:]+)` for filename; fails for `C:\...` and similar forms.  
+   Impact: incorrect stack-frame parsing in cross-platform contexts.
+
+9. **Magic numeric binding kinds in rendering are fragile and non-idiomatic**  
+   Where: `go-go-goja/cmd/smalltalk-inspector/app/view.go:324`, `go-go-goja/cmd/smalltalk-inspector/app/view.go:327`  
+   Evidence: literal `case 4` and `case 3` used instead of `jsparse.BindingClass`/`jsparse.BindingFunction`.  
+   Impact: silent break risk if enum definitions change.
+
+10. **REPL function-source fallback appends lines without rebuilding syntax spans**  
+    Where: `go-go-goja/cmd/smalltalk-inspector/app/model.go:716` to `go-go-goja/cmd/smalltalk-inspector/app/model.go:724`  
+    Evidence: path appends to `replSourceLines` but never calls `rebuildReplSyntaxSpans`.  
+    Impact: inconsistent highlight behavior after fallback source injection.
+
+11. **Runtime globals merge has correctness edge cases and stale-state behavior**  
+    Where: `go-go-goja/cmd/smalltalk-inspector/app/model.go:796` to `go-go-goja/cmd/smalltalk-inspector/app/model.go:922`  
+    Evidence:
+    - `extractDeclaredNames` is token-based heuristic (not parser-based).
+    - tracked names are added as `BindingConst` regardless of actual declaration kind.
+    - no removal path for deleted bindings.
+    Impact: global list can drift from actual runtime semantics over long sessions.
+
+12. **`pkg/inspector/analysis` is currently not integrated into the smalltalk-inspector path**  
+    Where: `go-go-goja/pkg/inspector/analysis/*.go` (implemented), no references from `go-go-goja/cmd/smalltalk-inspector/app`  
+    Impact: new abstractions exist but no production usage; architecture intent not yet realized.
+
+### Low Findings
+
+13. **Local helper duplication (`minInt`, `maxInt`, `padRight`) across command/runtime layers**  
+    Where: `go-go-goja/cmd/smalltalk-inspector/app/model.go:781`, `go-go-goja/cmd/smalltalk-inspector/app/view.go:609`, `go-go-goja/pkg/inspector/runtime/session.go:124`, `go-go-goja/cmd/inspector/app/model.go:1379`  
+    Impact: minor duplication noise; low immediate risk.
+
+14. **Some ticket docs are incomplete relative to actual implementation status**  
+    Where: `go-go-goja/ttmp/2026/02/14/GOJA-027-SYNTAX-HIGHLIGHT--syntax-highlighting-for-smalltalk-inspector-source-pane/changelog.md`, `go-go-goja/ttmp/2026/02/14/GOJA-027-SYNTAX-HIGHLIGHT--syntax-highlighting-for-smalltalk-inspector-source-pane/tasks.md`  
+    Evidence: minimal changelog; one validation task remains unchecked despite code merged.  
+    Impact: reduces long-term traceability and operational confidence.
+
+15. **Known docmgr doctor warning remains for imported raw source without frontmatter**  
+    Where: `go-go-goja/ttmp/2026/02/14/GOJA-024-SMALLTALK-INSPECTOR--smalltalk-inspector/sources/local/smalltalk-goja-inspector.md`  
+    Impact: low; acknowledged intentional exception, but should be documented as policy.
+
+---
+
+## Scope and Methodology
+
+This review covers work created from GOJA-024 onward:
+
+- GOJA-024: design + implementation plan for smalltalk-inspector.
+- GOJA-025: reusable component refactor in `cmd/inspector`.
+- GOJA-026: bug-fix wave for smalltalk-inspector behavior.
+- GOJA-027: syntax highlighting for source pane.
+
+Evidence basis used for this review:
+
+1. Code and docs inventory across ticket workspaces.
+2. Commit chronology and touched-file stats.
+3. Direct file-level inspection with line references.
+4. Runtime validation:
+   - `go test ./... -count=1` (green)
+   - targeted reproduction of crash in inheritance recursion.
+
+Quantitative context:
+
+- Diff from `b1e9add` (pre-ticket baseline) to `HEAD`: **52 files changed, 8318 insertions, 115 deletions**.
+- Non-ticket (`non-ttmp`) code/doc changes: **23 files, 4168 insertions, 115 deletions**.
+- New smalltalk-inspector command footprint: ~**2469 LOC** in app package + main.
+- New `pkg/inspector` footprint: ~**971 LOC**.
+
+---
+
+## What Was Built (By Ticket)
+
+## GOJA-024 (Design Ticket)
+
+Primary output was a detailed implementation and component-design blueprint. It established the intended decomposition and recommended reuse of GOJA-025 components (help/list/table/viewport/spinner/textinput/mode-keymap).
+
+Strength:
+
+- High-quality specification and screen-level mapping.
+
+Gap:
+
+- The implemented command path diverged from this decomposition and did not fully adopt the reusable baseline.
+
+## GOJA-025 (Reusable Inspector Refactor)
+
+Refactored `cmd/inspector` to introduce reusable Bubbles patterns and mode-aware key metadata.
+
+What landed:
+
+- `cmd/inspector/app/keymap.go`: mode tags and help integration.
+- `cmd/inspector/app/tree_list.go`: list adapter for tree rows.
+- `cmd/inspector/app/model.go`: spinner/help, list/viewport/table/textinput integration.
+
+Assessment:
+
+- Good foundational work and test-preserving refactor.
+- This is the strongest candidate base for extracting shared components.
+
+## GOJA-026 (Bug-Fix Wave)
+
+Delivered meaningful behavior fixes in smalltalk-inspector:
+
+- value globals get runtime member introspection.
+- REPL-defined globals are merged into globals list.
+- Enter-on-value opens inspect mode.
+- runtime init ordering corrected.
+- prototype chain footer improved.
+- nav stack reset on new eval.
+
+Assessment:
+
+- Functional correctness improved significantly.
+- Several fixes were tactical patches inside the existing monolith.
+
+## GOJA-027 (Syntax Highlighting)
+
+Added tree-sitter based syntax spans and rendering support for file + REPL source.
+
+What landed:
+
+- shared syntax types in `pkg/jsparse/highlight.go`.
+- integration into smalltalk source pane rendering.
+
+Assessment:
+
+- Feature quality is visible and useful.
+- Performance model and test coverage need hardening.
+
+---
+
+## How It Works Today (Architecture Map)
+
+### Command Layer
+
+`cmd/smalltalk-inspector/main.go` launches Bubble Tea alt-screen with a single root model.
+
+### Root UI State/Flow
+
+`cmd/smalltalk-inspector/app/model.go`, `update.go`, `view.go` currently implement a monolithic architecture:
+
+- State store: globals/members/source/repl/inspect/stack and navigation state in one struct.
+- Update flow: one large update router with pane-specific handlers.
+- View flow: large render switch for empty/normal/inspect/error layouts.
+
+### Domain Helpers
+
+- `pkg/inspector/runtime/*`: runtime eval/introspection/stack parsing/function mapping.
+- `pkg/inspector/analysis/*`: wrappers for static symbol/xref workflows (present, mostly unused by smalltalk command).
+
+### Static Parsing/Highlighting
+
+- `pkg/jsparse` handles parse/index/resolve and syntax spans.
+
+### Reusable Baseline Not Yet Unified
+
+`cmd/inspector/app/*` now includes reusable patterns (mode-keymap, list adapter, viewport, table, command input), but smalltalk-inspector re-implements many equivalents locally.
+
+---
+
+## Deep Technical Review
+
+### 1) Correctness and Safety
+
+#### 1.1 Inheritance recursion needs cycle guards
+
+`addInheritedMembers` should track visited class names and stop recursion on repeated nodes. Without this, self-cycles and indirect cycles can overflow stack.
+
+Recommended shape:
+
+```go
+func (m *Model) addInheritedMembers(className, source string, visited map[string]bool) {
+    if visited[className] { return }
+    visited[className] = true
+    defer delete(visited, className)
+    ...
+}
+```
+
+#### 1.2 Mode transition correctness is mostly good, but render/selection coupling is brittle
+
+Navigation state (`inspectIdx`, `stackIdx`) is not coupled to viewport offsets. This creates invisible selection states.
+
+Recommended shape:
+
+- Introduce `inspectScroll` and `stackScroll` with `ensureInspectVisible` / `ensureStackVisible`.
+- Render loops should start from scroll index instead of `0`.
+
+### 2) Architecture and Decomposition
+
+#### 2.1 Monolith drift
+
+Despite earlier design goals, most behavior still lives in three large files (`model.go` 932 lines, `update.go` 667 lines, `view.go` 615 lines).
+
+Refactor direction:
+
+- Keep a thin root model for orchestration.
+- Split feature models:
+  - globals/members/source/repl/inspect/stack/status.
+- Reuse `cmd/inspector` adapters where possible.
+
+#### 2.2 Unused domain package (`pkg/inspector/analysis`)
+
+The package was correctly added but not integrated. This causes duplicated static-analysis access patterns in command-layer logic.
+
+Refactor direction:
+
+- Route binding/xref/symbol responsibilities through `pkg/inspector/analysis`.
+- Keep UI layer focused on rendering and user interaction.
+
+### 3) Component Reuse and Generalization Opportunities
+
+High leverage opportunities:
+
+1. **Mode-keymap bridge component**
+- General-purpose wrapper used by both `cmd/inspector` and `cmd/smalltalk-inspector`.
+- Avoid duplicated key-mode logic and help wiring.
+
+2. **Selectable list model abstraction**
+- General-purpose scrolling/select window logic shared by globals/members/inspect/stack.
+- Could wrap `bubbles/list` with lightweight domain adapters.
+
+3. **Source pane component**
+- Shared code-view component with:
+  - source buffer abstraction (file vs REPL)
+  - highlight span cache
+  - jump/center APIs
+  - viewport-backed scrolling.
+
+4. **Inspector object browser component**
+- reusable property-table/list with symbol/property descriptors, proto jump, and drill-in stack.
+
+5. **Status + command line module**
+- standard status notices and command parsing including quoted arguments.
+
+### 4) Performance Characteristics
+
+#### 4.1 Highlighting path
+
+Current char-by-char + span-scan model is simple but slow for larger inputs.
+
+Recommended upgrade:
+
+- Build per-line span slices once, then render by segments rather than per-char global lookup.
+- Precompute visible-line styled content and invalidate on source/scroll changes.
+
+#### 4.2 Runtime introspection in render path
+
+Prototype footer currently can query runtime chain while rendering members pane.
+
+Recommended upgrade:
+
+- Cache proto chain per selected global until selection changes.
+- Avoid runtime calls inside hot render loops.
+
+### 5) API/UX Reliability
+
+#### 5.1 Command parser needs quoting support
+
+Current `strings.Fields` parsing breaks common path names. Replace with shell-like parser or command lexer.
+
+#### 5.2 REPL source tracking should be structured, not substring-based
+
+`showReplFunctionSource` matches by `strings.Contains` on expression/function strings. This can mis-associate sources and grows unbounded.
+
+Recommended approach:
+
+- maintain function identity map from eval result to source entry id when possible.
+- optionally cap REPL source log size and provide clear/reset command.
+
+### 6) Idiomatic Go and Maintainability
+
+1. Replace manual sort loops with `sort.Slice` in globals sorting.
+2. Replace numeric kind literals with typed constants.
+3. Move large builtin maps to package-level variables to avoid repeated allocations.
+4. Consolidate duplicate helper utilities in shared internal package.
+
+---
+
+## Deprecated or Unidiomatic Areas
+
+1. **Magic numbers for enum kinds**: `view.go` uses raw numeric literals for binding kinds.  
+2. **Comment claims mode-keymap integration, but implementation does not use it**: `keymap.go` comment is misleading.  
+3. **Manual scroll/list rendering in many panes** despite reusable component baseline in GOJA-025.  
+4. **String-field parsing for declarations** (`extractDeclaredNames`) instead of parser-backed approach.
+
+---
+
+## Refactor Plan (Pragmatic, Incremental)
+
+### Phase A: Stabilize (Safety + Regression)
+
+1. Add cycle detection to inheritance recursion.
+2. Add test coverage in `cmd/smalltalk-inspector/app` for:
+- globals/members selection sync
+- inspect/stack scroll visibility
+- command parser (`:load` with quoted paths)
+- REPL source rendering and syntax-span updates.
+3. Add crash/regression test for `class A extends A {}`.
+
+### Phase B: Component Alignment
+
+1. Introduce shared `internal/inspectorui` package with:
+- keyed-mode helper
+- scrollable selectable list model
+- source view model.
+2. Migrate smalltalk-inspector globals/members/inspect/stack to reusable list/table abstractions.
+3. Move command parser to reusable module and add quoted args support.
+
+### Phase C: Domain Layer Consolidation
+
+1. Integrate `pkg/inspector/analysis` into smalltalk command path.
+2. Keep `pkg/inspector/runtime` as single runtime truth source.
+3. Remove duplicated static-analysis logic from command model.
+
+### Phase D: Performance Hardening
+
+1. Optimize syntax highlight lookup strategy.
+2. Cache proto chains and descriptor rows per selection.
+3. Add benchmark for source-pane rendering at large file sizes.
+
+---
+
+## Suggested Task Backlog for GOJA-028
+
+1. Guard inherited-member recursion with cycle detection + tests.
+2. Add inspect and stack scrolling state/visibility guarantees.
+3. Fix source scrolling bounds when `showingReplSrc` is true.
+4. Rebuild REPL syntax spans after runtime fallback source append.
+5. Replace `strings.Fields` command parsing with quoted argument parser.
+6. Replace magic binding kind literals with typed constants.
+7. Introduce shared list/source/status components and migrate smalltalk panes.
+8. Integrate `pkg/inspector/analysis` in smalltalk path.
+9. Optimize syntax span lookup/rendering and add benchmark.
+10. Complete GOJA-027 documentation closure and validation task.
+
+---
+
+## Open Questions / Assumptions
+
+1. Should smalltalk-inspector intentionally remain separate from `cmd/inspector` abstractions, or is a shared `internal/inspectorui` module preferred?
+2. Is cross-platform stack parsing (Windows paths) an explicit near-term requirement?
+3. Should REPL source history persist across file loads, or reset on each `:load`?
+4. Should descriptor UI for symbol properties be included in immediate cleanup scope, or deferred?
+
+---
+
+## Implementation Notes for New Developers
+
+Start here in order:
+
+1. `go-go-goja/cmd/smalltalk-inspector/app/update.go` (interaction and state transitions)
+2. `go-go-goja/cmd/smalltalk-inspector/app/model.go` (data model and domain wiring)
+3. `go-go-goja/cmd/smalltalk-inspector/app/view.go` (render behavior and scrolling limitations)
+4. `go-go-goja/pkg/inspector/runtime/introspect.go` and `go-go-goja/pkg/inspector/runtime/errors.go`
+5. `go-go-goja/cmd/inspector/app/keymap.go` and `go-go-goja/cmd/inspector/app/tree_list.go` for reusable component patterns
+
+Recommended first command set:
+
+```bash
+cd go-go-goja
+
+go test ./... -count=1
+
+rg -n "addInheritedMembers|buildMembers|refreshRuntimeGlobals" cmd/smalltalk-inspector/app/model.go
+rg -n "handleInspectKey|handleStackKey|handleSourceKey|executeCommand" cmd/smalltalk-inspector/app/update.go
+rg -n "renderInspectPane|renderStackPane|renderSourcePane|renderSyntaxLine" cmd/smalltalk-inspector/app/view.go
+```
+
+---
+
+## Review Appendix: Commands Executed During Analysis
+
+```bash
+# baseline test coverage and health
+cd go-go-goja && go test ./... -count=1
+cd go-go-goja && go vet ./...
+
+# ticket and commit inventory
+find go-go-goja/ttmp -maxdepth 4 -type d | rg 'GOJA-0(2[4-9]|3[0-9])'
+git -C go-go-goja log --oneline -n 40
+
+# key code surface
+rg --files go-go-goja/cmd/smalltalk-inspector go-go-goja/pkg/inspector
+wc -l go-go-goja/cmd/smalltalk-inspector/app/*.go go-go-goja/pkg/inspector/**/*.go
+
+# crash reproduction (self extends)
+# (performed via temporary test; output showed fatal stack overflow)
+go test ./cmd/smalltalk-inspector/app -run TestTmpSelfExtends -count=1
+```
+
+---
+
+## Final Assessment
+
+The inspector effort since GOJA-024 delivered real user-facing capability quickly: the smalltalk-style browser works, runtime object inspection is functional, stack traces are viewable, and syntax coloring improved readability. GOJA-026 in particular fixed meaningful correctness gaps.
+
+The main risk now is not missing features; it is **structural drift**:
+
+- large monolithic command files,
+- incomplete reuse of GOJA-025 component infrastructure,
+- missing tests in the highest-change surface,
+- and one proven crash class in inheritance recursion.
+
+Addressing those items in GOJA-028 will convert the current implementation from feature-complete prototype quality into a stable, reusable inspector platform.

--- a/ttmp/2026/02/14/GOJA-028-CLEANUP-INSPECTOR--cleanup-inspector/reference/02-diary.md
+++ b/ttmp/2026/02/14/GOJA-028-CLEANUP-INSPECTOR--cleanup-inspector/reference/02-diary.md
@@ -1,0 +1,138 @@
+---
+Title: Diary
+Ticket: GOJA-028-CLEANUP-INSPECTOR
+Status: active
+Topics:
+    - go
+    - goja
+    - tui
+    - inspector
+    - refactor
+DocType: reference
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: go-go-goja/ttmp/2026/02/14/GOJA-028-CLEANUP-INSPECTOR--cleanup-inspector/reference/01-inspector-cleanup-review.md
+      Note: Main review output produced in this execution
+    - Path: go-go-goja/cmd/smalltalk-inspector/app/model.go
+      Note: Critical crash path identified during review
+    - Path: go-go-goja/cmd/smalltalk-inspector/app/update.go
+      Note: Interaction-state logic reviewed for cleanup risks
+    - Path: go-go-goja/cmd/smalltalk-inspector/app/view.go
+      Note: Rendering/scrolling behavior analyzed in depth
+    - Path: go-go-goja/ttmp/vocabulary.yaml
+      Note: Added topic entries to satisfy doctor checks
+ExternalSources: []
+Summary: Execution diary for GOJA-028 review work, including inventory, validation, crash reproduction, and deliverable publication steps.
+LastUpdated: 2026-02-14T18:52:00Z
+WhatFor: Preserve command-level traceability and review workflow context for the cleanup ticket.
+WhenToUse: Use when auditing how GOJA-028 findings were produced or reproducing the analysis workflow.
+---
+
+# Diary
+
+## Step 1: Ticket setup and scope inventory
+
+Created `GOJA-028-CLEANUP-INSPECTOR` and enumerated ticket workspaces from GOJA-024 through GOJA-027 to establish review scope.
+
+Commands used:
+
+```bash
+docmgr ticket create-ticket --ticket GOJA-028-CLEANUP-INSPECTOR --title "Cleanup Inspector" --topics go,goja,tui,refactor,inspector
+find go-go-goja/ttmp -maxdepth 4 -type d | rg 'GOJA-0(2[4-9]|3[0-9])' | sort
+```
+
+## Step 2: Commit and file-surface mapping
+
+Collected commit history and file-level diffs since the pre-ticket baseline to understand exactly what was implemented.
+
+Commands used:
+
+```bash
+git -C go-go-goja log --oneline -n 40
+git -C go-go-goja diff --name-status b1e9add..HEAD
+git -C go-go-goja diff --shortstat b1e9add..HEAD
+```
+
+## Step 3: Baseline validation
+
+Ran tests and vet across the repository to establish current health before deeper findings analysis.
+
+Commands used:
+
+```bash
+cd go-go-goja && go test ./... -count=1
+cd go-go-goja && go vet ./...
+```
+
+Outcome:
+
+- All tests passed.
+- `go vet` passed.
+
+## Step 4: Deep file inspection and targeted issue checks
+
+Inspected key files in `cmd/smalltalk-inspector/app`, `pkg/inspector/runtime`, `pkg/inspector/analysis`, and `pkg/jsparse/highlight.go` with line-numbered reads.
+
+Collected concrete evidence for architecture drift, scroll/render issues, parser/regex brittleness, and reuse gaps.
+
+## Step 5: Critical crash reproduction
+
+Validated a high-severity crash candidate: self-referential inheritance in class member traversal.
+
+Method:
+
+- Created a temporary test within `cmd/smalltalk-inspector/app` package to trigger `buildMembers()` on `class A extends A {}`.
+- Ran `go test` with timeout.
+- Observed runtime stack overflow with repeated frames in `addInheritedMembers`.
+
+Representative command:
+
+```bash
+cd go-go-goja && timeout 8s go test ./cmd/smalltalk-inspector/app -run TestTmpSelfExtends -count=1
+```
+
+Result:
+
+- `fatal error: stack overflow`
+- Repeated recursion at `cmd/smalltalk-inspector/app/model.go` in `addInheritedMembers`.
+
+Cleanup:
+
+- Removed temporary test file immediately after reproduction.
+
+## Step 6: Authored primary review deliverable
+
+Wrote `reference/01-inspector-cleanup-review.md` with:
+
+- severity-ranked findings first,
+- architecture and implementation analysis,
+- deprecated/unidiomatic items,
+- reusable component extraction opportunities,
+- phased cleanup roadmap and task backlog.
+
+## Step 7: Ticket metadata/task/changelog updates
+
+Updated:
+
+- `tasks.md` with completed analysis items + actionable cleanup backlog.
+- `index.md` with concrete summary and link map.
+- `changelog.md` with execution steps and related files.
+
+## Step 8: Validation and vocabulary hygiene
+
+Validated frontmatter for key GOJA-028 docs and ran `docmgr doctor`.
+
+Doctor initially reported unknown topics (`inspector`, `refactor`) in vocabulary.
+
+Fixed by adding vocabulary entries:
+
+```bash
+docmgr vocab add --category topics --slug inspector --description "Inspector tooling and workflows"
+docmgr vocab add --category topics --slug refactor --description "Codebase refactor and cleanup work"
+docmgr doctor --ticket GOJA-028-CLEANUP-INSPECTOR --stale-after 30
+```
+
+Final doctor status:
+
+- GOJA-028 checks passed.

--- a/ttmp/2026/02/14/GOJA-028-CLEANUP-INSPECTOR--cleanup-inspector/tasks.md
+++ b/ttmp/2026/02/14/GOJA-028-CLEANUP-INSPECTOR--cleanup-inspector/tasks.md
@@ -8,19 +8,19 @@
 - [x] Reproduce and document critical inheritance recursion crash (`class A extends A {}`)
 - [x] Author deep cleanup/review document with severity-ranked findings and architecture map
 
-- [ ] Implement cycle detection in inherited-member traversal and add regression test
-- [ ] Add inspect/stack scroll offsets and visibility guarantees
-- [ ] Fix source scroll bounds when showing REPL source
+- [x] Implement cycle detection in inherited-member traversal and add regression test
+- [x] Add inspect/stack scroll offsets and visibility guarantees
+- [x] Fix source scroll bounds when showing REPL source
 - [ ] Rebuild REPL syntax spans on runtime fallback source append
 - [ ] Replace command parsing with quoted-argument-safe parser for `:load`
 - [ ] Replace magic binding-kind numeric literals with typed constants
-- [ ] Introduce shared inspector UI components and migrate smalltalk panes incrementally
-- [ ] Integrate `pkg/inspector/analysis` into smalltalk-inspector command path
+- [x] Introduce shared inspector UI components and migrate smalltalk panes incrementally
+- [x] Integrate `pkg/inspector/analysis` into smalltalk-inspector command path
 - [ ] Optimize syntax highlighting lookup/render path and add benchmark coverage
-- [ ] Close GOJA-027 doc/task hygiene gaps and validate with `docmgr doctor`
+- [x] Close GOJA-027 doc/task hygiene gaps and validate with `docmgr doctor`
 
 ## Handoff Checklist
 
-- [ ] Confirm no regression in `cmd/inspector` while applying cleanup refactors
-- [ ] Keep each cleanup change small and test-backed
-- [ ] Update GOJA-028 changelog + diary (or equivalent notes) per milestone
+- [x] Confirm no regression in `cmd/inspector` while applying cleanup refactors
+- [x] Keep each cleanup change small and test-backed
+- [x] Update GOJA-028 changelog + diary (or equivalent notes) per milestone

--- a/ttmp/2026/02/14/GOJA-028-CLEANUP-INSPECTOR--cleanup-inspector/tasks.md
+++ b/ttmp/2026/02/14/GOJA-028-CLEANUP-INSPECTOR--cleanup-inspector/tasks.md
@@ -1,0 +1,26 @@
+# Tasks
+
+## TODO
+
+- [x] Create GOJA-028 ticket workspace
+- [x] Inventory GOJA-024 to GOJA-027 tickets, commits, and touched files
+- [x] Run validation baseline (`go test ./...`, `go vet ./...`) and record outcomes
+- [x] Reproduce and document critical inheritance recursion crash (`class A extends A {}`)
+- [x] Author deep cleanup/review document with severity-ranked findings and architecture map
+
+- [ ] Implement cycle detection in inherited-member traversal and add regression test
+- [ ] Add inspect/stack scroll offsets and visibility guarantees
+- [ ] Fix source scroll bounds when showing REPL source
+- [ ] Rebuild REPL syntax spans on runtime fallback source append
+- [ ] Replace command parsing with quoted-argument-safe parser for `:load`
+- [ ] Replace magic binding-kind numeric literals with typed constants
+- [ ] Introduce shared inspector UI components and migrate smalltalk panes incrementally
+- [ ] Integrate `pkg/inspector/analysis` into smalltalk-inspector command path
+- [ ] Optimize syntax highlighting lookup/render path and add benchmark coverage
+- [ ] Close GOJA-027 doc/task hygiene gaps and validate with `docmgr doctor`
+
+## Handoff Checklist
+
+- [ ] Confirm no regression in `cmd/inspector` while applying cleanup refactors
+- [ ] Keep each cleanup change small and test-backed
+- [ ] Update GOJA-028 changelog + diary (or equivalent notes) per milestone

--- a/ttmp/2026/02/14/GOJA-028-CLEANUP-INSPECTOR--cleanup-inspector/tasks.md
+++ b/ttmp/2026/02/14/GOJA-028-CLEANUP-INSPECTOR--cleanup-inspector/tasks.md
@@ -11,9 +11,9 @@
 - [x] Implement cycle detection in inherited-member traversal and add regression test
 - [x] Add inspect/stack scroll offsets and visibility guarantees
 - [x] Fix source scroll bounds when showing REPL source
-- [ ] Rebuild REPL syntax spans on runtime fallback source append
+- [x] Rebuild REPL syntax spans on runtime fallback source append
 - [ ] Replace command parsing with quoted-argument-safe parser for `:load`
-- [ ] Replace magic binding-kind numeric literals with typed constants
+- [x] Replace magic binding-kind numeric literals with typed constants
 - [x] Introduce shared inspector UI components and migrate smalltalk panes incrementally
 - [x] Integrate `pkg/inspector/analysis` into smalltalk-inspector command path
 - [ ] Optimize syntax highlighting lookup/render path and add benchmark coverage

--- a/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/README.md
+++ b/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/README.md
@@ -1,0 +1,21 @@
+# Inspector Component Alignment
+
+This is the document workspace for ticket GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr doc add --ticket GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT --doc-type design-doc --title "My Design"`
+- Import sources: `docmgr import file --ticket GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT --file /path/to/doc.md`
+- Update metadata: `docmgr meta update --ticket GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT --field Status --value review`

--- a/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/changelog.md
+++ b/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/changelog.md
@@ -89,3 +89,8 @@ Step 7: Added navigation/mode visibility tests for smalltalk-inspector and compl
 - /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/reference/01-diary.md — Recorded Step 6 completion diary
 - /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/tasks.md — All remaining tasks checked complete
 
+
+## 2026-02-14
+
+Ticket closed
+

--- a/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/changelog.md
+++ b/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/changelog.md
@@ -64,3 +64,17 @@ Step 5: Migrated source pane to viewport-backed scrolling and added shared viewp
 - /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/internal/inspectorui/viewportpane.go — Added shared viewport offset clamping
 - /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/reference/01-diary.md — Recorded Step 4 implementation diary
 
+
+## 2026-02-14
+
+Step 6: Consolidated duplicated layout/status utility helpers into internal inspectorui utilities and rewired app callsites.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/cmd/smalltalk-inspector/app/model.go — Removed duplicated local helper implementations
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/cmd/smalltalk-inspector/app/update.go — Min/max callsites migrated to shared utilities
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/cmd/smalltalk-inspector/app/view.go — Padding and status formatting migrated to shared utilities
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/internal/inspectorui/util.go — Shared utility helpers for min/max
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/internal/inspectorui/util_test.go — Utility helper tests
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/reference/01-diary.md — Recorded Step 5 implementation diary
+

--- a/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/changelog.md
+++ b/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/changelog.md
@@ -1,0 +1,15 @@
+# Changelog
+
+## 2026-02-14
+
+- Initial workspace created
+
+
+## 2026-02-14
+
+Step 1: Added detailed component alignment implementation plan with migration phases, target architecture, and test strategy.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/design/01-component-alignment-implementation-plan.md — Primary plan document
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/tasks.md — Task breakdown derived from plan

--- a/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/changelog.md
+++ b/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/changelog.md
@@ -78,3 +78,14 @@ Step 6: Consolidated duplicated layout/status utility helpers into internal insp
 - /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/internal/inspectorui/util_test.go — Utility helper tests
 - /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/reference/01-diary.md — Recorded Step 5 implementation diary
 
+
+## 2026-02-14
+
+Step 7: Added navigation/mode visibility tests for smalltalk-inspector and completed all GOJA-029 tasks with full regression validation.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/cmd/smalltalk-inspector/app/navigation_mode_test.go — New pane navigation and mode behavior tests
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/reference/01-diary.md — Recorded Step 6 completion diary
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/tasks.md — All remaining tasks checked complete
+

--- a/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/changelog.md
+++ b/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/changelog.md
@@ -13,3 +13,15 @@ Step 1: Added detailed component alignment implementation plan with migration ph
 
 - /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/design/01-component-alignment-implementation-plan.md — Primary plan document
 - /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/tasks.md — Task breakdown derived from plan
+
+
+## 2026-02-14
+
+Step 2: Implemented mode-keymap alignment in smalltalk-inspector key handling and mode updates; added diary baseline/test trace.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/cmd/smalltalk-inspector/app/keymap.go — Added keymap-mode tags and inspect/stack modes
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/cmd/smalltalk-inspector/app/update.go — Wired mode enablement in update transitions
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/cmd/smalltalk-inspector/app/model.go — Enabled initial mode-keymap state
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/reference/01-diary.md — Added implementation diary step

--- a/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/changelog.md
+++ b/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/changelog.md
@@ -51,3 +51,16 @@ Step 4: Extracted reusable listpane helper for globals/members scroll windows an
 - /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/internal/inspectorui/listpane_test.go — Unit tests for listpane helper invariants
 - /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/reference/01-diary.md — Recorded Step 3 implementation diary
 
+
+## 2026-02-14
+
+Step 5: Migrated source pane to viewport-backed scrolling and added shared viewport offset clamping helper.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/cmd/smalltalk-inspector/app/model.go — Added source viewport state and active-source helper
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/cmd/smalltalk-inspector/app/update.go — Source key handling now drives source viewport offset
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/cmd/smalltalk-inspector/app/view.go — Source pane now renders via viewport body
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/internal/inspectorui/viewportpane.go — Added shared viewport offset clamping
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/reference/01-diary.md — Recorded Step 4 implementation diary
+

--- a/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/changelog.md
+++ b/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/changelog.md
@@ -38,3 +38,16 @@ Step 3: Migrated inspect/stack panes to viewport-backed rendering, added reusabl
 - /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/internal/inspectorui/viewportpane.go — Reusable viewport row visibility helper
 - /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/reference/01-diary.md — Recorded Step 2 implementation diary
 
+
+## 2026-02-14
+
+Step 4: Extracted reusable listpane helper for globals/members scroll windows and added listpane unit tests.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/cmd/smalltalk-inspector/app/update.go — Globals/members visibility now uses shared listpane helper
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/cmd/smalltalk-inspector/app/view.go — Globals/members render window now derived from shared helper
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/internal/inspectorui/listpane.go — Shared list pane selection visibility and visible-range logic
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/internal/inspectorui/listpane_test.go — Unit tests for listpane helper invariants
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/reference/01-diary.md — Recorded Step 3 implementation diary
+

--- a/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/changelog.md
+++ b/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/changelog.md
@@ -25,3 +25,16 @@ Step 2: Implemented mode-keymap alignment in smalltalk-inspector key handling an
 - /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/cmd/smalltalk-inspector/app/update.go — Wired mode enablement in update transitions
 - /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/cmd/smalltalk-inspector/app/model.go — Enabled initial mode-keymap state
 - /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/reference/01-diary.md — Added implementation diary step
+
+## 2026-02-14
+
+Step 3: Migrated inspect/stack panes to viewport-backed rendering, added reusable row-visibility helper, and verified full regression suite.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/cmd/smalltalk-inspector/app/model.go — Added inspect/stack viewport state and pane-height helpers
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/cmd/smalltalk-inspector/app/update.go — Wired visibility maintenance and viewport offset resets
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/cmd/smalltalk-inspector/app/view.go — Migrated inspect/stack pane bodies to viewport rendering
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/internal/inspectorui/viewportpane.go — Reusable viewport row visibility helper
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/reference/01-diary.md — Recorded Step 2 implementation diary
+

--- a/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/design/01-component-alignment-implementation-plan.md
+++ b/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/design/01-component-alignment-implementation-plan.md
@@ -1,0 +1,190 @@
+---
+Title: Component Alignment Implementation Plan
+Ticket: GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT
+Status: active
+Topics:
+    - go
+    - goja
+    - tui
+    - inspector
+    - refactor
+DocType: design
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: go-go-goja/cmd/smalltalk-inspector/app/model.go
+      Note: Current monolithic state and member-building behavior
+    - Path: go-go-goja/cmd/smalltalk-inspector/app/update.go
+      Note: Current key handling and message routing
+    - Path: go-go-goja/cmd/smalltalk-inspector/app/view.go
+      Note: Current pane rendering and manual scrolling logic
+    - Path: go-go-goja/cmd/smalltalk-inspector/app/keymap.go
+      Note: Local keymap implementation to align with mode-keymap approach
+    - Path: go-go-goja/cmd/inspector/app/keymap.go
+      Note: GOJA-025 mode-keymap baseline to reuse
+    - Path: go-go-goja/cmd/inspector/app/tree_list.go
+      Note: GOJA-025 reusable list adapter pattern
+    - Path: go-go-goja/cmd/inspector/app/model.go
+      Note: Existing shared use of help/list/table/viewport/spinner/textinput
+    - Path: go-go-goja/ttmp/2026/02/14/GOJA-028-CLEANUP-INSPECTOR--cleanup-inspector/reference/01-inspector-cleanup-review.md
+      Note: Source of finding #5 and downstream cleanup priorities
+ExternalSources: []
+Summary: Incremental migration plan to align smalltalk-inspector with reusable inspector UI components and reduce architecture drift.
+LastUpdated: 2026-02-14T19:02:00Z
+WhatFor: Define a low-risk execution strategy for reusing GOJA-025 component primitives and reducing duplicated pane/state logic.
+WhenToUse: Use before and during GOJA-029 implementation work.
+---
+
+# Component Alignment Implementation Plan
+
+## Goal
+
+Address GOJA-028 finding #5 by aligning `cmd/smalltalk-inspector` with the reusable component baseline introduced in GOJA-025 (`help`, `viewport`, `list`, `table`, `spinner`, `textinput`, `mode-keymap`), while preserving existing behavior.
+
+## Why This Ticket Exists
+
+Current state:
+
+- `cmd/smalltalk-inspector` reimplements pane scrolling/selection/layout logic manually.
+- `cmd/inspector` already contains reusable patterns and tested component integrations.
+- Equivalent logic now diverges across two commands, increasing bug risk and maintenance cost.
+
+This ticket narrows that gap.
+
+## Scope
+
+In scope:
+
+1. Mode-aware key handling parity with GOJA-025 (`mode-keymap` style).
+2. Shared scrollable pane abstractions for list-style panes and long content panes.
+3. Refactor stack and inspect panes to viewport-backed rendering.
+4. Incremental extraction of shared UI helpers to a reusable package (`internal/inspectorui` preferred).
+5. Regression tests for navigation visibility and pane behavior.
+
+Out of scope:
+
+1. New end-user features unrelated to component alignment.
+2. Syntax-highlighting algorithm upgrades (covered by GOJA-030).
+3. Large runtime-domain rewrites (`pkg/inspector/runtime`) unless required for compatibility.
+
+## Target Architecture
+
+### Command Layer
+
+`cmd/smalltalk-inspector/app` should become orchestration-focused:
+
+- route messages,
+- coordinate feature models,
+- compose views from reusable components.
+
+### Shared UI Layer
+
+Add `go-go-goja/internal/inspectorui` with:
+
+1. `keymode` helper:
+- wraps mode switching and key filtering.
+- exposes consistent help rendering contract.
+
+2. `listpane` helper:
+- generic selected-index + scroll-window behavior.
+- optional `bubbles/list` adapter mode for richer list rendering.
+
+3. `viewportpane` helper:
+- long content + selected line visibility.
+- reusable for source, stack, inspect views.
+
+4. `statusline` helper:
+- consistent status formatting and transient notice composition.
+
+### Feature Models (Smalltalk)
+
+Keep feature-specific behavior local, but consume shared UI primitives:
+
+- globals pane model
+- members pane model
+- inspect pane model
+- stack pane model
+- source pane model
+- repl model
+
+## Implementation Strategy (Incremental)
+
+## Phase 1: Mode + Keymap Alignment
+
+1. Replace local ad-hoc mode handling with explicit mode-keymap approach modeled on `cmd/inspector/app/keymap.go`.
+2. Ensure `ShortHelp`/`FullHelp` reflect per-mode behavior.
+3. Keep existing key bindings to avoid UX churn; adjust internal dispatch only.
+
+Deliverable:
+
+- Smalltalk key handling aligned structurally with GOJA-025 baseline.
+
+## Phase 2: Pane Scrolling Abstractions
+
+1. Introduce shared `listpane` and `viewportpane` helpers.
+2. Migrate globals and members panes first.
+3. Migrate stack and inspect panes next (this also resolves GOJA-028 finding #3 if implemented with visibility guarantees).
+
+Deliverable:
+
+- No manual repeated `ensureXVisible`/window math per pane.
+
+## Phase 3: Source + Status + Command Alignment
+
+1. Reuse viewport component for source pane consistently.
+2. Consolidate status and command-line rendering helpers.
+3. Remove duplicate utility functions (`minInt`, `maxInt`, `padRight`) where possible.
+
+Deliverable:
+
+- Reduced duplicate logic in `model.go`, `update.go`, `view.go`.
+
+## Phase 4: Hardening and Cleanup
+
+1. Add tests for cross-pane navigation and visibility.
+2. Verify no regression in `cmd/inspector`.
+3. Remove dead code and stale compatibility shims.
+
+Deliverable:
+
+- Stable aligned component architecture with test coverage.
+
+## Testing Plan
+
+Mandatory:
+
+1. `go test ./cmd/smalltalk-inspector/... -count=1`
+2. `go test ./cmd/inspector/... -count=1`
+3. `go test ./pkg/inspector/... -count=1`
+4. `go test ./... -count=1`
+
+Add/expand tests:
+
+1. selection visibility in inspect/stack panes for long lists.
+2. pane switching and mode-specific key behavior.
+3. command mode open/close and help consistency.
+4. regression test for stack overflow cycle once bug fix lands.
+
+## Risks and Mitigations
+
+Risk: breaking interaction behavior during refactor.  
+Mitigation: phase-by-phase migration with behavior snapshots/tests.
+
+Risk: over-abstraction early.  
+Mitigation: extract only duplicated patterns used in at least two panes.
+
+Risk: conflating alignment with feature additions.  
+Mitigation: keep ticket scope strictly cleanup/refactor.
+
+## Definition of Done
+
+1. Smalltalk inspector uses shared component primitives for key mode, list panes, viewport panes, and status/help composition.
+2. Manual duplicated pane scrolling logic is removed from at least inspect+stack+globals/members paths.
+3. `cmd/inspector` and `cmd/smalltalk-inspector` behavior remains stable.
+4. Tests cover key aligned behaviors and pass in CI/local.
+
+## Notes on Relationship to GOJA-028 Finding #3
+
+Yes: completing this ticket should directly address finding #3 if stack/inspect pane migration to viewport/list abstractions includes explicit visibility management.
+
+No: it is not automatic. The implementation must include `selected item must remain visible` assertions and tests.

--- a/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/index.md
+++ b/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/index.md
@@ -1,0 +1,73 @@
+---
+Title: Inspector Component Alignment
+Ticket: GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT
+Status: active
+Topics:
+    - go
+    - goja
+    - tui
+    - inspector
+    - refactor
+DocType: index
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: go-go-goja/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/design/01-component-alignment-implementation-plan.md
+      Note: Primary implementation plan for this ticket
+    - Path: go-go-goja/cmd/smalltalk-inspector/app/model.go
+      Note: Current monolithic state/model logic targeted for alignment
+    - Path: go-go-goja/cmd/smalltalk-inspector/app/update.go
+      Note: Current key and message routing to be componentized
+    - Path: go-go-goja/cmd/smalltalk-inspector/app/view.go
+      Note: Current rendering/scroller logic to migrate to reusable components
+    - Path: go-go-goja/cmd/inspector/app/keymap.go
+      Note: GOJA-025 mode-aware baseline to align with
+    - Path: go-go-goja/cmd/inspector/app/tree_list.go
+      Note: GOJA-025 reusable list adapter pattern
+ExternalSources: []
+Summary: Execution ticket for aligning smalltalk-inspector with reusable GOJA-025 component architecture and reducing duplicated UI logic.
+LastUpdated: 2026-02-14T19:03:00Z
+WhatFor: Plan and track incremental migration from monolithic pane logic to shared component primitives.
+WhenToUse: Use as entrypoint when implementing GOJA-029 refactor tasks.
+---
+
+# Inspector Component Alignment
+
+## Overview
+
+This ticket addresses GOJA-028 finding #5 by aligning `cmd/smalltalk-inspector` with reusable component patterns already established in GOJA-025. It focuses on mode-aware key handling, shared pane abstractions, scroll/visibility correctness, and regression-safe migration.
+
+## Key Links
+
+- Implementation plan: `design/01-component-alignment-implementation-plan.md`
+- Tasks: `tasks.md`
+- Changelog: `changelog.md`
+
+## Status
+
+Current status: **active**
+
+## Topics
+
+- go
+- goja
+- tui
+- inspector
+- refactor
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/index.md
+++ b/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/index.md
@@ -1,7 +1,7 @@
 ---
 Title: Inspector Component Alignment
 Ticket: GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT
-Status: active
+Status: complete
 Topics:
     - go
     - goja
@@ -28,10 +28,11 @@ RelatedFiles:
       Note: GOJA-025 reusable list adapter pattern
 ExternalSources: []
 Summary: Execution ticket for aligning smalltalk-inspector with reusable GOJA-025 component architecture and reducing duplicated UI logic.
-LastUpdated: 2026-02-14T19:03:00Z
+LastUpdated: 2026-02-14T20:00:08.391923423-05:00
 WhatFor: Plan and track incremental migration from monolithic pane logic to shared component primitives.
 WhenToUse: Use as entrypoint when implementing GOJA-029 refactor tasks.
 ---
+
 
 # Inspector Component Alignment
 

--- a/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/index.md
+++ b/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/index.md
@@ -14,6 +14,8 @@ Owners: []
 RelatedFiles:
     - Path: go-go-goja/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/design/01-component-alignment-implementation-plan.md
       Note: Primary implementation plan for this ticket
+    - Path: go-go-goja/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/reference/01-diary.md
+      Note: Step-by-step implementation diary
     - Path: go-go-goja/cmd/smalltalk-inspector/app/model.go
       Note: Current monolithic state/model logic targeted for alignment
     - Path: go-go-goja/cmd/smalltalk-inspector/app/update.go
@@ -40,6 +42,7 @@ This ticket addresses GOJA-028 finding #5 by aligning `cmd/smalltalk-inspector` 
 ## Key Links
 
 - Implementation plan: `design/01-component-alignment-implementation-plan.md`
+- Diary: `reference/01-diary.md`
 - Tasks: `tasks.md`
 - Changelog: `changelog.md`
 

--- a/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/reference/01-diary.md
+++ b/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/reference/01-diary.md
@@ -20,6 +20,8 @@ RelatedFiles:
         Viewport model fields and pane height helpers
         Source viewport state and active-source helper in Step 4
         Removal of duplicated utility functions
+    - Path: cmd/smalltalk-inspector/app/navigation_mode_test.go
+      Note: Step 6 navigation/mode behavior coverage
     - Path: cmd/smalltalk-inspector/app/update.go
       Note: |-
         Mode update + mode-keymap activation logic
@@ -45,12 +47,15 @@ RelatedFiles:
       Note: |-
         Viewport row visibility utility introduced in Step 2
         Shared viewport offset clamp helper
+    - Path: ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/tasks.md
+      Note: Final GOJA-029 completion state
 ExternalSources: []
 Summary: Execution diary for GOJA-029 component alignment implementation.
-LastUpdated: 2026-02-15T00:45:00Z
+LastUpdated: 2026-02-15T01:00:00Z
 WhatFor: Track step-by-step migration progress and verification outputs.
 WhenToUse: Use while implementing and reviewing GOJA-029.
 ---
+
 
 
 
@@ -385,3 +390,76 @@ The migration was mechanical but broad, so I added focused unit tests for the ne
 ### Technical details
 
 - `PadRight` remains ANSI-width aware and truncation-safe by centralizing the previous view-level implementation.
+
+## Step 6: Navigation/mode visibility tests + GOJA-029 completion
+
+This final slice added focused tests for pane navigation visibility and mode precedence/dispatch behavior in smalltalk-inspector. With this, the ticket now has explicit coverage for the finding #3 class of visibility issues and mode behavior that had previously been exercised only manually.
+
+I also ran a full `go test ./... -count=1` pass and checked all remaining GOJA-029 tasks/done criteria, completing the ticket scope.
+
+### Prompt Context
+
+**User prompt (verbatim):** (see Step 2)
+
+**Assistant interpretation:** Continue through remaining GOJA-029 tasks and complete them end-to-end.
+
+**Inferred user intent:** Finish the refactor ticket with implementation, tests, and documentation all in sync.
+
+### What I did
+
+- Added `cmd/smalltalk-inspector/app/navigation_mode_test.go` covering:
+  - inspect pane selected-row visibility while navigating down,
+  - stack pane visibility + source-target synchronization,
+  - source pane viewport offset clamping/top-bottom/half-page controls,
+  - mode precedence (`stack` > `inspect` > focus mode) and REPL override behavior.
+- Ran:
+  - `go test ./cmd/smalltalk-inspector/app -count=1`
+  - `go test ./internal/inspectorui -count=1`
+  - `go test ./cmd/inspector/... -count=1`
+  - `go test ./... -count=1`
+- Checked GOJA-029 tasks: `10,13,14,15` (all remaining items).
+
+### Why
+
+- GOJA-029 required explicit test coverage for navigation visibility and mode-specific behavior.
+- Done criteria required no regression in `cmd/inspector` and explicit visibility coverage.
+
+### What worked
+
+- New tests pass and directly exercise the behavior that motivated the cleanup ticket.
+- Full repository test pass succeeded.
+- GOJA-029 tasks are now fully checked complete.
+
+### What didn't work
+
+- N/A in this slice; no failing commands/tests.
+
+### What I learned
+
+- Lightweight integration-style model tests provide strong confidence for interactive TUI behavior without requiring fragile snapshot assertions.
+
+### What was tricky to build
+
+- Writing stable key-input tests required constructing the right `tea.KeyMsg` variants (`KeyRunes`, `KeyCtrlD`) so bindings match exactly as they do in runtime interaction.
+
+### What warrants a second pair of eyes
+
+- Optional: verify expected feel of keyboard interactions manually in a real terminal session after the refactor (especially mixed source/inspect/stack transitions).
+
+### What should be done in the future
+
+- Consider closing GOJA-029 if no additional scope is desired.
+- If follow-up cleanup is needed, it should target cross-command abstraction reuse beyond smalltalk-inspector.
+
+### Code review instructions
+
+- Start with `go-go-goja/cmd/smalltalk-inspector/app/navigation_mode_test.go`.
+- Validate full state with:
+  - `go test ./cmd/smalltalk-inspector/app -count=1`
+  - `go test ./internal/inspectorui -count=1`
+  - `go test ./cmd/inspector/... -count=1`
+  - `go test ./... -count=1`
+
+### Technical details
+
+- Tests intentionally assert internal model invariants (selected index, viewport offsets, mode strings, source target) rather than brittle full-render output strings.

--- a/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/reference/01-diary.md
+++ b/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/reference/01-diary.md
@@ -1,0 +1,50 @@
+---
+Title: Diary
+Ticket: GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT
+Status: active
+Topics:
+    - go
+    - goja
+    - tui
+    - inspector
+    - refactor
+DocType: reference
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: go-go-goja/cmd/smalltalk-inspector/app/keymap.go
+      Note: Mode tag alignment for key bindings
+    - Path: go-go-goja/cmd/smalltalk-inspector/app/update.go
+      Note: Mode update + mode-keymap activation logic
+    - Path: go-go-goja/cmd/smalltalk-inspector/app/model.go
+      Note: Initial mode activation at model construction
+ExternalSources: []
+Summary: Execution diary for GOJA-029 component alignment implementation.
+LastUpdated: 2026-02-14T19:30:00Z
+WhatFor: Track step-by-step migration progress and verification outputs.
+WhenToUse: Use while implementing and reviewing GOJA-029.
+---
+
+# Diary
+
+## Step 1: Baseline + mode-keymap alignment
+
+Captured baseline test behavior and implemented actual mode-keymap activation for smalltalk-inspector.
+
+Changes:
+
+1. Added keymap mode tags in `cmd/smalltalk-inspector/app/keymap.go`.
+2. Added explicit `inspect` and `stack` modes.
+3. Wired `mode_keymap.EnableMode` in model initialization and `updateMode`.
+4. Updated mode transitions in eval/error/inspect clear paths to keep key mode state correct.
+
+Verification:
+
+```bash
+cd go-go-goja
+
+go test ./cmd/smalltalk-inspector/... -count=1
+go test ./cmd/inspector/... -count=1
+```
+
+Result: both test commands passed.

--- a/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/tasks.md
+++ b/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/tasks.md
@@ -5,8 +5,8 @@
 - [x] Create GOJA-029 ticket workspace
 - [x] Add component-alignment implementation plan document
 
-- [ ] Baseline: capture current interaction behavior and test outputs before refactor
-- [ ] Implement mode-keymap alignment for smalltalk-inspector key handling and help wiring
+- [x] Baseline: capture current interaction behavior and test outputs before refactor
+- [x] Implement mode-keymap alignment for smalltalk-inspector key handling and help wiring
 - [ ] Extract reusable list pane helper and migrate globals/members panes
 - [ ] Extract reusable viewport pane helper and migrate inspect/stack panes
 - [ ] Ensure inspect/stack selected row visibility with explicit scroll offsets

--- a/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/tasks.md
+++ b/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/tasks.md
@@ -12,12 +12,12 @@
 - [x] Ensure inspect/stack selected row visibility with explicit scroll offsets
 - [x] Migrate source pane to shared viewport helper where feasible
 - [x] Consolidate duplicated helper logic (`padRight`, min/max, status formatting) into shared utilities
-- [ ] Add/expand tests for pane navigation, visibility, and mode-specific key behavior
+- [x] Add/expand tests for pane navigation, visibility, and mode-specific key behavior
 - [x] Run full regression suite (`cmd/inspector`, `cmd/smalltalk-inspector`, `pkg/inspector`, full repo)
 - [x] Update docs/changelog with migration notes and residual follow-ups
 
 ## Done Criteria
 
-- [ ] Smalltalk inspector uses shared component primitives for key mode/list/viewport/status
-- [ ] Finding #3 visibility issue is resolved and covered by tests
-- [ ] No regression in existing `cmd/inspector` behavior
+- [x] Smalltalk inspector uses shared component primitives for key mode/list/viewport/status
+- [x] Finding #3 visibility issue is resolved and covered by tests
+- [x] No regression in existing `cmd/inspector` behavior

--- a/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/tasks.md
+++ b/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/tasks.md
@@ -7,7 +7,7 @@
 
 - [x] Baseline: capture current interaction behavior and test outputs before refactor
 - [x] Implement mode-keymap alignment for smalltalk-inspector key handling and help wiring
-- [ ] Extract reusable list pane helper and migrate globals/members panes
+- [x] Extract reusable list pane helper and migrate globals/members panes
 - [x] Extract reusable viewport pane helper and migrate inspect/stack panes
 - [x] Ensure inspect/stack selected row visibility with explicit scroll offsets
 - [ ] Migrate source pane to shared viewport helper where feasible

--- a/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/tasks.md
+++ b/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/tasks.md
@@ -8,13 +8,13 @@
 - [x] Baseline: capture current interaction behavior and test outputs before refactor
 - [x] Implement mode-keymap alignment for smalltalk-inspector key handling and help wiring
 - [ ] Extract reusable list pane helper and migrate globals/members panes
-- [ ] Extract reusable viewport pane helper and migrate inspect/stack panes
-- [ ] Ensure inspect/stack selected row visibility with explicit scroll offsets
+- [x] Extract reusable viewport pane helper and migrate inspect/stack panes
+- [x] Ensure inspect/stack selected row visibility with explicit scroll offsets
 - [ ] Migrate source pane to shared viewport helper where feasible
 - [ ] Consolidate duplicated helper logic (`padRight`, min/max, status formatting) into shared utilities
 - [ ] Add/expand tests for pane navigation, visibility, and mode-specific key behavior
-- [ ] Run full regression suite (`cmd/inspector`, `cmd/smalltalk-inspector`, `pkg/inspector`, full repo)
-- [ ] Update docs/changelog with migration notes and residual follow-ups
+- [x] Run full regression suite (`cmd/inspector`, `cmd/smalltalk-inspector`, `pkg/inspector`, full repo)
+- [x] Update docs/changelog with migration notes and residual follow-ups
 
 ## Done Criteria
 

--- a/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/tasks.md
+++ b/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/tasks.md
@@ -11,7 +11,7 @@
 - [x] Extract reusable viewport pane helper and migrate inspect/stack panes
 - [x] Ensure inspect/stack selected row visibility with explicit scroll offsets
 - [x] Migrate source pane to shared viewport helper where feasible
-- [ ] Consolidate duplicated helper logic (`padRight`, min/max, status formatting) into shared utilities
+- [x] Consolidate duplicated helper logic (`padRight`, min/max, status formatting) into shared utilities
 - [ ] Add/expand tests for pane navigation, visibility, and mode-specific key behavior
 - [x] Run full regression suite (`cmd/inspector`, `cmd/smalltalk-inspector`, `pkg/inspector`, full repo)
 - [x] Update docs/changelog with migration notes and residual follow-ups

--- a/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/tasks.md
+++ b/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/tasks.md
@@ -1,0 +1,23 @@
+# Tasks
+
+## TODO
+
+- [x] Create GOJA-029 ticket workspace
+- [x] Add component-alignment implementation plan document
+
+- [ ] Baseline: capture current interaction behavior and test outputs before refactor
+- [ ] Implement mode-keymap alignment for smalltalk-inspector key handling and help wiring
+- [ ] Extract reusable list pane helper and migrate globals/members panes
+- [ ] Extract reusable viewport pane helper and migrate inspect/stack panes
+- [ ] Ensure inspect/stack selected row visibility with explicit scroll offsets
+- [ ] Migrate source pane to shared viewport helper where feasible
+- [ ] Consolidate duplicated helper logic (`padRight`, min/max, status formatting) into shared utilities
+- [ ] Add/expand tests for pane navigation, visibility, and mode-specific key behavior
+- [ ] Run full regression suite (`cmd/inspector`, `cmd/smalltalk-inspector`, `pkg/inspector`, full repo)
+- [ ] Update docs/changelog with migration notes and residual follow-ups
+
+## Done Criteria
+
+- [ ] Smalltalk inspector uses shared component primitives for key mode/list/viewport/status
+- [ ] Finding #3 visibility issue is resolved and covered by tests
+- [ ] No regression in existing `cmd/inspector` behavior

--- a/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/tasks.md
+++ b/ttmp/2026/02/14/GOJA-029-INSPECTOR-COMPONENT-ALIGNMENT--inspector-component-alignment/tasks.md
@@ -10,7 +10,7 @@
 - [x] Extract reusable list pane helper and migrate globals/members panes
 - [x] Extract reusable viewport pane helper and migrate inspect/stack panes
 - [x] Ensure inspect/stack selected row visibility with explicit scroll offsets
-- [ ] Migrate source pane to shared viewport helper where feasible
+- [x] Migrate source pane to shared viewport helper where feasible
 - [ ] Consolidate duplicated helper logic (`padRight`, min/max, status formatting) into shared utilities
 - [ ] Add/expand tests for pane navigation, visibility, and mode-specific key behavior
 - [x] Run full regression suite (`cmd/inspector`, `cmd/smalltalk-inspector`, `pkg/inspector`, full repo)

--- a/ttmp/2026/02/14/GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS--syntax-highlighting-improvements/README.md
+++ b/ttmp/2026/02/14/GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS--syntax-highlighting-improvements/README.md
@@ -1,0 +1,21 @@
+# Syntax Highlighting Improvements
+
+This is the document workspace for ticket GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr doc add --ticket GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS --doc-type design-doc --title "My Design"`
+- Import sources: `docmgr import file --ticket GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS --file /path/to/doc.md`
+- Update metadata: `docmgr meta update --ticket GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS --field Status --value review`

--- a/ttmp/2026/02/14/GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS--syntax-highlighting-improvements/changelog.md
+++ b/ttmp/2026/02/14/GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS--syntax-highlighting-improvements/changelog.md
@@ -13,3 +13,12 @@ Step 1: Added detailed syntax-highlighting implementation plan with algorithm op
 
 - /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS--syntax-highlighting-improvements/design/01-syntax-highlighting-implementation-plan.md — Primary plan document
 - /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS--syntax-highlighting-improvements/tasks.md — Task breakdown with optional research spike
+
+## 2026-02-15
+
+Added a 6+ page algorithm research and recommendation memo for syntax highlighting (tree-sitter architecture, index/segment/cache design, migration plan, and validation strategy); reconciled research tasks.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS--syntax-highlighting-improvements/design/02-syntax-highlighting-algorithm-research.md — Detailed algorithm research memo and final recommendation
+

--- a/ttmp/2026/02/14/GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS--syntax-highlighting-improvements/changelog.md
+++ b/ttmp/2026/02/14/GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS--syntax-highlighting-improvements/changelog.md
@@ -1,0 +1,15 @@
+# Changelog
+
+## 2026-02-14
+
+- Initial workspace created
+
+
+## 2026-02-14
+
+Step 1: Added detailed syntax-highlighting implementation plan with algorithm options, phased rollout, and benchmark strategy.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS--syntax-highlighting-improvements/design/01-syntax-highlighting-implementation-plan.md — Primary plan document
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS--syntax-highlighting-improvements/tasks.md — Task breakdown with optional research spike

--- a/ttmp/2026/02/14/GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS--syntax-highlighting-improvements/changelog.md
+++ b/ttmp/2026/02/14/GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS--syntax-highlighting-improvements/changelog.md
@@ -22,3 +22,21 @@ Added a 6+ page algorithm research and recommendation memo for syntax highlighti
 
 - /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS--syntax-highlighting-improvements/design/02-syntax-highlighting-algorithm-research.md — Detailed algorithm research memo and final recommendation
 
+
+## 2026-02-15
+
+Added intern research guide for F (query/capture semantic highlighting) and G (incremental parse/invalidation), including experiments, deliverables, and acceptance rubric.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS--syntax-highlighting-improvements/design/03-intern-research-guide-f-and-g.md — New intern research execution guide
+
+
+## 2026-02-15
+
+Expanded intern research guide with zero-context primer and explicit F/G pattern catalog (F0-F4, G0-G4, FG-A/B/C), including comparison requirements and integration guidance for internet-only research.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS--syntax-highlighting-improvements/design/03-intern-research-guide-f-and-g.md — Added explicit pattern taxonomy and foundational context for no-context intern
+

--- a/ttmp/2026/02/14/GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS--syntax-highlighting-improvements/design/01-syntax-highlighting-implementation-plan.md
+++ b/ttmp/2026/02/14/GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS--syntax-highlighting-improvements/design/01-syntax-highlighting-implementation-plan.md
@@ -1,0 +1,227 @@
+---
+Title: Syntax Highlighting Improvement Plan
+Ticket: GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS
+Status: active
+Topics:
+    - go
+    - goja
+    - tui
+    - inspector
+    - refactor
+DocType: design
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: go-go-goja/pkg/jsparse/highlight.go
+      Note: Current syntax span model and lookup algorithm
+    - Path: go-go-goja/cmd/smalltalk-inspector/app/model.go
+      Note: Span rebuild flow for file and REPL source
+    - Path: go-go-goja/cmd/smalltalk-inspector/app/view.go
+      Note: Current per-character syntax rendering path
+    - Path: go-go-goja/pkg/jsparse/treesitter_parser.go
+      Note: Parser baseline used for syntax spans
+    - Path: go-go-goja/ttmp/2026/02/14/GOJA-027-SYNTAX-HIGHLIGHT--syntax-highlighting-for-smalltalk-inspector-source-pane/tasks.md
+      Note: Original highlighting feature implementation context
+    - Path: go-go-goja/ttmp/2026/02/14/GOJA-028-CLEANUP-INSPECTOR--cleanup-inspector/reference/01-inspector-cleanup-review.md
+      Note: Performance findings motivating this ticket
+ExternalSources: []
+Summary: Detailed plan to improve highlighting correctness and performance with measurable benchmarks and incremental algorithm upgrades.
+LastUpdated: 2026-02-14T19:02:00Z
+WhatFor: Provide a concrete implementation and benchmarking roadmap for upgrading current tree-sitter span rendering.
+WhenToUse: Use as the execution guide for GOJA-030.
+---
+
+# Syntax Highlighting Improvement Plan
+
+## Goal
+
+Improve syntax highlighting performance and correctness for source panes (file + REPL) without regressing visual quality.
+
+## Current Behavior Summary
+
+Current flow:
+
+1. Parse source with tree-sitter.
+2. Build flat span list (`[]SyntaxSpan`).
+3. During render, iterate each character in each visible line.
+4. For each character, find class using linear span scan (`SyntaxClassAt`).
+
+This is simple but costly for larger files and long REPL histories.
+
+## Problem Statement
+
+Primary issues:
+
+1. Span lookup cost scales poorly (`O(chars * spans)` on visible region).
+2. No per-line span indexing.
+3. No styled-line cache; repeated rendering recomputes same output.
+4. REPL fallback source append path can desync spans if rebuild is skipped.
+
+## Design Principles
+
+1. Keep tree-sitter as parser source of truth.
+2. Separate parse/index work from render work.
+3. Make rendering operate on pre-indexed line segments, not global span scans.
+4. Add benchmarks before and after each major change.
+5. Preserve current color mapping initially; optimize algorithm first.
+
+## Common Algorithm Options (Decision Set)
+
+## Option A: Flat spans + per-char scan (current)
+
+Pros:
+- simplest implementation.
+
+Cons:
+- poor scaling.
+
+Decision:
+- replace.
+
+## Option B: Per-line span buckets + binary search
+
+Data model:
+
+- `map[int][]LineSpan` or `[][]LineSpan` indexed by line.
+- each line span sorted by start column.
+
+Lookup:
+
+- binary search span containing column.
+
+Complexity:
+
+- near `O(chars * log(lineSpans))`.
+
+Decision:
+- adopt in Phase 1.
+
+## Option C: Segment-based line rendering (run-length style)
+
+Approach:
+
+- convert each visible line into style segments.
+- render whole segments instead of per-character lookups.
+
+Complexity:
+
+- near `O(segments + lineLength)` with lower constant factors.
+
+Decision:
+- adopt in Phase 2 after Phase 1 baseline.
+
+## Option D: Incremental parse/highlight with dirty ranges
+
+Approach:
+
+- re-parse only changed content ranges.
+- invalidate only affected line caches.
+
+Decision:
+- optional Phase 3; likely worthwhile for heavy REPL workflows.
+
+## Option E: Tree-sitter query-based semantic highlighting
+
+Approach:
+
+- use query captures for richer token categories (function names, types, properties).
+
+Decision:
+- defer unless correctness requirements exceed current class-based mapping.
+
+## Implementation Plan
+
+## Phase 0: Baseline Measurement
+
+1. Add benchmark(s):
+- highlight render on small, medium, large JS source.
+- REPL source accumulation scenario.
+2. Capture CPU and allocation profiles for current path.
+
+Deliverable:
+
+- baseline numbers committed in benchmark outputs/docs.
+
+## Phase 1: Per-line Span Index
+
+1. Add line-indexed span structure in `pkg/jsparse/highlight.go`.
+2. Build index once after `BuildSyntaxSpans`.
+3. Replace global linear lookup in `SyntaxClassAt` hot path for rendering.
+
+Deliverable:
+
+- measurable perf improvement with same visible output.
+
+## Phase 2: Segment Renderer
+
+1. Add line segment generation utility:
+- input raw line + line spans
+- output style segments.
+2. Replace per-char rendering loop in `renderSyntaxLine`.
+3. Add tests comparing output parity with current renderer on fixture lines.
+
+Deliverable:
+
+- further perf and allocation reduction.
+
+## Phase 3: Cache and Invalidation
+
+1. Add styled-line cache keyed by:
+- source identity/version
+- line number
+- active theme palette hash.
+2. Invalidate only dirty ranges on source changes.
+3. Ensure REPL append path triggers appropriate incremental updates.
+
+Deliverable:
+
+- stable latency during repeated scrolling.
+
+## Phase 4: Correctness Enhancements
+
+1. Expand token classification cases where needed.
+2. Add explicit tests for multiline tokens, template strings, comments.
+3. Verify REPL fallback source path always rebuilds spans.
+
+Deliverable:
+
+- stronger correctness with test coverage.
+
+## Benchmark and Verification Plan
+
+Required commands:
+
+```bash
+cd go-go-goja
+go test ./pkg/jsparse -bench Highlight -benchmem
+go test ./cmd/smalltalk-inspector/... -count=1
+go test ./... -count=1
+```
+
+Add profiles (if benchmark indicates hotspots remain):
+
+```bash
+go test ./pkg/jsparse -bench Highlight -benchmem -cpuprofile /tmp/highlight.cpu.out
+go tool pprof /tmp/highlight.cpu.out
+```
+
+## Should a Coworker Do Algorithm Research?
+
+Yes, for a short focused spike (1-2 days) it is worthwhile.
+
+What to ask them to deliver:
+
+1. Compare editor-grade highlight approaches for tree-sitter-backed TUIs.
+2. Recommend one near-term algorithm for this codebase (likely line-index + segment rendering).
+3. Provide expected complexity, implementation cost, and risks.
+4. Include at least one reference implementation pattern we can mirror.
+
+This is especially useful before Phase 3/Phase 4 decisions.
+
+## Definition of Done
+
+1. Highlighting render performance improved with benchmark evidence.
+2. Visible output quality maintained or improved.
+3. REPL and file-source highlighting both stable.
+4. Tests cover key token classes and multiline edge cases.
+5. No regressions in smalltalk-inspector interaction behavior.

--- a/ttmp/2026/02/14/GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS--syntax-highlighting-improvements/design/01-syntax-highlighting-implementation-plan.md
+++ b/ttmp/2026/02/14/GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS--syntax-highlighting-improvements/design/01-syntax-highlighting-implementation-plan.md
@@ -18,15 +18,17 @@ RelatedFiles:
       Note: Span rebuild flow for file and REPL source
     - Path: go-go-goja/cmd/smalltalk-inspector/app/view.go
       Note: Current per-character syntax rendering path
-    - Path: go-go-goja/pkg/jsparse/treesitter_parser.go
+    - Path: go-go-goja/pkg/jsparse/treesitter.go
       Note: Parser baseline used for syntax spans
     - Path: go-go-goja/ttmp/2026/02/14/GOJA-027-SYNTAX-HIGHLIGHT--syntax-highlighting-for-smalltalk-inspector-source-pane/tasks.md
       Note: Original highlighting feature implementation context
     - Path: go-go-goja/ttmp/2026/02/14/GOJA-028-CLEANUP-INSPECTOR--cleanup-inspector/reference/01-inspector-cleanup-review.md
       Note: Performance findings motivating this ticket
+    - Path: go-go-goja/ttmp/2026/02/14/GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS--syntax-highlighting-improvements/design/02-syntax-highlighting-algorithm-research.md
+      Note: Detailed 6+ page algorithm research and recommendation memo
 ExternalSources: []
 Summary: Detailed plan to improve highlighting correctness and performance with measurable benchmarks and incremental algorithm upgrades.
-LastUpdated: 2026-02-14T19:02:00Z
+LastUpdated: 2026-02-15T15:18:00Z
 WhatFor: Provide a concrete implementation and benchmarking roadmap for upgrading current tree-sitter span rendering.
 WhenToUse: Use as the execution guide for GOJA-030.
 ---
@@ -36,6 +38,21 @@ WhenToUse: Use as the execution guide for GOJA-030.
 ## Goal
 
 Improve syntax highlighting performance and correctness for source panes (file + REPL) without regressing visual quality.
+
+## Research Update (2026-02-15)
+
+The algorithm research spike has been completed and documented in:
+
+- `design/02-syntax-highlighting-algorithm-research.md`
+
+Confirmed decisions fed back into this plan:
+
+1. Keep tree-sitter parsing and kind-based class mapping in the near term.
+2. Prioritize per-line span indexing first.
+3. Move to segment-based rendering second.
+4. Add cache + invalidation with explicit source-version keys.
+5. Keep Bubble Tea `viewport`; optimize line generation pipeline feeding it.
+6. Fix REPL runtime fallback append path to rebuild/invalidate syntax artifacts immediately.
 
 ## Current Behavior Summary
 

--- a/ttmp/2026/02/14/GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS--syntax-highlighting-improvements/design/02-syntax-highlighting-algorithm-research.md
+++ b/ttmp/2026/02/14/GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS--syntax-highlighting-improvements/design/02-syntax-highlighting-algorithm-research.md
@@ -1,0 +1,1631 @@
+---
+Title: Syntax Highlighting Algorithm Research
+Ticket: GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS
+Status: active
+Topics:
+    - go
+    - goja
+    - tui
+    - inspector
+    - refactor
+DocType: design
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: go-go-goja/pkg/jsparse/highlight.go
+      Note: Current syntax span model and hot lookup function (`SyntaxClassAt`)
+    - Path: go-go-goja/pkg/jsparse/treesitter.go
+      Note: Parser behavior, full reparse strategy, and TS node coordinate model
+    - Path: go-go-goja/cmd/smalltalk-inspector/app/view.go
+      Note: Source-pane render loop and current per-character highlight path
+    - Path: go-go-goja/cmd/smalltalk-inspector/app/model.go
+      Note: File/REPL span rebuild flow and REPL fallback append behavior
+    - Path: go-go-goja/ttmp/2026/02/14/GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS--syntax-highlighting-improvements/design/01-syntax-highlighting-implementation-plan.md
+      Note: Baseline implementation plan being refined by this research
+ExternalSources: []
+Summary: Deep algorithm research memo covering current highlighting architecture, known bottlenecks, candidate algorithm families, recommended target design, and phased migration guidance for GOJA-030.
+LastUpdated: 2026-02-15T15:06:00Z
+WhatFor: Provide a defensible algorithm choice and concrete implementation details before performance and correctness refactors.
+WhenToUse: Read before implementing GOJA-030 tasks 4-14 and when reviewing future highlighting architecture changes.
+---
+
+# Syntax Highlighting Algorithm Research
+
+## Executive Summary
+
+This memo evaluates the current syntax-highlighting pipeline in `go-go-goja` and recommends a concrete algorithm stack that improves both latency and maintainability while preserving the existing visual behavior.
+
+The current implementation is functionally correct for many cases and already uses tree-sitter as its parser foundation. However, rendering cost scales poorly because each visible character performs a global linear scan over all syntax spans. This creates an avoidable `O(visible_chars * total_spans)` hot path.
+
+Recommended direction:
+
+1. Keep tree-sitter parsing and existing `SyntaxClass` taxonomy in place.
+2. Replace global span scans with per-line indexed spans and binary lookup.
+3. Move from per-character styling to segment-based line rendering.
+4. Add lightweight, invalidation-aware styled-line caching.
+5. Separate core highlighting engine code from Bubble Tea rendering adapters so the same core can later be reused by CLI batch output or REST APIs.
+
+This recommendation provides strong expected gains with low migration risk because it can be introduced in compatibility phases and verified with parity tests.
+
+## Scope and Constraints
+
+This research focuses on syntax-highlighting algorithm choices, not on re-theming colors or redesigning the UI. It addresses both file source and REPL source, including runtime fallback snippets.
+
+Constraints assumed:
+
+1. Language support remains JavaScript via tree-sitter.
+2. Output remains terminal-oriented (ANSI/lipgloss today).
+3. Existing `SyntaxClass` values and visible color behavior should remain stable during early phases.
+4. We need an architecture that can be reused outside Bubble Tea in a later phase.
+
+## Current Architecture (as implemented)
+
+### Parser and syntax spans
+
+Current flow:
+
+1. `pkg/jsparse/treesitter.go` creates a JavaScript tree-sitter parser (`NewTSParser`).
+2. `TSParser.Parse` currently reparses from scratch and snapshots a `TSNode` tree.
+3. `pkg/jsparse/highlight.go` traverses leaf nodes and maps node kinds to `SyntaxClass` via `ClassifySyntaxKind`.
+4. `BuildSyntaxSpans` emits a flat `[]SyntaxSpan` with 1-based start/end line/column coordinates.
+
+Important detail: highlighting is tree-sitter based today. It is not regex-only, and it is not using tree-sitter query captures yet. It classifies by node kind names from the CST walk.
+
+### Render path in the inspector
+
+In `cmd/smalltalk-inspector/app/view.go`, `renderSourcePane` calls `renderSyntaxLine` for non-target lines. `renderSyntaxLine` loops every character in the line and calls `jsparse.SyntaxClassAt(spans, lineNo, colNo)`.
+
+`SyntaxClassAt` scans the full span slice linearly and returns the first span that contains the position.
+
+That means visible rendering cost is:
+
+`visible_chars * linear_scan(all_spans)`
+
+This is the primary performance bottleneck.
+
+### Span rebuild lifecycle
+
+In `cmd/smalltalk-inspector/app/model.go`:
+
+1. File load triggers `rebuildFileSyntaxSpans`.
+2. REPL append via `appendReplSource` triggers `rebuildReplSyntaxSpans`.
+3. Runtime fallback append path in `showReplFunctionSource` appends lines, but does not rebuild REPL spans in that path.
+
+The fallback path creates a correctness and consistency gap: newly appended runtime snippet lines may show stale/no highlighting until a later rebuild event occurs.
+
+## Problem Analysis
+
+## 1) Time complexity hotspot
+
+The renderer repeatedly performs global span lookup for each character, causing worst-case behavior proportional to full document span count even when only a small viewport is visible.
+
+Symptoms:
+
+1. Larger files and long REPL histories produce slower redraws.
+2. Scrolling and focus transitions can feel heavy due to repeated recomputation.
+3. Allocation and CPU both trend up with input size.
+
+## 2) Missing structural index
+
+Spans are stored flat and unindexed. The lookup path does not exploit:
+
+1. line boundaries,
+2. sorted ranges,
+3. contiguous style runs.
+
+Without line locality, rendering redoes avoidable work.
+
+## 3) Rendering granularity mismatch
+
+The model captures token ranges, but rendering works per character. For terminal output, line-segment rendering is a better fit: apply style to contiguous ranges once, concatenate segments, and avoid per-character style decisions.
+
+## 4) Invalidation behavior gaps
+
+There is no styled-line cache, and fallback REPL source append currently misses span rebuild in one branch. This combination increases both stale-display risk and redundant compute.
+
+## 5) Test/benchmark coverage gap
+
+There is currently little dedicated benchmark coverage for highlight hot paths. Without baseline + after metrics, algorithm changes are harder to justify and tune.
+
+## Candidate Algorithm Families
+
+This section compares algorithm families that are relevant to the current codebase and expected workloads.
+
+### A. Flat spans + linear scan (current baseline)
+
+Approach:
+
+1. Keep one flat slice of spans.
+2. For each character, scan all spans until a match.
+
+Complexity:
+
+1. Lookup per char: `O(total_spans)`
+2. Visible line render: `O(visible_chars * total_spans)`
+
+Assessment:
+
+1. Simple but non-scalable.
+2. Should not remain the hot path.
+
+### B. Per-line buckets + binary search
+
+Approach:
+
+1. Pre-index spans by line.
+2. Each line holds sorted spans by start column.
+3. Lookup class at column via binary search, then local containment check.
+
+Complexity:
+
+1. Index build: `O(total_spans + multi_line_expansion)`
+2. Per char lookup: `O(log line_spans)` (often very small)
+3. Line render: `O(line_chars * log line_spans)`
+
+Assessment:
+
+1. Strong near-term improvement with moderate implementation cost.
+2. Works cleanly with current span model.
+3. Good first migration step.
+
+### C. Segment-based line renderer (run-length styling)
+
+Approach:
+
+1. Convert each line into ordered style segments.
+2. Render each segment once (unstyled prefix + styled runs).
+
+Complexity:
+
+1. Segment build per line: near `O(line_spans + line_chars_for_boundaries)`
+2. Render: `O(segments)` style applications, not `O(chars)`
+
+Assessment:
+
+1. Large constant-factor wins for terminal rendering.
+2. Pairs well with per-line index.
+3. Should be phase-two after indexing.
+
+### D. Interval tree over global spans
+
+Approach:
+
+1. Build an interval tree for all spans.
+2. Query intervals containing a given coordinate.
+
+Complexity:
+
+1. Query: ~`O(log n + k)`
+2. Build and memory overhead higher than line buckets.
+
+Assessment:
+
+1. Powerful but likely unnecessary for this workload.
+2. More complex than needed because rendering is line-oriented and viewport-limited.
+3. Better fit if global random-access querying dominates (not the case here).
+
+### E. Sweep-line event model
+
+Approach:
+
+1. For each line, precompute start/end events by column.
+2. Walk left-to-right maintaining active style.
+
+Complexity:
+
+1. Line build: `O(events + line_chars)`
+2. Useful with overlapping layers.
+
+Assessment:
+
+1. Good for richer multi-layer semantics.
+2. Adds complexity not required for current single-class output.
+3. Could be an evolution if semantic layers are added later.
+
+### F. Tree-sitter query captures
+
+Approach:
+
+1. Use query files/captures instead of node-kind mapping.
+2. Map captures to style categories.
+
+Benefits:
+
+1. More semantically precise highlighting.
+2. Easier language-specific tuning as query sets grow.
+
+Tradeoffs:
+
+1. Higher up-front complexity in query authoring.
+2. Requires robust capture-priority rules and test coverage.
+
+Assessment:
+
+1. Valuable long-term correctness enhancement.
+2. Not required for immediate performance optimization.
+
+### G. Incremental parse + partial invalidation
+
+Approach:
+
+1. Track edits and dirty ranges.
+2. Reparse incrementally.
+3. Rebuild spans/segments only for affected lines.
+
+Assessment:
+
+1. Very useful for true editor scenarios.
+2. Current inspector workload (load + occasional append) may not justify immediate complexity.
+3. Good phase-three/four direction after baseline optimization.
+
+## Recommended Target Design
+
+Recommended stack:
+
+1. Tree-sitter parse remains source of truth.
+2. Span extraction remains compatible with existing `SyntaxClass`.
+3. Add line index to avoid global scans.
+4. Add segment renderer for contiguous styling.
+5. Add optional styled-line cache with explicit invalidation.
+6. Encapsulate this in a core package independent from Bubble Tea.
+
+### Why this is the best fit now
+
+1. It directly addresses the measured bottleneck path.
+2. It avoids premature complexity (no interval tree required).
+3. It can be implemented in small, reviewable slices.
+4. It creates a reusable core for future REST/CLI use.
+
+## Core/UI Separation Design
+
+To satisfy the requirement of separating Bubble Tea UI concerns from reusable logic, split responsibilities as follows.
+
+### Core package (non-UI, reusable)
+
+Proposed package:
+
+`pkg/highlightcore` (or `pkg/jsparse/highlightcore`)
+
+Responsibilities:
+
+1. Token class model (`SyntaxClass` reused or aliased).
+2. Span extraction adapters from TS nodes.
+3. Line index construction.
+4. Segment generation from line text + indexed spans.
+5. Styled-line cache keys and invalidation policy.
+6. Pure data output (segments with class labels), no lipgloss calls.
+
+Interfaces:
+
+1. `BuildDocumentIndex(source []byte, root *TSNode) (DocumentIndex, error)`
+2. `SegmentsForLine(index DocumentIndex, lineNo int, line string) []Segment`
+3. `InvalidateLines(cache *Cache, startLine, endLine int)`
+
+### UI adapter package (Bubble Tea specific)
+
+Current likely location:
+
+`cmd/smalltalk-inspector/app` plus possible helpers in `internal/inspectorui`
+
+Responsibilities:
+
+1. Convert segment classes to styled strings using lipgloss.
+2. Integrate with viewport/list/table rendering.
+3. Manage pane focus, scroll offsets, and update loop messages.
+
+Outcome:
+
+1. Inspector uses core engine.
+2. Future CLI/REST can call the same core APIs and apply different formatting adapters.
+
+## Data Structures
+
+### Document index
+
+Proposed types:
+
+```go
+type LineSpan struct {
+    StartCol int // 1-based inclusive
+    EndCol   int // 1-based exclusive
+    Class    SyntaxClass
+}
+
+type DocumentIndex struct {
+    // lines[1] => spans for line 1
+    Lines [][]LineSpan
+}
+```
+
+Construction rules:
+
+1. Expand multi-line spans into line-local segments.
+2. Normalize bounds to `[1, lineLen+1]` where line length semantics are explicit.
+3. Sort by `StartCol`, then `EndCol`.
+4. Merge adjacent spans when class and boundaries permit.
+
+### Render segment
+
+```go
+type Segment struct {
+    Text  string
+    Class SyntaxClass
+}
+```
+
+Segment production invariant:
+
+1. Concatenated `Segment.Text` reproduces the input line exactly.
+2. Segment classes are maximal contiguous runs.
+
+### Cache key
+
+```go
+type StyledLineKey struct {
+    SourceVersion uint64
+    LineNo        int
+    ThemeHash     uint64
+}
+```
+
+Cache invalidation:
+
+1. File reload increments `SourceVersion`, invalidating all lines implicitly.
+2. REPL append invalidates appended line range only.
+3. Theme changes invalidate by hash mismatch.
+
+## Algorithms in Detail
+
+### Algorithm 1: Build line index from flat spans
+
+Pseudo-flow:
+
+1. Allocate line bucket slice from line count.
+2. For each span:
+3. For each line touched by span:
+4. Clip span to line-local start/end.
+5. Append `LineSpan` to that line bucket.
+6. Post-process each line: sort and coalesce.
+
+Pseudo-code:
+
+```text
+for span in spans:
+  for line = span.StartLine .. span.EndLine:
+    localStart = if line == span.StartLine then span.StartCol else 1
+    localEnd   = if line == span.EndLine then span.EndCol else lineMaxCol(line)
+    if localStart < localEnd:
+      lines[line].append(LineSpan{localStart, localEnd, span.Class})
+
+for each line bucket:
+  sort by (StartCol, EndCol)
+  normalize/merge compatible neighbors
+```
+
+### Algorithm 2: Lookup class at column with binary search
+
+Per line:
+
+1. Binary search nearest span with `StartCol <= col`.
+2. Check containment `col < EndCol`.
+3. Return class or none.
+
+This eliminates full-document scans and keeps line-local lookups cheap.
+
+### Algorithm 3: Segment renderer
+
+For a given line:
+
+1. Start at column 1.
+2. Walk spans in order.
+3. Emit unstyled segment for gap before span.
+4. Emit styled segment for span intersection.
+5. Continue until end of line.
+
+This reduces style calls and string-builder churn relative to per-character rendering.
+
+### Algorithm 4: Styled-line cache with invalidation
+
+1. Build styled line once on first view.
+2. Cache by `{sourceVersion, lineNo, themeHash}`.
+3. On re-render, return cached string if key matches.
+4. On edits/appends/theme changes, invalidate relevant keys.
+
+This provides stable scroll latency and avoids repeated recomputation for unchanged viewport lines.
+
+## Correctness Considerations
+
+### Span overlap precedence
+
+Current implementation effectively uses first-match precedence from DFS span order. After indexing/segmenting, precedence must remain deterministic.
+
+Recommended rule:
+
+1. Primary: smallest containing span wins when categories overlap.
+2. Secondary tie-break: earlier start, then shorter range, then stable insertion order.
+
+If behavior parity with current order is required initially, preserve current extraction order and apply only monotonic transforms.
+
+### Multi-line token handling
+
+Multi-line comments and template strings require careful clipping during line expansion. Tests should include:
+
+1. block comments spanning many lines,
+2. template literals with interpolations,
+3. escaped backticks and nested `${}`.
+
+### Column semantics and Unicode
+
+Tree-sitter columns are byte-oriented. Go string iteration in `range` also returns byte indices, which currently aligns for column mapping, but display width can still diverge for wide glyphs.
+
+Recommendation:
+
+1. Keep byte-based indexing for syntax correctness.
+2. Document that display alignment for non-ASCII wide characters may require a later terminal-width reconciliation layer.
+
+### REPL fallback source path
+
+In `showReplFunctionSource`, runtime fallback append currently does not call `rebuildReplSyntaxSpans`. This should be fixed as part of invalidation work, and verified with a regression test to ensure newly appended fallback snippets are highlighted immediately.
+
+## Benchmarks and Profiling Plan
+
+To make algorithm choice evidence-based, add repeatable benchmarks:
+
+1. Small file (200-500 lines)
+2. Medium file (2k-5k lines)
+3. Large file (20k+ lines or synthetic equivalent)
+4. REPL accumulation (append 500-2k expressions)
+
+Measure:
+
+1. ns/op for line render path
+2. allocations/op
+3. bytes/op
+4. end-to-end pane redraw latency in representative viewports
+
+Profile checkpoints:
+
+1. baseline current algorithm
+2. + line index
+3. + segment rendering
+4. + cache
+
+Success criteria:
+
+1. 3x+ speedup on medium/large render benchmarks
+2. clear allocation reduction
+3. no visible regression in highlight output parity tests
+
+## Migration Strategy (Incremental and Safe)
+
+### Phase 1: Introduce index behind compatibility API
+
+1. Keep `BuildSyntaxSpans` public behavior unchanged.
+2. Add `BuildLineIndex(spans, sourceLines)` and `SyntaxClassAtIndexed`.
+3. Add tests proving parity with `SyntaxClassAt` for sampled coordinates.
+
+### Phase 2: Add segment renderer
+
+1. Introduce `RenderSyntaxLineSegments`.
+2. Keep old per-char renderer behind a feature flag or test helper.
+3. Snapshot-test representative lines to verify output class parity.
+
+### Phase 3: Add cache + invalidation
+
+1. Cache only in source pane path first.
+2. Invalidate on file load, REPL append, and theme changes.
+3. Add targeted tests for invalidation correctness.
+
+### Phase 4: Correctness expansion
+
+1. Expand token kind mapping coverage.
+2. Add multiline/template/operator edge tests.
+3. Optionally evaluate tree-sitter query captures for semantic improvements.
+
+## What a Coworker Research Spike Should Cover
+
+A coworker research spike is still worthwhile for one focused question: if/when to move from node-kind mapping to tree-sitter query-capture highlighting for semantic precision.
+
+Requested deliverables:
+
+1. Comparison of query-capture systems in editor-like tools.
+2. Recommended capture-priority model for this codebase.
+3. Migration cost estimate from kind-based mapping.
+4. Test methodology for ensuring semantic correctness.
+
+This spike is optional for performance optimization itself, but valuable before deeper correctness/semantics phases.
+
+## Risks and Mitigations
+
+Risk: behavioral drift while changing lookup order.
+Mitigation: parity tests comparing old and new class outputs on fixtures.
+
+Risk: cache invalidation bugs causing stale lines.
+Mitigation: explicit invalidation API and versioned cache keys.
+
+Risk: increased complexity in core package boundaries.
+Mitigation: small interfaces and strict separation between pure core and UI adapters.
+
+Risk: over-optimizing before baseline measurement.
+Mitigation: require benchmark baseline and checkpoint reports before merging each phase.
+
+## Detailed Implementation Mapping (File-by-File)
+
+This section maps the algorithm work to concrete files and symbols so a developer can execute without rediscovering architecture.
+
+### `pkg/jsparse/highlight.go`
+
+Current responsibilities:
+
+1. Class taxonomy (`SyntaxClass`)
+2. Span extraction (`BuildSyntaxSpans`)
+3. Point lookup (`SyntaxClassAt`)
+4. Char-level rendering helpers (`RenderSyntaxChar`)
+
+Recommended additions:
+
+1. Keep existing exported types for compatibility.
+2. Add a new line-index type and builder.
+3. Add lookup functions that use the index.
+4. Add line-to-segment converter that produces class-labeled segments.
+
+Expected refactor shape:
+
+1. `BuildSyntaxSpans` remains as source-compatible baseline.
+2. `BuildLineIndex(spans []SyntaxSpan, lineCount int) *LineIndex`
+3. `ClassAt(index *LineIndex, lineNo, colNo int) SyntaxClass`
+4. `SegmentsForLine(index *LineIndex, line string, lineNo int) []Segment`
+
+`RenderSyntaxChar` can stay for compatibility, but the main render path should stop calling it in a character loop.
+
+### `cmd/smalltalk-inspector/app/view.go`
+
+Current hot path:
+
+1. `renderSourcePane` loops lines
+2. `renderSyntaxLine` loops each character
+3. each character calls `SyntaxClassAt` over global spans
+
+Recommended change:
+
+1. Build or receive a line index from model state.
+2. For each visible line, request precomputed segments.
+3. Style per segment, not per char.
+
+This preserves the Bubble Tea `viewport` usage and pane logic. The optimization is isolated to content generation before `vp.SetContent`.
+
+### `cmd/smalltalk-inspector/app/model.go`
+
+Current responsibilities include source lifecycle and span rebuild calls.
+
+Required updates:
+
+1. Model fields should include indexed highlight artifacts, not only flat spans.
+2. `rebuildFileSyntaxSpans` and `rebuildReplSyntaxSpans` should rebuild both flat spans (if still needed) and line index.
+3. `showReplFunctionSource` runtime fallback append path must call rebuild/invalidate.
+4. Add source-version counters for cache keying.
+
+This is also where invalidation boundaries are best computed because model code already owns file-load and REPL-append state transitions.
+
+### `pkg/jsparse/treesitter.go`
+
+No immediate parser changes are required for phase-one and phase-two optimization.
+
+However, document assumptions here:
+
+1. parse-from-scratch behavior is currently intentional.
+2. column coordinates are byte-based.
+3. a future incremental parse phase would start here.
+
+### Tests and benchmarks
+
+Recommended additions:
+
+1. `pkg/jsparse/highlight_bench_test.go` for synthetic and fixture-based benchmarks.
+2. `pkg/jsparse/highlight_index_test.go` for index correctness and parity tests.
+3. inspector integration tests for REPL fallback source append highlighting behavior.
+
+## Worked Example: Why Segment Rendering Helps
+
+Consider line:
+
+```js
+const msg = `Hello ${user.name}!`; // greet
+```
+
+Current approach:
+
+1. Iterate every visible character.
+2. For each character, scan all global spans.
+3. Style one character at a time.
+
+Even on this short line, style decisions are repeated for many adjacent characters that share the same class. On a medium file with many spans, this repeats thousands of unnecessary span checks per redraw.
+
+Segment approach:
+
+1. Convert the line into runs:
+2. `const` keyword run
+3. whitespace run
+4. identifier run
+5. operator run
+6. template literal runs
+7. punctuation run
+8. comment run
+
+Then style each run once and append.
+
+The segment method reduces both lookup calls and style object work. It also composes naturally with line caches because segment output is deterministic for `(line text, line spans, theme)`.
+
+## Benchmark Blueprint (Concrete)
+
+To avoid subjective optimization, create benchmarks with controlled fixtures.
+
+### Benchmark groups
+
+1. `BenchmarkHighlight_LineRender_Small`
+2. `BenchmarkHighlight_LineRender_Medium`
+3. `BenchmarkHighlight_LineRender_Large`
+4. `BenchmarkHighlight_REPLAppend_Rebuild`
+5. `BenchmarkHighlight_REPLAppend_InvalidateOnly`
+
+### Data setup strategy
+
+1. Use a few real JS fixture files committed under testdata.
+2. Add one synthetic stress fixture with repeated constructs.
+3. Generate a REPL transcript fixture with many appended snippets.
+
+### Metrics to capture
+
+1. time/op
+2. allocs/op
+3. bytes/op
+4. optional profile for large-case hot path
+
+### Benchmark acceptance gate
+
+A practical merge gate:
+
+1. no regression on small fixtures,
+2. at least 2x improvement on medium case,
+3. at least 3x improvement on large case,
+4. noticeable allocation drop.
+
+## Correctness Test Matrix
+
+The optimization should keep visible behavior stable unless explicitly improving classification.
+
+### Category A: parity tests
+
+Compare class outputs between old and new lookup for randomly sampled coordinates across fixtures.
+
+### Category B: edge-structure tests
+
+Include:
+
+1. nested template literals
+2. multiline block comments
+3. arrow functions and chained calls
+4. optional chaining and nullish coalescing
+5. destructuring patterns and shorthand properties
+6. regex literals if represented by tree-sitter kinds in current grammar version
+
+### Category C: REPL-specific tests
+
+Include:
+
+1. expression append triggers rebuild/invalidation,
+2. runtime fallback append highlights immediately,
+3. switching between file and REPL sources keeps correct line mapping.
+
+### Category D: stability tests
+
+Ensure no panics when:
+
+1. spans are empty,
+2. line index has sparse lines,
+3. requested line/column out of bounds,
+4. malformed node spans appear due to parser error nodes.
+
+## Cache Design Deep Dive
+
+Caching should be conservative and easy to reason about.
+
+### Key design
+
+Use three dimensions:
+
+1. source version
+2. line number
+3. theme hash
+
+### Why not cache whole pane strings
+
+Whole-pane caching becomes fragile with viewport offsets and mode banners. Line-level caching is simpler and reuses well across scroll operations.
+
+### Invalidation rules
+
+1. file load: bump source version (invalidate all implicitly),
+2. REPL append: invalidate appended lines only, keep earlier lines,
+3. theme change: new theme hash invalidates style layer while reusing structural index.
+
+### Memory bounds
+
+Use bounded map or small LRU:
+
+1. cap by number of lines or bytes,
+2. evict least recently used lines,
+3. expose simple metrics for hit rate.
+
+For this inspector, even a plain map with periodic reset may be enough at first. Add LRU only if memory profiling justifies it.
+
+## Common Syntax Highlighting Algorithms (General Landscape)
+
+This section answers the broader question of common algorithms beyond this codebase.
+
+### 1. Regex/tokenizer-based lexers
+
+Examples include Pygments-like token streams. Fast for simple grammars and static lexers, but weaker for nested language constructs and incremental parsing complexity.
+
+### 2. Parser-based AST/CST classification
+
+The current code is in this family: parse with tree-sitter, then classify nodes. Good structural correctness and robust for real code.
+
+### 3. Query-capture semantic highlighting
+
+Tree-sitter queries capture semantic nodes (`function.name`, `property`, `type`, etc.) and map captures to styles. Rich semantics, language-specific tuning, more configuration surface.
+
+### 4. Incremental region-based highlighters
+
+Used by editors that update only dirty regions after edits. Strong for interactive editing but requires edit tracking and careful invalidation.
+
+### 5. Rope/piece-table coupled highlighters
+
+Deep editor architectures co-locate text storage with highlight metadata for efficient edits. Probably unnecessary here unless the inspector evolves into a full editor.
+
+### 6. Hybrid lexical + semantic layers
+
+Common in modern IDEs: lexical base colors plus semantic overlays from language servers. Powerful but significantly more complex.
+
+For this project’s scope, parser-based classification plus indexed rendering is the right middle ground.
+
+## Why Bubble Tea `viewport` Should Stay
+
+The existing `viewport` component is not the problem. It efficiently handles scrolling and clipping, and it integrates with the inspector’s layout model.
+
+The expensive part is the string-generation path that feeds the viewport.
+
+Therefore:
+
+1. keep `viewport`,
+2. optimize the highlight generation pipeline,
+3. optionally cache rendered lines before joining into viewport content.
+
+This keeps UX behavior stable while solving core compute cost.
+
+## Addressing “Issue 5” and Relationship to “Issue 3”
+
+Based on prior ticket discussion context:
+
+1. issue 5 maps to highlight lookup/render inefficiency,
+2. issue 3 concerns viewport/render structure concerns.
+
+Does solving issue 5 address issue 3?
+
+Partially:
+
+1. It addresses perceived viewport sluggishness by reducing content-generation cost.
+2. It does not replace viewport architecture, but it removes the dominant hot path under it.
+
+If issue 3 includes broader pane-lifecycle concerns, those remain separate. But for rendering performance in source pane, this plan is the direct fix.
+
+## New Developer Orientation: Where to Look First
+
+A new contributor should traverse the code in this order:
+
+1. `cmd/smalltalk-inspector/app/model.go`
+   This is source lifecycle control: load, REPL append, mode transitions, rebuild hooks.
+2. `cmd/smalltalk-inspector/app/view.go`
+   This is where highlight output is consumed and piped into viewport content.
+3. `pkg/jsparse/highlight.go`
+   This is the current highlight engine and will host the index/segment refactor.
+4. `pkg/jsparse/treesitter.go`
+   This clarifies parser semantics and coordinate conventions.
+5. ticket docs in `ttmp/.../GOJA-030.../design`
+   These capture why the architecture is changing and in what phase order.
+
+Suggested review sequence for pull requests:
+
+1. inspect benchmark deltas,
+2. inspect parity/correctness tests,
+3. inspect model invalidation hooks,
+4. inspect renderer path changes.
+
+## Prototype Outline for `scripts/` (Optional)
+
+If we want quick empirical checks before full integration, add two scripts under GOJA-030:
+
+1. `scripts/highlight_bench_driver.go`
+   Loads fixture text, builds spans/index, runs timed render loops.
+2. `scripts/highlight_parity_check.go`
+   Compares old vs new class lookup on sampled coordinates and reports mismatches.
+
+These can be temporary but are useful during algorithm iterations before final benchmark tests are stabilized.
+
+## Final Recommendation
+
+Implement a hybrid of:
+
+1. per-line indexed spans,
+2. segment-based rendering,
+3. bounded styled-line caching,
+
+while retaining tree-sitter parse + current syntax class taxonomy in the short term.
+
+This combination is the best tradeoff for GOJA-030 because it gives immediate and substantial performance gains, keeps migration risk manageable, and creates the core/UI separation needed for future REST/CLI exposure.
+
+Short answer to active architecture questions:
+
+1. Yes, syntax highlighting is currently tree-sitter-based.
+2. Yes, Bubble Tea `viewport` remains the right scrolling primitive; optimize the line-generation pipeline feeding it.
+3. The plan directly addresses issue 5, and it resolves the performance aspect of issue 3 without requiring viewport replacement.
+4. The REPL fallback span-rebuild gap is separate and must be fixed explicitly in `model.go` invalidation flow.
+
+## Appendix A: End-to-End Pipeline Pseudocode
+
+This appendix spells out a concrete pipeline with clear ownership boundaries between core engine and UI adapter. The objective is to make implementation order unambiguous and keep side effects out of the core.
+
+### Core data flow
+
+```text
+source bytes
+  -> parse tree (tree-sitter)
+  -> flat spans (existing BuildSyntaxSpans-compatible)
+  -> line index (new)
+  -> per-line segments (new)
+  -> styled line cache lookup/write (new)
+  -> styled string output for viewport
+```
+
+### Suggested core API
+
+```go
+type Engine struct {
+    parser      *jsparse.TSParser
+    classMapper ClassMapper
+}
+
+type Document struct {
+    Version uint64
+    Source  []string
+    Spans   []SyntaxSpan
+    Index   *LineIndex
+}
+
+type Renderer struct {
+    Theme Theme
+    Cache *LineCache
+}
+```
+
+### Build document operation
+
+```text
+func BuildDocument(sourceText string) Document:
+  lines = splitLines(sourceText)
+  root = parser.Parse([]byte(sourceText))
+  spans = BuildSyntaxSpans(root)
+  index = BuildLineIndex(spans, len(lines), lineLengths(lines))
+  return Document{Version: nextVersion(), Source: lines, Spans: spans, Index: index}
+```
+
+Notes:
+
+1. `lineLengths(lines)` should be computed once and reused in line clipping operations.
+2. If source is empty, return a document with empty index and still-valid version.
+3. Keep build operation pure from UI state to simplify testing.
+
+### Render line operation
+
+```text
+func RenderLine(doc, lineNo):
+  key = {doc.Version, lineNo, themeHash}
+  if cache has key:
+    return cache[key]
+  lineText = doc.Source[lineNo-1]
+  spans = doc.Index.Lines[lineNo]
+  segments = SegmentsForLine(spans, lineText)
+  styled = styleSegments(segments, theme)
+  cache[key] = styled
+  return styled
+```
+
+The above can be adapted to both file-source and REPL-source documents. The UI only asks for visible lines and handles vertical composition.
+
+## Appendix B: Comparison Matrix With Practical Tradeoffs
+
+This matrix expands algorithm differences in terms that matter during implementation and code review.
+
+### Flat span scan
+
+Engineering properties:
+
+1. Minimal code size.
+2. Easy to understand.
+3. No up-front indexing cost.
+
+Operational drawbacks:
+
+1. Repeatedly does the same global search work.
+2. Cost spikes as spans increase, even when rendering a small viewport.
+3. Hard to cache effectively because work happens at per-character granularity.
+
+Where it still fits:
+
+1. Quick prototypes.
+2. Very tiny files.
+3. Debug baseline function for parity tests.
+
+### Per-line index + binary lookup
+
+Engineering properties:
+
+1. Moderate code size.
+2. Straightforward deterministic behavior.
+3. Easy to unit-test with table-driven inputs.
+
+Operational advantages:
+
+1. Excellent locality.
+2. Dramatically fewer candidate spans per lookup.
+3. Natural base for segment generation and line-level caching.
+
+Potential pitfalls:
+
+1. Off-by-one bugs during line clipping.
+2. Overlap precedence ambiguities if spans conflict.
+3. Need to define behavior for invalid/out-of-range coordinates.
+
+### Segment renderer
+
+Engineering properties:
+
+1. Slightly more complex than char-loop rendering.
+2. Requires robust string slicing rules.
+3. Needs strong unit tests for line reconstruction invariants.
+
+Operational advantages:
+
+1. Fewer style operations.
+2. Better allocation behavior with builders.
+3. Pairs naturally with cache.
+
+Potential pitfalls:
+
+1. Incorrect segment boundaries can drop or duplicate characters.
+2. Must preserve exact line text including whitespace.
+3. Must handle empty lines and trailing newline semantics consistently.
+
+### Interval tree
+
+Engineering properties:
+
+1. High complexity relative to present needs.
+2. Harder to reason about and debug.
+3. Harder onboarding for contributors unfamiliar with interval indexes.
+
+Operational advantages:
+
+1. Strong for arbitrary random-access point/range queries across whole doc.
+2. Good foundation when many cross-line queries are needed.
+
+Why not now:
+
+1. The source pane is line-and-viewport oriented.
+2. Complexity tax likely exceeds practical gain at this stage.
+
+## Appendix C: Coordinate and Boundary Semantics
+
+Syntax bugs in editors and inspectors often come from inconsistent coordinate conventions. This appendix defines explicit rules to avoid drift.
+
+### Coordinate system
+
+Adopt and document:
+
+1. Line numbers: 1-based external API.
+2. Columns: 1-based, end-exclusive.
+3. Internal slices: Go string byte indices when mapping from tree-sitter.
+
+### Required invariants
+
+1. `StartCol >= 1`
+2. `EndCol > StartCol`
+3. For any line-local span, `EndCol <= lineByteLength+1`
+4. For multi-line expansion, each expanded line span remains end-exclusive.
+
+### Multi-line expansion rules
+
+Given span `(startLine, startCol) -> (endLine, endCol)`:
+
+1. First line: `[startCol, lineLen+1)`
+2. Intermediate lines: `[1, lineLen+1)`
+3. Last line: `[1, endCol)`
+
+Corner cases:
+
+1. zero-length spans should be dropped,
+2. malformed spans where end precedes start should be ignored with debug count,
+3. spans on missing lines should be clamped or dropped depending on strictness mode.
+
+### Unicode and width
+
+Tree-sitter gives byte columns; terminals render display cells. Those are different dimensions.
+
+Strategy:
+
+1. Keep syntax boundaries byte-based for correctness.
+2. Keep display width handling as a separate concern in the UI layer.
+3. If needed later, add a byte-to-cell mapping adapter for wide glyph scenarios.
+
+## Appendix D: Integration Guide for New Contributors
+
+This section gives concrete starting points for developers newly joining the codebase.
+
+### Step 1: Understand model lifecycle
+
+Read `cmd/smalltalk-inspector/app/model.go` and follow:
+
+1. file load path (`MsgFileLoaded` handling),
+2. REPL result path (`MsgEvalResult`),
+3. source switching path (`activeSourceLines`, `showingReplSrc`),
+4. syntax rebuild hooks (`rebuildFileSyntaxSpans`, `rebuildReplSyntaxSpans`).
+
+Goal:
+
+Understand where source text mutates and where highlight artifacts should be rebuilt or invalidated.
+
+### Step 2: Understand rendering hot path
+
+Read `cmd/smalltalk-inspector/app/view.go`:
+
+1. `renderSourcePane`,
+2. `renderSyntaxLine`,
+3. viewport setup (`vp.SetContent`).
+
+Goal:
+
+Understand where highlight work impacts frame-time.
+
+### Step 3: Understand parser + spans
+
+Read:
+
+1. `pkg/jsparse/treesitter.go`,
+2. `pkg/jsparse/highlight.go`.
+
+Goal:
+
+Understand how token spans are produced and where indexing should hook in.
+
+### Step 4: Implement in safe slices
+
+Recommended pull request progression:
+
+1. PR1: add index types + tests, no UI path change yet.
+2. PR2: add indexed lookup path under flag + parity tests.
+3. PR3: add segment rendering and switch source pane.
+4. PR4: add cache and invalidation.
+5. PR5: add benchmark report and cleanup.
+
+This keeps review focused and rollback simple.
+
+### Step 5: Validate behavior manually
+
+Manual checklist:
+
+1. load small JS file,
+2. load large JS file,
+3. evaluate several REPL expressions,
+4. inspect runtime object to trigger fallback source display,
+5. scroll aggressively in source pane,
+6. verify no stale highlights after new REPL append.
+
+## Appendix E: Failure Modes and Debugging Playbook
+
+When refactoring highlighting code, certain bugs recur. This playbook lists symptoms and likely root causes.
+
+### Symptom: lines render with missing tail characters
+
+Likely cause:
+
+1. segment slicing dropped suffix after last span.
+
+Fix:
+
+1. ensure segment builder always emits trailing unstyled slice from current column to line end.
+
+### Symptom: highlighting shifts right or left on some lines
+
+Likely cause:
+
+1. mismatch between byte indices and rune/cell indices.
+
+Fix:
+
+1. keep all syntax boundaries in byte coordinates,
+2. avoid mixing rune position counters in boundary math.
+
+### Symptom: stale highlighting after REPL runtime fallback
+
+Likely cause:
+
+1. append path updated text but not spans/index/cache.
+
+Fix:
+
+1. ensure fallback append triggers `rebuildReplSyntaxSpans` or line-range incremental update,
+2. invalidate relevant cache keys.
+
+### Symptom: random class mismatches after indexing
+
+Likely cause:
+
+1. overlap precedence changed unintentionally.
+
+Fix:
+
+1. encode precedence explicitly,
+2. run parity tests against old lookup for known fixtures.
+
+### Symptom: performance improvement is smaller than expected
+
+Likely causes:
+
+1. style-rendering dominates after lookup optimization,
+2. excessive rebuilding rather than incremental invalidation,
+3. benchmark fixture too small.
+
+Fix:
+
+1. profile with realistic medium/large fixtures,
+2. ensure line cache is actually being hit,
+3. inspect allocations in segment/styling path.
+
+## Appendix F: Concrete Task Expansion for GOJA-030
+
+This section turns ticket tasks into implementation-ready substeps.
+
+### Task 4: per-line span index
+
+Substeps:
+
+1. add `LineSpan`, `LineIndex` types,
+2. add span expansion/clipping logic,
+3. add sorting and merge logic,
+4. unit-test with single-line and multi-line fixtures.
+
+Definition of done:
+
+1. all index tests pass,
+2. parity with baseline on sampled lookups,
+3. no behavior change in current renderer path yet.
+
+### Task 5: replace global lookup in renderer
+
+Substeps:
+
+1. wire indexed lookup into `renderSyntaxLine`,
+2. keep fallback path for testing,
+3. add benchmarks comparing old/new lookup.
+
+Definition of done:
+
+1. parity tests pass,
+2. benchmark shows lookup improvement.
+
+### Task 6: segment renderer
+
+Substeps:
+
+1. add segment builder,
+2. replace char loop in source pane path,
+3. add line reconstruction tests and class-boundary tests.
+
+Definition of done:
+
+1. output parity on fixtures,
+2. fewer allocations in benchmark output.
+
+### Task 7 and 8: cache + REPL fallback invalidation
+
+Substeps:
+
+1. add source version counters,
+2. add line cache in model or renderer adapter,
+3. call rebuild/invalidate in fallback append path,
+4. add regression test for immediate post-fallback highlighting.
+
+Definition of done:
+
+1. no stale render after fallback append,
+2. repeated scroll hits cache effectively.
+
+### Tasks 9-11: correctness and behavior validation
+
+Substeps:
+
+1. add edge-case fixtures,
+2. verify behavior in file-source and REPL-source modes,
+3. run full tests including inspector command path.
+
+Definition of done:
+
+1. zero regressions in test suite,
+2. explicit coverage for known prior failure modes.
+
+### Tasks 12-14: final documentation and recommendation loop
+
+Substeps:
+
+1. summarize chosen algorithm and measured outcomes,
+2. update plan document and ticket changelog,
+3. capture follow-ups for optional query-capture phase.
+
+Definition of done:
+
+1. implementation and research docs aligned,
+2. future work clearly separated from completed scope.
+
+## Appendix G: Tree-sitter Query Capture Migration Notes
+
+This appendix is forward-looking and intentionally optional for the immediate optimization.
+
+### Why consider query captures later
+
+Kind-based classification is stable but coarse. Query captures can identify richer categories such as:
+
+1. function declaration names,
+2. method definitions,
+3. property keys versus variable identifiers,
+4. parameter names and type-like identifiers (where grammar allows).
+
+### Migration strategy (if pursued)
+
+1. Keep existing kind mapper as fallback.
+2. Add capture layer that can override or refine class assignment.
+3. Introduce capture priority table to resolve conflicts.
+4. Add fixture tests for semantic distinctions.
+
+### Example priority rule
+
+If a token matches both generic identifier and function-name capture:
+
+1. use function-name style class,
+2. otherwise fallback to identifier class.
+
+### Risk profile
+
+1. Higher complexity than current scope,
+2. requires strong test coverage per language grammar version,
+3. can introduce visual drift if capture sets are incomplete.
+
+Recommendation:
+
+Treat query-capture migration as a separate ticket after GOJA-030 performance phases land.
+
+## Appendix H: Validation Commands and Review Checklist
+
+Use these commands during implementation milestones:
+
+```bash
+go test ./pkg/jsparse -count=1
+go test ./cmd/smalltalk-inspector/... -count=1
+go test ./... -count=1
+go test ./pkg/jsparse -bench Highlight -benchmem
+```
+
+When performance claims are made:
+
+```bash
+go test ./pkg/jsparse -bench Highlight -benchmem -cpuprofile /tmp/highlight.cpu
+go tool pprof /tmp/highlight.cpu
+```
+
+Reviewer checklist:
+
+1. Does the new index preserve coordinate semantics?
+2. Do parity tests cover the old and new paths?
+3. Is REPL fallback invalidation wired correctly?
+4. Are benchmark fixtures representative and reproducible?
+5. Is core logic free of Bubble Tea dependencies?
+6. Is UI adapter code thin and clearly separated?
+7. Are docs updated with algorithm choice and residual risks?
+
+## Appendix I: Scenario Modeling and Cost Estimation
+
+This appendix provides rough operation-count modeling to explain why each phase should produce measurable gains. The numbers are not exact runtime measurements, but they are useful for intuition and planning benchmark expectations.
+
+### Scenario 1: Medium file, normal viewport
+
+Assumptions:
+
+1. file has 3,000 lines,
+2. average line length in source pane is 80 bytes,
+3. visible viewport renders 45 lines,
+4. total spans across file are 25,000.
+
+Current method estimated checks per frame:
+
+1. visible characters = `45 * 80 = 3,600`,
+2. each char calls linear scan of up to 25,000 spans,
+3. rough containment checks per frame = `3,600 * 25,000 = 90,000,000`.
+
+Even if branch prediction and early exits reduce practical work, the ceiling is very high.
+
+Indexed method (line buckets + binary lookup):
+
+Assume average spans per visible line bucket = 20.
+
+1. per-char lookup ~`log2(20)` comparisons (~5),
+2. checks per frame ~`3,600 * 5 = 18,000` plus light overhead.
+
+This is several orders of magnitude lower than the global scan upper bound.
+
+Segment method:
+
+Assume average 14 segments per line.
+
+1. style applications per frame = `45 * 14 = 630`,
+2. boundary handling and string joins scale with segment count, not raw char count,
+3. additional speedup expected from lower style invocation frequency.
+
+### Scenario 2: Long REPL history
+
+Assumptions:
+
+1. REPL log has 1,200 entries,
+2. each entry averages 3 code lines plus separators,
+3. total REPL source lines near 5,000,
+4. total spans near 35,000.
+
+Current approach:
+
+1. every frame still scans global spans for each visible character,
+2. cost rises as history grows even if viewport remains constant height.
+
+Indexed + cached approach:
+
+1. append invalidates only appended lines,
+2. unchanged lines remain cache hits,
+3. steady-state scrolling cost primarily reflects cache misses for newly viewed lines.
+
+This is critical for REPL-heavy sessions where users inspect historical snippets repeatedly.
+
+### Scenario 3: Frequent focus switching
+
+When users move between panes and source pane rerenders:
+
+Current method:
+
+1. recomputes highlight classification for all visible lines each time.
+
+With cache:
+
+1. repeated line renders are mostly cache hits,
+2. focus switching overhead drops to pane composition + minimal string joins.
+
+### Scenario 4: Worst-case token density
+
+Some generated code has dense punctuation/operators and many short tokens.
+
+Current char-loop scan worsens because:
+
+1. many spans,
+2. short adjacent spans,
+3. frequent class changes.
+
+Segment renderer still helps because:
+
+1. classification work is done from indexed line spans,
+2. even with many segments, segment-level styling beats global scan-per-char.
+
+### Modeling takeaway
+
+The largest gain source is eliminating global span scans. Segment rendering and caching provide additional multiplicative improvements on top, especially during repeated redraw patterns.
+
+## Appendix J: Reference Implementation Sketch
+
+This appendix outlines a concrete implementation skeleton that contributors can map directly to production code.
+
+### Core engine package sketch
+
+```go
+package highlightcore
+
+type SyntaxClass int
+
+type Span struct {
+    StartLine int
+    StartCol  int
+    EndLine   int
+    EndCol    int
+    Class     SyntaxClass
+}
+
+type LineSpan struct {
+    StartCol int
+    EndCol   int
+    Class    SyntaxClass
+}
+
+type LineIndex struct {
+    Lines [][]LineSpan // 1-based logical access, 0 slot unused or mapped
+}
+
+type Segment struct {
+    StartCol int
+    EndCol   int
+    Class    SyntaxClass
+}
+```
+
+### Index build function sketch
+
+```go
+func BuildLineIndex(spans []Span, lineLens []int) *LineIndex {
+    idx := &LineIndex{Lines: make([][]LineSpan, len(lineLens)+1)}
+    for _, sp := range spans {
+        if sp.EndLine < sp.StartLine {
+            continue
+        }
+        for line := sp.StartLine; line <= sp.EndLine; line++ {
+            if line <= 0 || line > len(lineLens) {
+                continue
+            }
+            start := 1
+            end := lineLens[line-1] + 1
+            if line == sp.StartLine {
+                start = sp.StartCol
+            }
+            if line == sp.EndLine {
+                end = sp.EndCol
+            }
+            if start < 1 {
+                start = 1
+            }
+            if end > lineLens[line-1]+1 {
+                end = lineLens[line-1] + 1
+            }
+            if start >= end {
+                continue
+            }
+            idx.Lines[line] = append(idx.Lines[line], LineSpan{
+                StartCol: start,
+                EndCol:   end,
+                Class:    sp.Class,
+            })
+        }
+    }
+    normalizeIndex(idx)
+    return idx
+}
+```
+
+### Normalization sketch
+
+`normalizeIndex` should:
+
+1. sort by `(StartCol, EndCol)`,
+2. merge adjacent spans with same class where `prev.EndCol == next.StartCol`,
+3. preserve deterministic order for overlaps.
+
+### Segment conversion sketch
+
+```go
+func SegmentsForLine(lineText string, spans []LineSpan) []Segment {
+    // treat lineText in byte coordinates
+    // emit full coverage from 1..lineLen+1
+}
+```
+
+Expected behavior:
+
+1. all bytes are covered by exactly one segment class (including `SyntaxNone` gaps),
+2. no overlaps in output segments,
+3. output order strictly increasing by start col.
+
+### UI adapter sketch
+
+```go
+type Styler interface {
+    Render(class SyntaxClass, text string) string
+}
+
+func RenderStyledLine(line string, segs []Segment, styler Styler) string {
+    // slice by byte ranges and apply style per segment
+}
+```
+
+Bubble Tea integration:
+
+1. source pane asks renderer for each visible line,
+2. renderer returns styled strings,
+3. viewport receives joined lines.
+
+No Bubble Tea types should appear in core engine signatures.
+
+### Cache sketch
+
+```go
+type LineKey struct {
+    Version uint64
+    LineNo  int
+    Theme   uint64
+}
+
+type LineCache struct {
+    Data map[LineKey]string
+    // optional LRU metadata
+}
+```
+
+Cache API:
+
+1. `Get(key) (string, bool)`
+2. `Put(key, value)`
+3. `InvalidateVersion(version)`
+4. `InvalidateRange(version, startLine, endLine)`
+
+This is sufficient for initial rollout.
+
+## Appendix K: Rollout, Observability, and Maintenance
+
+Algorithm work succeeds long-term only if it remains observable and maintainable after merge.
+
+### Rollout strategy
+
+Use staged rollout with guardrails:
+
+1. introduce new index and renderer behind internal switch,
+2. run CI parity tests with both paths,
+3. default to new path once benchmarks and parity are stable,
+4. remove old path after one stabilization cycle.
+
+### Observability hooks
+
+Add lightweight counters in debug builds:
+
+1. cache hit/miss ratio,
+2. lines rendered per frame,
+3. index rebuild count,
+4. REPL append invalidation count.
+
+These counters help diagnose regressions without full profiling sessions.
+
+### Maintenance guidelines
+
+1. keep coordinate semantics documented near types,
+2. do not merge style-layer logic into core index code,
+3. require benchmark snippets in PR descriptions for hot-path changes,
+4. keep fixture corpus representative of real use cases,
+5. keep parser-kind mapping and tests updated as tree-sitter grammar versions evolve.
+
+### Dependency and upgrade considerations
+
+Since parsing depends on tree-sitter JavaScript bindings:
+
+1. grammar updates can change node kinds,
+2. classification mappings may need updates,
+3. semantic drift must be caught by fixture tests.
+
+A robust test suite around classification and segment parity reduces upgrade risk substantially.
+
+### Long-term options after GOJA-030
+
+Once the core optimization lands and stabilizes, future options include:
+
+1. query-capture semantic highlighting,
+2. optional incremental parsing for live-edit workflows,
+3. language-agnostic highlight core interfaces if multi-language support is desired,
+4. exporting highlight metadata as JSON for REST consumers.
+
+These should be treated as separate phases to keep GOJA-030 focused and shippable.

--- a/ttmp/2026/02/14/GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS--syntax-highlighting-improvements/design/03-intern-research-guide-f-and-g.md
+++ b/ttmp/2026/02/14/GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS--syntax-highlighting-improvements/design/03-intern-research-guide-f-and-g.md
@@ -1,0 +1,648 @@
+---
+Title: 'Intern Research Guide: F and G'
+Ticket: GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS
+Status: active
+Topics:
+    - go
+    - goja
+    - tui
+    - inspector
+    - refactor
+DocType: design
+Intent: long-term
+Owners: []
+RelatedFiles: []
+ExternalSources:
+    - https://tree-sitter.github.io/tree-sitter/
+    - https://tree-sitter.github.io/tree-sitter/using-parsers/queries/
+    - https://github.com/tree-sitter/tree-sitter/blob/master/lib/include/tree_sitter/api.h
+    - https://unpkg.com/monaco-editor@latest/esm/vs/editor/editor.api.d.ts
+    - https://github.com/microsoft/vscode/blob/main/src/vs/editor/common/model/textModelTokens.ts
+    - https://code.visualstudio.com/blogs/2017/02/08/syntax-highlighting-optimizations
+    - https://tree-sitter.github.io/tree-sitter/creating-parsers#using-grammarjs
+    - https://tree-sitter.github.io/tree-sitter/3-syntax-highlighting.html
+Summary: Internet-only research guide for an intern to investigate F and G with no prior context, including explicit pattern catalogs (F0-F4, G0-G4), architectural primers, and implementation-oriented deliverables based on public APIs/references.
+LastUpdated: 2026-02-15T16:10:00Z
+WhatFor: Provide a concrete research plan when intern access is limited to public internet resources.
+WhenToUse: Use when assigning API/reference deep research without private repository access.
+---
+
+# Intern Research Guide: F and G (Internet-Only)
+
+## Constraint
+
+The intern has **no access to our private codebase**.  
+This guide is intentionally designed for internet-only execution.
+
+## Purpose
+
+Research two technical tracks and deliver implementation-ready guidance:
+
+1. **F:** tree-sitter query/capture semantic highlighting.
+2. **G:** incremental parsing + dirty-range invalidation.
+
+The output should be a decision package we can map onto our code later.
+
+## Definitions (use these exactly)
+
+1. **F (semantic capture track):** classification quality.
+   Use tree-sitter query captures to identify semantic categories beyond simple token kinds.
+2. **G (incremental update track):** update efficiency.
+   Recompute only changed/affected regions rather than full-document highlight passes.
+3. **F and G are complementary.**
+   F improves correctness/semantic expressiveness, G improves latency/throughput.
+
+## Zero-Context Primer (Read This First)
+
+If you are new to syntax highlighting, start here.
+
+### What syntax highlighting is
+
+Syntax highlighting is the process of:
+
+1. reading source text,
+2. deciding what each piece of text *means* (keyword, function, comment, property, etc.),
+3. mapping those meanings to style categories,
+4. rendering the styled output.
+
+### Why there are two tracks (F and G)
+
+There are two orthogonal problems:
+
+1. **Classification quality problem (F):** are we assigning the right meaning/class to each token?
+2. **Update cost problem (G):** how much work do we do after changes/edits?
+
+You can have:
+
+1. good classifications but slow updates,
+2. fast updates but poor classifications,
+3. or both good if F and G are designed together.
+
+### Minimal architecture vocabulary
+
+Use these terms consistently in your report:
+
+1. **Parser:** builds syntax structure from text.
+2. **Token/classifier:** assigns categories to ranges.
+3. **Span/segment index:** organizes ranges for fast lookup/rendering.
+4. **Renderer:** converts classified ranges to styled output.
+5. **Invalidation engine:** decides which parts must be recomputed after change.
+6. **Cache:** stores previously computed render/classification artifacts.
+
+### Typical pipeline (conceptual)
+
+1. input text,
+2. parse/capture/classify,
+3. build line/range index,
+4. render visible region,
+5. on edits: invalidate affected ranges only.
+
+### What commonly goes wrong
+
+1. ambiguous classification precedence,
+2. full-document recomputation on small edits,
+3. stale cache after partial updates,
+4. byte/column and Unicode alignment mistakes,
+5. semantic layer and lexical layer conflicts.
+
+## Explicit Pattern Catalog: F (Classification Patterns)
+
+These are the concrete F patterns you must analyze. Use these exact IDs in your report.
+
+## F0: Kind-Based Classification (baseline)
+
+What it is:
+
+1. classify tokens directly from parser node kinds/types.
+
+Strengths:
+
+1. simple and fast to implement,
+2. low conceptual overhead.
+
+Weaknesses:
+
+1. semantics are coarse,
+2. hard to distinguish context-specific roles cleanly.
+
+When it fits:
+
+1. initial implementation,
+2. low semantic precision requirements.
+
+## F1: Query Capture Overlay on Top of Baseline
+
+What it is:
+
+1. keep F0 baseline,
+2. add tree-sitter query captures for higher-value semantic distinctions,
+3. captures override or refine baseline where matched.
+
+Strengths:
+
+1. incremental adoption,
+2. preserves fallback behavior.
+
+Weaknesses:
+
+1. overlap/precedence policy must be explicit,
+2. possible dual-path complexity.
+
+When it fits:
+
+1. migration from coarse to richer semantics with low risk.
+
+## F2: Capture-First Classification
+
+What it is:
+
+1. primary classification comes from query captures,
+2. node-kind fallback only for uncovered tokens.
+
+Strengths:
+
+1. strongest semantic flexibility,
+2. language-specific tuning via queries.
+
+Weaknesses:
+
+1. higher maintenance burden,
+2. gaps in query coverage can cause inconsistencies.
+
+When it fits:
+
+1. mature highlighting systems with strong query discipline.
+
+## F3: Multi-Layer Semantic Model
+
+What it is:
+
+1. lexical/base classes plus semantic overlay classes,
+2. rendering merges layers by priority.
+
+Strengths:
+
+1. robust fallback path,
+2. can evolve semantics without destabilizing lexical baseline.
+
+Weaknesses:
+
+1. layer merge logic can be complex,
+2. conflicts must be deterministic.
+
+When it fits:
+
+1. systems needing high resilience and gradual semantic rollout.
+
+## F4: External Semantic Provider Protocol
+
+What it is:
+
+1. semantic classifications delivered by a provider protocol (for example semantic tokens with legends/deltas),
+2. combined with local lexical tokenization.
+
+Strengths:
+
+1. can leverage rich external analyzers,
+2. supports dynamic semantic updates.
+
+Weaknesses:
+
+1. provider latency/availability concerns,
+2. integration complexity.
+
+When it fits:
+
+1. IDE-like environments with language-service infrastructure.
+
+## F Pattern Research Requirements
+
+For each F pattern (F0-F4), collect:
+
+1. required APIs,
+2. precedence/conflict model,
+3. performance impact expectations,
+4. correctness risks,
+5. migration feasibility from simple baseline.
+
+## Explicit Pattern Catalog: G (Update/Invalidation Patterns)
+
+These are the concrete G patterns you must analyze. Use these exact IDs in your report.
+
+## G0: Full Rebuild on Any Change
+
+What it is:
+
+1. parse and re-highlight entire document on every update.
+
+Strengths:
+
+1. simplest correctness model,
+2. lowest implementation complexity.
+
+Weaknesses:
+
+1. poor scalability,
+2. unnecessary work for local edits.
+
+When it fits:
+
+1. very small documents or early prototypes.
+
+## G1: Line-State Retokenization With Stop-on-Equal-State
+
+What it is:
+
+1. tokenize line-by-line,
+2. each line produces an end state,
+3. after edits, retokenize forward until end state matches prior state.
+
+Strengths:
+
+1. strong practical efficiency in many editors,
+2. predictable invalidation boundaries.
+
+Weaknesses:
+
+1. state model must be correct and comparable (`equals` semantics),
+2. can still cascade far in worst-case edits.
+
+When it fits:
+
+1. top-down tokenization architectures.
+
+## G2: Incremental Parse Tree + Dirty Ranges
+
+What it is:
+
+1. apply edit metadata to previous parse tree,
+2. reparse incrementally,
+3. derive changed ranges and invalidate only impacted highlights.
+
+Strengths:
+
+1. potentially strong performance for large documents,
+2. tightly coupled with syntax structure changes.
+
+Weaknesses:
+
+1. edit bookkeeping complexity,
+2. invalidation mapping from tree ranges to render ranges must be robust.
+
+When it fits:
+
+1. parser infrastructure supports incremental edits well.
+
+## G3: Semantic Token Delta Updates
+
+What it is:
+
+1. semantic layer returns deltas/edits against previous token stream,
+2. renderer applies only token differences.
+
+Strengths:
+
+1. efficient semantic refresh path,
+2. lower transport/work for unchanged regions.
+
+Weaknesses:
+
+1. delta protocol correctness is subtle,
+2. requires stable identity/versioning (`resultId`-like flows).
+
+When it fits:
+
+1. systems with semantic provider protocols.
+
+## G4: Multi-Tier Cache With Range Invalidation
+
+What it is:
+
+1. separate caches for parse artifacts, classified segments, and styled lines,
+2. invalidate by range and version keys.
+
+Strengths:
+
+1. high practical speed for repeated views,
+2. keeps rendering responsive under scrolling/navigation.
+
+Weaknesses:
+
+1. stale-cache bugs if invalidation policy is incomplete,
+2. memory management needed.
+
+When it fits:
+
+1. high-frequency render/update pipelines.
+
+## G Pattern Research Requirements
+
+For each G pattern (G0-G4), collect:
+
+1. invalidation trigger model,
+2. stop conditions,
+3. cache key strategy,
+4. asymptotic and practical performance implications,
+5. failure modes and mitigations.
+
+## F+G Composition Patterns (Integration Patterns)
+
+Use these integration IDs in your comparison matrix.
+
+## FG-A: Fast Lexical Baseline + Semantic Overlay (Recommended Default Pattern to Evaluate First)
+
+1. lexical/high-speed path provides stable base colors quickly,
+2. semantic layer refines classes asynchronously or incrementally,
+3. invalidation primarily handled by G1/G4 or G2/G4 combinations.
+
+Why important:
+
+1. balances responsiveness and semantic quality,
+2. robust fallback behavior.
+
+## FG-B: Unified Semantic-First Pipeline
+
+1. semantic captures/provider drive most classification directly,
+2. lexical layer is minimal fallback.
+
+Why important:
+
+1. potentially cleaner semantics,
+2. higher correctness risk if semantic coverage is incomplete.
+
+## FG-C: Adaptive Hybrid by Document Size/Mode
+
+1. lightweight mode for large or transient buffers,
+2. richer semantic mode for stable/important views,
+3. mode switching based on policy.
+
+Why important:
+
+1. operationally pragmatic for mixed workloads.
+
+## Mandatory Comparison Output for Patterns
+
+Your report must include one table with rows:
+
+1. F0, F1, F2, F3, F4
+2. G0, G1, G2, G3, G4
+3. FG-A, FG-B, FG-C
+
+Columns must include:
+
+1. implementation complexity,
+2. correctness risk,
+3. expected latency impact,
+4. maintenance cost,
+5. recommended rollout order.
+
+## What the Intern Should Not Do
+
+1. Do not reference private files or guess private architecture details.
+2. Do not claim repo-specific facts without explicit evidence from maintainers.
+3. Do not produce only narrative summaries without concrete API references and design artifacts.
+
+## Primary Research Corpus (Public Sources)
+
+Minimum required sources:
+
+1. Tree-sitter docs:
+   parser API, query language, captures, edits/incremental update behavior.
+2. Monaco public APIs:
+   token providers, semantic tokens providers, tokenizer state interfaces.
+3. VS Code tokenization architecture:
+   line-state invalidation and retokenization model.
+4. At least 2 additional editor/reference implementations (for example Helix/Neovim/Zed or similar) with public docs/source explaining F and/or G patterns.
+
+Every design claim must include source URLs.
+
+## Core Research Questions
+
+### F-track
+
+1. What capture models are common for JavaScript/TypeScript (function, property, parameter, type-like constructs)?
+2. How do mature systems resolve capture overlap/priority?
+3. How are semantic captures mapped to theme/token categories?
+4. What is the minimum viable capture set for high impact?
+5. What are typical failure modes (grammar drift, noisy captures, precedence bugs)?
+
+### G-track
+
+1. How do systems represent edit deltas and dirty ranges?
+2. How do they determine recompute stop conditions?
+3. How do they combine line-state invalidation with background tokenization?
+4. What cache key/invalidation strategies are common?
+5. What are tradeoffs between full-rebuild simplicity and incremental complexity?
+
+### F+G integration
+
+1. Where do F and G compose cleanly?
+2. Which layering works best:
+   lexical baseline + semantic overlay, or single capture-driven path?
+3. What phased rollout pattern minimizes correctness regression risk?
+
+## Required Outputs (Internet-Only)
+
+The intern must deliver:
+
+1. **API Reference Pack** (concise, source-linked):
+   key APIs/signatures for tree-sitter, Monaco, and VS Code-relevant concepts.
+2. **Architecture Comparison Matrix**:
+   F/G mechanisms across at least 3 systems.
+3. **Algorithm Option Memo**:
+   3-5 concrete algorithm options with complexity, risk, and expected payoff.
+4. **Integration Blueprint Template**:
+   repo-agnostic blueprint with placeholders we can map to our codebase.
+5. **Validation Plan**:
+   measurable benchmarks/tests we should run once mapped internally.
+6. **Final Recommendation Report (6+ pages)**:
+   phased implementation order, risks, and open questions for maintainers.
+
+If one of these is missing, research is incomplete.
+
+## Deliverable Format Requirements
+
+### 1) API Reference Pack
+
+For each relevant API:
+
+1. exact name/signature,
+2. where it lives (URL),
+3. what it solves (F/G),
+4. caveats/version notes,
+5. why it matters to implementation.
+
+### 2) Comparison Matrix
+
+Columns:
+
+1. system/tool,
+2. F mechanism,
+3. G mechanism,
+4. invalidation model,
+5. cache model,
+6. performance implications,
+7. complexity/risk notes.
+
+### 3) Blueprint Template
+
+Must include:
+
+1. component boundaries (parser, classifier, indexer, renderer, cache),
+2. data flow (source -> parse -> classify -> index -> render),
+3. invalidation flow (edit -> dirty range -> recompute),
+4. rollout phases and rollback points.
+
+No private file names are required; use abstract component names.
+
+## Suggested Technical Focus Areas
+
+1. Tree-sitter query syntax and capture precedence patterns.
+2. Tree-sitter incremental parse model and edit propagation.
+3. Semantic token delta protocols (`resultId`, edits).
+4. Line-state tokenization with end-state equality stop conditions.
+5. Segment-based rendering and line-level caching patterns.
+6. Correctness safeguards for multiline constructs and Unicode/byte-column semantics.
+
+## Research Method (Step-by-Step)
+
+### Step 1: Build the source map
+
+Create a bibliography table with:
+
+1. URL,
+2. source type (official docs/source/blog),
+3. reliability level,
+4. what topic it informs (F, G, or both).
+
+### Step 2: Extract API-level facts
+
+Pull only verifiable facts:
+
+1. function/interface names,
+2. required inputs/outputs,
+3. update/invalidation semantics,
+4. constraints and edge behavior.
+
+### Step 3: Build model diagrams
+
+Create two diagrams:
+
+1. F-only pipeline,
+2. G-only pipeline,
+
+then a merged F+G pipeline.
+
+### Step 4: Derive options
+
+Produce 3-5 candidate architectures and compare with weighted criteria:
+
+1. expected performance,
+2. implementation complexity,
+3. correctness risk,
+4. testability,
+5. maintainability.
+
+### Step 5: Produce phase recommendation
+
+Recommend phased rollout:
+
+1. what should be implemented first,
+2. what should be deferred,
+3. why.
+
+## Evidence Rules
+
+1. No uncited claims.
+2. Prefer primary sources (official API docs and source code).
+3. When source behavior is inferred, label it as inference.
+4. Include at least one concrete source quote or signature reference per major claim.
+
+## Quality Bar
+
+Recommendation quality is acceptable only if:
+
+1. evidence-backed,
+2. API-specific,
+3. architecture-level (not vague),
+4. phased and testable,
+5. explicit about unknowns that require maintainer input.
+
+## Questions the Intern Must Leave for Maintainers
+
+Since intern cannot see private code, final report must include a section:
+
+1. “Assumptions requiring confirmation”
+2. “Information needed from maintainers before implementation”
+3. “Potential integration blockers”
+
+This section is mandatory.
+
+## 10-Day Timeline (Internet-Only)
+
+### Day 1-2
+
+1. build bibliography,
+2. extract API facts for tree-sitter/Monaco/VS Code.
+
+### Day 3-4
+
+1. deep dive F mechanisms,
+2. draft capture precedence and mapping options.
+
+### Day 5-6
+
+1. deep dive G mechanisms,
+2. draft invalidation/cache options.
+
+### Day 7
+
+1. compare F/G/F+G architectures,
+2. score options.
+
+### Day 8
+
+1. draft 6+ page final report.
+
+### Day 9
+
+1. tighten citations,
+2. clarify assumptions and open questions.
+
+### Day 10
+
+1. deliver final package,
+2. present short walkthrough.
+
+## Final Report Template
+
+Use this section order:
+
+1. Scope and constraints.
+2. Source corpus and reliability.
+3. F deep dive.
+4. G deep dive.
+5. F+G integration patterns.
+6. Option matrix and scoring.
+7. Recommended phased plan.
+8. Risks and mitigations.
+9. Maintainer questions and required confirmations.
+10. Appendix with API references and citations.
+
+## Common Failure Modes
+
+1. Over-indexing on one editor implementation only.
+2. Mixing semantic quality claims with no performance discussion.
+3. Mixing performance claims with no invalidation model.
+4. Giving repo-specific advice without repo access.
+5. Recommending a final architecture without rollback strategy.
+
+## Mentor Acceptance Checklist
+
+Accept research only if:
+
+1. all required outputs are present,
+2. sources are primary and cited,
+3. recommendation is phased and testable,
+4. assumptions are explicit,
+5. integration questions for maintainers are clear.

--- a/ttmp/2026/02/14/GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS--syntax-highlighting-improvements/index.md
+++ b/ttmp/2026/02/14/GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS--syntax-highlighting-improvements/index.md
@@ -12,22 +12,25 @@ DocType: index
 Intent: long-term
 Owners: []
 RelatedFiles:
-    - Path: go-go-goja/ttmp/2026/02/14/GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS--syntax-highlighting-improvements/design/01-syntax-highlighting-implementation-plan.md
-      Note: Primary implementation plan for highlighting upgrades
-    - Path: go-go-goja/pkg/jsparse/highlight.go
-      Note: Current highlight span/lookup implementation target
-    - Path: go-go-goja/cmd/smalltalk-inspector/app/view.go
-      Note: Current render hot path using syntax spans
-    - Path: go-go-goja/cmd/smalltalk-inspector/app/model.go
+    - Path: cmd/smalltalk-inspector/app/model.go
       Note: Current syntax-span rebuild and REPL source tracking flow
-    - Path: go-go-goja/ttmp/2026/02/14/GOJA-027-SYNTAX-HIGHLIGHT--syntax-highlighting-for-smalltalk-inspector-source-pane/tasks.md
+    - Path: cmd/smalltalk-inspector/app/view.go
+      Note: Current render hot path using syntax spans
+    - Path: pkg/jsparse/highlight.go
+      Note: Current highlight span/lookup implementation target
+    - Path: ttmp/2026/02/14/GOJA-027-SYNTAX-HIGHLIGHT--syntax-highlighting-for-smalltalk-inspector-source-pane/tasks.md
       Note: Original feature ticket context and carry-over work
+    - Path: ttmp/2026/02/14/GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS--syntax-highlighting-improvements/design/01-syntax-highlighting-implementation-plan.md
+      Note: Primary implementation plan for highlighting upgrades
+    - Path: ttmp/2026/02/14/GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS--syntax-highlighting-improvements/design/02-syntax-highlighting-algorithm-research.md
+      Note: Deep algorithm research and recommendation memo used to drive implementation tasks
 ExternalSources: []
 Summary: Execution ticket for syntax-highlighting algorithm and performance improvements in smalltalk-inspector.
 LastUpdated: 2026-02-14T19:03:00Z
 WhatFor: Plan and track benchmark-driven optimization and correctness hardening of highlighting.
 WhenToUse: Use as entrypoint when implementing GOJA-030.
 ---
+
 
 # Syntax Highlighting Improvements
 

--- a/ttmp/2026/02/14/GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS--syntax-highlighting-improvements/index.md
+++ b/ttmp/2026/02/14/GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS--syntax-highlighting-improvements/index.md
@@ -24,12 +24,15 @@ RelatedFiles:
       Note: Primary implementation plan for highlighting upgrades
     - Path: ttmp/2026/02/14/GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS--syntax-highlighting-improvements/design/02-syntax-highlighting-algorithm-research.md
       Note: Deep algorithm research and recommendation memo used to drive implementation tasks
+    - Path: ttmp/2026/02/14/GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS--syntax-highlighting-improvements/design/03-intern-research-guide-f-and-g.md
+      Note: Intern handoff guide for deep F/G research execution
 ExternalSources: []
 Summary: Execution ticket for syntax-highlighting algorithm and performance improvements in smalltalk-inspector.
 LastUpdated: 2026-02-14T19:03:00Z
 WhatFor: Plan and track benchmark-driven optimization and correctness hardening of highlighting.
 WhenToUse: Use as entrypoint when implementing GOJA-030.
 ---
+
 
 
 # Syntax Highlighting Improvements

--- a/ttmp/2026/02/14/GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS--syntax-highlighting-improvements/index.md
+++ b/ttmp/2026/02/14/GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS--syntax-highlighting-improvements/index.md
@@ -1,0 +1,71 @@
+---
+Title: Syntax Highlighting Improvements
+Ticket: GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS
+Status: active
+Topics:
+    - go
+    - goja
+    - tui
+    - inspector
+    - refactor
+DocType: index
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: go-go-goja/ttmp/2026/02/14/GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS--syntax-highlighting-improvements/design/01-syntax-highlighting-implementation-plan.md
+      Note: Primary implementation plan for highlighting upgrades
+    - Path: go-go-goja/pkg/jsparse/highlight.go
+      Note: Current highlight span/lookup implementation target
+    - Path: go-go-goja/cmd/smalltalk-inspector/app/view.go
+      Note: Current render hot path using syntax spans
+    - Path: go-go-goja/cmd/smalltalk-inspector/app/model.go
+      Note: Current syntax-span rebuild and REPL source tracking flow
+    - Path: go-go-goja/ttmp/2026/02/14/GOJA-027-SYNTAX-HIGHLIGHT--syntax-highlighting-for-smalltalk-inspector-source-pane/tasks.md
+      Note: Original feature ticket context and carry-over work
+ExternalSources: []
+Summary: Execution ticket for syntax-highlighting algorithm and performance improvements in smalltalk-inspector.
+LastUpdated: 2026-02-14T19:03:00Z
+WhatFor: Plan and track benchmark-driven optimization and correctness hardening of highlighting.
+WhenToUse: Use as entrypoint when implementing GOJA-030.
+---
+
+# Syntax Highlighting Improvements
+
+## Overview
+
+This ticket improves syntax highlighting internals after GOJA-027 by replacing expensive lookup/render paths, adding benchmark coverage, and hardening correctness and cache invalidation for both file and REPL source views.
+
+## Key Links
+
+- Implementation plan: `design/01-syntax-highlighting-implementation-plan.md`
+- Tasks: `tasks.md`
+- Changelog: `changelog.md`
+
+## Status
+
+Current status: **active**
+
+## Topics
+
+- go
+- goja
+- tui
+- inspector
+- refactor
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/2026/02/14/GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS--syntax-highlighting-improvements/tasks.md
+++ b/ttmp/2026/02/14/GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS--syntax-highlighting-improvements/tasks.md
@@ -1,0 +1,22 @@
+# Tasks
+
+## TODO
+
+- [x] Create GOJA-030 ticket workspace
+- [x] Add syntax-highlighting improvement implementation plan
+
+- [ ] Baseline benchmarking: add benchmark cases and capture current performance/allocation metrics
+- [ ] Implement per-line span index in `pkg/jsparse/highlight.go`
+- [ ] Replace global linear span lookup in renderer with indexed lookup path
+- [ ] Implement segment-based line rendering to reduce per-character overhead
+- [ ] Add styled-line cache with invalidation strategy for source changes
+- [ ] Fix REPL fallback path to always rebuild/invalidate syntax spans
+- [ ] Expand correctness tests (multiline strings/comments/template literals/operator cases)
+- [ ] Add benchmark + profile comparison report (before/after)
+- [ ] Validate behavior in both file-source and REPL-source views
+- [ ] Document final algorithm choice and follow-up opportunities
+
+## Research Spike (Optional but Recommended)
+
+- [ ] Run a 1-2 day algorithm research spike (tree-sitter highlight architecture, interval indexing, cache invalidation patterns)
+- [ ] Produce short recommendation memo and feed decisions back into implementation plan

--- a/ttmp/2026/02/14/GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS--syntax-highlighting-improvements/tasks.md
+++ b/ttmp/2026/02/14/GOJA-030-SYNTAX-HIGHLIGHTING-IMPROVEMENTS--syntax-highlighting-improvements/tasks.md
@@ -14,9 +14,9 @@
 - [ ] Expand correctness tests (multiline strings/comments/template literals/operator cases)
 - [ ] Add benchmark + profile comparison report (before/after)
 - [ ] Validate behavior in both file-source and REPL-source views
-- [ ] Document final algorithm choice and follow-up opportunities
+- [x] Document final algorithm choice and follow-up opportunities
 
 ## Research Spike (Optional but Recommended)
 
-- [ ] Run a 1-2 day algorithm research spike (tree-sitter highlight architecture, interval indexing, cache invalidation patterns)
-- [ ] Produce short recommendation memo and feed decisions back into implementation plan
+- [x] Run a 1-2 day algorithm research spike (tree-sitter highlight architecture, interval indexing, cache invalidation patterns)
+- [x] Produce short recommendation memo and feed decisions back into implementation plan

--- a/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/README.md
+++ b/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/README.md
@@ -1,0 +1,21 @@
+# Inspector Phase A Stabilization
+
+This is the document workspace for ticket GOJA-031-INSPECTOR-PHASE-A-STABILIZATION.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr doc add --ticket GOJA-031-INSPECTOR-PHASE-A-STABILIZATION --doc-type design-doc --title "My Design"`
+- Import sources: `docmgr import file --ticket GOJA-031-INSPECTOR-PHASE-A-STABILIZATION --file /path/to/doc.md`
+- Update metadata: `docmgr meta update --ticket GOJA-031-INSPECTOR-PHASE-A-STABILIZATION --field Status --value review`

--- a/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/changelog.md
+++ b/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/changelog.md
@@ -35,3 +35,13 @@ Step 3: Added depth guard to inherited-member traversal and expanded core regres
 
 - /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/pkg/inspector/core/members.go — Added `maxInheritanceDepth`-bounded recursion
 - /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/pkg/inspector/core/members_test.go — Added deep-chain guard test
+
+
+## 2026-02-14
+
+Step 4: Added command-level regression tests for cyclic inheritance input and validated all relevant test suites.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/cmd/smalltalk-inspector/app/model_members_test.go — New command-level no-panic regressions
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/reference/01-diary.md — Updated with command outputs and commit trace

--- a/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/changelog.md
+++ b/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/changelog.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## 2026-02-14
+
+- Initial workspace created
+
+
+## 2026-02-14
+
+Step 1: Added Phase A implementation plan, task breakdown, and diary scaffold with explicit UI/core architecture boundary requirements.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/design/01-phase-a-implementation-plan.md — Detailed plan for extraction + stabilization
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/tasks.md — Executable task list
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/reference/01-diary.md — Diary started

--- a/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/changelog.md
+++ b/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/changelog.md
@@ -45,3 +45,8 @@ Step 4: Added command-level regression tests for cyclic inheritance input and va
 
 - /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/cmd/smalltalk-inspector/app/model_members_test.go — New command-level no-panic regressions
 - /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/reference/01-diary.md — Updated with command outputs and commit trace
+
+## 2026-02-14
+
+Ticket closed
+

--- a/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/changelog.md
+++ b/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/changelog.md
@@ -25,3 +25,13 @@ Step 2: Extracted class/function member analysis from `cmd/smalltalk-inspector` 
 - /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/pkg/inspector/core/members.go — New UI-independent member analysis API
 - /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/pkg/inspector/core/members_test.go — Core package tests for extraction behavior
 - /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/cmd/smalltalk-inspector/app/model.go — Rewired to consume core package
+
+
+## 2026-02-14
+
+Step 3: Added depth guard to inherited-member traversal and expanded core regression tests to include deep inheritance chain bounds.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/pkg/inspector/core/members.go — Added `maxInheritanceDepth`-bounded recursion
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/pkg/inspector/core/members_test.go — Added deep-chain guard test

--- a/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/changelog.md
+++ b/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/changelog.md
@@ -14,3 +14,14 @@ Step 1: Added Phase A implementation plan, task breakdown, and diary scaffold wi
 - /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/design/01-phase-a-implementation-plan.md — Detailed plan for extraction + stabilization
 - /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/tasks.md — Executable task list
 - /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/reference/01-diary.md — Diary started
+
+
+## 2026-02-14
+
+Step 2: Extracted class/function member analysis from `cmd/smalltalk-inspector` into `pkg/inspector/core` and rewired UI model call sites to use core APIs.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/pkg/inspector/core/members.go — New UI-independent member analysis API
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/pkg/inspector/core/members_test.go — Core package tests for extraction behavior
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/cmd/smalltalk-inspector/app/model.go — Rewired to consume core package

--- a/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/design/01-phase-a-implementation-plan.md
+++ b/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/design/01-phase-a-implementation-plan.md
@@ -1,0 +1,102 @@
+---
+Title: Phase A Implementation Plan
+Ticket: GOJA-031-INSPECTOR-PHASE-A-STABILIZATION
+Status: active
+Topics:
+    - go
+    - goja
+    - tui
+    - inspector
+    - refactor
+DocType: design
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: go-go-goja/cmd/smalltalk-inspector/app/model.go
+      Note: Current UI-centric member-building logic to split
+    - Path: go-go-goja/cmd/smalltalk-inspector/app/update.go
+      Note: Bubble Tea event flow that should consume core APIs
+    - Path: go-go-goja/pkg/inspector
+      Note: Domain package home for UI-independent core logic
+    - Path: go-go-goja/ttmp/2026/02/14/GOJA-028-CLEANUP-INSPECTOR--cleanup-inspector/reference/01-inspector-cleanup-review.md
+      Note: Source findings for Phase A stabilization priorities
+ExternalSources: []
+Summary: Phase A stabilization and extraction plan: fix critical recursion crash, add regression tests, and split core logic from Bubble Tea UI boundaries.
+LastUpdated: 2026-02-14T19:10:00Z
+WhatFor: Provide an execution-ready plan for Phase A safety and architecture boundary improvements.
+WhenToUse: Use while implementing GOJA-031 tasks.
+---
+
+# Phase A Implementation Plan
+
+## Objective
+
+Deliver Phase A stabilization with explicit architecture boundaries:
+
+1. Fix critical correctness issue (inheritance recursion crash).
+2. Add regression tests around the fixed behavior.
+3. Extract core non-UI behavior into `pkg/inspector/*` so it can later be exposed via CLI/REST.
+4. Keep Bubble Tea command code (`cmd/smalltalk-inspector`) focused on UI orchestration only.
+
+## Architecture Boundary Rule (Mandatory)
+
+UI layer (`cmd/smalltalk-inspector`):
+- Bubble Tea model/update/view.
+- Keyboard/navigation/rendering concerns.
+
+Core layer (`pkg/inspector/core`):
+- Member extraction from AST.
+- Inheritance traversal and cycle-safety.
+- Function/member structural analysis.
+- No Bubble Tea imports.
+
+Future API exposure implication:
+- Anything in `pkg/inspector/core` can be reused by REST handlers or non-TUI CLI commands without UI coupling.
+
+## Phase A Work Packages
+
+### WP1: Extract class/function member analysis into core package
+
+- Create `pkg/inspector/core/members.go`.
+- Move AST member extraction logic from UI model into core package.
+- Expose API oriented around analysis inputs/outputs (plain Go structs).
+
+### WP2: Fix recursion safety with cycle detection
+
+- Implement explicit visited set in inheritance traversal.
+- Add depth guard as a second safety net.
+- Ensure self-cycle and indirect-cycle class hierarchies cannot panic/overflow.
+
+### WP3: Wire UI to core APIs
+
+- Replace direct class/function AST traversal in `cmd/smalltalk-inspector/app/model.go` with calls into `pkg/inspector/core`.
+- Preserve current UI fields and behavior mapping.
+
+### WP4: Test hardening
+
+- Add core package tests for:
+  - self-cycle (`class A extends A`)
+  - indirect cycle (`A extends B`, `B extends A`)
+  - inherited method dedupe behavior.
+- Add command-level regression test ensuring `buildMembers` no longer panics on cycle input.
+
+### WP5: Validation and documentation
+
+- Run targeted and full test suites.
+- Update GOJA-031 diary/changelog/tasks with per-step results and commit IDs.
+
+## Acceptance Criteria
+
+1. No stack overflow for cyclic inheritance source.
+2. New core package exists and is used by smalltalk-inspector UI.
+3. Bubble Tea code no longer owns inheritance traversal internals.
+4. Tests cover the crash regression and pass.
+5. Ticket diary documents each implementation step.
+
+## Execution Sequence
+
+1. Create core package and move logic (WP1).
+2. Add safety guards (WP2).
+3. Integrate UI call sites (WP3).
+4. Add tests (WP4).
+5. Validate and document (WP5).

--- a/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/index.md
+++ b/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/index.md
@@ -1,7 +1,7 @@
 ---
 Title: Inspector Phase A Stabilization
 Ticket: GOJA-031-INSPECTOR-PHASE-A-STABILIZATION
-Status: active
+Status: complete
 Topics:
     - go
     - goja
@@ -22,10 +22,11 @@ RelatedFiles:
       Note: Core extraction target for non-UI logic
 ExternalSources: []
 Summary: Phase A stabilization ticket completed for recursion safety and core extraction from Bubble Tea UI, with regression coverage.
-LastUpdated: 2026-02-14T19:20:00Z
+LastUpdated: 2026-02-14T20:00:08.530531282-05:00
 WhatFor: Track implementation of safety and architecture-boundary improvements identified in GOJA-028.
 WhenToUse: Use as entrypoint for GOJA-031 execution and review.
 ---
+
 
 # Inspector Phase A Stabilization
 

--- a/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/index.md
+++ b/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/index.md
@@ -21,8 +21,8 @@ RelatedFiles:
     - Path: go-go-goja/pkg/inspector
       Note: Core extraction target for non-UI logic
 ExternalSources: []
-Summary: Phase A stabilization ticket to fix critical recursion crash and extract core inspector logic from Bubble Tea UI for future REST/CLI reuse.
-LastUpdated: 2026-02-14T19:10:00Z
+Summary: Phase A stabilization ticket completed for recursion safety and core extraction from Bubble Tea UI, with regression coverage.
+LastUpdated: 2026-02-14T19:20:00Z
 WhatFor: Track implementation of safety and architecture-boundary improvements identified in GOJA-028.
 WhenToUse: Use as entrypoint for GOJA-031 execution and review.
 ---
@@ -31,7 +31,7 @@ WhenToUse: Use as entrypoint for GOJA-031 execution and review.
 
 ## Overview
 
-This ticket implements Phase A stabilization work: fixing cyclic-inheritance crash risk, adding regression coverage, and separating core analysis functionality from UI/Bubble Tea concerns.
+This ticket implements Phase A stabilization work: fixing cyclic-inheritance crash risk, adding regression coverage, and separating core analysis functionality from UI/Bubble Tea concerns. The initial Phase A task set in `tasks.md` has been completed in this execution cycle.
 
 ## Key Links
 

--- a/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/index.md
+++ b/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/index.md
@@ -1,0 +1,70 @@
+---
+Title: Inspector Phase A Stabilization
+Ticket: GOJA-031-INSPECTOR-PHASE-A-STABILIZATION
+Status: active
+Topics:
+    - go
+    - goja
+    - tui
+    - inspector
+    - refactor
+DocType: index
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: go-go-goja/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/design/01-phase-a-implementation-plan.md
+      Note: Execution plan for this phase
+    - Path: go-go-goja/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/reference/01-diary.md
+      Note: Detailed implementation diary
+    - Path: go-go-goja/cmd/smalltalk-inspector/app/model.go
+      Note: UI code path consuming extracted core functionality
+    - Path: go-go-goja/pkg/inspector
+      Note: Core extraction target for non-UI logic
+ExternalSources: []
+Summary: Phase A stabilization ticket to fix critical recursion crash and extract core inspector logic from Bubble Tea UI for future REST/CLI reuse.
+LastUpdated: 2026-02-14T19:10:00Z
+WhatFor: Track implementation of safety and architecture-boundary improvements identified in GOJA-028.
+WhenToUse: Use as entrypoint for GOJA-031 execution and review.
+---
+
+# Inspector Phase A Stabilization
+
+## Overview
+
+This ticket implements Phase A stabilization work: fixing cyclic-inheritance crash risk, adding regression coverage, and separating core analysis functionality from UI/Bubble Tea concerns.
+
+## Key Links
+
+- Implementation plan: `design/01-phase-a-implementation-plan.md`
+- Diary: `reference/01-diary.md`
+- Tasks: `tasks.md`
+- Changelog: `changelog.md`
+
+## Status
+
+Current status: **active**
+
+## Topics
+
+- go
+- goja
+- tui
+- inspector
+- refactor
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/reference/01-diary.md
+++ b/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/reference/01-diary.md
@@ -82,3 +82,32 @@ go test ./pkg/inspector/core -count=1
 Outcome:
 
 - Core tests pass including self-cycle, indirect-cycle, and deep-chain bounds checks.
+
+## Step 4: Added command-level regression tests and ran full validation suite
+
+Added Bubble Tea command package regression tests:
+
+- `cmd/smalltalk-inspector/app/model_members_test.go`
+  - `TestBuildMembersSelfExtendsNoPanic`
+  - `TestBuildMembersIndirectCycleNoPanic`
+
+These tests exercise the UI-facing `buildMembers()` path directly so the previous stack-overflow class of bugs cannot silently re-enter through integration changes.
+
+Validation commands:
+
+```bash
+cd go-go-goja
+go test ./cmd/smalltalk-inspector/... -count=1
+go test ./pkg/inspector/... -count=1
+go test ./... -count=1
+```
+
+Outcome:
+
+- All tests passed.
+
+## Commit Trace (so far)
+
+1. `cc6fd92` — docs(GOJA-031): plan/tasks/diary scaffold
+2. `cd5227a` — inspector: extract member analysis into `pkg/inspector/core`
+3. `6d04d4b` — inspector/core: add bounded inheritance traversal safeguards

--- a/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/reference/01-diary.md
+++ b/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/reference/01-diary.md
@@ -1,0 +1,35 @@
+---
+Title: Diary
+Ticket: GOJA-031-INSPECTOR-PHASE-A-STABILIZATION
+Status: active
+Topics:
+    - go
+    - goja
+    - tui
+    - inspector
+    - refactor
+DocType: reference
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: go-go-goja/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/design/01-phase-a-implementation-plan.md
+      Note: Plan followed during implementation
+ExternalSources: []
+Summary: Implementation diary for GOJA-031 Phase A stabilization work.
+LastUpdated: 2026-02-14T19:10:00Z
+WhatFor: Preserve step-by-step execution, commands, and commit trace for Phase A implementation.
+WhenToUse: Use for review and reproducibility of GOJA-031 changes.
+---
+
+# Diary
+
+## Step 1: Ticket setup and plan
+
+Created GOJA-031 ticket workspace and authored implementation plan centered on Phase A stabilization.
+
+Scope locked for this ticket:
+
+1. Extract core non-UI member analysis from Bubble Tea command package.
+2. Fix inheritance recursion crash with cycle-safe traversal.
+3. Add regression tests.
+4. Keep UI package focused on orchestration.

--- a/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/reference/01-diary.md
+++ b/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/reference/01-diary.md
@@ -33,3 +33,33 @@ Scope locked for this ticket:
 2. Fix inheritance recursion crash with cycle-safe traversal.
 3. Add regression tests.
 4. Keep UI package focused on orchestration.
+
+## Step 2: Extracted non-UI member analysis into core package and rewired UI
+
+Implemented initial extraction of class/function member analysis from Bubble Tea model into a new UI-independent package:
+
+- `pkg/inspector/core/members.go`
+- `pkg/inspector/core/members_test.go`
+
+Changes made:
+
+1. Added core APIs for:
+   - `ClassExtends`
+   - `BuildClassMembers`
+   - `BuildFunctionMembers`
+2. Moved inheritance/member traversal logic out of `cmd/smalltalk-inspector/app/model.go`.
+3. Rewired UI model methods (`findClassExtends`, `buildClassMembers`, `buildFunctionMembers`) to call core package.
+4. Removed duplicated AST helper functions no longer needed in the UI package.
+
+Validation commands run:
+
+```bash
+cd go-go-goja
+go test ./pkg/inspector/core -count=1
+go test ./cmd/smalltalk-inspector/... -count=1
+go test ./pkg/inspector/... -count=1
+```
+
+Outcome:
+
+- Tests passed for the new core package and existing inspector packages.

--- a/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/reference/01-diary.md
+++ b/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/reference/01-diary.md
@@ -63,3 +63,22 @@ go test ./pkg/inspector/... -count=1
 Outcome:
 
 - Tests passed for the new core package and existing inspector packages.
+
+## Step 3: Added explicit depth guard + expanded core regression coverage
+
+Implemented a second safety net for inheritance traversal:
+
+1. Added `maxInheritanceDepth` guard in `pkg/inspector/core/members.go`.
+2. Updated recursive traversal to track `depth` and stop once limit is hit.
+3. Added deep-chain regression test in `pkg/inspector/core/members_test.go` to verify traversal remains bounded.
+
+Validation command:
+
+```bash
+cd go-go-goja
+go test ./pkg/inspector/core -count=1
+```
+
+Outcome:
+
+- Core tests pass including self-cycle, indirect-cycle, and deep-chain bounds checks.

--- a/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/tasks.md
+++ b/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/tasks.md
@@ -1,0 +1,14 @@
+# Tasks
+
+## TODO
+
+- [x] Create GOJA-031 ticket workspace
+- [x] Add Phase A implementation plan and diary scaffold
+
+- [ ] Extract class/function member analysis from Bubble Tea model into `pkg/inspector/core`
+- [ ] Add cycle-safe inheritance traversal (visited set + depth guard) in core layer
+- [ ] Rewire `cmd/smalltalk-inspector` member building to call core APIs
+- [ ] Add core regression tests for self/indirect inheritance cycles and inherited-member behavior
+- [ ] Add command-level regression test to ensure no panic on cyclic inheritance input
+- [ ] Run validation suite (`go test ./cmd/smalltalk-inspector/...`, `go test ./pkg/inspector/...`, `go test ./...`)
+- [ ] Update GOJA-031 diary/changelog/index with outcomes and commit references

--- a/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/tasks.md
+++ b/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/tasks.md
@@ -5,12 +5,10 @@
 - [x] Create GOJA-031 ticket workspace
 - [x] Add Phase A implementation plan and diary scaffold
 
-- [ ] Extract class/function member analysis from Bubble Tea model into `pkg/inspector/core`
-- [ ] Add cycle-safe inheritance traversal (visited set + depth guard) in core layer
 - [x] Extract class/function member analysis from Bubble Tea model into `pkg/inspector/core`
 - [x] Add cycle-safe inheritance traversal (visited set + depth guard) in core layer
 - [x] Rewire `cmd/smalltalk-inspector` member building to call core APIs
 - [x] Add core regression tests for self/indirect inheritance cycles and inherited-member behavior
-- [ ] Add command-level regression test to ensure no panic on cyclic inheritance input
-- [ ] Run validation suite (`go test ./cmd/smalltalk-inspector/...`, `go test ./pkg/inspector/...`, `go test ./...`)
-- [ ] Update GOJA-031 diary/changelog/index with outcomes and commit references
+- [x] Add command-level regression test to ensure no panic on cyclic inheritance input
+- [x] Run validation suite (`go test ./cmd/smalltalk-inspector/...`, `go test ./pkg/inspector/...`, `go test ./...`)
+- [x] Update GOJA-031 diary/changelog/index with outcomes and commit references

--- a/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/tasks.md
+++ b/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/tasks.md
@@ -7,7 +7,9 @@
 
 - [ ] Extract class/function member analysis from Bubble Tea model into `pkg/inspector/core`
 - [ ] Add cycle-safe inheritance traversal (visited set + depth guard) in core layer
-- [ ] Rewire `cmd/smalltalk-inspector` member building to call core APIs
+- [x] Extract class/function member analysis from Bubble Tea model into `pkg/inspector/core`
+- [ ] Add cycle-safe inheritance traversal (visited set + depth guard) in core layer
+- [x] Rewire `cmd/smalltalk-inspector` member building to call core APIs
 - [ ] Add core regression tests for self/indirect inheritance cycles and inherited-member behavior
 - [ ] Add command-level regression test to ensure no panic on cyclic inheritance input
 - [ ] Run validation suite (`go test ./cmd/smalltalk-inspector/...`, `go test ./pkg/inspector/...`, `go test ./...`)

--- a/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/tasks.md
+++ b/ttmp/2026/02/14/GOJA-031-INSPECTOR-PHASE-A-STABILIZATION--inspector-phase-a-stabilization/tasks.md
@@ -8,9 +8,9 @@
 - [ ] Extract class/function member analysis from Bubble Tea model into `pkg/inspector/core`
 - [ ] Add cycle-safe inheritance traversal (visited set + depth guard) in core layer
 - [x] Extract class/function member analysis from Bubble Tea model into `pkg/inspector/core`
-- [ ] Add cycle-safe inheritance traversal (visited set + depth guard) in core layer
+- [x] Add cycle-safe inheritance traversal (visited set + depth guard) in core layer
 - [x] Rewire `cmd/smalltalk-inspector` member building to call core APIs
-- [ ] Add core regression tests for self/indirect inheritance cycles and inherited-member behavior
+- [x] Add core regression tests for self/indirect inheritance cycles and inherited-member behavior
 - [ ] Add command-level regression test to ensure no panic on cyclic inheritance input
 - [ ] Run validation suite (`go test ./cmd/smalltalk-inspector/...`, `go test ./pkg/inspector/...`, `go test ./...`)
 - [ ] Update GOJA-031 diary/changelog/index with outcomes and commit references

--- a/ttmp/2026/02/15/GOJA-032-ANALYSIS-INTEGRATION--smalltalk-inspector-analysis-session-integration/README.md
+++ b/ttmp/2026/02/15/GOJA-032-ANALYSIS-INTEGRATION--smalltalk-inspector-analysis-session-integration/README.md
@@ -1,0 +1,21 @@
+# Smalltalk Inspector Analysis Session Integration
+
+This is the document workspace for ticket GOJA-032-ANALYSIS-INTEGRATION.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr doc add --ticket GOJA-032-ANALYSIS-INTEGRATION --doc-type design-doc --title "My Design"`
+- Import sources: `docmgr import file --ticket GOJA-032-ANALYSIS-INTEGRATION --file /path/to/doc.md`
+- Update metadata: `docmgr meta update --ticket GOJA-032-ANALYSIS-INTEGRATION --field Status --value review`

--- a/ttmp/2026/02/15/GOJA-032-ANALYSIS-INTEGRATION--smalltalk-inspector-analysis-session-integration/changelog.md
+++ b/ttmp/2026/02/15/GOJA-032-ANALYSIS-INTEGRATION--smalltalk-inspector-analysis-session-integration/changelog.md
@@ -40,3 +40,14 @@ Step 3: Migrated smalltalk static-analysis callsites (globals/members/jumps/stat
 - /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/cmd/smalltalk-inspector/app/view.go — Status parse-error check now uses analysis session
 - /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/15/GOJA-032-ANALYSIS-INTEGRATION--smalltalk-inspector-analysis-session-integration/reference/01-diary.md — Recorded Step 2 diary
 
+
+## 2026-02-15
+
+Step 4: Added mixed static/runtime behavior tests, ran full regression suite, and linked GOJA-028 task #13 execution handoff to GOJA-032.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/cmd/smalltalk-inspector/app/model_members_test.go — Added runtime-derived and session-backed jump behavior tests
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-028-CLEANUP-INSPECTOR--cleanup-inspector/changelog.md — Cross-ticket handoff note for extracted task #13
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/15/GOJA-032-ANALYSIS-INTEGRATION--smalltalk-inspector-analysis-session-integration/reference/01-diary.md — Recorded Step 3 completion diary
+

--- a/ttmp/2026/02/15/GOJA-032-ANALYSIS-INTEGRATION--smalltalk-inspector-analysis-session-integration/changelog.md
+++ b/ttmp/2026/02/15/GOJA-032-ANALYSIS-INTEGRATION--smalltalk-inspector-analysis-session-integration/changelog.md
@@ -51,3 +51,8 @@ Step 4: Added mixed static/runtime behavior tests, ran full regression suite, an
 - /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/14/GOJA-028-CLEANUP-INSPECTOR--cleanup-inspector/changelog.md — Cross-ticket handoff note for extracted task #13
 - /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/15/GOJA-032-ANALYSIS-INTEGRATION--smalltalk-inspector-analysis-session-integration/reference/01-diary.md — Recorded Step 3 completion diary
 
+
+## 2026-02-15
+
+Ticket closed
+

--- a/ttmp/2026/02/15/GOJA-032-ANALYSIS-INTEGRATION--smalltalk-inspector-analysis-session-integration/changelog.md
+++ b/ttmp/2026/02/15/GOJA-032-ANALYSIS-INTEGRATION--smalltalk-inspector-analysis-session-integration/changelog.md
@@ -1,0 +1,29 @@
+# Changelog
+
+## 2026-02-15
+
+- Initial workspace created
+
+
+## 2026-02-15
+
+Step 1: Added detailed implementation guide and task breakdown to execute GOJA-028 task #13 as a dedicated ticket.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/15/GOJA-032-ANALYSIS-INTEGRATION--smalltalk-inspector-analysis-session-integration/design/01-implementation-guide-integrate-pkg-inspector-analysis-into-smalltalk-inspector.md — Primary implementation guide
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/15/GOJA-032-ANALYSIS-INTEGRATION--smalltalk-inspector-analysis-session-integration/index.md — Ticket overview and objective context
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/15/GOJA-032-ANALYSIS-INTEGRATION--smalltalk-inspector-analysis-session-integration/tasks.md — Detailed execution tasks and done criteria
+
+
+## 2026-02-15
+
+Step 2: Added analysis-session APIs for globals/members/source-jump metadata and added unit tests.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/pkg/inspector/analysis/session.go — Added shared rootScope helper
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/pkg/inspector/analysis/smalltalk_session.go — New analysis-session API surface for smalltalk integration
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/pkg/inspector/analysis/smalltalk_session_test.go — Unit tests for sorting/membership/decl-line lookups
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/15/GOJA-032-ANALYSIS-INTEGRATION--smalltalk-inspector-analysis-session-integration/reference/01-diary.md — Recorded Step 1 implementation diary
+

--- a/ttmp/2026/02/15/GOJA-032-ANALYSIS-INTEGRATION--smalltalk-inspector-analysis-session-integration/changelog.md
+++ b/ttmp/2026/02/15/GOJA-032-ANALYSIS-INTEGRATION--smalltalk-inspector-analysis-session-integration/changelog.md
@@ -27,3 +27,16 @@ Step 2: Added analysis-session APIs for globals/members/source-jump metadata and
 - /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/pkg/inspector/analysis/smalltalk_session_test.go — Unit tests for sorting/membership/decl-line lookups
 - /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/15/GOJA-032-ANALYSIS-INTEGRATION--smalltalk-inspector-analysis-session-integration/reference/01-diary.md — Recorded Step 1 implementation diary
 
+
+## 2026-02-15
+
+Step 3: Migrated smalltalk static-analysis callsites (globals/members/jumps/status parse check) to analysis session APIs.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/cmd/smalltalk-inspector/app/model.go — Moved globals/members/jump static-analysis access to session methods
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/cmd/smalltalk-inspector/app/model_members_test.go — Test fixture setup now initializes analysis session
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/cmd/smalltalk-inspector/app/update.go — Initialized analysis session during file load
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/cmd/smalltalk-inspector/app/view.go — Status parse-error check now uses analysis session
+- /home/manuel/workspaces/2026-02-14/smalltalk-inspector/go-go-goja/ttmp/2026/02/15/GOJA-032-ANALYSIS-INTEGRATION--smalltalk-inspector-analysis-session-integration/reference/01-diary.md — Recorded Step 2 diary
+

--- a/ttmp/2026/02/15/GOJA-032-ANALYSIS-INTEGRATION--smalltalk-inspector-analysis-session-integration/design/01-implementation-guide-integrate-pkg-inspector-analysis-into-smalltalk-inspector.md
+++ b/ttmp/2026/02/15/GOJA-032-ANALYSIS-INTEGRATION--smalltalk-inspector-analysis-session-integration/design/01-implementation-guide-integrate-pkg-inspector-analysis-into-smalltalk-inspector.md
@@ -1,0 +1,184 @@
+---
+Title: 'Implementation Guide: Integrate pkg/inspector/analysis into smalltalk-inspector'
+Ticket: GOJA-032-ANALYSIS-INTEGRATION
+Status: active
+Topics:
+    - go
+    - goja
+    - inspector
+    - refactor
+    - tui
+DocType: design
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: cmd/smalltalk-inspector/app/model.go
+      Note: Current UI-level static analysis traversal that will migrate to analysis session methods
+    - Path: cmd/smalltalk-inspector/app/update.go
+      Note: File-load and state transition points impacted by analysis session wiring
+    - Path: pkg/inspector/analysis/session.go
+      Note: Existing session wrapper to extend
+    - Path: pkg/inspector/core/members.go
+      Note: Reusable member extraction primitives consumed by analysis layer
+ExternalSources: []
+Summary: Detailed implementation guide for extracting smalltalk-inspector static-analysis access behind pkg/inspector/analysis session APIs.
+LastUpdated: 2026-02-15T00:45:00Z
+WhatFor: 'Break out GOJA-028 task #13 into an explicit plan that reduces UI coupling to jsparse internals and enables reuse from future CLI/REST frontends.'
+WhenToUse: Use when implementing or reviewing analysis-layer integration work for smalltalk-inspector.
+---
+
+
+# Implementation Guide: Integrate pkg/inspector/analysis into smalltalk-inspector
+
+## Goal
+
+Move `cmd/smalltalk-inspector` from direct `jsparse.AnalysisResult` graph access to `pkg/inspector/analysis` session APIs, so analysis behavior is reusable and UI-independent.
+
+This ticket is the extracted implementation work for GOJA-028 task `#13`.
+
+## Problem Statement
+
+Current `smalltalk-inspector` code still reaches directly into:
+
+- `analysis.Resolution.Scopes[...]`
+- `analysis.Index.Nodes[...]`
+- `analysis.Program.Body`
+
+This creates three problems:
+
+1. UI package owns domain traversal logic.
+2. Analysis behavior is harder to reuse from non-TUI surfaces.
+3. Future parser/index changes require broad UI edits.
+
+## Existing Architecture Snapshot
+
+### Current flow
+
+1. `loadFile` runs `jsparse.Analyze(...)`.
+2. Result is stored in `Model.analysis` (`*jsparse.AnalysisResult`).
+3. UI model methods use raw result internals for:
+- globals list construction,
+- class/function member lookup,
+- source jump targets.
+
+### Existing reusable pieces
+
+- `pkg/inspector/core` already provides:
+- `BuildClassMembers(...)`
+- `BuildFunctionMembers(...)`
+- `ClassExtends(...)`
+- `pkg/inspector/analysis` already provides:
+- `Session` wrapper around `AnalysisResult`,
+- baseline xref/method-symbol helpers.
+
+## Target Architecture
+
+### Layering
+
+1. `cmd/smalltalk-inspector/app` (UI orchestration):
+- calls analysis-session methods only.
+2. `pkg/inspector/analysis` (domain API):
+- exposes stable methods for globals/members/jump metadata.
+3. `pkg/jsparse` (parsing/index engine):
+- remains an implementation dependency of analysis layer, not UI.
+
+### New/expanded analysis-session API
+
+Add methods on `pkg/inspector/analysis.Session` (or small helper types in same package):
+
+1. `Globals() []GlobalBinding`
+- sorted class/function/value,
+- includes extends name when known.
+
+2. `BindingDeclLine(name string) (line int, ok bool)`
+- for global declaration jumps.
+
+3. `ClassMembers(className string) []core.Member`
+- delegates to `pkg/inspector/core`.
+
+4. `FunctionMembers(funcName string) []core.Member`
+- delegates to `pkg/inspector/core`.
+
+5. `MemberDeclLine(className, memberName string) (line int, ok bool)`
+- encapsulates AST/index traversal currently in UI.
+
+6. `ParseError() error`
+- lightweight status access for UI status bar decisions.
+
+The UI keeps runtime-only value inspection behavior in place (that part is not static analysis).
+
+## Migration Plan
+
+## Phase 1: Add analysis APIs + tests
+
+1. Extend `pkg/inspector/analysis` with the methods above.
+2. Add unit tests for:
+- globals sorting semantics,
+- class/function member extraction wiring,
+- declaration line resolution and not-found behavior.
+3. Keep methods deterministic and nil-safe.
+
+## Phase 2: Switch smalltalk model state
+
+1. Introduce `analysisSession *analysis.Session` in smalltalk model.
+2. Set session in file-load path using `analysis.NewSessionFromResult(...)` (or direct constructor).
+3. Keep existing `*jsparse.AnalysisResult` temporarily for compatibility while migrating method call sites.
+
+## Phase 3: Replace direct graph access call sites
+
+Refactor these areas to use analysis-session methods:
+
+1. `buildGlobals`
+2. `buildClassMembers`
+3. `buildFunctionMembers`
+4. `jumpToBinding`
+5. `jumpToMember`
+6. status parse-error check
+
+Remove UI-level direct scope/index traversal once equivalent session methods exist.
+
+## Phase 4: Remove compatibility fields and harden
+
+1. Remove leftover `Model.analysis` usage where session fully covers static-analysis needs.
+2. Ensure runtime-only paths remain unchanged:
+- runtime value inspection,
+- REPL evaluation/stack inspection.
+3. Update docs and related ticket references (GOJA-028, GOJA-032).
+
+## Testing Strategy
+
+Required:
+
+1. `go test ./pkg/inspector/analysis -count=1`
+2. `go test ./cmd/smalltalk-inspector/... -count=1`
+3. `go test ./cmd/inspector/... -count=1`
+4. `go test ./... -count=1`
+
+Add or update smalltalk tests to verify:
+
+1. globals list behavior is unchanged,
+2. class/function member list behavior is unchanged,
+3. source jump behavior remains correct.
+
+## Risk and Mitigations
+
+1. Risk: semantic drift in globals/member ordering.
+- Mitigation: snapshot-like tests on representative source fixtures.
+
+2. Risk: line mapping regressions for source jumps.
+- Mitigation: method-level tests for `BindingDeclLine` and `MemberDeclLine`.
+
+3. Risk: partial migration leaving mixed abstractions.
+- Mitigation: explicit checklist in tasks; do not close ticket until direct graph reads are removed from smalltalk app static-analysis paths.
+
+## Out of Scope
+
+1. Runtime value inspection redesign.
+2. Syntax-highlighting algorithm optimization (GOJA-030 scope).
+3. Command parser improvements for `:load`.
+
+## Deliverables
+
+1. New analysis-session API surface with tests.
+2. Smalltalk inspector using session methods for static analysis paths.
+3. Updated docs/tasks/changelog in GOJA-032 and cross-reference note in GOJA-028.

--- a/ttmp/2026/02/15/GOJA-032-ANALYSIS-INTEGRATION--smalltalk-inspector-analysis-session-integration/index.md
+++ b/ttmp/2026/02/15/GOJA-032-ANALYSIS-INTEGRATION--smalltalk-inspector-analysis-session-integration/index.md
@@ -1,7 +1,7 @@
 ---
 Title: Smalltalk Inspector Analysis Session Integration
 Ticket: GOJA-032-ANALYSIS-INTEGRATION
-Status: active
+Status: complete
 Topics:
     - go
     - goja
@@ -13,11 +13,12 @@ Intent: long-term
 Owners: []
 RelatedFiles: []
 ExternalSources: []
-Summary: Execution ticket for extracting GOJA-028 task #13 into a dedicated implementation stream that integrates pkg/inspector/analysis with smalltalk-inspector.
-LastUpdated: 2026-02-15T00:45:00Z
+Summary: 'Execution ticket for extracting GOJA-028 task #13 into a dedicated implementation stream that integrates pkg/inspector/analysis with smalltalk-inspector.'
+LastUpdated: 2026-02-15T09:18:30.686187497-05:00
 WhatFor: Isolate analysis-layer integration work from broader cleanup tasks and provide a clear implementation path.
 WhenToUse: Use when implementing, reviewing, or tracking analysis-session integration in smalltalk-inspector.
 ---
+
 
 # Smalltalk Inspector Analysis Session Integration
 

--- a/ttmp/2026/02/15/GOJA-032-ANALYSIS-INTEGRATION--smalltalk-inspector-analysis-session-integration/index.md
+++ b/ttmp/2026/02/15/GOJA-032-ANALYSIS-INTEGRATION--smalltalk-inspector-analysis-session-integration/index.md
@@ -1,0 +1,68 @@
+---
+Title: Smalltalk Inspector Analysis Session Integration
+Ticket: GOJA-032-ANALYSIS-INTEGRATION
+Status: active
+Topics:
+    - go
+    - goja
+    - inspector
+    - refactor
+    - tui
+DocType: index
+Intent: long-term
+Owners: []
+RelatedFiles: []
+ExternalSources: []
+Summary: Execution ticket for extracting GOJA-028 task #13 into a dedicated implementation stream that integrates pkg/inspector/analysis with smalltalk-inspector.
+LastUpdated: 2026-02-15T00:45:00Z
+WhatFor: Isolate analysis-layer integration work from broader cleanup tasks and provide a clear implementation path.
+WhenToUse: Use when implementing, reviewing, or tracking analysis-session integration in smalltalk-inspector.
+---
+
+# Smalltalk Inspector Analysis Session Integration
+
+## Overview
+
+This ticket isolates GOJA-028 cleanup task `#13` into a dedicated implementation effort.
+
+Primary objective:
+
+- route smalltalk-inspector static-analysis behavior through `pkg/inspector/analysis` instead of direct `jsparse` graph traversal in UI code.
+
+Implementation guide:
+
+- `design/01-implementation-guide-integrate-pkg-inspector-analysis-into-smalltalk-inspector.md`
+
+## Key Links
+
+- **Related Files**: See frontmatter RelatedFiles field
+- **External Sources**: See frontmatter ExternalSources field
+
+## Status
+
+Current status: **active**
+
+## Topics
+
+- go
+- goja
+- inspector
+- refactor
+- tui
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/2026/02/15/GOJA-032-ANALYSIS-INTEGRATION--smalltalk-inspector-analysis-session-integration/reference/01-diary.md
+++ b/ttmp/2026/02/15/GOJA-032-ANALYSIS-INTEGRATION--smalltalk-inspector-analysis-session-integration/reference/01-diary.md
@@ -12,6 +12,14 @@ DocType: reference
 Intent: long-term
 Owners: []
 RelatedFiles:
+    - Path: cmd/smalltalk-inspector/app/model.go
+      Note: Session-backed static-analysis migration
+    - Path: cmd/smalltalk-inspector/app/model_members_test.go
+      Note: Updated tests for session-backed model
+    - Path: cmd/smalltalk-inspector/app/update.go
+      Note: Session initialization in load path
+    - Path: cmd/smalltalk-inspector/app/view.go
+      Note: Session-backed parse-error status wiring
     - Path: pkg/inspector/analysis/session.go
       Note: Root-scope helper introduced for session API layering
     - Path: pkg/inspector/analysis/smalltalk_session.go
@@ -24,6 +32,7 @@ LastUpdated: 2026-02-15T05:50:00Z
 WhatFor: Track implementation progress, rationale, validation outputs, and review handoff notes.
 WhenToUse: Use while executing GOJA-032 tasks and when reviewing integration decisions.
 ---
+
 
 
 # Diary
@@ -106,3 +115,83 @@ I validated this slice with package tests before moving on to model integration.
 ### Technical details
 
 - `MemberDeclLine(...)` accepts both `className` and optional `sourceClass` to support inherited-member jump behavior without forcing UI AST traversal.
+
+## Step 2: Migrate smalltalk model callsites to analysis session
+
+Migrated smalltalk-inspector static-analysis callsites from direct `AnalysisResult` graph traversal to `analysis.Session` methods. This includes globals construction, class/function member population, and source jump resolution for bindings/members.
+
+Runtime paths were intentionally left intact; only static-analysis access routes changed in this slice.
+
+### Prompt Context
+
+**User prompt (verbatim):** "continue"
+
+**Assistant interpretation:** Continue execution and progress GOJA-032 in incremental, committed slices.
+
+**Inferred user intent:** Keep moving through the implementation plan with concrete, validated milestones.
+
+### What I did
+
+- Added `session *analysis.Session` field to smalltalk model.
+- Initialized session on file-load (`NewSessionFromResult`) in update path.
+- Replaced direct static-analysis access in model methods:
+  - `buildGlobals`
+  - `buildMembers`
+  - `buildClassMembers`
+  - `buildFunctionMembers`
+  - `jumpToBinding`
+  - `jumpToMember`
+- Updated status rendering to use `session.ParseError()`.
+- Updated model tests (`model_members_test.go`) to initialize the analysis session.
+- Removed now-obsolete AST helper and direct raw graph reads for migrated paths.
+- Ran:
+  - `go test ./pkg/inspector/analysis -count=1`
+  - `go test ./cmd/smalltalk-inspector/... -count=1`
+  - `go test ./cmd/inspector/... -count=1`
+
+### Why
+
+- This is the core integration work required by GOJA-032 to decouple UI from `Resolution.Scopes` and `Index.Nodes`.
+
+### What worked
+
+- Migration compiled cleanly and focused tests passed.
+- `cmd/smalltalk-inspector` no longer directly reads `Resolution.Scopes` / `Index.Nodes` for globals/members/jumps.
+
+### What didn't work
+
+- N/A in this slice.
+
+### What I learned
+
+- The new session API was sufficient to replace all targeted static-analysis callsites without touching runtime inspection logic.
+
+### What was tricky to build
+
+- Preserving existing jump semantics for inherited members required carrying `member.Source` through `MemberDeclLine(...)` instead of flattening lookup to a single class name.
+
+### What warrants a second pair of eyes
+
+- Verify member jump behavior for class fields/computed members still matches intended behavior after delegation.
+
+### What should be done in the future
+
+- Run full-repo regression pass and close remaining GOJA-032 tasks.
+- Add GOJA-028 cross-reference/handoff update.
+
+### Code review instructions
+
+- Start with:
+  - `cmd/smalltalk-inspector/app/model.go`
+  - `cmd/smalltalk-inspector/app/update.go`
+  - `cmd/smalltalk-inspector/app/view.go`
+- Then verify test adjustments:
+  - `cmd/smalltalk-inspector/app/model_members_test.go`
+- Validate with:
+  - `go test ./pkg/inspector/analysis -count=1`
+  - `go test ./cmd/smalltalk-inspector/... -count=1`
+  - `go test ./cmd/inspector/... -count=1`
+
+### Technical details
+
+- Direct `m.analysis` remains only for runtime function-to-source mapping in inspect flow; static-analysis UI traversal now goes through `m.session`.

--- a/ttmp/2026/02/15/GOJA-032-ANALYSIS-INTEGRATION--smalltalk-inspector-analysis-session-integration/reference/01-diary.md
+++ b/ttmp/2026/02/15/GOJA-032-ANALYSIS-INTEGRATION--smalltalk-inspector-analysis-session-integration/reference/01-diary.md
@@ -15,7 +15,9 @@ RelatedFiles:
     - Path: cmd/smalltalk-inspector/app/model.go
       Note: Session-backed static-analysis migration
     - Path: cmd/smalltalk-inspector/app/model_members_test.go
-      Note: Updated tests for session-backed model
+      Note: |-
+        Updated tests for session-backed model
+        Mixed runtime/static behavior and jump tests for final verification
     - Path: cmd/smalltalk-inspector/app/update.go
       Note: Session initialization in load path
     - Path: cmd/smalltalk-inspector/app/view.go
@@ -26,12 +28,15 @@ RelatedFiles:
       Note: New analysis-session integration methods
     - Path: pkg/inspector/analysis/smalltalk_session_test.go
       Note: API behavior tests for GOJA-032 phase 1
+    - Path: ttmp/2026/02/14/GOJA-028-CLEANUP-INSPECTOR--cleanup-inspector/changelog.md
+      Note: GOJA-028 cross-ticket handoff entry
 ExternalSources: []
 Summary: Execution diary for GOJA-032 implementation slices.
 LastUpdated: 2026-02-15T05:50:00Z
 WhatFor: Track implementation progress, rationale, validation outputs, and review handoff notes.
 WhenToUse: Use while executing GOJA-032 tasks and when reviewing integration decisions.
 ---
+
 
 
 
@@ -195,3 +200,74 @@ Runtime paths were intentionally left intact; only static-analysis access routes
 ### Technical details
 
 - Direct `m.analysis` remains only for runtime function-to-source mapping in inspect flow; static-analysis UI traversal now goes through `m.session`.
+
+## Step 3: Runtime-compat verification, full regression, and GOJA-028 cross-reference
+
+Added targeted tests for mixed static/runtime behavior and jump semantics, then ran full regression. After verification, I updated GOJA-028 changelog to explicitly point task #13 execution to GOJA-032 as the extracted implementation ticket.
+
+This closes all remaining GOJA-032 tasks except bookkeeping finalization for this step.
+
+### Prompt Context
+
+**User prompt (verbatim):** (see Step 2)
+
+**Assistant interpretation:** Continue executing the ticket and finish remaining tasks with commits and diary updates.
+
+**Inferred user intent:** Complete the integration ticket end-to-end with explicit validation and documentation traceability.
+
+### What I did
+
+- Added tests in `cmd/smalltalk-inspector/app/model_members_test.go` for:
+  - runtime-derived value member behavior (`buildValueMembers` path),
+  - session-backed binding/member source jumps.
+- Ran verification suite:
+  - `go test ./cmd/smalltalk-inspector/... -count=1`
+  - `go test ./cmd/inspector/... -count=1`
+  - `go test ./pkg/inspector/analysis -count=1`
+  - `go test ./... -count=1`
+- Added GOJA-028 cross-reference changelog entry indicating task `#13` execution in GOJA-032.
+
+### Why
+
+- GOJA-032 required proof that runtime-only behavior remained stable and that full regression remained clean.
+- GOJA-028 backlog needed an explicit cross-ticket handoff/completion note.
+
+### What worked
+
+- All tests passed across focused and full-repo runs.
+- Cross-ticket handoff note is now recorded in GOJA-028 changelog.
+
+### What didn't work
+
+- N/A in this slice.
+
+### What I learned
+
+- Session migration can preserve runtime behavior cleanly when static-analysis and runtime concerns are kept separated in model methods and tests.
+
+### What was tricky to build
+
+- Ensuring test coverage hit both static-analysis-backed and runtime-derived member flows without introducing brittle UI-render assertions.
+
+### What warrants a second pair of eyes
+
+- Confirm there are no desired further opportunities to reduce remaining `m.analysis` usage (currently retained for runtime function mapping only).
+
+### What should be done in the future
+
+- If desired, close GOJA-032 after commit.
+- Optionally back-propagate task status updates into GOJA-028 task list items tied to this extraction.
+
+### Code review instructions
+
+- Start with new tests in `cmd/smalltalk-inspector/app/model_members_test.go`.
+- Review cross-ticket documentation update in `ttmp/2026/02/14/GOJA-028-CLEANUP-INSPECTOR--cleanup-inspector/changelog.md`.
+- Re-run:
+  - `go test ./cmd/smalltalk-inspector/... -count=1`
+  - `go test ./cmd/inspector/... -count=1`
+  - `go test ./pkg/inspector/analysis -count=1`
+  - `go test ./... -count=1`
+
+### Technical details
+
+- GOJA-032 now verifies both static analysis integration and runtime-member continuity with tests instead of relying only on manual behavior checks.

--- a/ttmp/2026/02/15/GOJA-032-ANALYSIS-INTEGRATION--smalltalk-inspector-analysis-session-integration/reference/01-diary.md
+++ b/ttmp/2026/02/15/GOJA-032-ANALYSIS-INTEGRATION--smalltalk-inspector-analysis-session-integration/reference/01-diary.md
@@ -1,0 +1,108 @@
+---
+Title: Diary
+Ticket: GOJA-032-ANALYSIS-INTEGRATION
+Status: active
+Topics:
+    - go
+    - goja
+    - inspector
+    - refactor
+    - tui
+DocType: reference
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: pkg/inspector/analysis/session.go
+      Note: Root-scope helper introduced for session API layering
+    - Path: pkg/inspector/analysis/smalltalk_session.go
+      Note: New analysis-session integration methods
+    - Path: pkg/inspector/analysis/smalltalk_session_test.go
+      Note: API behavior tests for GOJA-032 phase 1
+ExternalSources: []
+Summary: Execution diary for GOJA-032 implementation slices.
+LastUpdated: 2026-02-15T05:50:00Z
+WhatFor: Track implementation progress, rationale, validation outputs, and review handoff notes.
+WhenToUse: Use while executing GOJA-032 tasks and when reviewing integration decisions.
+---
+
+
+# Diary
+
+## Goal
+
+Capture step-by-step implementation of GOJA-032, including code changes, tests, and ticket bookkeeping.
+
+## Step 1: Add analysis-session APIs for smalltalk static-analysis paths
+
+Implemented the first execution slice by expanding `pkg/inspector/analysis` with methods required to remove direct smalltalk UI dependency on raw `jsparse` graph access. This slice only touches analysis package code and tests, keeping migration risk isolated.
+
+I validated this slice with package tests before moving on to model integration.
+
+### Prompt Context
+
+**User prompt (verbatim):** "alright, go ahead, commit at appropriate intervals, keep your diary"
+
+**Assistant interpretation:** Execute GOJA-032 implementation in incremental commit-sized slices and keep an explicit implementation diary.
+
+**Inferred user intent:** Maintain momentum with traceable, low-risk refactor steps and clear review artifacts.
+
+### What I did
+
+- Added `pkg/inspector/analysis/smalltalk_session.go` with new APIs:
+  - `ParseError()`
+  - `Program()`
+  - `Index()`
+  - `Globals()`
+  - `ClassMembers(...)`
+  - `FunctionMembers(...)`
+  - `BindingDeclLine(...)`
+  - `MemberDeclLine(...)`
+- Updated `pkg/inspector/analysis/session.go` with `rootScope()` helper and reused it in `GlobalBindings()`.
+- Added `pkg/inspector/analysis/smalltalk_session_test.go` for:
+  - globals ordering + extends metadata,
+  - binding/member declaration line lookups,
+  - class/function member accessors,
+  - parse-error accessor behavior.
+- Ran:
+  - `go test ./pkg/inspector/analysis -count=1`
+
+### Why
+
+- GOJA-032 tasks 1 and 2 require a stable analysis-session API before migrating smalltalk UI callsites.
+- This creates a reusable domain layer for later CLI/REST exposure and reduces UI coupling.
+
+### What worked
+
+- New analysis API compiles and package tests pass.
+- Existing `Session` behavior remains backward-compatible.
+
+### What didn't work
+
+- N/A in this slice.
+
+### What I learned
+
+- A small `Session` API expansion can cover most smalltalk static-analysis needs without exposing raw scope/index maps directly to UI code.
+
+### What was tricky to build
+
+- Preserving old ordering semantics (class > function > value + alphabetical tie-break) while moving logic behind analysis-session methods.
+
+### What warrants a second pair of eyes
+
+- Review naming/shape of new session methods to ensure they are generic enough for other frontends and not overfit to current TUI behavior.
+
+### What should be done in the future
+
+- Migrate smalltalk model callsites to these methods (next slice).
+
+### Code review instructions
+
+- Start with `pkg/inspector/analysis/smalltalk_session.go`.
+- Then review `pkg/inspector/analysis/smalltalk_session_test.go` coverage quality.
+- Validate with:
+  - `go test ./pkg/inspector/analysis -count=1`
+
+### Technical details
+
+- `MemberDeclLine(...)` accepts both `className` and optional `sourceClass` to support inherited-member jump behavior without forcing UI AST traversal.

--- a/ttmp/2026/02/15/GOJA-032-ANALYSIS-INTEGRATION--smalltalk-inspector-analysis-session-integration/tasks.md
+++ b/ttmp/2026/02/15/GOJA-032-ANALYSIS-INTEGRATION--smalltalk-inspector-analysis-session-integration/tasks.md
@@ -8,15 +8,15 @@
 - [x] Migrate `buildGlobals` to consume analysis-session API (remove direct root-scope traversal from UI)
 - [x] Migrate class/function member builders to analysis-session API
 - [x] Migrate source jump helpers (`jumpToBinding`, `jumpToMember`) to analysis-session API
-- [ ] Keep runtime-only inspection paths unchanged and verify mixed static/runtime behavior
+- [x] Keep runtime-only inspection paths unchanged and verify mixed static/runtime behavior
 - [x] Remove obsolete direct `jsparse` graph reads from smalltalk-inspector static-analysis paths
-- [ ] Run regression suite: `pkg/inspector/analysis`, `cmd/smalltalk-inspector`, `cmd/inspector`, `go test ./...`
-- [ ] Update GOJA-032 changelog + diary with milestone notes and verification outputs
-- [ ] Add GOJA-028 cross-reference update noting GOJA-032 execution handoff/completion
+- [x] Run regression suite: `pkg/inspector/analysis`, `cmd/smalltalk-inspector`, `cmd/inspector`, `go test ./...`
+- [x] Update GOJA-032 changelog + diary with milestone notes and verification outputs
+- [x] Add GOJA-028 cross-reference update noting GOJA-032 execution handoff/completion
 
 ## Done Criteria
 
 - [x] Smalltalk inspector static-analysis behavior is served via `pkg/inspector/analysis` session methods
 - [x] No direct UI dependency on `Resolution.Scopes` / `Index.Nodes` for migrated paths
-- [ ] Existing globals/members/jump behavior remains stable by tests
-- [ ] Full regression suite passes
+- [x] Existing globals/members/jump behavior remains stable by tests
+- [x] Full regression suite passes

--- a/ttmp/2026/02/15/GOJA-032-ANALYSIS-INTEGRATION--smalltalk-inspector-analysis-session-integration/tasks.md
+++ b/ttmp/2026/02/15/GOJA-032-ANALYSIS-INTEGRATION--smalltalk-inspector-analysis-session-integration/tasks.md
@@ -4,19 +4,19 @@
 
 - [x] Add/expand analysis session API in `pkg/inspector/analysis` for globals, members, and source-jump metadata
 - [x] Add unit tests for new analysis-session methods (sorting, membership, declaration line lookup)
-- [ ] Introduce `analysisSession` field in smalltalk-inspector model and initialize on file load
-- [ ] Migrate `buildGlobals` to consume analysis-session API (remove direct root-scope traversal from UI)
-- [ ] Migrate class/function member builders to analysis-session API
-- [ ] Migrate source jump helpers (`jumpToBinding`, `jumpToMember`) to analysis-session API
+- [x] Introduce `analysisSession` field in smalltalk-inspector model and initialize on file load
+- [x] Migrate `buildGlobals` to consume analysis-session API (remove direct root-scope traversal from UI)
+- [x] Migrate class/function member builders to analysis-session API
+- [x] Migrate source jump helpers (`jumpToBinding`, `jumpToMember`) to analysis-session API
 - [ ] Keep runtime-only inspection paths unchanged and verify mixed static/runtime behavior
-- [ ] Remove obsolete direct `jsparse` graph reads from smalltalk-inspector static-analysis paths
+- [x] Remove obsolete direct `jsparse` graph reads from smalltalk-inspector static-analysis paths
 - [ ] Run regression suite: `pkg/inspector/analysis`, `cmd/smalltalk-inspector`, `cmd/inspector`, `go test ./...`
 - [ ] Update GOJA-032 changelog + diary with milestone notes and verification outputs
 - [ ] Add GOJA-028 cross-reference update noting GOJA-032 execution handoff/completion
 
 ## Done Criteria
 
-- [ ] Smalltalk inspector static-analysis behavior is served via `pkg/inspector/analysis` session methods
-- [ ] No direct UI dependency on `Resolution.Scopes` / `Index.Nodes` for migrated paths
+- [x] Smalltalk inspector static-analysis behavior is served via `pkg/inspector/analysis` session methods
+- [x] No direct UI dependency on `Resolution.Scopes` / `Index.Nodes` for migrated paths
 - [ ] Existing globals/members/jump behavior remains stable by tests
 - [ ] Full regression suite passes

--- a/ttmp/2026/02/15/GOJA-032-ANALYSIS-INTEGRATION--smalltalk-inspector-analysis-session-integration/tasks.md
+++ b/ttmp/2026/02/15/GOJA-032-ANALYSIS-INTEGRATION--smalltalk-inspector-analysis-session-integration/tasks.md
@@ -1,0 +1,22 @@
+# Tasks
+
+## TODO
+
+- [x] Add/expand analysis session API in `pkg/inspector/analysis` for globals, members, and source-jump metadata
+- [x] Add unit tests for new analysis-session methods (sorting, membership, declaration line lookup)
+- [ ] Introduce `analysisSession` field in smalltalk-inspector model and initialize on file load
+- [ ] Migrate `buildGlobals` to consume analysis-session API (remove direct root-scope traversal from UI)
+- [ ] Migrate class/function member builders to analysis-session API
+- [ ] Migrate source jump helpers (`jumpToBinding`, `jumpToMember`) to analysis-session API
+- [ ] Keep runtime-only inspection paths unchanged and verify mixed static/runtime behavior
+- [ ] Remove obsolete direct `jsparse` graph reads from smalltalk-inspector static-analysis paths
+- [ ] Run regression suite: `pkg/inspector/analysis`, `cmd/smalltalk-inspector`, `cmd/inspector`, `go test ./...`
+- [ ] Update GOJA-032 changelog + diary with milestone notes and verification outputs
+- [ ] Add GOJA-028 cross-reference update noting GOJA-032 execution handoff/completion
+
+## Done Criteria
+
+- [ ] Smalltalk inspector static-analysis behavior is served via `pkg/inspector/analysis` session methods
+- [ ] No direct UI dependency on `Resolution.Scopes` / `Index.Nodes` for migrated paths
+- [ ] Existing globals/members/jump behavior remains stable by tests
+- [ ] Full regression suite passes

--- a/ttmp/2026/02/15/GOJA-033-INSPECTOR-EXTRACTION--inspector-extraction-from-cmd-inspector-into-pkg/README.md
+++ b/ttmp/2026/02/15/GOJA-033-INSPECTOR-EXTRACTION--inspector-extraction-from-cmd-inspector-into-pkg/README.md
@@ -1,0 +1,21 @@
+# Inspector Extraction from cmd/inspector into pkg
+
+This is the document workspace for ticket GOJA-033-INSPECTOR-EXTRACTION.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr doc add --ticket GOJA-033-INSPECTOR-EXTRACTION --doc-type design-doc --title "My Design"`
+- Import sources: `docmgr import file --ticket GOJA-033-INSPECTOR-EXTRACTION --file /path/to/doc.md`
+- Update metadata: `docmgr meta update --ticket GOJA-033-INSPECTOR-EXTRACTION --field Status --value review`

--- a/ttmp/2026/02/15/GOJA-033-INSPECTOR-EXTRACTION--inspector-extraction-from-cmd-inspector-into-pkg/changelog.md
+++ b/ttmp/2026/02/15/GOJA-033-INSPECTOR-EXTRACTION--inspector-extraction-from-cmd-inspector-into-pkg/changelog.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## 2026-02-15
+
+- Initialized GOJA-033 workspace with plan/tasks/diary scaffolding.
+- Uploaded implementation plan and tasks bundle to reMarkable (`/ai/2026/02/15/GOJA-033`).
+- Extracted reusable tree row shaping into `pkg/inspector/tree` with tests (`b49af1f`).
+- Extracted reusable source/tree sync helpers into `pkg/inspector/navigation` with tests (`b49af1f`).
+- Rewired `cmd/inspector/app` to consume extracted pkg helpers and added regression coverage (`b49af1f`).
+- Validated extraction with:
+  - `go test ./pkg/inspector/... -count=1`
+  - `go test ./cmd/inspector/... -count=1`
+  - `go test ./... -count=1`

--- a/ttmp/2026/02/15/GOJA-033-INSPECTOR-EXTRACTION--inspector-extraction-from-cmd-inspector-into-pkg/design/01-inspector-extraction-implementation-plan.md
+++ b/ttmp/2026/02/15/GOJA-033-INSPECTOR-EXTRACTION--inspector-extraction-from-cmd-inspector-into-pkg/design/01-inspector-extraction-implementation-plan.md
@@ -1,0 +1,165 @@
+---
+Title: Inspector Extraction Implementation Plan
+Ticket: GOJA-033-INSPECTOR-EXTRACTION
+Status: active
+Topics:
+    - go
+    - goja
+    - inspector
+    - refactor
+    - tui
+DocType: design
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: go-go-goja/cmd/inspector/app/model.go
+      Note: Source/tree sync and selection logic extraction source
+    - Path: go-go-goja/cmd/inspector/app/tree_list.go
+      Note: Tree row/title/description shaping logic extraction source
+    - Path: go-go-goja/cmd/inspector/app/drawer.go
+      Note: Candidate salvage surface for future extraction passes
+    - Path: go-go-goja/pkg/inspector/analysis
+      Note: Existing extracted reusable analysis utilities
+    - Path: go-go-goja/pkg/inspector/runtime
+      Note: Existing extracted runtime utilities
+    - Path: go-go-goja/ttmp/2026/02/14/GOJA-028-CLEANUP-INSPECTOR--cleanup-inspector/reference/01-inspector-cleanup-review.md
+      Note: Original findings that motivated extraction work
+ExternalSources: []
+Summary: Implementation plan for extracting old inspector reusable logic from cmd layer into pkg/inspector while keeping UI-framework coupling out of pkg APIs; now updated with completed extraction slices and deferred surfaces.
+LastUpdated: 2026-02-15T10:55:00-05:00
+WhatFor: Guide incremental extraction of tree/sync logic so it can be reused by CLI/LSP/REST adapters later.
+WhenToUse: Use while implementing GOJA-033 extraction tasks.
+---
+
+# Inspector Extraction Implementation Plan
+
+## Goal
+
+Extract generally reusable logic from `cmd/inspector/app` into `pkg/inspector/*` with these constraints:
+
+1. no Bubble Tea/Bubbles/lipgloss types in extracted APIs,
+2. pure data + pure logic functions only,
+3. old inspector behavior preserved by regression tests.
+
+This ticket is extraction-focused only. Final API design/packaging polish is intentionally deferred to a later pass.
+
+## Scope
+
+In scope:
+
+1. Tree row/view-model shaping from AST index/usage context.
+2. Source cursor <-> tree node synchronization helpers.
+3. Rewiring `cmd/inspector/app` to consume extracted helpers.
+4. Package-level tests and command-level regression checks.
+
+Out of scope:
+
+1. UI theme/layout restyling.
+2. Complete drawer component extraction.
+3. Broad API redesign and versioned public contracts.
+4. Syntax-highlighting algorithm redesign (GOJA-030).
+
+## Extraction Principles
+
+1. Extract only logic that is stable and domain-level.
+2. Keep serialization-friendly structs as boundaries.
+3. Keep UI adapters thin in `cmd/`.
+4. Add tests at extraction site (`pkg`) and integration site (`cmd`).
+
+## Target Package Additions
+
+## `pkg/inspector/tree`
+
+Purpose:
+
+1. Convert visible AST nodes into reusable row data structures.
+2. Attach optional hints (scope/reference/usage) without UI dependencies.
+
+Expected API shape (initial):
+
+1. Row DTO with `NodeID`, `Title`, `Description`.
+2. `BuildRows(index, usageHighlights)` style helper.
+
+## `pkg/inspector/navigation`
+
+Purpose:
+
+1. Source-byte offset calculation from `(line, col)`.
+2. Selection/sync helpers between source cursor and visible tree node lists.
+3. Cursor placement helpers from selected node spans.
+
+Expected API shape (initial):
+
+1. `SourceOffset(lines, line, col)` helper.
+2. `FindVisibleNodeIndex(visibleIDs, targetID)` helper.
+3. Sync helper(s) for source-to-tree and tree-to-source transitions.
+
+## Implementation Phases
+
+## Phase 0: Baseline + docs scaffolding
+
+1. Create GOJA-033 plan/tasks/diary.
+2. Upload plan/tasks to reMarkable.
+
+## Phase 1: Tree extraction
+
+1. Add `pkg/inspector/tree` DTO + row builder.
+2. Add unit tests for row shaping and usage hints.
+
+## Phase 2: Navigation extraction
+
+1. Add `pkg/inspector/navigation` utilities.
+2. Add unit tests for offset conversion, visible index lookup, sync outputs.
+
+## Phase 3: Rewire old inspector
+
+1. Replace local tree-list item shaping to call `pkg/inspector/tree`.
+2. Replace local sync helpers in `cmd/inspector/app/model.go` to call `pkg/inspector/navigation`.
+3. Keep behavior stable.
+
+## Phase 4: Validate + document
+
+1. Run targeted and full tests.
+2. Update GOJA-033 diary/changelog/tasks with per-step outcomes and commit IDs.
+
+## Validation Commands
+
+```bash
+go test ./pkg/inspector/... -count=1
+go test ./cmd/inspector/... -count=1
+go test ./... -count=1
+```
+
+## Risks and Mitigation
+
+Risk:
+
+1. subtle sync behavior drift while moving logic out of model methods.
+
+Mitigation:
+
+1. preserve old behavior with command-level regression tests and selective snapshots.
+
+Risk:
+
+1. extracting UI-coupled logic into pkg by accident.
+
+Mitigation:
+
+1. reject any `pkg` code that imports Bubble Tea/Bubbles/lipgloss.
+
+## Done Criteria
+
+1. Reusable tree + navigation logic lives in `pkg/inspector/*`.
+2. `cmd/inspector` compiles and tests pass with extracted dependencies.
+3. No Bubble Tea/Bubbles imports in newly extracted pkg code.
+4. Diary and changelog reflect each extraction slice with commit references.
+
+## Deferred Surfaces for API/Packaging Pass
+
+These areas intentionally remain in `cmd/inspector/app` and should be addressed in the next API design ticket:
+
+1. Drawer editing session state and tree-sitter lifecycle (`drawer.go`), including completion UI decisions.
+2. Bubble Tea mode/keymap orchestration (`keymap.go`, mode switching in `model.go`) as an adapter layer over future transport-agnostic commands.
+3. View rendering and layout composition (`View`/pane rendering methods in `model.go`) which should stay UI-only, but consume pkg contracts.
+4. Command palette textinput + status messaging behavior that could later map to CLI/REST endpoints via an application service layer.

--- a/ttmp/2026/02/15/GOJA-033-INSPECTOR-EXTRACTION--inspector-extraction-from-cmd-inspector-into-pkg/index.md
+++ b/ttmp/2026/02/15/GOJA-033-INSPECTOR-EXTRACTION--inspector-extraction-from-cmd-inspector-into-pkg/index.md
@@ -1,0 +1,76 @@
+---
+Title: Inspector Extraction from cmd/inspector into pkg
+Ticket: GOJA-033-INSPECTOR-EXTRACTION
+Status: active
+Topics:
+    - go
+    - goja
+    - inspector
+    - refactor
+    - tui
+DocType: index
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: go-go-goja/pkg/inspector/tree/rows.go
+      Note: Reusable row-view model shaping extracted from old inspector
+    - Path: go-go-goja/pkg/inspector/navigation/sync.go
+      Note: Reusable source/tree synchronization helpers
+    - Path: go-go-goja/cmd/inspector/app/model.go
+      Note: cmd adapter now consuming extracted navigation helpers
+    - Path: go-go-goja/cmd/inspector/app/tree_list.go
+      Note: cmd adapter now consuming extracted tree helper
+ExternalSources: []
+Summary: Extraction ticket that moved old inspector tree/sync domain logic into reusable pkg helpers with regression coverage.
+LastUpdated: 2026-02-15T10:58:00-05:00
+WhatFor: Track GOJA-033 extraction implementation and handoff context for the later API/packaging pass.
+WhenToUse: Use when reviewing what was extracted from cmd/inspector and what remains deferred.
+---
+
+# Inspector Extraction from cmd/inspector into pkg
+
+## Overview
+
+GOJA-033 extracts stable, reusable logic from `cmd/inspector/app` into `pkg/inspector/*` while preserving existing old-inspector behavior. This pass focused on:
+
+- tree row/view-model shaping (`pkg/inspector/tree`)
+- source/tree sync helpers (`pkg/inspector/navigation`)
+- cmd rewiring + regression tests
+
+The packaging/API design pass remains intentionally separate.
+
+## Key Links
+
+- **Related Files**: See frontmatter RelatedFiles field
+- **External Sources**: See frontmatter ExternalSources field
+
+## Status
+
+Current status: **active**
+
+Implementation status: **extraction complete**, ready for API design pass.
+
+## Topics
+
+- go
+- goja
+- inspector
+- refactor
+- tui
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/2026/02/15/GOJA-033-INSPECTOR-EXTRACTION--inspector-extraction-from-cmd-inspector-into-pkg/reference/01-diary.md
+++ b/ttmp/2026/02/15/GOJA-033-INSPECTOR-EXTRACTION--inspector-extraction-from-cmd-inspector-into-pkg/reference/01-diary.md
@@ -1,0 +1,137 @@
+---
+Title: Diary
+Ticket: GOJA-033-INSPECTOR-EXTRACTION
+Status: active
+Topics:
+    - go
+    - goja
+    - inspector
+    - refactor
+    - tui
+DocType: reference
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: go-go-goja/pkg/inspector/tree/rows.go
+      Note: Extracted UI-agnostic tree row view-model shaping
+    - Path: go-go-goja/pkg/inspector/navigation/sync.go
+      Note: Extracted source-tree synchronization helpers
+    - Path: go-go-goja/cmd/inspector/app/model.go
+      Note: Old inspector rewired to consume extracted navigation helpers
+    - Path: go-go-goja/cmd/inspector/app/tree_list.go
+      Note: Old inspector rewired to consume extracted tree row helpers
+ExternalSources: []
+Summary: Step-by-step implementation diary for GOJA-033 extraction work.
+LastUpdated: 2026-02-15T10:57:00-05:00
+WhatFor: Preserve exact implementation decisions, errors, and validation during extraction.
+WhenToUse: Use when reviewing or continuing GOJA-033 extraction.
+---
+
+# Diary
+
+## Goal
+
+Capture the GOJA-033 extraction sequence from ticket scaffolding through code extraction, testing, and documentation updates.
+
+## Step 1: Extract Tree and Navigation Logic into pkg/inspector
+
+This step moved old inspector logic out of `cmd/inspector/app` and into transport-agnostic packages under `pkg/inspector`. The extraction was intentionally narrow: row shaping and source/tree sync logic only.
+
+The command-side code was kept as thin adapters so later API design can move orchestration into reusable services without unpicking Bubble Tea rendering code first.
+
+### Prompt Context
+
+**User prompt (verbatim):** "create a new ticket for the inspector extraction. Add implementation plan and tasks and upload to remarkable.
+
+then work through the tasks with commit and diary at appropriate places as usual.
+
+We'll do a nice api design + packaging pass once everything is extracted."
+
+**Assistant interpretation:** Create GOJA-033, write plan/tasks, upload docs to reMarkable, then execute extraction tasks with commits and diary updates.
+
+**Inferred user intent:** Finish concrete extraction work now, while preserving a clean handoff into a later API/packaging design pass.
+
+**Commit (code):** `b49af1f` — "inspector: extract reusable tree and navigation helpers"
+
+### What I did
+
+- Replaced duplicated tree-row formatting logic in `cmd/inspector/app/tree_list.go` with a thin adapter over `pkg/inspector/tree.BuildRow`.
+- Added `pkg/inspector/tree` package:
+  - `rows.go` (`Row`, `BuildRowsFromIndex`, `BuildRow`)
+  - `rows_test.go` (row rendering, usage hints, scope hints).
+- Added `pkg/inspector/navigation` package:
+  - `sync.go` (`SourceOffset`, `SelectionAtSourceCursor`, `FindVisibleNodeIndex`, `SelectionFromVisibleTree`)
+  - `sync_test.go` (offset clamping, source selection, visible index lookup, tree selection mapping).
+- Rewired `cmd/inspector/app/model.go`:
+  - `syncSourceToTree` now uses `SelectionAtSourceCursor` + `FindVisibleNodeIndex`.
+  - `syncTreeToSource` now uses `SelectionFromVisibleTree`.
+  - removed local `sourceCursorOffset`.
+- Added cmd-level regression test `TestModelTreeListItemIncludesUsageHint` in `cmd/inspector/app/model_test.go`.
+- Ran validation:
+  - `go test ./pkg/inspector/... -count=1`
+  - `go test ./cmd/inspector/... -count=1`
+  - `go test ./... -count=1`
+
+### Why
+
+- Keep domain logic reusable across future UI/CLI/REST/LSP surfaces.
+- Remove duplicate implementations and centralize behavior in package-level tests.
+- Preserve old inspector behavior while improving layering.
+
+### What worked
+
+- Extraction boundaries were stable and clean: no Bubble Tea/Bubbles/lipgloss dependencies entered new pkg code.
+- Existing cmd behavior stayed intact once rewired.
+- Added tests caught mismatches quickly and gave confidence for commit.
+
+### What didn't work
+
+- First run of `go test ./pkg/inspector/... -count=1` failed:
+  - `pkg/inspector/tree/rows_test.go:35:46: n.Text undefined`
+  - `pkg/inspector/tree/rows_test.go:60:46: n.Text undefined`
+  - Cause: test used outdated field name; fixed by using `strings.Contains(n.DisplayLabel(), "x")`.
+- First run of `go test ./cmd/inspector/... -count=1` failed:
+  - `TestModelTreeListItemIncludesUsageHint`: usage node not visible.
+  - Cause: deep node row not visible without expanding ancestors.
+  - Fix: `m.index.ExpandTo(usageID)` + `m.refreshTreeVisible()` before assertion.
+- Pre-commit hook `go generate ./...` logged Dagger pull timeout for `node:20.18.1` and fell back to local npm build automatically; commit still completed.
+
+### What I learned
+
+- The old inspector’s source/tree sync logic can be extracted cleanly without changing state model ownership.
+- Command-level tests still need explicit visibility setup for non-root tree nodes, even when extraction logic is correct.
+
+### What was tricky to build
+
+- The main sharp edge was visibility coupling: `treeSelectedIdx` is over visible nodes only, so source-selected nodes require ancestor expansion before index lookup.
+- This manifested as a false-negative test failure, not a runtime panic, which made the issue easy to miss without explicit visibility setup.
+
+### What warrants a second pair of eyes
+
+- Cursor/offset behavior around UTF-8 multibyte characters is still byte-oriented; verify expected semantics for future editor integrations.
+- Tree row ordering assumptions depend on `VisibleNodes()` and should be re-checked if index traversal semantics change.
+
+### What should be done in the future
+
+- API/packaging pass: define service-level interfaces around navigation/tree logic so non-TUI adapters can consume the same commands.
+- Consider additional edge-case tests for source offsets near EOF and empty last lines.
+
+### Code review instructions
+
+- Start here:
+  - `pkg/inspector/tree/rows.go`
+  - `pkg/inspector/navigation/sync.go`
+  - `cmd/inspector/app/model.go`
+  - `cmd/inspector/app/tree_list.go`
+- Validate with:
+  - `go test ./pkg/inspector/... -count=1`
+  - `go test ./cmd/inspector/... -count=1`
+  - `go test ./... -count=1`
+
+### Technical details
+
+- Extracted APIs are pure-value in/out helpers:
+  - `tree.BuildRow(*NodeRecord, []NodeID, *Resolution) Row`
+  - `navigation.SelectionAtSourceCursor(*Index, []string, int, int) (SourceSelection, bool)`
+  - `navigation.SelectionFromVisibleTree(*Index, []NodeID, int) (TreeSelection, bool)`
+- Command model remains owner of UI state (`focus`, `treeSelectedIdx`, viewport offsets, etc.); pkg APIs only compute selections and row DTOs.

--- a/ttmp/2026/02/15/GOJA-033-INSPECTOR-EXTRACTION--inspector-extraction-from-cmd-inspector-into-pkg/tasks.md
+++ b/ttmp/2026/02/15/GOJA-033-INSPECTOR-EXTRACTION--inspector-extraction-from-cmd-inspector-into-pkg/tasks.md
@@ -1,0 +1,22 @@
+# Tasks
+
+## TODO
+
+- [x] Create GOJA-033 ticket workspace
+- [x] Add GOJA-033 implementation plan document
+- [x] Add GOJA-033 diary scaffold
+- [x] Upload implementation plan + tasks to reMarkable
+- [x] Extract tree row/view-model shaping from `cmd/inspector/app/tree_list.go` into `pkg/inspector/tree`
+- [x] Add unit tests for extracted `pkg/inspector/tree` behavior
+- [x] Extract source/tree sync helpers from `cmd/inspector/app/model.go` into `pkg/inspector/navigation`
+- [x] Add unit tests for `pkg/inspector/navigation` offset/sync helpers
+- [x] Rewire `cmd/inspector/app` to consume extracted tree/navigation helpers
+- [x] Add/adjust command-level regression tests to guard behavior parity
+- [x] Run validation suite (`go test ./pkg/inspector/...`, `go test ./cmd/inspector/...`, `go test ./...`)
+- [x] Update GOJA-033 diary/changelog/index/tasks with commit-linked progress
+
+## Handoff Checklist
+
+- [x] Extracted pkg code has no Bubble Tea/Bubbles/lipgloss imports
+- [x] Old inspector behavior is preserved (tested)
+- [x] Remaining non-extracted surfaces are documented for later API packaging pass

--- a/ttmp/2026/02/15/GOJA-034-USER-FACING-INSPECTOR-API--user-facing-inspector-analysis-api-design/README.md
+++ b/ttmp/2026/02/15/GOJA-034-USER-FACING-INSPECTOR-API--user-facing-inspector-analysis-api-design/README.md
@@ -1,0 +1,21 @@
+# User-Facing Inspector Analysis API Design
+
+This is the document workspace for ticket GOJA-034-USER-FACING-INSPECTOR-API.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr doc add --ticket GOJA-034-USER-FACING-INSPECTOR-API --doc-type design-doc --title "My Design"`
+- Import sources: `docmgr import file --ticket GOJA-034-USER-FACING-INSPECTOR-API --file /path/to/doc.md`
+- Update metadata: `docmgr meta update --ticket GOJA-034-USER-FACING-INSPECTOR-API --field Status --value review`

--- a/ttmp/2026/02/15/GOJA-034-USER-FACING-INSPECTOR-API--user-facing-inspector-analysis-api-design/changelog.md
+++ b/ttmp/2026/02/15/GOJA-034-USER-FACING-INSPECTOR-API--user-facing-inspector-analysis-api-design/changelog.md
@@ -12,3 +12,18 @@
 - Expanded tasks for executable implementation phases and added GOJA-034 diary scaffold:
   - `tasks.md`
   - `reference/01-diary.md`
+- Committed planning artifacts:
+  - `b31157b` — `docs(goja-034): add clean-cutover implementation plan and tasks`
+- Implemented phase-A hybrid facade and clean cutover:
+  - `cd823ad` — `inspectorapi: add hybrid service layer and cut over smalltalk static flows`
+  - Added `pkg/inspectorapi` with:
+    - document lifecycle (open/update/close),
+    - globals/members/declaration methods,
+    - runtime merge + REPL declaration extraction,
+    - tree/sync wrappers.
+  - Cut over `cmd/smalltalk-inspector/app` static orchestration from `inspectoranalysis.Session` to `inspectorapi.Service`.
+  - Added service tests and updated smalltalk member tests.
+  - Validation completed:
+    - `go test ./pkg/inspectorapi/... -count=1`
+    - `go test ./cmd/smalltalk-inspector/... -count=1`
+    - `go test ./... -count=1`

--- a/ttmp/2026/02/15/GOJA-034-USER-FACING-INSPECTOR-API--user-facing-inspector-analysis-api-design/changelog.md
+++ b/ttmp/2026/02/15/GOJA-034-USER-FACING-INSPECTOR-API--user-facing-inspector-analysis-api-design/changelog.md
@@ -7,3 +7,8 @@
   - `design/01-user-facing-inspector-api-analysis-and-design-guide.md`
   - 4,460 words (8+ page equivalent) with architecture onboarding, capability inventory, API option analysis, decision matrix, pseudocode, and contract sketches.
 - Updated ticket index and tasks to reflect completion of design/analysis objectives.
+- Added detailed phase-A implementation plan for hybrid architecture with clean cutover assumptions:
+  - `design/02-hybrid-implementation-plan-clean-cutover.md`
+- Expanded tasks for executable implementation phases and added GOJA-034 diary scaffold:
+  - `tasks.md`
+  - `reference/01-diary.md`

--- a/ttmp/2026/02/15/GOJA-034-USER-FACING-INSPECTOR-API--user-facing-inspector-analysis-api-design/changelog.md
+++ b/ttmp/2026/02/15/GOJA-034-USER-FACING-INSPECTOR-API--user-facing-inspector-analysis-api-design/changelog.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 2026-02-15
+
+- Created GOJA-034 ticket workspace for user-facing API design over extracted inspector functionality.
+- Added detailed design guide:
+  - `design/01-user-facing-inspector-api-analysis-and-design-guide.md`
+  - 4,460 words (8+ page equivalent) with architecture onboarding, capability inventory, API option analysis, decision matrix, pseudocode, and contract sketches.
+- Updated ticket index and tasks to reflect completion of design/analysis objectives.

--- a/ttmp/2026/02/15/GOJA-034-USER-FACING-INSPECTOR-API--user-facing-inspector-analysis-api-design/changelog.md
+++ b/ttmp/2026/02/15/GOJA-034-USER-FACING-INSPECTOR-API--user-facing-inspector-analysis-api-design/changelog.md
@@ -27,3 +27,9 @@
     - `go test ./pkg/inspectorapi/... -count=1`
     - `go test ./cmd/smalltalk-inspector/... -count=1`
     - `go test ./... -count=1`
+- Added Glazed-style help documentation for the new hybrid API layer:
+  - `pkg/doc/07-inspectorapi-hybrid-service-guide.md`
+  - Frontmatter + section structure aligned with:
+    - `glazed/pkg/doc/topics/01-help-system.md`
+    - `glazed/pkg/doc/topics/how-to-write-good-documentation-pages.md`
+    - `glazed/pkg/doc/topics/14-writing-help-entries.md`

--- a/ttmp/2026/02/15/GOJA-034-USER-FACING-INSPECTOR-API--user-facing-inspector-analysis-api-design/design/01-user-facing-inspector-api-analysis-and-design-guide.md
+++ b/ttmp/2026/02/15/GOJA-034-USER-FACING-INSPECTOR-API--user-facing-inspector-analysis-api-design/design/01-user-facing-inspector-api-analysis-and-design-guide.md
@@ -1,0 +1,1308 @@
+---
+Title: User-Facing Inspector API Analysis and Design Guide
+Ticket: GOJA-034-USER-FACING-INSPECTOR-API
+Status: active
+Topics:
+    - go
+    - goja
+    - inspector
+    - api
+    - architecture
+DocType: design
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: cmd/inspector/app/model.go
+      Note: Legacy inspector Bubble Tea adapter layer
+    - Path: cmd/smalltalk-inspector/app/model.go
+      Note: |-
+        Smalltalk inspector Bubble Tea adapter layer
+        Adapter layer examples used in migration section
+    - Path: internal/inspectorui/listpane.go
+      Note: Reused viewport/list utility behavior in UI layer
+    - Path: pkg/inspector/analysis/globals_merge.go
+      Note: Static+runtime global merge strategy
+    - Path: pkg/inspector/analysis/repl_declarations.go
+      Note: Parser-backed REPL declaration extraction
+    - Path: pkg/inspector/analysis/session.go
+      Note: High-level analysis session facade used by inspector UIs
+    - Path: pkg/inspector/analysis/smalltalk_session.go
+      Note: |-
+        Globals/members/jump helpers and inspector-centric adapters
+        Current high-level static analysis behavior mapped in the design
+    - Path: pkg/inspector/core/members.go
+      Note: Inheritance-aware class/function member extraction
+    - Path: pkg/inspector/navigation/sync.go
+      Note: |-
+        UI-agnostic source/tree synchronization helpers
+        Extracted sync primitives referenced in API sketches
+    - Path: pkg/inspector/runtime/function_map.go
+      Note: Runtime function to AST/source mapping
+    - Path: pkg/inspector/runtime/introspect.go
+      Note: Object/property/prototype introspection
+    - Path: pkg/inspector/runtime/session.go
+      Note: |-
+        Runtime eval/session abstractions over goja
+        Runtime session API discussed for facade contracts
+    - Path: pkg/inspector/tree/rows.go
+      Note: |-
+        UI-agnostic tree row shaping
+        Extracted tree DTO shaping referenced in API sketches
+    - Path: pkg/jsparse/analyze.go
+      Note: |-
+        Core parser+index+resolution entry point for static analysis
+        Core entrypoint that the proposed service layer should wrap
+    - Path: pkg/jsparse/completion.go
+      Note: CST/AST-based completion context and candidate resolution
+    - Path: pkg/jsparse/highlight.go
+      Note: Syntax span generation and syntax class model
+    - Path: pkg/jsparse/index.go
+      Note: Node index and source offset/tree visibility primitives
+    - Path: pkg/jsparse/resolve.go
+      Note: Scope and binding resolution model
+ExternalSources: []
+Summary: Deep onboarding and design guide for building a user-facing API over extracted inspector analysis/runtime/navigation functionality.
+LastUpdated: 2026-02-15T11:09:00-05:00
+WhatFor: Help new and existing developers converge on a clean public API and packaging strategy for analysis/inspection features.
+WhenToUse: Read before designing new CLI/REST/LSP adapters or restructuring inspector service boundaries.
+---
+
+
+# User-Facing Inspector API Analysis and Design Guide
+
+## Executive Summary
+
+The repository now has a meaningful split between reusable inspection logic in `pkg/` and Bubble Tea application behavior in `cmd/`. We are at a good inflection point: enough extraction has happened to design a stable user-facing API, but not so much has solidified that we are locked into accidental abstractions.
+
+This guide has four goals:
+
+1. onboard a new developer quickly by mapping current architecture and capabilities,
+2. explain how the current APIs actually work and what contracts already exist,
+3. propose multiple user-facing API shapes with tradeoffs,
+4. recommend a practical path that supports CLI, TUI, REST, and eventual LSP use without duplicating business logic.
+
+The core recommendation is a **hybrid layered API**:
+
+1. keep low-level primitives in `pkg/jsparse` and `pkg/inspector/*`,
+2. add a new orchestration layer (proposed `pkg/inspectorapi` or `pkg/inspector/service`) that exposes stable use-case level operations,
+3. keep Bubble Tea in `cmd/*` as thin adapters,
+4. later expose the same orchestration over REST/CLI/LSP adapters.
+
+This gives us fast iteration now and stable long-term packaging.
+
+## Who This Is For
+
+This document is written for:
+
+1. a new engineer joining the codebase who needs to become productive quickly,
+2. maintainers deciding how to package extracted functionality,
+3. implementers building next adapters (REST endpoints, non-interactive CLI commands, LSP features).
+
+If you are brand new, start with:
+
+1. `pkg/jsparse/analyze.go`,
+2. `pkg/inspector/analysis/session.go`,
+3. `pkg/inspector/runtime/session.go`,
+4. `cmd/smalltalk-inspector/app/model.go`,
+5. this guide’s “Recommended Architecture” and “Phased Plan” sections.
+
+## Project Context and Current State
+
+### What has already been extracted
+
+Recent tickets extracted reusable logic from inspector command models into packages:
+
+1. runtime/global merge and REPL declaration helpers moved to `pkg/inspector/analysis` and `pkg/inspector/runtime`,
+2. source/tree synchronization moved to `pkg/inspector/navigation`,
+3. tree row shaping moved to `pkg/inspector/tree`,
+4. view-scroll behavior consolidated in `internal/inspectorui` for Bubble Tea adapters.
+
+This means we already have reuse across:
+
+1. old inspector (`cmd/inspector`),
+2. smalltalk inspector (`cmd/smalltalk-inspector`),
+3. shared parsing/resolution engine (`pkg/jsparse`).
+
+### What is still adapter-local
+
+The following remain in `cmd/*` and should not become the public API themselves:
+
+1. key handling and mode transitions,
+2. Bubble Tea component wiring,
+3. command palette and status-line presentation,
+4. layout rendering and styling,
+5. some orchestration glue now duplicated between frontends.
+
+This remaining glue is exactly what a user-facing API layer should absorb.
+
+## Architecture Map
+
+### Layer map as it exists today
+
+```text
++---------------------------------------------------------+
+| cmd/smalltalk-inspector, cmd/inspector                  |
+| Bubble Tea models, keymaps, views, pane orchestration   |
++-------------------------|-------------------------------+
+                          |
++-------------------------v-------------------------------+
+| pkg/inspector/*                                          |
+| analysis, runtime, navigation, tree, core               |
+| use-case helpers + DTO-level logic                       |
++-------------------------|-------------------------------+
+                          |
++-------------------------v-------------------------------+
+| pkg/jsparse                                               |
+| parse, AST index, scope resolution, completion, syntax   |
++-------------------------|-------------------------------+
+                          |
++-------------------------v-------------------------------+
+| dependencies                                              |
+| goja parser/runtime, tree-sitter JS                       |
++----------------------------------------------------------+
+```
+
+### Layer intent
+
+1. `pkg/jsparse` is the language foundation.
+2. `pkg/inspector/*` is domain behavior and workflows around parsed code and runtime objects.
+3. `cmd/*` is interaction and presentation.
+
+That split is mostly good, but it is missing an explicit “public orchestration layer” that presents stable, task-oriented APIs.
+
+## Codebase Tour for New Developers
+
+### Static analysis foundation: `pkg/jsparse`
+
+Primary entry points:
+
+1. `Analyze(filename, source, opts)` returns `AnalysisResult` with parse output, AST index, and scope resolution.
+2. `BuildIndex(program, src)` constructs a flattened, queryable AST node index.
+3. `Resolve(program, idx)` builds lexical scopes and binding graph.
+4. `BuildSyntaxSpans(root)` classifies tree-sitter leaf tokens for highlighting.
+5. `ExtractCompletionContext` and `ResolveCandidates` power completion.
+
+Important contracts:
+
+1. offsets in index are 1-based byte offsets,
+2. line/col from index are 1-based,
+3. tree-sitter node positions are 0-based row/col then adapted where needed,
+4. `Index.VisibleNodes()` depends on `NodeRecord.Expanded` state.
+
+Why this matters for API design:
+
+1. any user-facing API must define consistent coordinate systems,
+2. cursor and range conversions need explicit helper contracts,
+3. parse and completion may rely on different parse trees (goja AST vs tree-sitter CST).
+
+### Domain helpers: `pkg/inspector/analysis`
+
+Current scope:
+
+1. session wrapper around `AnalysisResult` (`Session`),
+2. sorted global bindings + class extends metadata,
+3. class/function members for inspector panels,
+4. declaration jump helpers (`BindingDeclLine`, `MemberDeclLine`),
+5. cross references and method symbol extraction,
+6. REPL declaration extraction and static/runtime global merge.
+
+This package is closest to a current “user API”, but still narrowly tuned to current UI workflows.
+
+### Runtime helpers: `pkg/inspector/runtime`
+
+Current scope:
+
+1. goja runtime session lifecycle (`NewSession`, `Load`, `Eval`, `EvalWithCapture`),
+2. value preview formatting,
+3. object inspection (`InspectObject`),
+4. prototype traversal (`WalkPrototypeChain`, `PrototypeChainNames`),
+5. descriptor extraction (`GetDescriptor`),
+6. error parsing (`ParseException`),
+7. function-to-source mapping (`MapFunctionToSource`),
+8. runtime global kind inference (`RuntimeGlobalKinds`).
+
+This already has enough capability for CLI or REST object inspection, as long as we wrap it in safe request/response structs.
+
+### Navigation and tree helpers
+
+`pkg/inspector/navigation`:
+
+1. source cursor to node mapping,
+2. node selection to source cursor mapping,
+3. visible node index lookup,
+4. cursor offset calculations.
+
+`pkg/inspector/tree`:
+
+1. tree row view model data from index and highlights.
+
+These two packages are explicitly UI-framework agnostic and are good examples of extraction style to continue.
+
+### UI support utilities
+
+`internal/inspectorui` has reusable scroll and viewport helpers.
+
+These are internal and Bubble Tea-aware in part, which is fine for UI adapter reuse but should not be exposed as public analysis API.
+
+## Capability Inventory (What We Can Do Today)
+
+This section reframes current code as user-visible capabilities.
+
+### Parse and structural analysis
+
+We can currently:
+
+1. parse JavaScript source with goja parser,
+2. index AST nodes with spans, tree relations, display labels, visibility state,
+3. resolve lexical scopes and bindings,
+4. find node at source offset,
+5. compute diagnostics from parse errors.
+
+Current rough API path:
+
+```go
+result := jsparse.Analyze(filename, source, nil)
+if result.ParseErr != nil { ... }
+node := result.NodeAtOffset(123)
+```
+
+### Symbol and member exploration
+
+We can currently:
+
+1. list top-level globals and classify by binding kind,
+2. determine class inheritance parent name,
+3. compute class own + inherited members with cycle/depth guards,
+4. compute top-level function parameters,
+5. derive declaration lines for globals and members.
+
+Current rough API path:
+
+```go
+s := analysis.NewSessionFromResult(result)
+globals := s.Globals()
+members := s.ClassMembers("MyClass")
+line, ok := s.BindingDeclLine("foo")
+```
+
+### Cross-reference and scope-centric helpers
+
+We can currently:
+
+1. list xrefs for a binding name or record,
+2. derive method-local symbol summaries in a source span.
+
+Rough path:
+
+```go
+xrefs := analysis.CrossReferences(result.Resolution, result.Index, "foo")
+symbols := analysis.MethodSymbols(result.Resolution, result.Index, start, end)
+```
+
+### Runtime inspection and REPL integration
+
+We can currently:
+
+1. run source into goja VM,
+2. evaluate expressions with structured error capture,
+3. inspect object properties and prototype chain,
+4. parse stack frames from goja exceptions,
+5. map runtime function values back to AST source when possible,
+6. infer runtime global kinds and merge with static bindings,
+7. extract REPL declarations from snippet text safely via parser.
+
+Rough path:
+
+```go
+rt := runtime.NewSession()
+_ = rt.Load(fileSource)
+res := rt.EvalWithCapture("someExpr")
+if obj, ok := res.Value.(*goja.Object); ok {
+    props := runtime.InspectObject(obj, rt.VM)
+    _ = props
+}
+```
+
+### Syntax highlighting and completion
+
+We can currently:
+
+1. build tree-sitter CST snapshots,
+2. derive syntax spans by token class,
+3. compute completion context and candidates from CST + AST resolution,
+4. include drawer-local declarations in completion.
+
+This is useful for editor-like frontends, but current API is still low-level and split across multiple functions.
+
+## Current API Friction Points
+
+### Friction 1: no single use-case facade
+
+Consumers currently compose many calls manually across packages.
+
+Impact:
+
+1. repeated orchestration code in UI adapters,
+2. inconsistent error handling and fallback behavior,
+3. harder onboarding for new developers.
+
+### Friction 2: coordinate conventions are implicit
+
+Some helpers use 0-based row/col inputs, others produce 1-based line/col, index offsets are 1-based byte indices.
+
+Impact:
+
+1. subtle bugs when adding endpoints or adapters,
+2. duplicated conversion logic.
+
+### Friction 3: static and runtime models are separate but intertwined
+
+Smalltalk inspector merges static globals + runtime values + REPL declarations in model code.
+
+Impact:
+
+1. business logic lives in adapter layer,
+2. hard to reuse from CLI/REST without copying behavior.
+
+### Friction 4: DTOs are package-local and partially UI-shaped
+
+Some DTOs are great (`tree.Row`, `navigation.SourceSelection`), others are implicit through package types.
+
+Impact:
+
+1. no explicit public contract set for third-party or future adapters,
+2. model evolution risk without versioned API boundaries.
+
+### Friction 5: lifecycle ownership is unclear for long-lived sessions
+
+`runtime.Session` and `jsparse.TSParser` have separate lifecycles. Current UIs handle this ad hoc.
+
+Impact:
+
+1. memory/resource leaks risk in future server mode,
+2. inconsistent caching semantics.
+
+## User-Facing API Design Goals
+
+A new user-facing API should:
+
+1. expose task-oriented operations, not parser internals,
+2. stay transport-agnostic (usable by TUI, CLI, REST, LSP),
+3. provide explicit DTOs and stable contracts,
+4. centralize coordinate and range conventions,
+5. compose static and runtime information predictably,
+6. make session and cache ownership explicit,
+7. preserve ability to call low-level packages directly for advanced needs.
+
+Non-goals for initial version:
+
+1. full language-server protocol in one step,
+2. replacing all existing package-level APIs,
+3. implementing distributed multi-user runtime state,
+4. changing existing parser engines.
+
+## Design Options
+
+## Option A: Library-First Facade
+
+### Idea
+
+Add a Go package with high-level methods and typed request/response structs. No server assumptions.
+
+Potential package:
+
+1. `pkg/inspectorapi`.
+
+Example API sketch:
+
+```go
+type Service struct {
+    parserFactory ParserFactory
+    runtimeFactory RuntimeFactory
+}
+
+func (s *Service) AnalyzeFile(ctx context.Context, req AnalyzeFileRequest) (AnalyzeFileResponse, error)
+func (s *Service) ListGlobals(ctx context.Context, req ListGlobalsRequest) (ListGlobalsResponse, error)
+func (s *Service) InspectValue(ctx context.Context, req InspectValueRequest) (InspectValueResponse, error)
+func (s *Service) Complete(ctx context.Context, req CompleteRequest) (CompleteResponse, error)
+```
+
+Pros:
+
+1. quickest to ship,
+2. easy to integrate into existing cmd apps,
+3. strong type safety in Go.
+
+Cons:
+
+1. REST/LSP adapters still need another layer later,
+2. might accidentally leak Go-specific types into public contract.
+
+Best when:
+
+1. immediate priority is code reuse across in-repo Go apps.
+
+## Option B: Service-First (REST-centric)
+
+### Idea
+
+Define HTTP API first and treat Go packages as implementation detail.
+
+Pros:
+
+1. strongest language/tooling neutrality,
+2. easiest for external consumers.
+
+Cons:
+
+1. higher upfront scope,
+2. harder local debugging initially,
+3. risks premature stabilization of contracts before internal API matures.
+
+Best when:
+
+1. external clients are immediate priority.
+
+## Option C: Hybrid Layered API (Recommended)
+
+### Idea
+
+Build a use-case layer with stable DTOs and interfaces in Go first, then expose adapter packages:
+
+1. Go facade package for internal consumers,
+2. optional REST adapter that reuses same service methods,
+3. optional LSP/CLI adapters later.
+
+Pros:
+
+1. fast internal value with strong architecture,
+2. avoids duplicate orchestration logic,
+3. clean migration path to REST/LSP,
+4. easier testing at domain layer.
+
+Cons:
+
+1. requires discipline to keep adapters thin,
+2. needs careful DTO and interface design upfront.
+
+Best when:
+
+1. we want both near-term implementation speed and long-term reuse.
+
+## Recommended Architecture (Hybrid)
+
+### Proposed package layout
+
+```text
+pkg/inspectorapi/
+  contracts.go          // shared request/response DTOs and enums
+  coordinates.go        // canonical position/range helpers
+  service.go            // high-level Service facade
+  analysis_service.go   // static analysis use-cases
+  runtime_service.go    // runtime eval/inspect use-cases
+  completion_service.go // completion + syntax span use-cases
+  session_store.go      // document/runtime session lifecycle
+
+pkg/inspectorapi/adapters/
+  rest/...
+  cli/...
+  tui/...
+  lsp/... (future)
+```
+
+Keep existing packages as implementation dependencies:
+
+1. `pkg/jsparse`,
+2. `pkg/inspector/analysis`,
+3. `pkg/inspector/runtime`,
+4. `pkg/inspector/navigation`,
+5. `pkg/inspector/tree`,
+6. `pkg/inspector/core`.
+
+### Proposed domain model
+
+Introduce explicit concepts:
+
+1. `DocumentSession`: static source + analysis snapshot + optional CST cache,
+2. `RuntimeSession`: goja VM associated with a document or ephemeral snippet,
+3. `InspectorService`: stateless facade over stores/managers,
+4. `Snapshot`: immutable analysis/range/tree data returned to clients.
+
+### Key principle
+
+The service should return DTOs that are independent of Bubble Tea, goja internals, and AST node concrete types.
+
+## API Contract Sketches
+
+## Core contracts
+
+```go
+type Position struct {
+    Line int // 1-based
+    Col  int // 1-based
+}
+
+type ByteOffset struct {
+    Value int // 1-based byte offset
+}
+
+type Range struct {
+    Start Position
+    End   Position // exclusive
+}
+
+type NodeRef struct {
+    NodeID int
+    Kind   string
+    Label  string
+    Range  Range
+}
+```
+
+## Session API
+
+```go
+type OpenDocumentRequest struct {
+    URI      string
+    Source   string
+    Language string // "javascript"
+}
+
+type OpenDocumentResponse struct {
+    DocumentID string
+    Diagnostics []Diagnostic
+}
+
+type UpdateDocumentRequest struct {
+    DocumentID string
+    Source     string
+}
+
+type UpdateDocumentResponse struct {
+    Diagnostics []Diagnostic
+    Version     int
+}
+```
+
+## Analysis API
+
+```go
+type ListGlobalsRequest struct {
+    DocumentID string
+    IncludeRuntime bool
+}
+
+type GlobalEntry struct {
+    Name    string
+    Kind    string
+    Extends string
+    Source  string // "static" | "runtime" | "merged"
+}
+
+type ListGlobalsResponse struct {
+    Globals []GlobalEntry
+}
+```
+
+```go
+type ListMembersRequest struct {
+    DocumentID string
+    SymbolName string
+}
+
+type MemberEntry struct {
+    Name      string
+    Kind      string
+    Preview   string
+    Inherited bool
+    Source    string
+}
+
+type ListMembersResponse struct {
+    Members []MemberEntry
+}
+```
+
+```go
+type GoToDeclarationRequest struct {
+    DocumentID string
+    SymbolName string
+    Context    string // optional class/function scope
+}
+
+type GoToDeclarationResponse struct {
+    Location *Location
+}
+
+type Location struct {
+    URI   string
+    Range Range
+}
+```
+
+## Runtime inspection API
+
+```go
+type EvalRequest struct {
+    RuntimeID   string
+    Expression  string
+    CaptureMeta bool
+}
+
+type EvalResponse struct {
+    ValuePreview string
+    ValueKind    string
+    Error        *ErrorInfo
+    ObjectHandle string
+}
+```
+
+```go
+type InspectObjectRequest struct {
+    RuntimeID     string
+    ObjectHandle  string
+    IncludeProto  bool
+    IncludeHidden bool
+}
+
+type PropertyEntry struct {
+    Name       string
+    Kind       string
+    Preview    string
+    IsSymbol   bool
+    HasGetter  bool
+    HasSetter  bool
+    ChildHandle string
+}
+
+type InspectObjectResponse struct {
+    Properties []PropertyEntry
+    PrototypeChain []PrototypeEntry
+}
+```
+
+## Navigation and tree API
+
+```go
+type SyncSourceToTreeRequest struct {
+    DocumentID string
+    Cursor     Position
+}
+
+type SyncSourceToTreeResponse struct {
+    SelectedNode NodeRef
+    VisibleIndex int
+    Highlight    Range
+}
+```
+
+```go
+type BuildTreeRowsRequest struct {
+    DocumentID      string
+    UsageHighlights []int
+}
+
+type TreeRow struct {
+    NodeID      int
+    Title       string
+    Description string
+}
+
+type BuildTreeRowsResponse struct {
+    Rows []TreeRow
+}
+```
+
+## Completion and syntax API
+
+```go
+type CompleteRequest struct {
+    DocumentID string
+    Cursor     Position
+    Prefix     string
+    IncludeRuntime bool
+}
+
+type CompletionItem struct {
+    Label  string
+    Kind   string
+    Detail string
+}
+
+type CompleteResponse struct {
+    Items []CompletionItem
+}
+```
+
+```go
+type SyntaxSpansRequest struct {
+    DocumentID string
+}
+
+type SyntaxSpan struct {
+    Start Position
+    End   Position
+    Class string
+}
+
+type SyntaxSpansResponse struct {
+    Spans []SyntaxSpan
+}
+```
+
+## Orchestration Pseudocode
+
+### Open/update document lifecycle
+
+```go
+func (svc *Service) OpenDocument(ctx context.Context, req OpenDocumentRequest) (OpenDocumentResponse, error) {
+    result := jsparse.Analyze(req.URI, req.Source, nil)
+
+    doc := &DocumentSession{
+        ID:       newID(),
+        URI:      req.URI,
+        Source:   req.Source,
+        Analysis: result,
+        Version:  1,
+    }
+
+    if svc.enableCST {
+        doc.CST = svc.ts.Parse([]byte(req.Source))
+    }
+
+    svc.docs.Put(doc)
+
+    return OpenDocumentResponse{
+        DocumentID: doc.ID,
+        Diagnostics: mapDiagnostics(result.Diagnostics()),
+    }, nil
+}
+```
+
+```go
+func (svc *Service) UpdateDocument(ctx context.Context, req UpdateDocumentRequest) (UpdateDocumentResponse, error) {
+    doc := svc.docs.MustGet(req.DocumentID)
+    doc.Source = req.Source
+    doc.Analysis = jsparse.Analyze(doc.URI, doc.Source, nil)
+    doc.Version++
+
+    if doc.CSTParser != nil {
+        doc.CST = doc.CSTParser.Parse([]byte(doc.Source))
+    }
+
+    return UpdateDocumentResponse{
+        Diagnostics: mapDiagnostics(doc.Analysis.Diagnostics()),
+        Version:     doc.Version,
+    }, nil
+}
+```
+
+### Globals flow with static+runtime merge
+
+```go
+func (svc *Service) ListGlobals(ctx context.Context, req ListGlobalsRequest) (ListGlobalsResponse, error) {
+    doc := svc.docs.MustGet(req.DocumentID)
+    s := analysis.NewSessionFromResult(doc.Analysis)
+
+    globals := s.Globals()
+    if !req.IncludeRuntime {
+        return ListGlobalsResponse{Globals: mapGlobals(globals, "static")}, nil
+    }
+
+    rt := svc.runtime.ForDocument(doc.ID)
+    runtimeKinds := runtime.RuntimeGlobalKinds(rt.VM)
+    declared := doc.REPLDeclared
+
+    merged := analysis.MergeGlobals(
+        globals,
+        runtimeKinds,
+        declared,
+        func(name string) bool {
+            v := rt.GlobalValue(name)
+            return v != nil && !goja.IsUndefined(v)
+        },
+    )
+
+    return ListGlobalsResponse{Globals: mapGlobals(merged, "merged")}, nil
+}
+```
+
+### Cursor sync flow
+
+```go
+func (svc *Service) SyncSourceToTree(ctx context.Context, req SyncSourceToTreeRequest) (SyncSourceToTreeResponse, error) {
+    doc := svc.docs.MustGet(req.DocumentID)
+    idx := doc.Analysis.Index
+    lines := strings.Split(doc.Source, "\n")
+
+    sel, ok := navigation.SelectionAtSourceCursor(
+        idx,
+        lines,
+        req.Cursor.Line-1,
+        req.Cursor.Col-1,
+    )
+    if !ok {
+        return SyncSourceToTreeResponse{}, ErrNoNodeAtCursor
+    }
+
+    idx.ExpandTo(sel.NodeID)
+    visible := idx.VisibleNodes()
+    visibleIdx := navigation.FindVisibleNodeIndex(visible, sel.NodeID)
+
+    node := idx.Nodes[sel.NodeID]
+    return SyncSourceToTreeResponse{
+        SelectedNode: mapNode(node),
+        VisibleIndex: visibleIdx,
+        Highlight:    mapOffsetsToRange(idx, sel.HighlightStart, sel.HighlightEnd),
+    }, nil
+}
+```
+
+### Runtime evaluation and object inspection flow
+
+```go
+func (svc *Service) Eval(ctx context.Context, req EvalRequest) (EvalResponse, error) {
+    rt := svc.runtimes.MustGet(req.RuntimeID)
+    result := rt.EvalWithCapture(req.Expression)
+
+    if result.Error != nil {
+        var info *runtime.ErrorInfo
+        if ex, ok := result.Error.(*goja.Exception); ok {
+            parsed := runtime.ParseException(ex)
+            info = &parsed
+        }
+        return EvalResponse{
+            ValuePreview: "",
+            ValueKind:    "error",
+            Error:        info,
+        }, nil
+    }
+
+    handle := ""
+    kind := classifyValue(result.Value)
+    if obj, ok := result.Value.(*goja.Object); ok {
+        handle = svc.objects.Store(rt.ID, obj)
+    }
+
+    return EvalResponse{
+        ValuePreview: runtime.ValuePreview(result.Value, rt.VM, 80),
+        ValueKind:    kind,
+        ObjectHandle: handle,
+    }, nil
+}
+```
+
+## API Shape Decisions That Matter
+
+### Decision 1: explicit coordinate system
+
+Recommendation:
+
+1. all user-facing contracts use 1-based `Position` and `Range`,
+2. keep internal adapters for 0-based UI or tree-sitter values,
+3. centralize conversions in one utility module.
+
+Why:
+
+1. line-oriented tools and editors often present 1-based lines,
+2. prevents repeated off-by-one bugs.
+
+### Decision 2: session identity and mutability
+
+Recommendation:
+
+1. document sessions identified by `DocumentID`,
+2. version increment per update,
+3. runtime session either per document or explicit detached runtime for REPL experiments.
+
+Why:
+
+1. enables deterministic caches,
+2. makes REST and LSP synchronization tractable.
+
+### Decision 3: sync vs async boundaries
+
+Recommendation:
+
+1. keep parse/eval APIs synchronous initially,
+2. permit context cancellation,
+3. add async job model only if heavy workloads appear.
+
+Why:
+
+1. complexity stays low while workloads are small.
+
+### Decision 4: error model
+
+Recommendation:
+
+1. structured domain errors (`ErrDocumentNotFound`, `ErrRuntimeNotFound`, `ErrInvalidPosition`),
+2. include optional machine code + user message,
+3. preserve raw runtime error payload where possible.
+
+Why:
+
+1. adapter layers need predictable HTTP status/CLI exits.
+
+## Migration Strategy from Current Code
+
+### Step 1: define contracts without moving code
+
+1. create `pkg/inspectorapi/contracts.go` and map current package outputs into DTOs,
+2. write pure mapping tests.
+
+### Step 2: wrap existing logic with service methods
+
+1. implement analysis flows by calling `jsparse` + `inspector/analysis`,
+2. implement runtime flows by calling `inspector/runtime`,
+3. implement navigation/tree flows via `inspector/navigation` and `inspector/tree`.
+
+### Step 3: reduce command-model orchestration
+
+1. move repeated model logic to service methods,
+2. leave keymaps/view rendering untouched.
+
+### Step 4: add one non-TUI adapter
+
+1. add minimal CLI command or HTTP handler that consumes `inspectorapi.Service`,
+2. validate no Bubble Tea imports in service package.
+
+### Step 5: tighten compatibility tests
+
+1. add golden or behavioral parity tests comparing old command behavior and new service-backed behavior,
+2. freeze first contract set before externalizing.
+
+## Suggested Public Interfaces (Detailed)
+
+### Service interface
+
+```go
+type InspectorService interface {
+    OpenDocument(ctx context.Context, req OpenDocumentRequest) (OpenDocumentResponse, error)
+    UpdateDocument(ctx context.Context, req UpdateDocumentRequest) (UpdateDocumentResponse, error)
+    CloseDocument(ctx context.Context, req CloseDocumentRequest) error
+
+    ListGlobals(ctx context.Context, req ListGlobalsRequest) (ListGlobalsResponse, error)
+    ListMembers(ctx context.Context, req ListMembersRequest) (ListMembersResponse, error)
+    GoToDeclaration(ctx context.Context, req GoToDeclarationRequest) (GoToDeclarationResponse, error)
+    CrossReferences(ctx context.Context, req CrossReferencesRequest) (CrossReferencesResponse, error)
+
+    BuildTreeRows(ctx context.Context, req BuildTreeRowsRequest) (BuildTreeRowsResponse, error)
+    SyncSourceToTree(ctx context.Context, req SyncSourceToTreeRequest) (SyncSourceToTreeResponse, error)
+    SyncTreeToSource(ctx context.Context, req SyncTreeToSourceRequest) (SyncTreeToSourceResponse, error)
+
+    Eval(ctx context.Context, req EvalRequest) (EvalResponse, error)
+    InspectObject(ctx context.Context, req InspectObjectRequest) (InspectObjectResponse, error)
+    PrototypeChain(ctx context.Context, req PrototypeChainRequest) (PrototypeChainResponse, error)
+
+    Complete(ctx context.Context, req CompleteRequest) (CompleteResponse, error)
+    SyntaxSpans(ctx context.Context, req SyntaxSpansRequest) (SyntaxSpansResponse, error)
+}
+```
+
+### Storage interfaces
+
+```go
+type DocumentStore interface {
+    Put(*DocumentSession)
+    Get(id string) (*DocumentSession, bool)
+    Delete(id string)
+}
+
+type RuntimeStore interface {
+    Put(*RuntimeSession)
+    Get(id string) (*RuntimeSession, bool)
+    Delete(id string)
+}
+```
+
+These interfaces allow:
+
+1. in-memory implementation now,
+2. pluggable persistence later if needed.
+
+## Decision Matrix
+
+| Criterion | Option A Library-First | Option B Service-First | Option C Hybrid (Recommended) |
+|---|---:|---:|---:|
+| Time to first value | High | Low | High |
+| Internal code reuse | Medium | Medium | High |
+| External API readiness | Low | High | Medium |
+| Risk of premature contracts | Medium | High | Medium |
+| Testability | High | Medium | High |
+| Migration complexity | Low | High | Medium |
+| Long-term flexibility | Medium | Medium | High |
+
+Interpretation:
+
+1. Option C gives strongest total score for this codebase phase.
+
+## New Developer Onboarding Path
+
+### Day 1 reading order
+
+1. `pkg/jsparse/analyze.go`,
+2. `pkg/jsparse/index.go`,
+3. `pkg/inspector/analysis/smalltalk_session.go`,
+4. `pkg/inspector/runtime/session.go`,
+5. `pkg/inspector/navigation/sync.go`,
+6. `cmd/smalltalk-inspector/app/model.go`.
+
+### Day 1 runnable checklist
+
+1. run `go test ./pkg/jsparse ./pkg/inspector/... -count=1`,
+2. run `go test ./cmd/smalltalk-inspector/... ./cmd/inspector/... -count=1`,
+3. open and follow one behavior path end-to-end:
+   1. load file,
+   2. list globals,
+   3. jump to source,
+   4. evaluate expression,
+   5. inspect object.
+
+### Day 2 contribution starter tasks
+
+1. add one service-level DTO and mapper,
+2. add one service method wrapping existing helper logic,
+3. add tests for coordinate conversion edge-cases,
+4. wire one cmd flow through new service method.
+
+## Risks and Mitigations
+
+### Risk: DTO churn during early design
+
+Mitigation:
+
+1. mark first contracts as experimental version,
+2. isolate mappers so internal types can evolve.
+
+### Risk: leaking goja/tree-sitter types into public API
+
+Mitigation:
+
+1. keep public DTO package free of goja/tree-sitter imports,
+2. compile-time checks in adapter packages.
+
+### Risk: behavior drift between command apps
+
+Mitigation:
+
+1. shared service parity tests,
+2. maintain targeted command regression tests.
+
+### Risk: runtime session safety in server mode
+
+Mitigation:
+
+1. avoid shared mutable runtime across concurrent requests unless locked,
+2. expose explicit runtime/session ownership semantics.
+
+## Testing Strategy for the New User-Facing API
+
+### Unit tests
+
+1. DTO mapping correctness,
+2. coordinate conversion correctness,
+3. service methods with mocked stores.
+
+### Integration tests
+
+1. parse to globals to members pipeline,
+2. eval to inspect to function-map pipeline,
+3. completion and syntax spans against known fixture files.
+
+### Contract tests
+
+1. JSON serialization stability for REST payloads,
+2. backwards compatibility checks for key response fields.
+
+### Parity tests
+
+1. compare outputs of cmd model flow before and after service adoption on fixed fixtures,
+2. ensure tree sync and highlight ranges remain equivalent.
+
+## Implementation Brainstorming Notes
+
+### Idea: “analysis snapshot” object
+
+Introduce immutable snapshot object to avoid accidental mutation of shared index state:
+
+```go
+type AnalysisSnapshot struct {
+    DocumentID string
+    Version    int
+    Result     *jsparse.AnalysisResult
+}
+```
+
+Usage:
+
+1. session updates create new snapshot,
+2. read APIs consume snapshot by value or pointer without mutating index visibility directly,
+3. UI-specific visibility state moves out of shared index if needed.
+
+Tradeoff:
+
+1. may need a separate `TreeState` structure to track expand/collapse per client.
+
+### Idea: separate “tree state” from AST index
+
+Current `Index` stores `Expanded` in nodes, which is convenient but UI-stateful.
+
+Alternative:
+
+1. keep index immutable structural data,
+2. track expanded node IDs in per-client `TreeViewState`.
+
+Sketch:
+
+```go
+type TreeViewState struct {
+    Expanded map[int]bool
+}
+
+func VisibleNodes(idx *jsparse.Index, st TreeViewState) []int
+```
+
+Benefit:
+
+1. avoids cross-client bleed in server contexts.
+
+Cost:
+
+1. more plumbing in existing cmd apps.
+
+Recommendation:
+
+1. defer until multi-client adapter appears,
+2. design service methods so migration remains possible.
+
+### Idea: runtime object handles
+
+For REST/LSP adapters, object values cannot cross process boundaries directly.
+
+Use handle registry:
+
+1. store goja objects in runtime session object map,
+2. return short opaque handles in API responses,
+3. inspect by handle in follow-up calls.
+
+Sketch:
+
+```go
+type ObjectRegistry interface {
+    Put(runtimeID string, obj *goja.Object) string
+    Get(runtimeID, handle string) (*goja.Object, bool)
+    DeleteRuntime(runtimeID string)
+}
+```
+
+### Idea: capability flags on responses
+
+Add lightweight capability metadata to help adapters avoid assumptions.
+
+Example:
+
+```go
+type Capability struct {
+    Name string // e.g. "runtime-map-function-source"
+    Enabled bool
+}
+```
+
+Use case:
+
+1. if runtime map-to-source is unavailable, UI can show fallback quickly.
+
+## Recommended Next Steps
+
+1. Create a follow-up implementation ticket to scaffold `pkg/inspectorapi` with contracts and minimal service skeleton.
+2. Implement first four methods end-to-end:
+   1. `OpenDocument`,
+   2. `ListGlobals`,
+   3. `ListMembers`,
+   4. `GoToDeclaration`.
+3. Move static+runtime globals merge behavior from `cmd/smalltalk-inspector/app/model.go` into service layer.
+4. Add `SyncSourceToTree` and `BuildTreeRows` service methods using already extracted packages.
+5. Wire one command path in `cmd/smalltalk-inspector` through service layer and add parity tests.
+6. Add a thin CLI or REST proof-of-concept adapter to validate transport neutrality.
+
+## Appendix A: Detailed API Mapping from Existing Code
+
+### Existing function to future service mapping
+
+| Existing API | Proposed service operation |
+|---|---|
+| `jsparse.Analyze` | `OpenDocument`, `UpdateDocument` |
+| `analysis.Session.Globals` | `ListGlobals` |
+| `analysis.Session.ClassMembers`, `FunctionMembers` | `ListMembers` |
+| `analysis.Session.BindingDeclLine`, `MemberDeclLine` | `GoToDeclaration` |
+| `analysis.CrossReferences` | `CrossReferences` |
+| `runtime.Session.EvalWithCapture` | `Eval` |
+| `runtime.InspectObject` | `InspectObject` |
+| `runtime.WalkPrototypeChain` | `PrototypeChain` |
+| `runtime.MapFunctionToSource` | `ResolveRuntimeFunctionLocation` |
+| `navigation.SelectionAtSourceCursor` | `SyncSourceToTree` |
+| `navigation.SelectionFromVisibleTree` | `SyncTreeToSource` |
+| `tree.BuildRowsFromIndex` | `BuildTreeRows` |
+| `jsparse.ResolveCandidates` | `Complete` |
+| `jsparse.BuildSyntaxSpans` | `SyntaxSpans` |
+
+## Appendix B: Practical “How to Decide” Checklist
+
+When evaluating an API addition, use this checklist:
+
+1. Is this behavior domain logic or UI interaction logic?
+2. Can it be represented with plain DTOs and primitive types?
+3. Does it need document session state, runtime state, or both?
+4. What coordinate system does it accept and return?
+5. Is behavior deterministic and testable without UI framework?
+6. Can this be reused by at least two adapters (TUI + one of CLI/REST/LSP)?
+7. What are failure modes, and are they represented structurally?
+8. Does this leak internal dependency types?
+
+If answers are strong on 1, 2, 5, 6, it belongs in user-facing service API.
+
+## Appendix C: Minimal First Implementation Example
+
+```go
+// Package inspectorapi
+func (s *Service) ListMembers(ctx context.Context, req ListMembersRequest) (ListMembersResponse, error) {
+    doc, ok := s.docs.Get(req.DocumentID)
+    if !ok {
+        return ListMembersResponse{}, ErrDocumentNotFound
+    }
+
+    sess := analysis.NewSessionFromResult(doc.Analysis)
+    globals := sess.Globals()
+
+    var selected *analysis.GlobalBinding
+    for i := range globals {
+        if globals[i].Name == req.SymbolName {
+            selected = &globals[i]
+            break
+        }
+    }
+    if selected == nil {
+        return ListMembersResponse{}, nil
+    }
+
+    switch selected.Kind {
+    case jsparse.BindingClass:
+        members := sess.ClassMembers(selected.Name)
+        return ListMembersResponse{Members: mapClassMembers(members)}, nil
+    case jsparse.BindingFunction:
+        members := sess.FunctionMembers(selected.Name)
+        return ListMembersResponse{Members: mapFunctionMembers(members)}, nil
+    default:
+        return s.listRuntimeValueMembers(ctx, doc, selected.Name)
+    }
+}
+```
+
+This style keeps existing domain logic intact while giving adapters a stable surface.
+
+## Closing Note
+
+The hard part is no longer “how do we inspect JavaScript?”. We already do that across static and runtime paths. The hard part now is packaging and contract quality. A disciplined service layer with explicit DTOs will let us move quickly without re-embedding logic into each frontend.
+
+This is the right moment to lock in those boundaries.

--- a/ttmp/2026/02/15/GOJA-034-USER-FACING-INSPECTOR-API--user-facing-inspector-analysis-api-design/design/01-user-facing-inspector-api-analysis-and-design-guide.md
+++ b/ttmp/2026/02/15/GOJA-034-USER-FACING-INSPECTOR-API--user-facing-inspector-analysis-api-design/design/01-user-facing-inspector-api-analysis-and-design-guide.md
@@ -20,6 +20,8 @@ RelatedFiles:
         Adapter layer examples used in migration section
     - Path: internal/inspectorui/listpane.go
       Note: Reused viewport/list utility behavior in UI layer
+    - Path: pkg/doc/07-inspectorapi-hybrid-service-guide.md
+      Note: Help-system-facing documentation derived from hybrid API design
     - Path: pkg/inspector/analysis/globals_merge.go
       Note: Static+runtime global merge strategy
     - Path: pkg/inspector/analysis/repl_declarations.go
@@ -66,6 +68,7 @@ LastUpdated: 2026-02-15T11:09:00-05:00
 WhatFor: Help new and existing developers converge on a clean public API and packaging strategy for analysis/inspection features.
 WhenToUse: Read before designing new CLI/REST/LSP adapters or restructuring inspector service boundaries.
 ---
+
 
 
 # User-Facing Inspector API Analysis and Design Guide

--- a/ttmp/2026/02/15/GOJA-034-USER-FACING-INSPECTOR-API--user-facing-inspector-analysis-api-design/design/02-hybrid-implementation-plan-clean-cutover.md
+++ b/ttmp/2026/02/15/GOJA-034-USER-FACING-INSPECTOR-API--user-facing-inspector-analysis-api-design/design/02-hybrid-implementation-plan-clean-cutover.md
@@ -1,0 +1,173 @@
+---
+Title: Hybrid Implementation Plan (Clean Cutover)
+Ticket: GOJA-034-USER-FACING-INSPECTOR-API
+Status: active
+Topics:
+    - go
+    - goja
+    - inspector
+    - api
+    - architecture
+DocType: design
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: go-go-goja/pkg/inspectorapi
+      Note: New user-facing API service layer (to be implemented in this ticket)
+    - Path: go-go-goja/cmd/smalltalk-inspector/app/model.go
+      Note: Primary clean-cutover consumer for API layer adoption
+    - Path: go-go-goja/cmd/smalltalk-inspector/app/update.go
+      Note: File load and REPL flows will be switched to API service methods
+    - Path: go-go-goja/pkg/inspector/analysis
+      Note: Existing static analysis helpers used by the new facade
+    - Path: go-go-goja/pkg/inspector/runtime
+      Note: Existing runtime helpers used by the new facade
+    - Path: go-go-goja/pkg/inspector/navigation
+      Note: Existing source/tree sync helpers wrapped by new facade methods
+    - Path: go-go-goja/pkg/inspector/tree
+      Note: Existing tree row builder wrapped by new facade methods
+ExternalSources: []
+Summary: Detailed implementation plan for hybrid user-facing inspector API with clean cutover and no backward-compatibility shims.
+LastUpdated: 2026-02-15T11:26:00-05:00
+WhatFor: Guide execution of the first implementation slice of the hybrid architecture.
+WhenToUse: Use while implementing GOJA-034 code changes and migration.
+---
+
+# Hybrid Implementation Plan (Clean Cutover)
+
+## Decision and Scope
+
+We will implement the hybrid approach as a **clean cutover**:
+
+1. No compatibility shims for old adapter-local static analysis orchestration.
+2. Frontend command models should consume the new facade directly.
+3. Existing low-level packages (`pkg/jsparse`, `pkg/inspector/*`) remain the implementation substrate.
+
+This plan intentionally prioritizes tightening and simplification over preserving intermediate APIs.
+
+## Target Architecture (Phase A)
+
+Introduce a new package:
+
+1. `pkg/inspectorapi`
+
+Phase A capabilities:
+
+1. Document session lifecycle:
+   1. open from source or existing analysis result,
+   2. update source,
+   3. close document.
+2. Static analysis use cases:
+   1. list globals,
+   2. list members for selected global,
+   3. declaration jumps for globals/members.
+3. Runtime-integrated global/member behavior:
+   1. merge runtime globals and REPL declarations,
+   2. runtime-derived member listing for value globals.
+4. Navigation/tree wrappers:
+   1. source->tree sync,
+   2. tree->source sync,
+   3. tree row building.
+5. Smalltalk inspector cutover:
+   1. replace direct `inspector/analysis` orchestration calls with `inspectorapi.Service`.
+
+Out of scope for this slice:
+
+1. REST adapter implementation.
+2. LSP adapter implementation.
+3. Deeper runtime object-handle protocol.
+4. Tree-state decoupling from `jsparse.Index.Expanded`.
+
+## Data and Contract Direction
+
+Phase A contract strategy:
+
+1. Expose explicit request/response structs in `pkg/inspectorapi`.
+2. Keep DTOs UI-framework agnostic.
+3. Reuse existing domain enums where stable (`jsparse.BindingKind`).
+4. Keep coordinate conventions explicit in comments (0-based vs 1-based).
+
+## Clean Cutover Rules
+
+1. `cmd/smalltalk-inspector/app` should stop depending on `inspectoranalysis.Session` for globals/members/jumps.
+2. Static analysis orchestration logic should move into `pkg/inspectorapi`.
+3. No adapter-local duplicate logic should remain for:
+   1. global list creation,
+   2. member list creation,
+   3. declaration line lookup,
+   4. runtime-global merge.
+
+## Implementation Phases
+
+## Phase 1: Service Foundation
+
+1. Add `pkg/inspectorapi` package with:
+   1. service struct and in-memory document registry,
+   2. core contracts and error types,
+   3. open/update/close/get document operations.
+
+## Phase 2: Static + Runtime Use Cases
+
+1. Implement facade methods:
+   1. list globals,
+   2. list members,
+   3. go-to declaration helpers,
+   4. runtime-global merge helper.
+2. Add parser-backed REPL declaration extraction helper in facade namespace.
+
+## Phase 3: Navigation/Tree Facade Methods
+
+1. Wrap existing extracted packages:
+   1. `pkg/inspector/navigation`,
+   2. `pkg/inspector/tree`.
+2. Expose service methods for source/tree sync and tree rows.
+
+## Phase 4: Smalltalk Inspector Cutover
+
+1. Introduce `inspectorapi.Service` in model state.
+2. Route file-load setup through service open/register path.
+3. Switch globals/members/jump and merge logic to service methods.
+4. Remove obsolete adapter-local static orchestration dependencies.
+
+## Phase 5: Validation and Documentation
+
+1. Add/adjust service unit tests.
+2. Update smalltalk inspector tests for new service wiring.
+3. Run:
+   1. `go test ./pkg/inspectorapi/... -count=1`
+   2. `go test ./cmd/smalltalk-inspector/... -count=1`
+   3. `go test ./... -count=1`
+4. Update GOJA-034 tasks/changelog/diary with commit-linked progress.
+
+## Risk Assessment
+
+Risk:
+
+1. Cutover introduces behavior drift in globals/members panels.
+
+Mitigation:
+
+1. Keep existing tests green; add service-level tests for the moved logic.
+
+Risk:
+
+1. Mixed index/line conventions create off-by-one regressions.
+
+Mitigation:
+
+1. Make service method coordinate behavior explicit and test both sync directions.
+
+Risk:
+
+1. Runtime-dependent member listing differs due to orchestration move.
+
+Mitigation:
+
+1. Add regression tests for runtime-derived value members and global merge.
+
+## Done Criteria
+
+1. `pkg/inspectorapi` exists with phase-A methods and tests.
+2. `cmd/smalltalk-inspector/app` uses the new service for static analysis orchestration.
+3. No compatibility shims added for prior adapter-local static orchestration.
+4. Full tests pass and GOJA-034 docs are updated.

--- a/ttmp/2026/02/15/GOJA-034-USER-FACING-INSPECTOR-API--user-facing-inspector-analysis-api-design/index.md
+++ b/ttmp/2026/02/15/GOJA-034-USER-FACING-INSPECTOR-API--user-facing-inspector-analysis-api-design/index.md
@@ -28,7 +28,7 @@ RelatedFiles:
       Note: Extracted tree row shaping primitives for reusable API endpoints
 ExternalSources: []
 Summary: Ticket for designing a stable user-facing API over extracted analysis and inspection functionality.
-LastUpdated: 2026-02-15T11:10:00-05:00
+LastUpdated: 2026-02-15T11:32:00-05:00
 WhatFor: Track architecture decisions and contracts for a reusable inspector service layer.
 WhenToUse: Use when implementing shared APIs for TUI, CLI, REST, and future LSP adapters.
 ---
@@ -48,8 +48,7 @@ This ticket defines how to expose extracted inspector functionality as a clean u
 
 Current status: **active**
 
-Progress: design and brainstorming guide delivered (8+ pages), ready for implementation ticket(s).
-Progress update: phase-A implementation plan and execution task breakdown added.
+Progress: design and brainstorming guide delivered (8+ pages), phase-A implementation plan authored, and first hybrid cutover slice completed in code (`pkg/inspectorapi` + smalltalk static flow migration).
 
 ## Topics
 

--- a/ttmp/2026/02/15/GOJA-034-USER-FACING-INSPECTOR-API--user-facing-inspector-analysis-api-design/index.md
+++ b/ttmp/2026/02/15/GOJA-034-USER-FACING-INSPECTOR-API--user-facing-inspector-analysis-api-design/index.md
@@ -26,9 +26,11 @@ RelatedFiles:
       Note: Extracted source/tree sync primitives for reusable API endpoints
     - Path: go-go-goja/pkg/inspector/tree
       Note: Extracted tree row shaping primitives for reusable API endpoints
+    - Path: go-go-goja/pkg/doc/07-inspectorapi-hybrid-service-guide.md
+      Note: Glazed-compliant help entry documenting the new hybrid service layer
 ExternalSources: []
 Summary: Ticket for designing a stable user-facing API over extracted analysis and inspection functionality.
-LastUpdated: 2026-02-15T11:32:00-05:00
+LastUpdated: 2026-02-15T11:44:00-05:00
 WhatFor: Track architecture decisions and contracts for a reusable inspector service layer.
 WhenToUse: Use when implementing shared APIs for TUI, CLI, REST, and future LSP adapters.
 ---

--- a/ttmp/2026/02/15/GOJA-034-USER-FACING-INSPECTOR-API--user-facing-inspector-analysis-api-design/index.md
+++ b/ttmp/2026/02/15/GOJA-034-USER-FACING-INSPECTOR-API--user-facing-inspector-analysis-api-design/index.md
@@ -1,0 +1,72 @@
+---
+Title: User-Facing Inspector Analysis API Design
+Ticket: GOJA-034-USER-FACING-INSPECTOR-API
+Status: active
+Topics:
+    - go
+    - goja
+    - inspector
+    - api
+    - architecture
+DocType: index
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: go-go-goja/ttmp/2026/02/15/GOJA-034-USER-FACING-INSPECTOR-API--user-facing-inspector-analysis-api-design/design/01-user-facing-inspector-api-analysis-and-design-guide.md
+      Note: Primary 8+ page onboarding, analysis, and API design document
+    - Path: go-go-goja/pkg/inspector/analysis
+      Note: Existing high-level analysis helpers to be wrapped by user-facing service layer
+    - Path: go-go-goja/pkg/inspector/runtime
+      Note: Runtime inspection and eval helpers for API packaging
+    - Path: go-go-goja/pkg/inspector/navigation
+      Note: Extracted source/tree sync primitives for reusable API endpoints
+    - Path: go-go-goja/pkg/inspector/tree
+      Note: Extracted tree row shaping primitives for reusable API endpoints
+ExternalSources: []
+Summary: Ticket for designing a stable user-facing API over extracted analysis and inspection functionality.
+LastUpdated: 2026-02-15T11:10:00-05:00
+WhatFor: Track architecture decisions and contracts for a reusable inspector service layer.
+WhenToUse: Use when implementing shared APIs for TUI, CLI, REST, and future LSP adapters.
+---
+
+# User-Facing Inspector Analysis API Design
+
+## Overview
+
+This ticket defines how to expose extracted inspector functionality as a clean user-facing API. The design document maps current capabilities, explains architecture for new developers, and proposes concrete API contracts and migration paths.
+
+## Key Links
+
+- **Related Files**: See frontmatter RelatedFiles field
+- **External Sources**: See frontmatter ExternalSources field
+
+## Status
+
+Current status: **active**
+
+Progress: design and brainstorming guide delivered (8+ pages), ready for implementation ticket(s).
+
+## Topics
+
+- go
+- goja
+- inspector
+- api
+- architecture
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/2026/02/15/GOJA-034-USER-FACING-INSPECTOR-API--user-facing-inspector-analysis-api-design/index.md
+++ b/ttmp/2026/02/15/GOJA-034-USER-FACING-INSPECTOR-API--user-facing-inspector-analysis-api-design/index.md
@@ -14,6 +14,10 @@ Owners: []
 RelatedFiles:
     - Path: go-go-goja/ttmp/2026/02/15/GOJA-034-USER-FACING-INSPECTOR-API--user-facing-inspector-analysis-api-design/design/01-user-facing-inspector-api-analysis-and-design-guide.md
       Note: Primary 8+ page onboarding, analysis, and API design document
+    - Path: go-go-goja/ttmp/2026/02/15/GOJA-034-USER-FACING-INSPECTOR-API--user-facing-inspector-analysis-api-design/design/02-hybrid-implementation-plan-clean-cutover.md
+      Note: Phase-A execution plan for hybrid service-layer implementation with clean cutover
+    - Path: go-go-goja/ttmp/2026/02/15/GOJA-034-USER-FACING-INSPECTOR-API--user-facing-inspector-analysis-api-design/reference/01-diary.md
+      Note: Implementation diary for execution and validation tracking
     - Path: go-go-goja/pkg/inspector/analysis
       Note: Existing high-level analysis helpers to be wrapped by user-facing service layer
     - Path: go-go-goja/pkg/inspector/runtime
@@ -45,6 +49,7 @@ This ticket defines how to expose extracted inspector functionality as a clean u
 Current status: **active**
 
 Progress: design and brainstorming guide delivered (8+ pages), ready for implementation ticket(s).
+Progress update: phase-A implementation plan and execution task breakdown added.
 
 ## Topics
 

--- a/ttmp/2026/02/15/GOJA-034-USER-FACING-INSPECTOR-API--user-facing-inspector-analysis-api-design/reference/01-diary.md
+++ b/ttmp/2026/02/15/GOJA-034-USER-FACING-INSPECTOR-API--user-facing-inspector-analysis-api-design/reference/01-diary.md
@@ -1,0 +1,26 @@
+---
+Title: Diary
+Ticket: GOJA-034-USER-FACING-INSPECTOR-API
+Status: active
+Topics:
+    - go
+    - goja
+    - inspector
+    - api
+    - architecture
+DocType: reference
+Intent: long-term
+Owners: []
+RelatedFiles: []
+ExternalSources: []
+Summary: Implementation diary for GOJA-034 hybrid API plan and execution.
+LastUpdated: 2026-02-15T11:27:00-05:00
+WhatFor: Track implementation steps, decisions, regressions, and validation for GOJA-034.
+WhenToUse: Use when reviewing or continuing GOJA-034 implementation work.
+---
+
+# Diary
+
+## Goal
+
+Capture step-by-step execution of the GOJA-034 hybrid user-facing API implementation with a clean cutover strategy.

--- a/ttmp/2026/02/15/GOJA-034-USER-FACING-INSPECTOR-API--user-facing-inspector-analysis-api-design/reference/01-diary.md
+++ b/ttmp/2026/02/15/GOJA-034-USER-FACING-INSPECTOR-API--user-facing-inspector-analysis-api-design/reference/01-diary.md
@@ -12,24 +12,27 @@ DocType: reference
 Intent: long-term
 Owners: []
 RelatedFiles:
-    - Path: go-go-goja/pkg/inspectorapi/contracts.go
-      Note: New hybrid facade contracts and request/response DTOs
-    - Path: go-go-goja/pkg/inspectorapi/service.go
-      Note: Service implementation for document lifecycle and inspector use cases
-    - Path: go-go-goja/pkg/inspectorapi/service_test.go
-      Note: Regression tests for phase-A service behavior
-    - Path: go-go-goja/cmd/smalltalk-inspector/app/model.go
+    - Path: cmd/smalltalk-inspector/app/model.go
       Note: Smalltalk static-flow cutover to inspectorapi service
-    - Path: go-go-goja/cmd/smalltalk-inspector/app/update.go
-      Note: File load and REPL declaration flow switched to inspectorapi
-    - Path: go-go-goja/cmd/smalltalk-inspector/app/model_members_test.go
+    - Path: cmd/smalltalk-inspector/app/model_members_test.go
       Note: Updated tests for service-backed model setup
+    - Path: cmd/smalltalk-inspector/app/update.go
+      Note: File load and REPL declaration flow switched to inspectorapi
+    - Path: pkg/doc/07-inspectorapi-hybrid-service-guide.md
+      Note: New Glazed-compliant user-facing help page documented in Step 3
+    - Path: pkg/inspectorapi/contracts.go
+      Note: New hybrid facade contracts and request/response DTOs
+    - Path: pkg/inspectorapi/service.go
+      Note: Service implementation for document lifecycle and inspector use cases
+    - Path: pkg/inspectorapi/service_test.go
+      Note: Regression tests for phase-A service behavior
 ExternalSources: []
 Summary: Implementation diary for GOJA-034 hybrid API plan and phase-A cutover.
-LastUpdated: 2026-02-15T11:33:00-05:00
+LastUpdated: 2026-02-15T11:46:00-05:00
 WhatFor: Track implementation steps, decisions, regressions, and validation for GOJA-034.
 WhenToUse: Use when reviewing or continuing GOJA-034 implementation work.
 ---
+
 
 # Diary
 
@@ -208,3 +211,79 @@ Smalltalk inspector static orchestration was migrated from adapter-local `inspec
   - `SyncSourceToTree`
   - `SyncTreeToSource`
   - `DeclaredBindingsFromSource` (package-level helper).
+
+## Step 3: Author Glazed-Compliant Help Documentation for inspectorapi
+
+This step produced user-facing documentation for the hybrid service layer in the repository help-doc system (`pkg/doc`). The page was written against the same rules used by Glazed help entries, including strict frontmatter, section-intro paragraphs, troubleshooting table, and `See Also` references.
+
+The content targets new contributors who need both conceptual orientation and practical integration steps for `pkg/inspectorapi`.
+
+### Prompt Context
+
+**User prompt (verbatim):** "Now write a great documentation for it, following the glazed writing guidelines glazed/pkg/doc/topics/01-help-system.md and glazed/pkg/doc/topics/how-to-write-good-documentation-pages.md and glazed/pkg/doc/topics/14-writing-help-entries.md"
+
+**Assistant interpretation:** Write a high-quality help page for the new hybrid inspector API and align structure/style with the specific Glazed guideline topics.
+
+**Inferred user intent:** Ensure this new architecture is documented in the same quality and discoverability model as existing Glazed CLI help pages.
+
+### What I did
+
+- Located and reviewed guideline docs from the pinned Glazed version in `go.mod` (`v0.7.13`):
+  - `.../glazed@v0.7.13/pkg/doc/topics/01-help-system.md`
+  - `.../glazed@v0.7.13/pkg/doc/topics/how-to-write-good-documentation-pages.md`
+  - `.../glazed@v0.7.13/pkg/doc/topics/14-writing-help-entries.md`
+- Added new help page:
+  - `pkg/doc/07-inspectorapi-hybrid-service-guide.md`
+- Ensured page follows key conventions:
+  - YAML frontmatter with Glazed metadata fields,
+  - no top-level `#` title in body,
+  - section-opening explanatory paragraphs,
+  - practical code examples and migration checklist,
+  - troubleshooting table,
+  - `See Also` with `glaze help <slug>` references.
+
+### Why
+
+- `pkg/inspectorapi` is now a primary integration boundary and needs first-class help-system documentation, not only ticket docs.
+- Keeping docs in `pkg/doc` makes content discoverable through existing help loading via `pkg/doc/doc.go`.
+
+### What worked
+
+- Existing `pkg/doc` structure already matched Glazed help conventions, so adding one new section required no loader changes.
+- The guideline-driven format naturally aligned with this repository’s prior help pages.
+
+### What didn't work
+
+- N/A.
+
+### What I learned
+
+- The most important style constraints for help usability here are:
+  - strong opening paragraph per section,
+  - concise metadata,
+  - explicit troubleshooting and cross-links.
+
+### What was tricky to build
+
+- Balancing reference depth and practical onboarding in one page required careful section ordering. The final structure starts with intent/architecture, then workflows/API surface, then migration/testing/ops guidance.
+
+### What warrants a second pair of eyes
+
+- Verify command tags and topic tags in frontmatter are exactly what maintainers want for discoverability and filtering.
+
+### What should be done in the future
+
+- Add companion Example/Application help entries demonstrating:
+  - a minimal non-TUI CLI consumer,
+  - a thin REST adapter over `pkg/inspectorapi`.
+
+### Code review instructions
+
+- Review content and frontmatter in:
+  - `pkg/doc/07-inspectorapi-hybrid-service-guide.md`
+- Optionally validate load path by reviewing:
+  - `pkg/doc/doc.go`
+
+### Technical details
+
+- The new page was intentionally authored as `SectionType: GeneralTopic` and `IsTopLevel: true` to keep it visible during early adoption.

--- a/ttmp/2026/02/15/GOJA-034-USER-FACING-INSPECTOR-API--user-facing-inspector-analysis-api-design/reference/01-diary.md
+++ b/ttmp/2026/02/15/GOJA-034-USER-FACING-INSPECTOR-API--user-facing-inspector-analysis-api-design/reference/01-diary.md
@@ -11,10 +11,22 @@ Topics:
 DocType: reference
 Intent: long-term
 Owners: []
-RelatedFiles: []
+RelatedFiles:
+    - Path: go-go-goja/pkg/inspectorapi/contracts.go
+      Note: New hybrid facade contracts and request/response DTOs
+    - Path: go-go-goja/pkg/inspectorapi/service.go
+      Note: Service implementation for document lifecycle and inspector use cases
+    - Path: go-go-goja/pkg/inspectorapi/service_test.go
+      Note: Regression tests for phase-A service behavior
+    - Path: go-go-goja/cmd/smalltalk-inspector/app/model.go
+      Note: Smalltalk static-flow cutover to inspectorapi service
+    - Path: go-go-goja/cmd/smalltalk-inspector/app/update.go
+      Note: File load and REPL declaration flow switched to inspectorapi
+    - Path: go-go-goja/cmd/smalltalk-inspector/app/model_members_test.go
+      Note: Updated tests for service-backed model setup
 ExternalSources: []
-Summary: Implementation diary for GOJA-034 hybrid API plan and execution.
-LastUpdated: 2026-02-15T11:27:00-05:00
+Summary: Implementation diary for GOJA-034 hybrid API plan and phase-A cutover.
+LastUpdated: 2026-02-15T11:33:00-05:00
 WhatFor: Track implementation steps, decisions, regressions, and validation for GOJA-034.
 WhenToUse: Use when reviewing or continuing GOJA-034 implementation work.
 ---
@@ -23,4 +35,176 @@ WhenToUse: Use when reviewing or continuing GOJA-034 implementation work.
 
 ## Goal
 
-Capture step-by-step execution of the GOJA-034 hybrid user-facing API implementation with a clean cutover strategy.
+Capture execution of GOJA-034 from implementation planning through the first hybrid service-layer cutover into `cmd/smalltalk-inspector`.
+
+## Step 1: Plan Phase-A Cutover and Expand Executable Tasks
+
+This step converted the prior design-only ticket state into an executable implementation plan with concrete phases and clean-cutover constraints. The plan explicitly removed compatibility-shim expectations to keep refactoring boundaries tight and direct.
+
+The output was a task graph that could be executed in one pass: service creation, use-case methods, smalltalk cutover, tests, and documentation closure.
+
+### Prompt Context
+
+**User prompt (verbatim):** "Create an implementation plan for the hybrid approach. We can do clean cutover, no need to maintain compatibility, which should make refactoring and tightening easier. Then add detailed tasks to the ticket, and work on them, committing and updating your diary at appropriate points, checking off tasks as you go."
+
+**Assistant interpretation:** Author a detailed GOJA-034 implementation plan with explicit clean-cutover assumptions, convert it to detailed tasks, then implement and document progress with commit-linked diary updates.
+
+**Inferred user intent:** Move from architecture discussion to concrete delivery of the first hybrid API slice and migration, without being slowed by backwards-compatibility constraints.
+
+**Commit (code):** `b31157b` — "docs(goja-034): add clean-cutover implementation plan and tasks"
+
+### What I did
+
+- Added implementation plan:
+  - `ttmp/2026/02/15/GOJA-034-USER-FACING-INSPECTOR-API--user-facing-inspector-analysis-api-design/design/02-hybrid-implementation-plan-clean-cutover.md`
+- Expanded tasks in ticket `tasks.md` into executable phases.
+- Added GOJA-034 diary scaffold and updated ticket index/changelog.
+
+### Why
+
+- The ticket needed a delivery-grade plan and task decomposition before code execution.
+- Clean-cutover constraints needed to be documented explicitly to avoid accidental compatibility work.
+
+### What worked
+
+- The implementation phases mapped cleanly onto existing extraction work and package boundaries.
+- The plan naturally translated into concrete coding tasks for immediate execution.
+
+### What didn't work
+
+- N/A.
+
+### What I learned
+
+- The existing extraction baseline was sufficient to start the facade layer directly without intermediate scaffolding tickets.
+
+### What was tricky to build
+
+- The key planning challenge was balancing breadth (hybrid architecture) and a shippable first slice. The resolution was to lock “phase-A” boundaries and keep adapters thin.
+
+### What warrants a second pair of eyes
+
+- Ensure phase-A scope remains aligned with product priorities before expanding into REST/LSP adapters.
+
+### What should be done in the future
+
+- Follow-on ticket for phase-B service expansion (runtime object handles, transport adapters).
+
+### Code review instructions
+
+- Read:
+  - `ttmp/2026/02/15/GOJA-034-USER-FACING-INSPECTOR-API--user-facing-inspector-analysis-api-design/design/02-hybrid-implementation-plan-clean-cutover.md`
+  - `ttmp/2026/02/15/GOJA-034-USER-FACING-INSPECTOR-API--user-facing-inspector-analysis-api-design/tasks.md`
+
+### Technical details
+
+- Plan codifies:
+  - service package target: `pkg/inspectorapi`,
+  - phase-A capability set,
+  - clean cutover rules for `cmd/smalltalk-inspector/app`.
+
+## Step 2: Implement Hybrid Service Layer and Cut Over Smalltalk Static Flows
+
+This step implemented the first production slice of the hybrid architecture. A new `pkg/inspectorapi` package now provides a task-oriented facade over extracted analysis/runtime/navigation/tree functionality.
+
+Smalltalk inspector static orchestration was migrated from adapter-local `inspectoranalysis.Session` wiring to `inspectorapi.Service`, matching the clean-cutover requirement and removing duplicate orchestration logic from the command model.
+
+### Prompt Context
+
+**User prompt (verbatim):** (same as Step 1)
+
+**Assistant interpretation:** Execute the planned tasks end-to-end with commits, tests, and diary updates.
+
+**Inferred user intent:** Deliver actual code migration and verify that the new service boundary is practical and stable.
+
+**Commit (code):** `cd823ad` — "inspectorapi: add hybrid service layer and cut over smalltalk static flows"
+
+### What I did
+
+- Added new package:
+  - `pkg/inspectorapi/contracts.go`
+  - `pkg/inspectorapi/service.go`
+  - `pkg/inspectorapi/service_test.go`
+- Implemented service features:
+  - document lifecycle: open/update/close,
+  - globals and members retrieval,
+  - declaration line lookups,
+  - REPL declaration extraction wrapper,
+  - runtime global merge,
+  - tree row builder wrapper,
+  - source<->tree sync wrappers,
+  - analysis retrieval.
+- Cut over `cmd/smalltalk-inspector/app`:
+  - `model.go`: replaced `inspectoranalysis.Session` orchestration with `inspectorapi.Service`,
+  - `update.go`: register file loads via service and use service-level declaration extraction,
+  - `view.go`: parse-error status derived from `m.analysis`,
+  - `model_members_test.go`: updated model setup to open service document sessions.
+- Validated with:
+  - `go test ./pkg/inspectorapi/... -count=1`
+  - `go test ./cmd/smalltalk-inspector/... -count=1`
+  - `go test ./... -count=1`
+
+### Why
+
+- Centralize reusable inspector use cases in a single user-facing API layer.
+- Remove adapter-local duplication and tighten architecture for upcoming CLI/REST/LSP adapters.
+
+### What worked
+
+- Service API was sufficient to absorb existing smalltalk static workflows without compatibility shims.
+- Existing smalltalk tests passed after focused updates.
+- Full repository tests remained green.
+
+### What didn't work
+
+- Pre-commit `go generate ./...` Dagger image fetch for `node:20.18.1` timed out (`lookup registry-1.docker.io: i/o timeout`) and automatically fell back to local npm build; this did not block commit.
+
+### What I learned
+
+- The extracted packages were mature enough for immediate composition into a higher-level facade.
+- Clean cutover reduced code complexity versus carrying temporary bridges.
+
+### What was tricky to build
+
+- The main complexity was preserving runtime-derived member behavior while moving static orchestration to the new service.
+- This required keeping runtime session as an explicit argument in service calls that need it, instead of coupling runtime ownership into document sessions prematurely.
+
+### What warrants a second pair of eyes
+
+- Concurrency semantics in `inspectorapi.Service`: current in-memory registry uses coarse locking and returns document pointers; this is fine for current TUI use but should be reviewed before server-grade concurrency.
+- Coordinate conventions in sync wrappers (0-based cursor inputs, 1-based index offsets) should receive dedicated API-contract tests as surface area expands.
+
+### What should be done in the future
+
+- Add phase-B contracts for runtime object handles and transport-safe inspection responses.
+- Add one non-TUI adapter (CLI or REST) on top of `pkg/inspectorapi` to validate transport neutrality.
+
+### Code review instructions
+
+- Start with:
+  - `pkg/inspectorapi/service.go`
+  - `pkg/inspectorapi/contracts.go`
+  - `cmd/smalltalk-inspector/app/model.go`
+  - `cmd/smalltalk-inspector/app/update.go`
+- Validate with:
+  - `go test ./pkg/inspectorapi/... -count=1`
+  - `go test ./cmd/smalltalk-inspector/... -count=1`
+  - `go test ./... -count=1`
+
+### Technical details
+
+- Service methods currently implemented:
+  - `OpenDocument`
+  - `OpenDocumentFromAnalysis`
+  - `UpdateDocument`
+  - `CloseDocument`
+  - `Analysis`
+  - `ListGlobals`
+  - `ListMembers`
+  - `BindingDeclarationLine`
+  - `MemberDeclarationLine`
+  - `MergeRuntimeGlobals`
+  - `BuildTreeRows`
+  - `SyncSourceToTree`
+  - `SyncTreeToSource`
+  - `DeclaredBindingsFromSource` (package-level helper).

--- a/ttmp/2026/02/15/GOJA-034-USER-FACING-INSPECTOR-API--user-facing-inspector-analysis-api-design/tasks.md
+++ b/ttmp/2026/02/15/GOJA-034-USER-FACING-INSPECTOR-API--user-facing-inspector-analysis-api-design/tasks.md
@@ -5,3 +5,12 @@
 - [x] Map current analysis/inspection capabilities and package boundaries
 - [x] Design user-facing API options (library-first, service-first, hybrid)
 - [x] Write detailed onboarding and decision guide with pseudocode and API sketches (8+ pages)
+- [x] Write GOJA-034 phase-A hybrid implementation plan with clean-cutover assumptions
+- [ ] Create `pkg/inspectorapi` service foundation (contracts, registry, open/update/close)
+- [ ] Implement static analysis facade methods (globals, members, declaration lookups)
+- [ ] Implement runtime merge and REPL declaration facade helpers
+- [ ] Implement navigation/tree facade methods (sync + rows)
+- [ ] Cut over `cmd/smalltalk-inspector/app` static orchestration to `pkg/inspectorapi`
+- [ ] Add/adjust tests for new facade and smalltalk cutover behavior
+- [ ] Run validation suite (`go test ./pkg/inspectorapi/...`, `go test ./cmd/smalltalk-inspector/...`, `go test ./...`)
+- [ ] Update GOJA-034 changelog/index/diary/tasks with commit-linked progress

--- a/ttmp/2026/02/15/GOJA-034-USER-FACING-INSPECTOR-API--user-facing-inspector-analysis-api-design/tasks.md
+++ b/ttmp/2026/02/15/GOJA-034-USER-FACING-INSPECTOR-API--user-facing-inspector-analysis-api-design/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+## TODO
+
+- [x] Map current analysis/inspection capabilities and package boundaries
+- [x] Design user-facing API options (library-first, service-first, hybrid)
+- [x] Write detailed onboarding and decision guide with pseudocode and API sketches (8+ pages)

--- a/ttmp/2026/02/15/GOJA-034-USER-FACING-INSPECTOR-API--user-facing-inspector-analysis-api-design/tasks.md
+++ b/ttmp/2026/02/15/GOJA-034-USER-FACING-INSPECTOR-API--user-facing-inspector-analysis-api-design/tasks.md
@@ -14,3 +14,4 @@
 - [x] Add/adjust tests for new facade and smalltalk cutover behavior
 - [x] Run validation suite (`go test ./pkg/inspectorapi/...`, `go test ./cmd/smalltalk-inspector/...`, `go test ./...`)
 - [x] Update GOJA-034 changelog/index/diary/tasks with commit-linked progress
+- [x] Write Glazed-guideline help documentation page for `pkg/inspectorapi` in `pkg/doc`

--- a/ttmp/2026/02/15/GOJA-034-USER-FACING-INSPECTOR-API--user-facing-inspector-analysis-api-design/tasks.md
+++ b/ttmp/2026/02/15/GOJA-034-USER-FACING-INSPECTOR-API--user-facing-inspector-analysis-api-design/tasks.md
@@ -6,11 +6,11 @@
 - [x] Design user-facing API options (library-first, service-first, hybrid)
 - [x] Write detailed onboarding and decision guide with pseudocode and API sketches (8+ pages)
 - [x] Write GOJA-034 phase-A hybrid implementation plan with clean-cutover assumptions
-- [ ] Create `pkg/inspectorapi` service foundation (contracts, registry, open/update/close)
-- [ ] Implement static analysis facade methods (globals, members, declaration lookups)
-- [ ] Implement runtime merge and REPL declaration facade helpers
-- [ ] Implement navigation/tree facade methods (sync + rows)
-- [ ] Cut over `cmd/smalltalk-inspector/app` static orchestration to `pkg/inspectorapi`
-- [ ] Add/adjust tests for new facade and smalltalk cutover behavior
-- [ ] Run validation suite (`go test ./pkg/inspectorapi/...`, `go test ./cmd/smalltalk-inspector/...`, `go test ./...`)
-- [ ] Update GOJA-034 changelog/index/diary/tasks with commit-linked progress
+- [x] Create `pkg/inspectorapi` service foundation (contracts, registry, open/update/close)
+- [x] Implement static analysis facade methods (globals, members, declaration lookups)
+- [x] Implement runtime merge and REPL declaration facade helpers
+- [x] Implement navigation/tree facade methods (sync + rows)
+- [x] Cut over `cmd/smalltalk-inspector/app` static orchestration to `pkg/inspectorapi`
+- [x] Add/adjust tests for new facade and smalltalk cutover behavior
+- [x] Run validation suite (`go test ./pkg/inspectorapi/...`, `go test ./cmd/smalltalk-inspector/...`, `go test ./...`)
+- [x] Update GOJA-034 changelog/index/diary/tasks with commit-linked progress

--- a/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/README.md
+++ b/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/README.md
@@ -1,0 +1,21 @@
+# Inspector UI regressions: tree pane width/scroll and REPL source mapping
+
+This is the document workspace for ticket GOJA-035-INSPECTOR-UI-REGRESSIONS.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr doc add --ticket GOJA-035-INSPECTOR-UI-REGRESSIONS --doc-type design-doc --title "My Design"`
+- Import sources: `docmgr import file --ticket GOJA-035-INSPECTOR-UI-REGRESSIONS --file /path/to/doc.md`
+- Update metadata: `docmgr meta update --ticket GOJA-035-INSPECTOR-UI-REGRESSIONS --field Status --value review`

--- a/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/changelog.md
+++ b/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/changelog.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## 2026-02-15
+
+- Initial workspace created.
+- Added tmux-based analysis document with verbatim capture excerpts and root-cause analysis for both regressions.
+- Added reproducible tmux automation script and stored pre-fix captures under `scripts/`.
+- Fixed smalltalk-inspector REPL symbol source fallback by storing declared names in REPL source entries and falling back when file declaration lookup misses.
+- Added regression test: `TestJumpToBindingFallsBackToReplSource`.
+- Improved inspector tree pane ergonomics:
+  - source/tree split moved to ~60/40
+  - tree row description rendering disabled for compact mode
+  - width-aware tree title clamping with ellipsis
+  - reduced tree metadata height to improve visible row count
+- Added tree UX tests: `TestTreePaneWidthKeepsTreeCompact` and `TestBuildTreeListItemClampsTitle`.
+- Validated with:
+  - `go test ./cmd/smalltalk-inspector/app ./cmd/inspector/app -count=1`

--- a/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/changelog.md
+++ b/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/changelog.md
@@ -15,3 +15,15 @@
 - Added tree UX tests: `TestTreePaneWidthKeepsTreeCompact` and `TestBuildTreeListItemClampsTitle`.
 - Validated with:
   - `go test ./cmd/smalltalk-inspector/app ./cmd/inspector/app -count=1`
+- Follow-up review fixes:
+  - deterministic drawer lexical binding resolution for shadowed identifiers
+  - globals half-page navigation guard for empty lists
+  - runtime method source mapping disambiguation by normalized source snippets
+- Added follow-up regression tests:
+  - `TestModelDrawerGoToDefinitionUsesLexicalScope`
+  - `TestModelDrawerHighlightUsagesUsesLexicalScope`
+  - `TestGlobalsHalfPageNavigationNoopWhenEmpty`
+  - `TestMapFunctionToSourceDisambiguatesSameMethodNameAcrossClasses`
+- Validation rerun:
+  - `go test ./cmd/inspector/app ./cmd/smalltalk-inspector/app ./pkg/inspector/runtime -count=1`
+  - `go test ./... -count=1`

--- a/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/design/01-tmux-analysis-tree-pane-width-scroll-and-repl-symbol-source-regression.md
+++ b/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/design/01-tmux-analysis-tree-pane-width-scroll-and-repl-symbol-source-regression.md
@@ -1,0 +1,160 @@
+---
+Title: 'tmux analysis: tree pane width/scroll and REPL symbol source regression'
+Ticket: GOJA-035-INSPECTOR-UI-REGRESSIONS
+Status: active
+Topics:
+    - go
+    - goja
+    - inspector
+    - bugfix
+    - ui
+DocType: design
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: go-go-goja/cmd/inspector/app/model.go
+      Note: Tree/source split layout and tree pane rendering details.
+    - Path: go-go-goja/cmd/inspector/app/tree_list.go
+      Note: AST tree list delegate behavior and item shaping.
+    - Path: go-go-goja/cmd/smalltalk-inspector/app/model.go
+      Note: REPL source log, jump-to-source behavior, fallback logic.
+    - Path: go-go-goja/cmd/smalltalk-inspector/app/update.go
+      Note: REPL eval pipeline and REPL source tracking calls.
+    - Path: go-go-goja/cmd/smalltalk-inspector/app/model_members_test.go
+      Note: Regression coverage for REPL binding source fallback.
+    - Path: go-go-goja/cmd/inspector/app/model_test.go
+      Note: Tree pane width and list title clamping coverage.
+    - Path: go-go-goja/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/scripts/repro-tmux-goja-035.sh
+      Note: Repro automation script used for tmux captures.
+    - Path: go-go-goja/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/scripts/smalltalk-globals-bottom.txt
+      Note: tmux capture proving REPL symbol selected while source pane still shows file source (pre-fix).
+ExternalSources: []
+Summary: Root-cause analysis and fix plan for two UI regressions: oversized/awkward inspector tree pane behavior and missing REPL source fallback for REPL-defined globals.
+LastUpdated: 2026-02-15T17:44:00Z
+WhatFor: Provide a reproducible, evidence-backed implementation guide to fix both regressions quickly and safely.
+WhenToUse: Use when validating GOJA-035 behavior or reworking tree/list/source mapping in inspector UIs.
+---
+
+# GOJA-035 tmux Analysis
+
+## Scope
+
+This ticket covers two regressions:
+
+1. `cmd/inspector`: AST tree pane feels too wide/awkward and scrolling quality degrades under long node labels.
+2. `cmd/smalltalk-inspector`: selecting a REPL-defined global symbol no longer shows REPL source in the Source pane.
+
+## Reproduction Setup
+
+- Environment: tmux 3.4
+- Commands used:
+  - `go run ./cmd/inspector /tmp/long-tree.js`
+  - `go run ./cmd/smalltalk-inspector testdata/inspector-test.js`
+- Capture automation script: `scripts/repro-tmux-goja-035.sh`
+
+## Evidence: Issue 1 (Tree Pane Width/Scroll)
+
+From `scripts/inspector-narrow-initial.txt` (pre-fix):
+
+```text
+=== narrow initial ===
+  4       deeplyNestedPropertyWithVerbos    ▼ LexicalDeclaration const
+  5         message: "this is a ridiculo
+  6       }
+  7     }                                     ▶ Binding
+  8   }
+  9 };
+ 10                                         ▼ FunctionDeclaration "makeMonsterF…
+ 11 function makeMonsterFunctionWithExtr
+ 12   const localBindingWithLongName = p
+ 13   return {                                ▶ FunctionLiteral "makeMonsterFun…
+```
+
+From `scripts/inspector-narrow-scroll.txt` (pre-fix):
+
+```text
+=== narrow scroll ===
+ 13   return {                          │     ▶ BlockStatement
+ 14     localBindingWithLongName,       │
+ 15     nested: {
+ 16       desc: "another very long descr
+```
+
+Observations:
+
+- Tree rows and source rows interleave visually in narrow tmux widths.
+- Long row labels create clutter; visual boundaries are weak.
+- With a 50/50 split, tree pane dominates real estate for a secondary pane.
+
+## Evidence: Issue 2 (REPL Symbol Source Fallback)
+
+From `scripts/smalltalk-globals-bottom.txt` (pre-fix):
+
+```text
+Globals ───────────────────── zzzReplFn: Members ────────── Source ────────────────────────────────────────────────────
+...
+▸ ●  zzzReplFn                                               13 class Shape {
+...
+```
+
+From `scripts/smalltalk-after-enter-zzz.txt` (pre-fix):
+
+```text
+REPL Result: zzzReplFn ──────────────────────────────────── Source ────────────────────────────────────────────────────
+▸ ·  length : 1  number                                      67     case "rectangle":
+...
+```
+
+Observations:
+
+- `zzzReplFn` exists in globals list (runtime merge works).
+- Source pane remains on file source, not REPL source.
+- Regression affects both plain selection and enter-to-inspect flow.
+
+## Root Cause Analysis
+
+### Issue 1
+
+- `cmd/inspector/app/model.go` used a strict 50/50 source/tree split.
+- Tree rows were displayed with default list delegate visuals and verbose labels; this increased noise in narrow terminals.
+- Tree metadata section consumed several lines (`metaHeight=5`), reducing effective tree viewport and perceived scroll quality.
+
+### Issue 2
+
+- `cmd/smalltalk-inspector/app/model.go:jumpToSource()` always resets `showingReplSrc=false` before binding lookup.
+- `jumpToBinding()` only looked for static declaration lines via `BindingDeclarationLine`.
+- REPL-defined names have no file-backed declaration in static analysis, so lookup returns not found and source stays in file mode.
+- `replSourceLog` tracked expressions but did not track declared symbol names, so no deterministic fallback from global name -> REPL source entry was possible.
+
+## Fix Plan
+
+1. **Smalltalk REPL source mapping**
+- Track declared symbol names per REPL expression entry.
+- Add fallback `showReplSourceForBinding(name)` that maps selected global names to REPL source log entries.
+- Update `jumpToBinding` to use fallback when static declaration lookup fails.
+- Ensure REPL source appends include parser-backed declarations.
+
+2. **Inspector tree pane ergonomics**
+- Reduce tree pane width share from 50% to ~40% (source gets ~60%).
+- Disable description rendering in tree list delegate for cleaner rows.
+- Clamp tree row titles with ellipsis to prevent long-label spillover.
+- Reduce tree metadata height (4 -> 2 on constrained content) to increase visible tree rows.
+
+## Validation Plan
+
+1. Unit tests:
+- `go test ./cmd/smalltalk-inspector/app ./cmd/inspector/app -count=1`
+- Add explicit regression test for REPL fallback mapping.
+- Add explicit tests for tree pane width policy and title clamping.
+
+2. tmux manual validation:
+- Re-run `scripts/repro-tmux-goja-035.sh`.
+- Confirm `Source (REPL)` appears when selecting REPL-defined global.
+- Confirm tree pane is narrower and long labels clamp cleanly.
+
+## Acceptance Criteria
+
+- Selecting REPL-defined globals shows REPL source context in Source pane.
+- Enter on REPL-defined function keeps REPL source context visible.
+- Tree pane no longer dominates layout at typical tmux widths.
+- Long tree labels are clamped and easier to scan; scrolling remains stable.

--- a/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/index.md
+++ b/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/index.md
@@ -1,0 +1,49 @@
+---
+Title: 'Inspector UI regressions: tree pane width/scroll and REPL source mapping'
+Ticket: GOJA-035-INSPECTOR-UI-REGRESSIONS
+Status: active
+Topics:
+    - go
+    - goja
+    - inspector
+    - bugfix
+    - ui
+DocType: index
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: go-go-goja/cmd/inspector/app/model.go
+      Note: Tree pane split and render behavior.
+    - Path: go-go-goja/cmd/inspector/app/tree_list.go
+      Note: AST row display shaping.
+    - Path: go-go-goja/cmd/smalltalk-inspector/app/model.go
+      Note: REPL source fallback.
+    - Path: go-go-goja/cmd/smalltalk-inspector/app/update.go
+      Note: REPL source append pipeline.
+ExternalSources: []
+Summary: Ticket workspace for fixing inspector tree pane UX issues and REPL source-window regression.
+LastUpdated: 2026-02-15T17:44:00Z
+WhatFor: Track analysis, implementation, and validation of GOJA-035 bugfix work.
+WhenToUse: Use when reviewing or extending these UI fixes.
+---
+
+# Inspector UI regressions: tree pane width/scroll and REPL source mapping
+
+## Overview
+
+This ticket fixes two regressions reported after inspector refactors:
+
+1. `cmd/inspector` tree pane ergonomics were poor in tmux/narrow widths.
+2. `cmd/smalltalk-inspector` no longer showed REPL source when selecting REPL-defined globals.
+
+## Key Links
+
+- Analysis: `design/01-tmux-analysis-tree-pane-width-scroll-and-repl-symbol-source-regression.md`
+- Diary: `reference/01-diary.md`
+- Tasks: `tasks.md`
+- Changelog: `changelog.md`
+- Repro script + captures: `scripts/`
+
+## Status
+
+Current status: **active** (implementation complete, pending commit/push in this working session).

--- a/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/reference/01-diary.md
+++ b/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/reference/01-diary.md
@@ -1,0 +1,259 @@
+---
+Title: Diary
+Ticket: GOJA-035-INSPECTOR-UI-REGRESSIONS
+Status: active
+Topics:
+    - go
+    - goja
+    - inspector
+    - bugfix
+    - ui
+DocType: reference
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: go-go-goja/cmd/smalltalk-inspector/app/model.go
+      Note: Added REPL declaration-aware source fallback path.
+    - Path: go-go-goja/cmd/smalltalk-inspector/app/update.go
+      Note: Appends REPL source entries with parser-backed declarations.
+    - Path: go-go-goja/cmd/smalltalk-inspector/app/model_members_test.go
+      Note: Regression test for REPL global source fallback.
+    - Path: go-go-goja/cmd/inspector/app/model.go
+      Note: Adjusted pane split + metadata height + width-driven tree item rebuild.
+    - Path: go-go-goja/cmd/inspector/app/tree_list.go
+      Note: Compact tree delegate and title clamping.
+    - Path: go-go-goja/cmd/inspector/app/model_test.go
+      Note: Tests for tree width policy and clamping.
+    - Path: go-go-goja/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/design/01-tmux-analysis-tree-pane-width-scroll-and-repl-symbol-source-regression.md
+      Note: Analysis and root-cause document.
+ExternalSources: []
+Summary: Implementation diary for GOJA-035, covering tmux reproductions, bugfix implementation, testing, and follow-up review points.
+LastUpdated: 2026-02-15T17:44:00Z
+WhatFor: Preserve implementation reasoning and validation sequence for later debugging/refactoring.
+WhenToUse: Use when reviewing GOJA-035 changes or debugging similar regressions in inspector panes and REPL source mapping.
+---
+
+# Diary
+
+## Goal
+
+Capture the end-to-end implementation path for two regressions: tree pane UX issues in `cmd/inspector` and missing REPL source fallback for REPL-defined globals in `cmd/smalltalk-inspector`.
+
+## Step 1: Reproduce Both Regressions in tmux
+
+I created a new ticket workspace and drove both UIs through tmux sessions with deterministic key sequences. I stored raw pane captures under `scripts/` so the regression evidence is reproducible without relying on screenshots.
+
+The captures showed that REPL symbols were visible in the globals list but the Source pane remained file-backed. They also showed that AST tree pane rows were visually noisy at narrow widths and that the tree pane took too much horizontal space.
+
+### Prompt Context
+
+**User prompt (verbatim):** "Two issues:
+
+Create a bugfix ticket and store an analysis document for:
+
+- inspector tree view is way too wide and ugly and doesn't seem to scroll all that well. Run in tmux and analyze.
+- going over a REPL defined symbol in the smalltalk-inspector doesn't show the REPL code anymore in the code window. At some point it used to, i'm pretty sure.
+
+
+Then add tasks to fix the bug, and work on them."
+
+**Assistant interpretation:** Create a new GOJA ticket, gather tmux-based evidence for both regressions, document analysis, define tasks, then implement and validate fixes.
+
+**Inferred user intent:** Restore practical inspector usability and eliminate recent UI regression behavior with reproducible documentation.
+
+**Commit (code):** 4f647f6 — "fix(inspector): restore repl-source fallback and compact tree pane"
+
+### What I did
+
+- Created ticket `GOJA-035-INSPECTOR-UI-REGRESSIONS` with design + diary docs.
+- Ran tmux captures for:
+  - `cmd/inspector` with narrow layout and long-label stress input.
+  - `cmd/smalltalk-inspector` with REPL-defined symbol `zzzReplFn`.
+- Stored captures in `ttmp/.../GOJA-035.../scripts/`.
+- Added repro script `scripts/repro-tmux-goja-035.sh`.
+
+### Why
+
+- Needed reproducible evidence before changing behavior.
+- Needed direct tmux artifacts to satisfy the request and anchor root-cause analysis.
+
+### What worked
+
+- Reproduced both behaviors consistently.
+- Captures clearly showed wrong source pane behavior for REPL-defined globals.
+
+### What didn't work
+
+- First attempt to emit tmux Escape key used an invalid shell token:
+  - command context: `tmux send-keys ... C-[`
+  - error: `zsh:15: bad pattern: C-[`
+- Switched to a deterministic focus path (`Tab` from REPL back to globals).
+
+### What I learned
+
+- REPL symbol merge into globals was functioning; source mapping fallback was the actual missing piece.
+- Tree pane ergonomics were mostly layout/list-presentation issues, not a parser/index issue.
+
+### What was tricky to build
+
+- TUI repro in CI-like shell context required careful key-sequence automation and delays.
+- Capturing meaningful alt-screen output required timing retries.
+
+### What warrants a second pair of eyes
+
+- REPL source log growth behavior across long sessions.
+- Tree pane split ratios on ultra-small terminal widths.
+
+### What should be done in the future
+
+- Add a small set of scripted TUI smoke checks in CI for regression-prone key flows.
+
+### Code review instructions
+
+- Start with analysis doc + tmux captures in GOJA-035 `design/` and `scripts/`.
+- Verify pre/post behavior by running `scripts/repro-tmux-goja-035.sh`.
+
+### Technical details
+
+- Key tmux captures:
+  - `scripts/smalltalk-globals-bottom.txt`
+  - `scripts/smalltalk-after-enter-zzz.txt`
+  - `scripts/inspector-narrow-initial.txt`
+  - `scripts/inspector-narrow-scroll.txt`
+
+## Step 2: Fix REPL Symbol Source Fallback in smalltalk-inspector
+
+I made REPL source entries declaration-aware and added a deterministic fallback from global symbol name to REPL source entry. The fallback is only used when static declaration lookup misses, which preserves file-backed behavior for normal symbols.
+
+I also added a focused unit test to guard against regression and re-ran package tests.
+
+### Prompt Context
+
+**User prompt (verbatim):** (see Step 1)
+
+**Assistant interpretation:** Implement the REPL source bugfix and prove it with tests.
+
+**Inferred user intent:** Ensure selecting REPL-defined globals immediately gives code context in Source pane.
+
+**Commit (code):** 4f647f6 — "fix(inspector): restore repl-source fallback and compact tree pane"
+
+### What I did
+
+- Updated `cmd/smalltalk-inspector/app/model.go`:
+  - `replSourceEntry` now stores declared names.
+  - `appendReplSource` now accepts declaration list and stores a set.
+  - Added `showReplSourceForBinding(name)`.
+  - `jumpToBinding` now falls back to REPL source when no file declaration exists.
+- Updated `cmd/smalltalk-inspector/app/update.go` to append REPL source with parser-backed declarations.
+- Added `TestJumpToBindingFallsBackToReplSource` in `cmd/smalltalk-inspector/app/model_members_test.go`.
+
+### Why
+
+- Static binding lookup cannot locate REPL-only declarations in file analysis.
+- REPL source log already had location data; it only lacked symbol-level indexing.
+
+### What worked
+
+- Test passed and tmux post-fix capture shows `Source (REPL)` with `zzzReplFn` code.
+
+### What didn't work
+
+- N/A
+
+### What I learned
+
+- Keeping fallback in `jumpToBinding` keeps behavior localized and predictable.
+
+### What was tricky to build
+
+- Avoiding heuristic substring matching for symbol mapping; declaration-aware entries were needed for deterministic lookup.
+
+### What warrants a second pair of eyes
+
+- Memory growth in `replSourceLog` over long sessions.
+
+### What should be done in the future
+
+- Consider bounded REPL source history with configurable cap and pruning policy.
+
+### Code review instructions
+
+- Review `jumpToBinding` and `showReplSourceForBinding` interaction in `cmd/smalltalk-inspector/app/model.go`.
+- Run `go test ./cmd/smalltalk-inspector/app -count=1`.
+
+### Technical details
+
+- Validation command:
+  - `go test ./cmd/smalltalk-inspector/app -count=1`
+
+## Step 3: Improve inspector Tree Pane Ergonomics
+
+I reduced tree pane dominance and visual noise by changing split policy, clamping tree labels, and simplifying tree row rendering. I also reduced metadata panel footprint to return more vertical space to actual tree navigation.
+
+This keeps list/table components in place while improving readability in tmux.
+
+### Prompt Context
+
+**User prompt (verbatim):** (see Step 1)
+
+**Assistant interpretation:** Make tree pane less visually heavy and improve practical scroll/navigation feel.
+
+**Inferred user intent:** Restore a usable, readable tree pane in small/narrow terminals.
+
+**Commit (code):** 4f647f6 — "fix(inspector): restore repl-source fallback and compact tree pane"
+
+### What I did
+
+- Updated `cmd/inspector/app/model.go`:
+  - Added `treePaneWidth()` policy (~60/40 source/tree with minimums).
+  - Applied new split in `View()`.
+  - Reduced tree metadata height (`4`, constrained to `2` on small content).
+  - Rebuild tree list items on `WindowSizeMsg` so clamp responds to width changes.
+- Updated `cmd/inspector/app/tree_list.go`:
+  - Disabled description rendering in list delegate.
+  - Added `clampTreeTitle` and applied width-based clamping in `buildTreeListItem`.
+- Added tests in `cmd/inspector/app/model_test.go`:
+  - `TestTreePaneWidthKeepsTreeCompact`
+  - `TestBuildTreeListItemClampsTitle`
+
+### Why
+
+- A 50/50 split and verbose rows made tree pane feel oversized and noisy.
+- Width-aware clamping improves scanability and reduces pane boundary clutter.
+
+### What worked
+
+- tmux post-fix captures show cleaner tree rows and narrower tree pane.
+- Package tests pass.
+
+### What didn't work
+
+- One tmux run captured blank output due insufficient startup wait after `go run`; reran with longer delay.
+
+### What I learned
+
+- For terminal UI regressions, small layout changes and item shaping often provide outsized UX gains without deep model rewrites.
+
+### What was tricky to build
+
+- Width logic needed to stay deterministic across very small terminal sizes.
+
+### What warrants a second pair of eyes
+
+- Whether clamping threshold should be user-configurable.
+- Whether tree description should be toggleable for power users.
+
+### What should be done in the future
+
+- Add a toggle for “compact tree mode” vs “verbose tree mode”.
+
+### Code review instructions
+
+- Focus on `cmd/inspector/app/model.go` split + meta-height changes and `cmd/inspector/app/tree_list.go` clamp behavior.
+- Run:
+  - `go test ./cmd/inspector/app -count=1`
+
+### Technical details
+
+- Validation command:
+  - `go test ./cmd/smalltalk-inspector/app ./cmd/inspector/app -count=1`

--- a/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/reference/01-diary.md
+++ b/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/reference/01-diary.md
@@ -257,3 +257,75 @@ This keeps list/table components in place while improving readability in tmux.
 
 - Validation command:
   - `go test ./cmd/smalltalk-inspector/app ./cmd/inspector/app -count=1`
+
+## Step 4: Finalize Ticket Artifacts and Validation Record
+
+After code changes landed, I consolidated ticket artifacts so another developer can re-run the reproductions and understand exactly what changed. I included raw tmux captures, a repro script, an analysis document with verbatim excerpts, and a fully checked-off task list.
+
+I also ran the full repository test suite to verify no collateral regressions.
+
+### Prompt Context
+
+**User prompt (verbatim):** (see Step 1)
+
+**Assistant interpretation:** Complete the ticket workflow, not just code changes.
+
+**Inferred user intent:** Ensure the bugfix is documented, reproducible, and maintainable for follow-on work.
+**Commit (code):** 319d273 — "docs(goja-035): add analysis tasks diary and tmux repro artifacts"
+
+### What I did
+
+- Wrote `design/01-tmux-analysis-tree-pane-width-scroll-and-repl-symbol-source-regression.md`.
+- Replaced placeholder tasks with completed implementation checklist in `tasks.md`.
+- Updated `changelog.md` and `index.md` with status and key links.
+- Added and validated `scripts/repro-tmux-goja-035.sh`.
+- Ran full validation:
+  - `go test ./... -count=1`
+
+### Why
+
+- Ticket needs durable context, not only source changes.
+- Raw tmux artifacts provide a baseline for future UI tuning discussions.
+
+### What worked
+
+- Repro script generated expected capture files.
+- Full test suite passed.
+
+### What didn't work
+
+- N/A
+
+### What I learned
+
+- Keeping capture artifacts in-ticket significantly reduces ambiguity in terminal UI bug reports.
+
+### What was tricky to build
+
+- Balancing enough detail for future debugging without overwhelming the ticket with narrative noise.
+
+### What warrants a second pair of eyes
+
+- Whether to keep all raw captures long-term or archive older pre-fix artifacts after follow-up stabilization.
+
+### What should be done in the future
+
+- Optionally add a compact playbook that compares pre-fix and post-fix captures side by side.
+
+### Code review instructions
+
+- Read `design/01-tmux-analysis-tree-pane-width-scroll-and-repl-symbol-source-regression.md`.
+- Review diffs in:
+  - `cmd/smalltalk-inspector/app/model.go`
+  - `cmd/smalltalk-inspector/app/update.go`
+  - `cmd/inspector/app/model.go`
+  - `cmd/inspector/app/tree_list.go`
+- Validate with:
+  - `go test ./... -count=1`
+  - `ttmp/.../GOJA-035.../scripts/repro-tmux-goja-035.sh /tmp/goja-035-verify`
+
+### Technical details
+
+- Commits:
+  - `4f647f6` code + tests
+  - `319d273` ticket docs + captures

--- a/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/scripts/inspector-initial.txt
+++ b/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/scripts/inspector-initial.txt
@@ -1,0 +1,30 @@
+  8   theme: "dark",
+  9   fontSize: 14,
+ 10   lineNumbers: true,                                   ▼ LexicalDeclaration const
+ 11 };
+ 12
+ 13 class Shape {                                            ▶ Binding
+ 14   constructor(color) {
+ 15     this.color = color;
+ 16     this.visible = true;                               ▼ LexicalDeclaration const
+ 17   }
+ 18
+ 19   describe() {                                           ▶ Binding
+ 20     return `A ${this.color} shape`;
+ 21   }
+ 22                                                        ▼ ClassDeclaration "Shape"
+ 23   hide() {
+ 24     this.visible = false;
+ 25   }                                                      ▶ ClassLiteral "Shape"
+ 26 }
+
+                                                           ▼ ClassDeclaration "Circle"
+
+                                                       ───────────────────────────────────────────────────────
+                                                        Field             Value
+                                                        Focus             source
+                                                        Node              Program
+                                                        Span              [161..1792]
+                                                        Lines             4:1 → 92:2
+ ✓ parse ok │ nodes: 332 │ selected: Program [161..1792] (4:1 → 92:2) │ cursor: 1:1
+ tab next pane • i drawer • : command • d/ctrl+d go to def • esc close/clear • q/ctrl+c quit

--- a/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/scripts/inspector-long-bottom.txt
+++ b/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/scripts/inspector-long-bottom.txt
@@ -1,0 +1,24 @@
+  2   deeplyNestedPropertyWithVerboseNameOne: {       ▶ BinaryExpression <
+  3     deeplyNestedPropertyWithVerboseNameTwo:
+  4       deeplyNestedPropertyWithVerboseNameThr
+  5         message: "this is a ridiculously lon      ▶ UnaryExpression ++
+  6       }
+  7     }
+  8   }                                         │     ▶ BlockStatement
+  9 };                                          │
+ 10
+ 11 function makeMonsterFunctionWithExtraLongNam
+ 12   const localBindingWithLongName = parameter
+ 13   return {
+ 14     localBindingWithLongName,
+ 15     nested: {
+ 16       desc: "another very long descriptor to
+ 17     }
+ 18   };                                        ────────────────────────────────────────────────
+ 19 }                                            Field             Value
+ 20                                              Focus             tree
+ 21 for (let i = 0; i < 80; i++) {               Node              BlockStatement
+                                                 Span              [893..970]
+                                                 Lines             21:30 → 23:2
+ ✓ parse ok │ nodes: 68 │ selected: BlockStatement [893..970] (21:30 → 23:2) │ cursor: 21:30
+ tab next pane • i drawer • : command • d/ctrl+d go to def • esc close/clear • q/ctrl+c quit

--- a/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/scripts/inspector-long-initial.txt
+++ b/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/scripts/inspector-long-initial.txt
@@ -1,0 +1,24 @@
+  5         message: "this is a ridiculously lon
+  6       }
+  7     }                                             ▶ Binding
+  8   }
+  9 };
+ 10                                                 ▼ FunctionDeclaration "makeMonsterFunctionW…
+ 11 function makeMonsterFunctionWithExtraLongNam
+ 12   const localBindingWithLongName = parameter
+ 13   return {                                        ▶ FunctionLiteral "makeMonsterFunctionWit…
+ 14     localBindingWithLongName,
+ 15     nested: {
+ 16       desc: "another very long descriptor to    ▼ ForStatement
+ 17     }
+ 18   };
+ 19 }                                                 ▶ ForLoopInitializerLexicalDecl
+ 20
+                                                ────────────────────────────────────────────────
+                                                 Field             Value
+                                                 Focus             source
+                                                 Node              Program
+                                                 Span              [1..970]
+                                                 Lines             1:1 → 23:2
+ ✓ parse ok │ nodes: 68 │ selected: Program [1..970] (1:1 → 23:2) │ cursor: 1:1
+ tab next pane • i drawer • : command • d/ctrl+d go to def • esc close/clear • q/ctrl+c quit

--- a/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/scripts/inspector-long-scroll.txt
+++ b/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/scripts/inspector-long-scroll.txt
@@ -1,0 +1,24 @@
+  2   deeplyNestedPropertyWithVerboseNameOne: {       ▶ BinaryExpression <
+  3     deeplyNestedPropertyWithVerboseNameTwo:
+  4       deeplyNestedPropertyWithVerboseNameThr
+  5         message: "this is a ridiculously lon      ▶ UnaryExpression ++
+  6       }
+  7     }
+  8   }                                         │     ▶ BlockStatement
+  9 };                                          │
+ 10
+ 11 function makeMonsterFunctionWithExtraLongNam
+ 12   const localBindingWithLongName = parameter
+ 13   return {
+ 14     localBindingWithLongName,
+ 15     nested: {
+ 16       desc: "another very long descriptor to
+ 17     }
+ 18   };                                        ────────────────────────────────────────────────
+ 19 }                                            Field             Value
+ 20                                              Focus             tree
+ 21 for (let i = 0; i < 80; i++) {               Node              BlockStatement
+                                                 Span              [893..970]
+                                                 Lines             21:30 → 23:2
+ ✓ parse ok │ nodes: 68 │ selected: BlockStatement [893..970] (21:30 → 23:2) │ cursor: 21:30
+ tab next pane • i drawer • : command • d/ctrl+d go to def • esc close/clear • q/ctrl+c quit

--- a/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/scripts/inspector-narrow-initial.txt
+++ b/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/scripts/inspector-narrow-initial.txt
@@ -1,0 +1,22 @@
+  4       deeplyNestedPropertyWithVerbos    ▼ LexicalDeclaration const
+  5         message: "this is a ridiculo
+  6       }
+  7     }                                     ▶ Binding
+  8   }
+  9 };
+ 10                                         ▼ FunctionDeclaration "makeMonsterF…
+ 11 function makeMonsterFunctionWithExtr
+ 12   const localBindingWithLongName = p
+ 13   return {                                ▶ FunctionLiteral "makeMonsterFun…
+ 14     localBindingWithLongName,
+ 15     nested: {
+ 16       desc: "another very long descr    ▼ ForStatement
+ 17     }
+ 18   };                                ────────────────────────────────────────
+                                         Field             Value
+                                         Focus             source
+                                         Node              Program
+                                         Span              [1..970]
+                                         Lines             1:1 → 23:2
+ ✓ parse ok │ nodes: 68 │ selected: Program [1..970] (1:1 → 23:2) │ cursor: 1:1
+ tab next pane • i drawer • : command • d/ctrl+d go to def • esc close/clear …

--- a/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/scripts/inspector-narrow-scroll.txt
+++ b/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/scripts/inspector-narrow-scroll.txt
@@ -1,0 +1,22 @@
+  6       }
+  7     }                                     ▶ BinaryExpression <
+  8   }
+  9 };
+ 10                                           ▶ UnaryExpression ++
+ 11 function makeMonsterFunctionWithExtr
+ 12   const localBindingWithLongName = p
+ 13   return {                          │     ▶ BlockStatement
+ 14     localBindingWithLongName,       │
+ 15     nested: {
+ 16       desc: "another very long descr
+ 17     }
+ 18   };
+ 19 }                                   ────────────────────────────────────────
+ 20                                      Field             Value
+ 21 for (let i = 0; i < 80; i++) {       Focus             tree
+                                         Node              BlockStatement
+                                         Span              [893..970]
+                                         Lines             21:30 → 23:2
+ ✓ parse ok │ nodes: 68 │ selected: BlockStatement [893..970] (21:30 → 23:2) │
+ cursor: 21:30
+ tab next pane • i drawer • : command • d/ctrl+d go to def • esc close/clear …

--- a/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/scripts/inspector-tree-bottom.txt
+++ b/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/scripts/inspector-tree-bottom.txt
@@ -1,0 +1,30 @@
+ 65     case "circle":
+ 66       return new Circle(color, args[0] || 1);          ▼ LexicalDeclaration const
+ 67     case "rectangle":
+ 68       return new Rectangle(color, args[0] || 1, arg
+ 69     default:                                             ▶ Binding
+ 70       return new Shape(color);
+ 71   }
+ 72 }                                                      ▼ FunctionDeclaration "main"
+ 73
+ 74 function totalArea(shapes) {
+ 75   let sum = 0;                                     │     ▶ FunctionLiteral "main"
+ 76   for (const s of shapes) {                        │
+ 77     if (typeof s.area === "function") {
+ 78       sum += s.area();
+ 79     }
+ 80   }
+ 81   return sum;
+ 82 }
+ 83
+ 84 const myCircle = new Circle("red", 5);
+ 85 const myRect = new Rectangle("blue", 3, 4);
+ 86 const shapes = [myCircle, myRect];
+ 87                                                    ───────────────────────────────────────────────────────
+ 88 function main() {                                   Field             Value
+                                                        Focus             tree
+                                                        Node              FunctionLiteral
+                                                        Span              [1603..1792]
+                                                        Lines             88:1 → 92:2
+ ✓ parse ok │ nodes: 332 │ selected: FunctionLiteral [1603..1792] (88:1 → 92:2) │ cursor: 88:1
+ tab next pane • i drawer • : command • d/ctrl+d go to def • esc close/clear • q/ctrl+c quit

--- a/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/scripts/inspector-tree-scroll.txt
+++ b/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/scripts/inspector-tree-scroll.txt
@@ -1,0 +1,30 @@
+ 66       return new Circle(color, args[0] || 1);
+ 67     case "rectangle":
+ 68       return new Rectangle(color, args[0] || 1, arg    ▼ FunctionDeclaration "createShape"
+ 69     default:
+ 70       return new Shape(color);
+ 71   }                                                      ▶ FunctionLiteral "createShape"
+ 72 }
+ 73
+ 74 function totalArea(shapes) {                           ▼ FunctionDeclaration "totalArea"
+ 75   let sum = 0;
+ 76   for (const s of shapes) {
+ 77     if (typeof s.area === "function") {                  ▶ FunctionLiteral "totalArea"
+ 78       sum += s.area();
+ 79     }
+ 80   }                                                │   ▼ LexicalDeclaration const
+ 81   return sum;                                      │
+ 82 }
+ 83                                                          ▶ Binding
+ 84 const myCircle = new Circle("red", 5);
+
+                                                           ▼ LexicalDeclaration const
+
+                                                       ───────────────────────────────────────────────────────
+                                                        Field             Value
+                                                        Focus             tree
+                                                        Node              LexicalDeclaration
+                                                        Span              [1484..1521]
+                                                        Lines             84:1 → 84:38
+ ✓ parse ok │ nodes: 332 │ selected: LexicalDeclaration [1484..1521] (84:1 → 84:38) │ cursor: 84:1
+ tab next pane • i drawer • : command • d/ctrl+d go to def • esc close/clear • q/ctrl+c quit

--- a/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/scripts/repro-tmux-goja-035.sh
+++ b/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/scripts/repro-tmux-goja-035.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../../../../.." && pwd)"
+OUT_DIR="${1:-/tmp/goja-035}"
+mkdir -p "$OUT_DIR"
+
+run_inspector_repro() {
+  local session="goja035_inspector"
+  tmux kill-session -t "$session" 2>/dev/null || true
+  tmux new-session -d -x 96 -y 24 -s "$session" "cd $REPO_ROOT && go run ./cmd/inspector /tmp/long-tree.js"
+  sleep 1.2
+  tmux capture-pane -t "$session":0.0 -p > "$OUT_DIR/inspector-narrow-initial.txt"
+  tmux send-keys -t "$session":0.0 Tab
+  for _ in $(seq 1 15); do tmux send-keys -t "$session":0.0 j; done
+  sleep 0.3
+  tmux capture-pane -t "$session":0.0 -p > "$OUT_DIR/inspector-narrow-scroll.txt"
+  tmux send-keys -t "$session":0.0 q
+  sleep 0.2
+  tmux kill-session -t "$session" 2>/dev/null || true
+}
+
+run_smalltalk_repro() {
+  local session="goja035_smalltalk"
+  tmux kill-session -t "$session" 2>/dev/null || true
+  tmux new-session -d -x 120 -y 34 -s "$session" "cd $REPO_ROOT && go run ./cmd/smalltalk-inspector testdata/inspector-test.js"
+  sleep 1.2
+
+  for _ in 1 2 3; do tmux send-keys -t "$session":0.0 Tab; done
+  tmux send-keys -t "$session":0.0 "const zzzReplFn = function zzzReplFn(value) { return value + 42; }"
+  tmux send-keys -t "$session":0.0 Enter
+  sleep 0.5
+
+  tmux send-keys -t "$session":0.0 Tab
+  sleep 0.2
+  tmux send-keys -t "$session":0.0 G
+  sleep 0.3
+  tmux capture-pane -t "$session":0.0 -p > "$OUT_DIR/smalltalk-globals-bottom.txt"
+
+  tmux send-keys -t "$session":0.0 Enter
+  sleep 0.2
+  tmux capture-pane -t "$session":0.0 -p > "$OUT_DIR/smalltalk-after-enter-zzz.txt"
+
+  tmux send-keys -t "$session":0.0 q
+  sleep 0.2
+  tmux kill-session -t "$session" 2>/dev/null || true
+}
+
+cat > /tmp/long-tree.js <<'JS'
+const veryLongTopLevelBindingNameThatKeepsGoingAndGoingAndGoing = {
+  deeplyNestedPropertyWithVerboseNameOne: {
+    deeplyNestedPropertyWithVerboseNameTwo: {
+      deeplyNestedPropertyWithVerboseNameThree: {
+        message: "this is a ridiculously long string literal that should force tree rows to clamp and never wrap across pane boundaries in the inspector tree view"
+      }
+    }
+  }
+};
+
+function makeMonsterFunctionWithExtraLongNameAndManyParameters(parameterOneWithLongName, parameterTwoWithLongName, parameterThreeWithLongName) {
+  const localBindingWithLongName = parameterOneWithLongName + parameterTwoWithLongName + parameterThreeWithLongName;
+  return {
+    localBindingWithLongName,
+    nested: {
+      desc: "another very long descriptor to trigger row overflow behavior in the tree pane and verify vertical scrolling remains stable"
+    }
+  };
+}
+
+for (let i = 0; i < 80; i++) {
+  makeMonsterFunctionWithExtraLongNameAndManyParameters(i, i + 1, i + 2);
+}
+JS
+
+run_inspector_repro
+run_smalltalk_repro
+
+echo "Wrote captures to: $OUT_DIR"

--- a/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/scripts/smalltalk-after-enter-zzz.txt
+++ b/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/scripts/smalltalk-after-enter-zzz.txt
@@ -1,0 +1,34 @@
+ goja-inspector ─── testdata/inspector-test.js                                                          [INSPECT]
+ REPL Result: zzzReplFn ──────────────────────────────────── Source ────────────────────────────────────────────────────
+▸ ·  length : 1  number                                      67     case "rectangle":
+  ·  name : "zzzReplFn"  string                              68       return new Rectangle(color, args[0] || 1, args[1]
+  ·  prototype : {}  object                                  69     default:
+  ·  [[Proto]] : Function.prototype  object                  70       return new Shape(color);
+                                                             71   }
+                                                             72 }
+                                                             73
+                                                             74 function totalArea(shapes) {
+                                                             75   let sum = 0;
+                                                             76   for (const s of shapes) {
+                                                             77     if (typeof s.area === "function") {
+                                                             78       sum += s.area();
+                                                             79     }
+                                                             80   }
+                                                             81   return sum;
+                                                             82 }
+                                                             83
+                                                             84 const myCircle = new Circle("red", 5);
+                                                             85 const myRect = new Rectangle("blue", 3, 4);
+                                                             86 const shapes = [myCircle, myRect];
+                                                             87
+                                                             88 function main() {
+                                                             89   const c = createShape("circle", "green", 10);
+                                                             90   const r = createShape("rectangle", "yellow", 6, 8);
+                                                             91   return { circle: c, rectangle: r, totalArea: totalArea
+                                                             92 }
+                                                             93
+ REPL ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+→ ƒ zzzReplFn()
+» (tab to REPL)
+ ✓ parse ok │ globals: 13 │ selected: zzzReplFn │ ✓ Loaded testdata/inspector-test.js (93 lines, 12 globals)
+ tab next pane • : command • enter select/inspect • esc back/close • ctrl+c quit

--- a/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/scripts/smalltalk-after-repl.txt
+++ b/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/scripts/smalltalk-after-repl.txt
@@ -1,0 +1,34 @@
+ goja-inspector ─── testdata/inspector-test.js                                                             [REPL]
+ Globals ───────────────────── Circle: Members ───────────── Source ────────────────────────────────────────────────────
+▸ C  Circle ← Shape           ▸ ƒ  constructor(color, radius  1 // inspector-test.js — A file for testing the Smalltalk
+  C  Rectangle ← Shape          ƒ  area()                     2 // Covers: classes, inheritance, functions, constants, s
+  C  Shape                      ƒ  perimeter()                3
+  ƒ  createShape                ƒ  describe()                 4 const VERSION = "1.0.0";
+  ƒ  main                      ── inherited (Shape)           5 const MAX_ITEMS = 100;
+  ƒ  totalArea                  ƒ  hide()                     6
+  ●  MAX_ITEMS                                                7 const settings = {
+  ●  VERSION                                                  8   theme: "dark",
+  ●  myCircle                                                 9   fontSize: 14,
+  ●  myRect                                                  10   lineNumbers: true,
+  ●  settings                                                11 };
+  ●  shapes                                                  12
+  ●  zzzReplFn                                               13 class Shape {
+                                                             14   constructor(color) {
+                                                             15     this.color = color;
+                                                             16     this.visible = true;
+                                                             17   }
+                                                             18
+                                                             19   describe() {
+                                                             20     return `A ${this.color} shape`;
+                                                             21   }
+                                                             22
+                                                             23   hide() {
+                                                             24     this.visible = false;
+                                                             25   }
+                                                             26 }
+ 13 bindings                   proto: Shape → Object         27
+ REPL ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+→ undefined
+» evaluate expression...
+ ✓ parse ok │ globals: 13 │ selected: Circle │ ✓ Loaded testdata/inspector-test.js (93 lines, 12 globals)
+ tab next pane • : command • enter select/inspect • esc back/close • ctrl+c quit

--- a/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/scripts/smalltalk-global-zzz.txt
+++ b/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/scripts/smalltalk-global-zzz.txt
@@ -1,0 +1,34 @@
+ goja-inspector ─── testdata/inspector-test.js                                                             [REPL]
+ Globals ───────────────────── Circle: Members ───────────── Source ────────────────────────────────────────────────────
+▸ C  Circle ← Shape           ▸ ƒ  constructor(color, radius  1 // inspector-test.js — A file for testing the Smalltalk
+  C  Rectangle ← Shape          ƒ  area()                     2 // Covers: classes, inheritance, functions, constants, s
+  C  Shape                      ƒ  perimeter()                3
+  ƒ  createShape                ƒ  describe()                 4 const VERSION = "1.0.0";
+  ƒ  main                      ── inherited (Shape)           5 const MAX_ITEMS = 100;
+  ƒ  totalArea                  ƒ  hide()                     6
+  ●  MAX_ITEMS                                                7 const settings = {
+  ●  VERSION                                                  8   theme: "dark",
+  ●  myCircle                                                 9   fontSize: 14,
+  ●  myRect                                                  10   lineNumbers: true,
+  ●  settings                                                11 };
+  ●  shapes                                                  12
+  ●  zzzReplFn                                               13 class Shape {
+                                                             14   constructor(color) {
+                                                             15     this.color = color;
+                                                             16     this.visible = true;
+                                                             17   }
+                                                             18
+                                                             19   describe() {
+                                                             20     return `A ${this.color} shape`;
+                                                             21   }
+                                                             22
+                                                             23   hide() {
+                                                             24     this.visible = false;
+                                                             25   }
+                                                             26 }
+ 13 bindings                   proto: Shape → Object         27
+ REPL ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+→ undefined
+» G
+ ✓ parse ok │ globals: 13 │ selected: Circle
+ tab next pane • : command • enter select/inspect • esc back/close • ctrl+c quit

--- a/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/scripts/smalltalk-globals-bottom-jk.txt
+++ b/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/scripts/smalltalk-globals-bottom-jk.txt
@@ -1,0 +1,34 @@
+ goja-inspector ─── testdata/inspector-test.js                                                          [GLOBALS]
+ Globals ───────────────────── zzzReplFn: Members ────────── Source ────────────────────────────────────────────────────
+  C  Circle ← Shape            (no members)                  67     case "rectangle":
+  C  Rectangle ← Shape                                       68       return new Rectangle(color, args[0] || 1, args[1]
+  C  Shape                                                   69     default:
+  ƒ  createShape                                             70       return new Shape(color);
+  ƒ  main                                                    71   }
+  ƒ  totalArea                                               72 }
+  ●  MAX_ITEMS                                               73
+  ●  VERSION                                                 74 function totalArea(shapes) {
+  ●  myCircle                                                75   let sum = 0;
+  ●  myRect                                                  76   for (const s of shapes) {
+  ●  settings                                                77     if (typeof s.area === "function") {
+  ●  shapes                                                  78       sum += s.area();
+▸ ●  zzzReplFn                                               79     }
+                                                             80   }
+                                                             81   return sum;
+                                                             82 }
+                                                             83
+                                                             84 const myCircle = new Circle("red", 5);
+                                                             85 const myRect = new Rectangle("blue", 3, 4);
+                                                             86 const shapes = [myCircle, myRect];
+                                                             87
+                                                             88 function main() {
+                                                             89   const c = createShape("circle", "green", 10);
+                                                             90   const r = createShape("rectangle", "yellow", 6, 8);
+                                                             91   return { circle: c, rectangle: r, totalArea: totalArea
+                                                             92 }
+ 13 bindings                   proto: Function → Object      93
+ REPL ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+→ undefined
+» (tab to REPL)
+ ✓ parse ok │ globals: 13 │ selected: zzzReplFn │ ✓ Loaded testdata/inspector-test.js (93 lines, 12 globals)
+ tab next pane • : command • enter select/inspect • esc back/close • ctrl+c quit

--- a/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/scripts/smalltalk-globals-bottom.txt
+++ b/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/scripts/smalltalk-globals-bottom.txt
@@ -1,0 +1,34 @@
+ goja-inspector ─── testdata/inspector-test.js                                                          [GLOBALS]
+ Globals ───────────────────── zzzReplFn: Members ────────── Source ────────────────────────────────────────────────────
+  C  Circle ← Shape            (no members)                   1 // inspector-test.js — A file for testing the Smalltalk
+  C  Rectangle ← Shape                                        2 // Covers: classes, inheritance, functions, constants, s
+  C  Shape                                                    3
+  ƒ  createShape                                              4 const VERSION = "1.0.0";
+  ƒ  main                                                     5 const MAX_ITEMS = 100;
+  ƒ  totalArea                                                6
+  ●  MAX_ITEMS                                                7 const settings = {
+  ●  VERSION                                                  8   theme: "dark",
+  ●  myCircle                                                 9   fontSize: 14,
+  ●  myRect                                                  10   lineNumbers: true,
+  ●  settings                                                11 };
+  ●  shapes                                                  12
+▸ ●  zzzReplFn                                               13 class Shape {
+                                                             14   constructor(color) {
+                                                             15     this.color = color;
+                                                             16     this.visible = true;
+                                                             17   }
+                                                             18
+                                                             19   describe() {
+                                                             20     return `A ${this.color} shape`;
+                                                             21   }
+                                                             22
+                                                             23   hide() {
+                                                             24     this.visible = false;
+                                                             25   }
+                                                             26 }
+ 13 bindings                   proto: Function → Object      27
+ REPL ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+→ undefined
+» (tab to REPL)
+ ✓ parse ok │ globals: 13 │ selected: zzzReplFn │ ✓ Loaded testdata/inspector-test.js (93 lines, 12 globals)
+ tab next pane • : command • enter select/inspect • esc back/close • ctrl+c quit

--- a/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/scripts/smalltalk-initial.txt
+++ b/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/scripts/smalltalk-initial.txt
@@ -1,0 +1,34 @@
+ goja-inspector ─── testdata/inspector-test.js                                                          [GLOBALS]
+ Globals ───────────────────── Circle: Members ───────────── Source ────────────────────────────────────────────────────
+▸ C  Circle ← Shape           ▸ ƒ  constructor(color, radius  1 // inspector-test.js — A file for testing the Smalltalk
+  C  Rectangle ← Shape          ƒ  area()                     2 // Covers: classes, inheritance, functions, constants, s
+  C  Shape                      ƒ  perimeter()                3
+  ƒ  createShape                ƒ  describe()                 4 const VERSION = "1.0.0";
+  ƒ  main                      ── inherited (Shape)           5 const MAX_ITEMS = 100;
+  ƒ  totalArea                  ƒ  hide()                     6
+  ●  MAX_ITEMS                                                7 const settings = {
+  ●  VERSION                                                  8   theme: "dark",
+  ●  myCircle                                                 9   fontSize: 14,
+  ●  myRect                                                  10   lineNumbers: true,
+  ●  settings                                                11 };
+  ●  shapes                                                  12
+                                                             13 class Shape {
+                                                             14   constructor(color) {
+                                                             15     this.color = color;
+                                                             16     this.visible = true;
+                                                             17   }
+                                                             18
+                                                             19   describe() {
+                                                             20     return `A ${this.color} shape`;
+                                                             21   }
+                                                             22
+                                                             23   hide() {
+                                                             24     this.visible = false;
+                                                             25   }
+                                                             26 }
+ 12 bindings                   proto: Shape → Object         27
+ REPL ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+» (tab to REPL)
+ ✓ parse ok │ globals: 12 │ selected: Circle │ ✓ Loaded testdata/inspector-test.js (93 lines, 12 globals)
+ tab next pane • : command • enter select/inspect • esc back/close • ctrl+c quit

--- a/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/tasks.md
+++ b/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/tasks.md
@@ -1,5 +1,12 @@
 # Tasks
 
+## TODO (Follow-up Findings)
+
+- [x] Fix drawer lexical binding resolution to avoid nondeterministic scope-map lookups (`cmd/inspector/app/model.go`) and add shadowing tests.
+- [x] Guard globals half-page navigation when list is empty (`cmd/smalltalk-inspector/app/update.go`) and add regression test.
+- [x] Disambiguate runtime method source mapping by candidate source matching (`pkg/inspector/runtime/function_map.go`) and add ambiguity test.
+- [x] Run targeted + full test suite and record outcomes in ticket changelog/diary.
+
 ## Done
 
 - [x] Reproduce both regressions in tmux and capture evidence logs in `scripts/`.

--- a/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/tasks.md
+++ b/ttmp/2026/02/15/GOJA-035-INSPECTOR-UI-REGRESSIONS--inspector-ui-regressions-tree-pane-width-scroll-and-repl-source-mapping/tasks.md
@@ -1,0 +1,12 @@
+# Tasks
+
+## Done
+
+- [x] Reproduce both regressions in tmux and capture evidence logs in `scripts/`.
+- [x] Write GOJA-035 analysis doc with root-cause breakdown and fix plan.
+- [x] Implement REPL-symbol source fallback in `cmd/smalltalk-inspector` using declaration-aware REPL source log entries.
+- [x] Add regression test for REPL symbol source fallback behavior.
+- [x] Implement tree pane UX cleanup in `cmd/inspector` (narrower split, clamped tree rows, cleaner list delegate, reduced meta height).
+- [x] Add tests for tree pane width policy and tree title clamping.
+- [x] Validate fixes with `go test` and tmux re-runs.
+- [x] Update ticket diary/changelog with commands, outcomes, and review notes.

--- a/ttmp/vocabulary.yaml
+++ b/ttmp/vocabulary.yaml
@@ -11,6 +11,10 @@ topics:
       description: Go language
     - slug: tui
       description: Terminal user interfaces
+    - slug: inspector
+      description: Inspector tooling and workflows
+    - slug: refactor
+      description: Codebase refactor and cleanup work
 docTypes:
     - slug: index
       description: Ticket index documents

--- a/ttmp/vocabulary.yaml
+++ b/ttmp/vocabulary.yaml
@@ -7,6 +7,10 @@ topics:
       description: Migration planning and execution
     - slug: tooling
       description: Developer tooling and utilities
+    - slug: go
+      description: Go language
+    - slug: tui
+      description: Terminal user interfaces
 docTypes:
     - slug: index
       description: Ticket index documents

--- a/ttmp/vocabulary.yaml
+++ b/ttmp/vocabulary.yaml
@@ -15,6 +15,8 @@ topics:
       description: Inspector tooling and workflows
     - slug: refactor
       description: Codebase refactor and cleanup work
+    - slug: ui
+      description: User interface work
 docTypes:
     - slug: index
       description: Ticket index documents
@@ -26,3 +28,5 @@ intent:
 status:
     - slug: active
       description: Active in-progress ticket
+    - slug: complete
+      description: Completed ticket


### PR DESCRIPTION
This PR introduces a new `smalltalk-inspector` TUI and extracts a comprehensive,
reusable inspector framework into new packages. It also refactors the existing
`inspector` to use standard Bubble Tea components.

### New Smalltalk Inspector (`cmd/smalltalk-inspector`)

A new, feature-rich TUI for live JavaScript inspection, inspired by Smalltalk
browsers.

*   **Three-Pane Layout:** Browse Globals, Members, and Source code.
*   **Live REPL:** Evaluate expressions and inspect results in real-time.
*   **Object Inspection:** Drill into objects, view properties, and walk the
    prototype chain using `[[Proto]]` links.
*   **Breadcrumb Navigation:** Keeps track of your inspection path, with `Esc` to
    go back.
*   **Stack Trace Viewer:** When a REPL expression throws an error, the call stack
    is displayed and can be navigated, with the source pane jumping to the
    corresponding location.
*   **Syntax Highlighting:** Source code is highlighted using tree-sitter.

### Reusable Inspector Framework

The core logic for JS inspection has been extracted into a set of reusable,
UI-agnostic packages.

*   **`pkg/inspectorapi`:** A new user-facing service facade that orchestrates
    analysis and runtime inspection. It provides stable, task-oriented methods for:
    *   Document session lifecycle (open, update, close).
    *   Listing globals and members (static and runtime).
    *   Jumping to declarations.
    *   Merging runtime globals from REPL sessions.
    *   Source/AST tree synchronization.
*   **`pkg/inspector/*`:** Domain packages for specific concerns:
    *   `analysis`: Static analysis helpers (sessions, globals, members, xref).
    *   `runtime`: Goja runtime interaction (sessions, introspection, error
      parsing).
    *   `core`: AST traversal for member extraction with cycle safety.
    *   `navigation` & `tree`: UI-agnostic helpers for syncing views and shaping
      tree data.
*   **`internal/inspectorui`:** Shared Bubble Tea helpers for panes and scrolling.

### `cmd/inspector` Refactor

The existing AST inspector has been refactored for better stability and
maintainability.

*   **Component Migration:** Now uses standard Bubble Tea components: `list`,
    `viewport`, `table`, `help`, `spinner`, and `textinput`.
*   **Mode-Aware Keymap:** A new key system (`bobatea/mode-keymap`) provides
    context-aware key bindings.
*   **Command Palette:** A `:` command mode for actions like `clear`, `help`, and
    `quit`.
*   **Metadata Panel:** A new table view displays detailed information about the
    selected AST node.