### PR TITLE
Refactor engine to use explicit builder and owned runtime

### DIFF
--- a/cmd/js-repl/main.go
+++ b/cmd/js-repl/main.go
@@ -49,6 +49,9 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	defer func() {
+		_ = evaluator.Close()
+	}()
 
 	cfg := repl.DefaultConfig()
 	cfg.Title = "go-go-goja JavaScript REPL (Bobatea UI + jsparse completion/help)"

--- a/cmd/smalltalk-inspector/app/model.go
+++ b/cmd/smalltalk-inspector/app/model.go
@@ -170,6 +170,10 @@ func NewModel(filename string) Model {
 
 // Close releases resources (tree-sitter parser).
 func (m *Model) Close() {
+	if m.replAssist != nil {
+		_ = m.replAssist.Close()
+		m.replAssist = nil
+	}
 	if m.tsParser != nil {
 		m.tsParser.Close()
 		m.tsParser = nil

--- a/cmd/smalltalk-inspector/app/repl_widgets.go
+++ b/cmd/smalltalk-inspector/app/repl_widgets.go
@@ -89,6 +89,9 @@ func (a replInputBufferAdapter) SetCursorByte(cursor int) {
 }
 
 func (m *Model) setupReplWidgetsForRuntime() {
+	if m.replAssist != nil {
+		_ = m.replAssist.Close()
+	}
 	m.replAssist = nil
 	m.replSuggestWidget = nil
 	m.replContextBarWidget = nil

--- a/cmd/smalltalk-inspector/main.go
+++ b/cmd/smalltalk-inspector/main.go
@@ -17,7 +17,18 @@ func main() {
 	model := app.NewModel(filename)
 
 	p := tea.NewProgram(model, tea.WithAltScreen())
-	if _, err := p.Run(); err != nil {
+	finalModel, err := p.Run()
+	if finalModel != nil {
+		switch fm := finalModel.(type) {
+		case app.Model:
+			fm.Close()
+		case *app.Model:
+			fm.Close()
+		}
+	} else {
+		model.Close()
+	}
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}

--- a/engine/factory.go
+++ b/engine/factory.go
@@ -1,46 +1,180 @@
 package engine
 
 import (
-	"log"
+	"context"
+	"fmt"
+	"strings"
 
 	"github.com/dop251/goja"
 	"github.com/dop251/goja_nodejs/console"
+	"github.com/dop251/goja_nodejs/eventloop"
 	"github.com/dop251/goja_nodejs/require"
-
-	"github.com/go-go-golems/go-go-goja/modules"
+	"github.com/go-go-golems/go-go-goja/pkg/runtimeowner"
 )
 
-// Factory prebuilds reusable runtime bootstrap state and can create multiple
-// fresh runtimes with lower per-runtime setup overhead.
-type Factory struct {
-	settings openSettings
-	registry *require.Registry
+// FactoryBuilder composes explicit module and runtime initializer configuration
+// before producing an immutable Factory.
+type FactoryBuilder struct {
+	settings builderSettings
+
+	modules             []ModuleSpec
+	runtimeInitializers []RuntimeInitializer
+	built               bool
 }
 
-// NewFactory creates a reusable runtime factory from engine options.
-func NewFactory(opts ...Option) *Factory {
-	settings := defaultOpenSettings()
+// Factory creates runtime instances from an immutable build plan.
+type Factory struct {
+	registry            *require.Registry
+	runtimeInitializers []RuntimeInitializer
+}
+
+// NewBuilder starts a new explicit runtime composition flow.
+func NewBuilder(opts ...Option) *FactoryBuilder {
+	settings := defaultBuilderSettings()
 	for _, opt := range opts {
 		if opt != nil {
 			opt(&settings)
 		}
 	}
-
-	reg := require.NewRegistry(settings.requireOptions...)
-	modules.EnableAll(reg)
-	log.Printf("go-go-goja: native modules enabled")
-
-	return &Factory{
+	return &FactoryBuilder{
 		settings: settings,
-		registry: reg,
 	}
 }
 
-// NewRuntime creates a new runtime from this factory using the factory's
-// preconfigured bootstrap state.
-func (f *Factory) NewRuntime() (*goja.Runtime, *require.RequireModule) {
+func (b *FactoryBuilder) assertMutable() {
+	if b == nil {
+		panic("engine builder is nil")
+	}
+	if b.built {
+		panic("engine builder is already built and immutable")
+	}
+}
+
+// WithRequireOptions appends require options to the current builder.
+func (b *FactoryBuilder) WithRequireOptions(opts ...require.Option) *FactoryBuilder {
+	b.assertMutable()
+	b.settings.requireOptions = append(b.settings.requireOptions, opts...)
+	return b
+}
+
+// WithModules appends static module registrations.
+func (b *FactoryBuilder) WithModules(mods ...ModuleSpec) *FactoryBuilder {
+	b.assertMutable()
+	b.modules = append(b.modules, mods...)
+	return b
+}
+
+// WithRuntimeInitializers appends runtime initialization hooks executed for
+// each created runtime instance.
+func (b *FactoryBuilder) WithRuntimeInitializers(inits ...RuntimeInitializer) *FactoryBuilder {
+	b.assertMutable()
+	b.runtimeInitializers = append(b.runtimeInitializers, inits...)
+	return b
+}
+
+func validateUniqueIDs[T interface{ ID() string }](entries []T, kind string) error {
+	seen := map[string]int{}
+	for i, entry := range entries {
+		id := strings.TrimSpace(entry.ID())
+		if id == "" {
+			return fmt.Errorf("%s at index %d has empty ID", kind, i)
+		}
+		if j, ok := seen[id]; ok {
+			return fmt.Errorf("duplicate %s ID %q at indexes %d and %d", kind, id, j, i)
+		}
+		seen[id] = i
+	}
+	return nil
+}
+
+// Build validates and freezes the composition into an immutable Factory.
+func (b *FactoryBuilder) Build() (*Factory, error) {
+	if b == nil {
+		return nil, fmt.Errorf("engine builder is nil")
+	}
+	b.assertMutable()
+
+	modules_ := make([]ModuleSpec, 0, len(b.modules))
+	for i, mod := range b.modules {
+		if mod == nil {
+			return nil, fmt.Errorf("module spec at index %d is nil", i)
+		}
+		modules_ = append(modules_, mod)
+	}
+	inits := make([]RuntimeInitializer, 0, len(b.runtimeInitializers))
+	for i, init := range b.runtimeInitializers {
+		if init == nil {
+			return nil, fmt.Errorf("runtime initializer at index %d is nil", i)
+		}
+		inits = append(inits, init)
+	}
+
+	if err := validateUniqueIDs(modules_, "module"); err != nil {
+		return nil, err
+	}
+	if err := validateUniqueIDs(inits, "runtime initializer"); err != nil {
+		return nil, err
+	}
+
+	reg := require.NewRegistry(b.settings.requireOptions...)
+	for _, mod := range modules_ {
+		if err := mod.Register(reg); err != nil {
+			return nil, fmt.Errorf("register module %q: %w", mod.ID(), err)
+		}
+	}
+
+	b.built = true
+
+	return &Factory{
+		registry:            reg,
+		runtimeInitializers: append([]RuntimeInitializer(nil), inits...),
+	}, nil
+}
+
+// NewRuntime creates a new owned runtime instance from this factory's frozen
+// composition plan.
+func (f *Factory) NewRuntime(ctx context.Context) (*Runtime, error) {
+	if f == nil {
+		return nil, fmt.Errorf("factory is nil")
+	}
+	if f.registry == nil {
+		return nil, fmt.Errorf("factory has no require registry")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	vm := goja.New()
+	loop := eventloop.NewEventLoop()
+	go loop.Start()
+
+	owner := runtimeowner.NewRunner(vm, loop, runtimeowner.Options{
+		Name:          "go-go-goja-runtime",
+		RecoverPanics: true,
+	})
+
 	reqMod := f.registry.Enable(vm)
 	console.Enable(vm)
-	return vm, reqMod
+
+	rt := &Runtime{
+		VM:      vm,
+		Require: reqMod,
+		Loop:    loop,
+		Owner:   owner,
+	}
+
+	initCtx := &RuntimeContext{
+		VM:      vm,
+		Require: reqMod,
+		Loop:    loop,
+		Owner:   owner,
+	}
+	for _, init := range f.runtimeInitializers {
+		if err := init.InitRuntime(initCtx); err != nil {
+			_ = rt.Close(ctx)
+			return nil, fmt.Errorf("runtime initializer %q: %w", init.ID(), err)
+		}
+	}
+
+	return rt, nil
 }

--- a/engine/module_specs.go
+++ b/engine/module_specs.go
@@ -1,0 +1,82 @@
+package engine
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/dop251/goja"
+	"github.com/dop251/goja_nodejs/eventloop"
+	"github.com/dop251/goja_nodejs/require"
+	"github.com/go-go-golems/go-go-goja/modules"
+	"github.com/go-go-golems/go-go-goja/pkg/runtimeowner"
+)
+
+// ModuleSpec is a static registration unit applied at factory build time.
+type ModuleSpec interface {
+	ID() string
+	Register(reg *require.Registry) error
+}
+
+// RuntimeInitializer is a per-runtime initialization hook executed after VM and
+// require setup.
+type RuntimeInitializer interface {
+	ID() string
+	InitRuntime(ctx *RuntimeContext) error
+}
+
+// RuntimeContext exposes runtime-scoped objects to initializers.
+type RuntimeContext struct {
+	VM      *goja.Runtime
+	Require *require.RequireModule
+	Loop    *eventloop.EventLoop
+	Owner   runtimeowner.Runner
+}
+
+// NativeModuleSpec registers a single native module loader.
+type NativeModuleSpec struct {
+	ModuleID   string
+	ModuleName string
+	Loader     require.ModuleLoader
+}
+
+func (s NativeModuleSpec) ID() string {
+	if strings.TrimSpace(s.ModuleID) != "" {
+		return strings.TrimSpace(s.ModuleID)
+	}
+	return "native:" + strings.TrimSpace(s.ModuleName)
+}
+
+func (s NativeModuleSpec) Register(reg *require.Registry) error {
+	if reg == nil {
+		return fmt.Errorf("require registry is nil")
+	}
+	name := strings.TrimSpace(s.ModuleName)
+	if name == "" {
+		return fmt.Errorf("module name is empty")
+	}
+	if s.Loader == nil {
+		return fmt.Errorf("native module %q loader is nil", name)
+	}
+	reg.RegisterNativeModule(name, s.Loader)
+	return nil
+}
+
+type defaultRegistryModulesSpec struct{}
+
+func (s defaultRegistryModulesSpec) ID() string {
+	return "default-registry-modules"
+}
+
+func (s defaultRegistryModulesSpec) Register(reg *require.Registry) error {
+	if reg == nil {
+		return fmt.Errorf("require registry is nil")
+	}
+	modules.EnableAll(reg)
+	return nil
+}
+
+// DefaultRegistryModules returns a ModuleSpec that registers every module from
+// go-go-goja/modules.DefaultRegistry. This is explicit and opt-in.
+func DefaultRegistryModules() ModuleSpec {
+	return defaultRegistryModulesSpec{}
+}

--- a/engine/options.go
+++ b/engine/options.go
@@ -2,20 +2,20 @@ package engine
 
 import "github.com/dop251/goja_nodejs/require"
 
-type openSettings struct {
+type builderSettings struct {
 	requireOptions []require.Option
 }
 
-func defaultOpenSettings() openSettings {
-	return openSettings{}
+func defaultBuilderSettings() builderSettings {
+	return builderSettings{}
 }
 
-// Option configures engine.Open behavior.
-type Option func(*openSettings)
+// Option configures engine builder behavior.
+type Option func(*builderSettings)
 
 // WithRequireOptions appends require registry options for module loading.
 func WithRequireOptions(opts ...require.Option) Option {
-	return func(s *openSettings) {
+	return func(s *builderSettings) {
 		s.requireOptions = append(s.requireOptions, opts...)
 	}
 }

--- a/engine/runtime.go
+++ b/engine/runtime.go
@@ -1,33 +1,50 @@
 package engine
 
 import (
-	"github.com/dop251/goja"
-	"github.com/dop251/goja_nodejs/require"
+	"context"
+	"sync"
 
-	// Blank imports ensure module init() functions run so they can register themselves.
+	"github.com/dop251/goja"
+	"github.com/dop251/goja_nodejs/eventloop"
+	"github.com/dop251/goja_nodejs/require"
+	"github.com/go-go-golems/go-go-goja/pkg/runtimeowner"
+
+	// Blank imports ensure module init() functions run so they can register
+	// themselves in modules.DefaultRegistry. Registration is still explicit:
+	// callers must opt in via DefaultRegistryModules().
 	_ "github.com/go-go-golems/go-go-goja/modules/database"
 	_ "github.com/go-go-golems/go-go-goja/modules/exec"
 	_ "github.com/go-go-golems/go-go-goja/modules/fs"
 	_ "github.com/go-go-golems/go-go-goja/modules/glazehelp"
 )
 
-// New creates a fresh goja.Runtime ready for execution with Node-style
-// `require()` enabled and all native modules registered.
-//
-// The returned *goja.Runtime can be used directly with RunString/run etc. The
-// second return value is the require.Module instance so that callers can load
-// entry-point JavaScript files via req.Require(path).
-func New() (*goja.Runtime, *require.RequireModule) {
-	return Open()
+// Runtime is an owned runtime instance with explicit lifecycle.
+type Runtime struct {
+	VM      *goja.Runtime
+	Require *require.RequireModule
+	Loop    *eventloop.EventLoop
+	Owner   runtimeowner.Runner
+
+	closeOnce sync.Once
 }
 
-// NewWithOptions creates a runtime like New, but allows callers to customize
-// the goja_nodejs/require registry (for example, to install a custom loader).
-func NewWithOptions(opts ...require.Option) (*goja.Runtime, *require.RequireModule) {
-	return Open(WithRequireOptions(opts...))
-}
+// Close shuts down runtime-owned resources.
+func (r *Runtime) Close(ctx context.Context) error {
+	if r == nil {
+		return nil
+	}
 
-// Open creates a fresh runtime using option-driven configuration.
-func Open(opts ...Option) (*goja.Runtime, *require.RequireModule) {
-	return NewFactory(opts...).NewRuntime()
+	var retErr error
+	r.closeOnce.Do(func() {
+		if r.Owner != nil {
+			if err := r.Owner.Shutdown(ctx); err != nil && retErr == nil {
+				retErr = err
+			}
+		}
+		if r.Loop != nil {
+			r.Loop.Stop()
+		}
+	})
+
+	return retErr
 }

--- a/engine/runtime_test.go
+++ b/engine/runtime_test.go
@@ -1,13 +1,14 @@
 package engine
 
 import (
+	"context"
 	"strings"
 	"testing"
 
 	"github.com/dop251/goja_nodejs/require"
 )
 
-func TestOpenWithRequireOptions(t *testing.T) {
+func TestBuilderWithRequireOptions(t *testing.T) {
 	loader := func(path string) ([]byte, error) {
 		trimmed := strings.TrimPrefix(path, "./")
 		if trimmed == "entry.js" {
@@ -16,13 +17,27 @@ func TestOpenWithRequireOptions(t *testing.T) {
 		return nil, require.ModuleFileDoesNotExistError
 	}
 
-	vm, req := Open(WithRequireOptions(require.WithLoader(loader)))
-	val, err := req.Require("./entry.js")
+	factory, err := NewBuilder(
+		WithRequireOptions(require.WithLoader(loader)),
+	).Build()
+	if err != nil {
+		t.Fatalf("build factory: %v", err)
+	}
+
+	rt, err := factory.NewRuntime(context.Background())
+	if err != nil {
+		t.Fatalf("new runtime: %v", err)
+	}
+	defer func() {
+		_ = rt.Close(context.Background())
+	}()
+
+	val, err := rt.Require.Require("./entry.js")
 	if err != nil {
 		t.Fatalf("require entry.js: %v", err)
 	}
 
-	obj := val.ToObject(vm)
+	obj := val.ToObject(rt.VM)
 	if got := obj.Get("ok").ToInteger(); got != 42 {
 		t.Fatalf("ok = %d, want 42", got)
 	}

--- a/pkg/repl/adapters/bobatea/javascript.go
+++ b/pkg/repl/adapters/bobatea/javascript.go
@@ -63,6 +63,14 @@ func (e *JavaScriptEvaluator) GetHelpDrawer(ctx context.Context, req bobarepl.He
 	return e.core.GetHelpDrawer(ctx, req)
 }
 
+// Close releases evaluator-owned runtime resources.
+func (e *JavaScriptEvaluator) Close() error {
+	if e == nil || e.core == nil {
+		return nil
+	}
+	return e.core.Close()
+}
+
 var _ bobarepl.Evaluator = (*JavaScriptEvaluator)(nil)
 var _ bobarepl.InputCompleter = (*JavaScriptEvaluator)(nil)
 var _ bobarepl.HelpBarProvider = (*JavaScriptEvaluator)(nil)

--- a/pkg/repl/evaluators/javascript/evaluator.go
+++ b/pkg/repl/evaluators/javascript/evaluator.go
@@ -617,6 +617,22 @@ func (e *Evaluator) Reset() error {
 	return nil
 }
 
+// Close releases owned runtime resources when this evaluator created its own runtime.
+// It is a no-op when evaluator reuses an externally provided runtime.
+func (e *Evaluator) Close() error {
+	e.runtimeMu.Lock()
+	ownedRuntime := e.ownedRuntime
+	e.ownedRuntime = nil
+	e.runtimeMu.Unlock()
+
+	if ownedRuntime != nil {
+		if err := ownedRuntime.Close(context.Background()); err != nil {
+			return errors.Wrap(err, "failed to close owned runtime")
+		}
+	}
+	return nil
+}
+
 // GetConfig returns the current configuration
 func (e *Evaluator) GetConfig() Config {
 	return e.config

--- a/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/changelog.md
+++ b/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/changelog.md
@@ -76,3 +76,13 @@ Step 5: refreshed root README for canonical builder/factory/runtime API and remo
 - /home/manuel/workspaces/2026-02-21/entity-extraction-js/go-go-goja/README.md — Updated runtime API docs to NewBuilder/Build/NewRuntime/Close model
 - /home/manuel/workspaces/2026-02-21/entity-extraction-js/go-go-goja/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/reference/01-diary.md — Added Step 5 entry for README refresh
 
+
+## 2026-02-21
+
+Step 6: fixed evaluator owned-runtime cleanup on init errors and made reset non-destructive by swapping before close (commit 993fbfe).
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-21/entity-extraction-js/go-go-goja/pkg/repl/evaluators/javascript/evaluator.go — Lifecycle hardening for constructor failure cleanup and reset ordering
+- /home/manuel/workspaces/2026-02-21/entity-extraction-js/go-go-goja/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/reference/01-diary.md — Added Step 6 review-response entry
+

--- a/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/changelog.md
+++ b/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/changelog.md
@@ -51,3 +51,8 @@ Step 3: closed remaining docs checklist item after per-step diary/changelog alig
 - /home/manuel/workspaces/2026-02-21/entity-extraction-js/go-go-goja/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/reference/01-diary.md — Added closure step for execution checklist
 - /home/manuel/workspaces/2026-02-21/entity-extraction-js/go-go-goja/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/tasks.md — Marked final docs execution task complete
 
+
+## 2026-02-21
+
+Ticket closed
+

--- a/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/changelog.md
+++ b/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/changelog.md
@@ -86,3 +86,18 @@ Step 6: fixed evaluator owned-runtime cleanup on init errors and made reset non-
 - /home/manuel/workspaces/2026-02-21/entity-extraction-js/go-go-goja/pkg/repl/evaluators/javascript/evaluator.go — Lifecycle hardening for constructor failure cleanup and reset ordering
 - /home/manuel/workspaces/2026-02-21/entity-extraction-js/go-go-goja/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/reference/01-diary.md — Added Step 6 review-response entry
 
+
+## 2026-02-21
+
+Step 7: added explicit evaluator Close lifecycle and wired teardown at REPL call sites (commit 7a842da).
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-21/entity-extraction-js/go-go-goja/cmd/js-repl/main.go — Deferred evaluator close on REPL shutdown
+- /home/manuel/workspaces/2026-02-21/entity-extraction-js/go-go-goja/cmd/smalltalk-inspector/app/model.go — Model.Close now disposes assist evaluator
+- /home/manuel/workspaces/2026-02-21/entity-extraction-js/go-go-goja/cmd/smalltalk-inspector/app/repl_widgets.go — Close previous assist evaluator before replacement
+- /home/manuel/workspaces/2026-02-21/entity-extraction-js/go-go-goja/cmd/smalltalk-inspector/main.go — Close final model resources after tea program run
+- /home/manuel/workspaces/2026-02-21/entity-extraction-js/go-go-goja/pkg/repl/adapters/bobatea/javascript.go — Adapter Close() forwards teardown to core evaluator
+- /home/manuel/workspaces/2026-02-21/entity-extraction-js/go-go-goja/pkg/repl/evaluators/javascript/evaluator.go — Added evaluator Close() to release owned runtime resources
+- /home/manuel/workspaces/2026-02-21/entity-extraction-js/go-go-goja/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/reference/01-diary.md — Added Step 7 lifecycle teardown documentation
+

--- a/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/changelog.md
+++ b/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/changelog.md
@@ -30,3 +30,14 @@ Replaced the research-oriented task list with an implementation sequence for a n
 
 - /home/manuel/workspaces/2026-02-21/entity-extraction-js/go-go-goja/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/tasks.md — Detailed execution tasks for clean API cutover
 - /home/manuel/workspaces/2026-02-21/entity-extraction-js/go-go-goja/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/reference/01-diary.md — Implementation diary initialized
+
+## 2026-02-21
+
+Step 2: landed no-compat builder/factory/runtime rewrite and migrated callsites (commit 4059db5).
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-21/entity-extraction-js/go-go-goja/engine/factory.go — Canonical builder/factory runtime construction and initialization sequencing
+- /home/manuel/workspaces/2026-02-21/entity-extraction-js/go-go-goja/engine/module_specs.go — ModuleSpec and RuntimeInitializer contracts with explicit default registry module
+- /home/manuel/workspaces/2026-02-21/entity-extraction-js/go-go-goja/pkg/repl/evaluators/javascript/evaluator.go — REPL evaluator migrated to owned runtime lifecycle and reset handling
+

--- a/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/changelog.md
+++ b/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/changelog.md
@@ -41,3 +41,13 @@ Step 2: landed no-compat builder/factory/runtime rewrite and migrated callsites 
 - /home/manuel/workspaces/2026-02-21/entity-extraction-js/go-go-goja/engine/module_specs.go — ModuleSpec and RuntimeInitializer contracts with explicit default registry module
 - /home/manuel/workspaces/2026-02-21/entity-extraction-js/go-go-goja/pkg/repl/evaluators/javascript/evaluator.go — REPL evaluator migrated to owned runtime lifecycle and reset handling
 
+
+## 2026-02-21
+
+Step 3: closed remaining docs checklist item after per-step diary/changelog alignment.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-21/entity-extraction-js/go-go-goja/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/reference/01-diary.md — Added closure step for execution checklist
+- /home/manuel/workspaces/2026-02-21/entity-extraction-js/go-go-goja/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/tasks.md — Marked final docs execution task complete
+

--- a/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/changelog.md
+++ b/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/changelog.md
@@ -66,3 +66,13 @@ Step 4: refreshed ticket index metadata and overview to reflect completed implem
 - /home/manuel/workspaces/2026-02-21/entity-extraction-js/go-go-goja/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/index.md — Updated summary/status/key links and related-files metadata for completed ticket state
 - /home/manuel/workspaces/2026-02-21/entity-extraction-js/go-go-goja/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/reference/01-diary.md — Added Step 4 documentation consistency audit and remediation record
 
+
+## 2026-02-21
+
+Step 5: refreshed root README for canonical builder/factory/runtime API and removed legacy wrapper guidance (commit 998a03b).
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-21/entity-extraction-js/go-go-goja/README.md — Updated runtime API docs to NewBuilder/Build/NewRuntime/Close model
+- /home/manuel/workspaces/2026-02-21/entity-extraction-js/go-go-goja/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/reference/01-diary.md — Added Step 5 entry for README refresh
+

--- a/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/changelog.md
+++ b/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/changelog.md
@@ -56,3 +56,13 @@ Step 3: closed remaining docs checklist item after per-step diary/changelog alig
 
 Ticket closed
 
+
+## 2026-02-21
+
+Step 4: refreshed ticket index metadata and overview to reflect completed implementation state and v2 design links.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-21/entity-extraction-js/go-go-goja/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/index.md — Updated summary/status/key links and related-files metadata for completed ticket state
+- /home/manuel/workspaces/2026-02-21/entity-extraction-js/go-go-goja/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/reference/01-diary.md — Added Step 4 documentation consistency audit and remediation record
+

--- a/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/changelog.md
+++ b/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/changelog.md
@@ -22,3 +22,11 @@ Added follow-up backlog tasks and enriched ticket index metadata/overview so the
 - /home/manuel/workspaces/2026-02-18/goja-performance/go-go-goja/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/index.md — Added summary
 - /home/manuel/workspaces/2026-02-18/goja-performance/go-go-goja/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/tasks.md — Seeded concrete implementation backlog for future execution
 
+## 2026-02-21
+
+Replaced the research-oriented task list with an implementation sequence for a no-backward-compatibility rewrite, explicitly excluding dependency solver work from this pass. Added a new diary document and started step-by-step execution logging.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-02-21/entity-extraction-js/go-go-goja/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/tasks.md — Detailed execution tasks for clean API cutover
+- /home/manuel/workspaces/2026-02-21/entity-extraction-js/go-go-goja/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/reference/01-diary.md — Implementation diary initialized

--- a/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/design/02-pragmatic-mvp-api-for-module-composition-and-runtime-ownership.md
+++ b/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/design/02-pragmatic-mvp-api-for-module-composition-and-runtime-ownership.md
@@ -1,0 +1,432 @@
+---
+Title: Pragmatic MVP API for module composition and runtime ownership
+Ticket: GC-05-ENGINE-MODULE-COMPOSITION
+Status: active
+Topics:
+    - go
+    - architecture
+    - refactor
+    - tooling
+DocType: design
+Intent: long-term
+Owners: []
+RelatedFiles: []
+ExternalSources: []
+Summary: ""
+LastUpdated: 2026-02-21T15:24:25.02584737-05:00
+WhatFor: ""
+WhenToUse: ""
+---
+
+# Pragmatic MVP API for module composition and runtime ownership
+
+## Executive Summary
+
+This document proposes a practical MVP for `go-go-goja` engine composition that intentionally **does not include dependency resolution yet**.
+
+Revision: **v2** (2026-02-21) updates the proposal to a **clean API rewrite with no backward-compatibility requirement** and adds explicit analysis of runtime-scoped registration pain points.
+
+Goals of this MVP:
+
+1. Make module registration explicit (no hidden global side effects).
+2. Make runtime ownership/concurrency safe by default.
+3. Enable clean integration of runtime-scoped modules like `require("geppetto")`.
+4. Remove legacy API ambiguity by cutting over to one composition model.
+
+Out of scope for this MVP:
+
+- topological dependency solver
+- conflict graph/resolution policies beyond duplicate ID checks
+- dynamic post-build module hot-add
+
+## Problem Statement
+
+Current `go-go-goja` behavior in `engine/factory.go`:
+
+- creates one `require.Registry`
+- calls `modules.EnableAll(reg)`
+- returns VM+require module via `NewRuntime()`
+
+This works for baseline modules, but it has two practical gaps:
+
+1. Composition is mostly implicit/global.
+2. Runtime-scoped module registration (for example Geppetto with a runtime owner runner) is awkward.
+
+Additionally, host applications repeatedly reconstruct similar bootstrap logic:
+
+- event loop creation
+- runtime owner bridge
+- module registration with per-runtime options
+- require loader/global folder configuration
+
+The MVP should centralize this without overengineering.
+
+## Why runtime-scoped module registration is awkward today
+
+Runtime-scoped registration means module setup needs values that exist only per runtime instance:
+
+- `*goja.Runtime`
+- event loop
+- runtime owner runner
+- runtime lifecycle (startup/shutdown boundaries)
+
+Current awkwardness comes from a model mismatch:
+
+1. **Timing mismatch**
+   - Factory registers modules early (registry phase).
+   - Runtime-scoped modules need to bind later (runtime phase), when VM/runner exist.
+
+2. **Registry access mismatch**
+   - Factory-owned registry is internal.
+   - Callers cannot cleanly inject per-runtime registration logic into that path.
+
+3. **One-registry vs many-runtimes mismatch**
+   - One factory can create many runtimes.
+   - Capturing one runtime's owner inside static registration is wrong for subsequent runtimes.
+
+4. **Lifecycle mismatch**
+   - Runtime-scoped modules need startup and teardown hooks.
+   - Static registration path has no explicit runtime lifecycle callbacks.
+
+5. **Concurrency safety mismatch**
+   - goja requires single-owner access discipline.
+   - Using stale/wrong owner bridge can post work to wrong or closed loop.
+
+Conclusion: we need an API where runtime lifecycle is first-class, not bolted on.
+
+## Proposed MVP Architecture
+
+### Core idea
+
+Split composition into two explicit layers:
+
+1. **Static factory modules** (registered on factory-owned `require.Registry` before runtime creation).
+2. **Runtime initializers** (run after VM creation, with access to VM/event loop/runner).
+
+This supports both:
+
+- plain native modules (`database`, `fs`, `exec`)
+- runtime-aware modules (`geppetto` with `runtimeowner.Runner` in options)
+
+## Clean rewrite (no backwards compatibility)
+
+This v2 proposal intentionally removes legacy paths:
+
+- remove `engine.New()`
+- remove `engine.Open(...)`
+- remove `engine.NewWithOptions(...)`
+- remove implicit `modules.EnableAll(...)` bootstrapping
+
+New required flow:
+
+1. `engine.NewBuilder()`
+2. explicit `WithRequireOptions(...)`
+3. explicit `WithModules(...)`
+4. `Build()`
+5. `Factory.NewRuntime(...)`
+
+## Proposed Public API (MVP)
+
+### 1) Factory builder
+
+```go
+package engine
+
+type FactoryBuilder struct {
+    opts       []Option
+    modules    []ModuleSpec
+    runtimeInits []RuntimeInitializer
+    built      bool
+}
+
+func NewBuilder(opts ...Option) *FactoryBuilder
+
+func (b *FactoryBuilder) WithModules(mods ...ModuleSpec) *FactoryBuilder
+func (b *FactoryBuilder) WithRuntimeInitializers(inits ...RuntimeInitializer) *FactoryBuilder
+func (b *FactoryBuilder) Build() (*Factory, error)
+```
+
+### 2) Module specs (static registration)
+
+```go
+package engine
+
+import "github.com/dop251/goja_nodejs/require"
+
+type ModuleSpec interface {
+    ID() string
+    Register(reg *require.Registry) error
+}
+
+type NativeModuleSpec struct {
+    ModuleName string
+    Loader     require.ModuleLoader
+}
+```
+
+Behavior:
+
+- duplicate module IDs fail at `Build()`
+- registration order is the user-provided order (deterministic, no sorting yet)
+
+### 3) Runtime initializer hooks
+
+```go
+package engine
+
+import (
+    "github.com/dop251/goja"
+    "github.com/dop251/goja_nodejs/require"
+    "github.com/dop251/goja_nodejs/eventloop"
+    "github.com/go-go-golems/go-go-goja/pkg/runtimeowner"
+)
+
+type RuntimeContext struct {
+    VM       *goja.Runtime
+    Require  *require.RequireModule
+    Loop     *eventloop.EventLoop
+    Owner    runtimeowner.Runner
+}
+
+type RuntimeInitializer interface {
+    ID() string
+    InitRuntime(ctx *RuntimeContext) error
+}
+```
+
+Behavior:
+
+- runtime initializers run in explicit order after VM + require are ready
+- duplicate initializer IDs fail in `Build()`
+
+### 4) Owned runtime object
+
+```go
+package engine
+
+type OwnedRuntime struct {
+    VM      *goja.Runtime
+    Require *require.RequireModule
+    Loop    *eventloop.EventLoop
+    Owner   runtimeowner.Runner
+}
+
+func (r *OwnedRuntime) Close(ctx context.Context) error
+```
+
+Factory API:
+
+```go
+func (f *Factory) NewOwnedRuntime() (*OwnedRuntime, error)
+```
+
+This gives host apps a clean, concurrency-safe runtime package.
+
+## Lifecycle Semantics
+
+```text
+compose builder
+  -> validate duplicate IDs
+  -> build immutable Factory
+      -> prepare require.Registry
+      -> register static ModuleSpecs
+
+Factory.NewOwnedRuntime()
+  -> create VM
+  -> create/start event loop
+  -> create runtimeowner.Runner
+  -> enable require on VM
+  -> run RuntimeInitializers in order
+  -> return OwnedRuntime
+```
+
+## Why this is enough for MVP
+
+It solves immediate product needs:
+
+- deterministic composition without globals
+- reusable runtime owner concurrency contract
+- clean Geppetto registration path
+- no dependency solver complexity yet
+
+It also leaves clear extension points for later:
+
+- dependency metadata on `ModuleSpec`
+- conflict key policies
+- optional module sets/presets
+
+## Concrete Code Example: Register Geppetto cleanly
+
+### Runtime initializer for Geppetto
+
+```go
+package geppettoinit
+
+import (
+    "github.com/dop251/goja_nodejs/require"
+    gp "github.com/go-go-golems/geppetto/pkg/js/modules/geppetto"
+    "github.com/go-go-golems/go-go-goja/engine"
+    "github.com/rs/zerolog"
+)
+
+type Init struct {
+    Logger zerolog.Logger
+}
+
+func (i Init) ID() string { return "geppetto-runtime-init" }
+
+func (i Init) InitRuntime(ctx *engine.RuntimeContext) error {
+    // Register native module against a runtime-scoped registry and enable it.
+    reg := require.NewRegistry()
+    gp.Register(reg, gp.Options{
+        Runner: ctx.Owner,
+        Logger: i.Logger,
+    })
+    reg.Enable(ctx.VM)
+    return nil
+}
+```
+
+Note:
+
+- For MVP we can keep this simple by using an initializer-managed registry for Geppetto.
+- In a refinement pass, we can expose the factory registry directly on `RuntimeContext` if needed.
+
+### Host usage
+
+```go
+builder := engine.NewFactoryBuilder(
+    engine.WithRequireOptions(
+        require.WithLoader(require.DefaultSourceLoader),
+        require.WithGlobalFolders("./scripts"),
+    ),
+)
+
+builder = builder.WithRuntimeInitializers(
+    geppettoinit.Init{Logger: logger},
+)
+
+factory, err := builder.Build()
+if err != nil { return err }
+
+rt, err := factory.NewOwnedRuntime()
+if err != nil { return err }
+defer rt.Close(context.Background())
+
+_, err = rt.VM.RunScript("/abs/path/scripts/main.js", scriptSource)
+if err != nil { return err }
+```
+
+## Concrete Code Example: Static module composition
+
+```go
+fsSpec := engine.NativeModuleSpec{
+    ModuleName: "fs",
+    Loader:     fsModule.Loader,
+}
+dbSpec := engine.NativeModuleSpec{
+    ModuleName: "database",
+    Loader:     dbModule.Loader,
+}
+
+factory, err := engine.NewFactoryBuilder().
+    WithModules(fsSpec, dbSpec).
+    Build()
+```
+
+Validation behavior:
+
+- if both specs return same `ID()`, `Build()` returns explicit error.
+
+## API sketch for backward compatibility
+
+Not applicable in v2. This design assumes a hard cutover.
+
+Legacy compatibility wrappers are intentionally omitted to keep one canonical runtime composition model.
+
+## Error model (MVP)
+
+`Build()` should fail fast on:
+
+1. duplicate module IDs
+2. duplicate runtime initializer IDs
+3. module registration errors
+
+`NewOwnedRuntime()` should fail fast on:
+
+1. runtime initialization hook errors
+2. owner/loop construction failures
+
+No best-effort partial startup; explicit failures are easier to debug.
+
+## Concurrency Model
+
+goja runtime constraint:
+
+- one runtime, one goroutine at a time.
+
+MVP enforcement:
+
+- `OwnedRuntime.Owner` is always created and provided.
+- async/module callbacks should use owner runner (`Call`/`Post`) rather than touching VM directly from arbitrary goroutines.
+
+This gives us a consistent safety baseline across modules.
+
+## Migration Plan
+
+### Phase 1: Implement new canonical API
+
+1. Add `FactoryBuilder`, `ModuleSpec`, `RuntimeInitializer`, `OwnedRuntime`.
+2. Delete old entrypoints and implicit module enable path.
+
+### Phase 2: Adopt in first host
+
+1. Update one app (for example extraction runner) to use `NewFactoryBuilder`.
+2. Move manual runtime bootstrap code into initializers.
+
+### Phase 3: Promote docs/examples
+
+1. Make builder API the primary documented path.
+2. Remove legacy references from docs and examples.
+
+## Risks and Mitigations
+
+1. Risk: Two registries accidentally diverge (factory registry vs initializer local registry).
+   - Mitigation: document pattern; optionally expose shared registry on runtime context in follow-up.
+2. Risk: Initializer order sensitivity.
+   - Mitigation: explicit order in API docs; keep IDs for diagnostics.
+3. Risk: Lifecycle leaks (event loop not stopped).
+   - Mitigation: `OwnedRuntime.Close()` required; include in examples and tests.
+
+## Implementation Checklist (no dependency solver)
+
+- [ ] Add `FactoryBuilder` and `Build()`.
+- [ ] Add `ModuleSpec` + helper `NativeModuleSpec`.
+- [ ] Add `RuntimeInitializer`.
+- [ ] Add `OwnedRuntime` and `Close()`.
+- [ ] Add duplicate-ID validation.
+- [ ] Route existing `Open/New/NewWithOptions` through new path.
+- [ ] Add tests:
+  - [ ] duplicate module IDs fail
+  - [ ] duplicate initializer IDs fail
+  - [ ] initializer order is deterministic
+  - [ ] owned runtime close shuts down owner and loop
+  - [ ] Geppetto initializer integration smoke test
+
+## Open Questions (deferred to post-MVP)
+
+1. Should `RuntimeContext` expose shared `*require.Registry` to initializers?
+2. Do we want initializer conflict keys in addition to ID checks?
+3. Should we add a minimal optional `Requires() []string` API before full dependency solver?
+
+## Recommendation
+
+Implement this v2 MVP rewrite now, explicitly skipping dependency resolution for this iteration.
+
+This gives immediate value:
+
+- better ergonomics
+- safer runtime concurrency defaults
+- cleaner Geppetto integration path
+
+and a single, unambiguous API surface for future dependency/conflict resolution work.

--- a/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/index.md
+++ b/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/index.md
@@ -1,7 +1,7 @@
 ---
 Title: EngineFactory module composition and registration lifecycle
 Ticket: GC-05-ENGINE-MODULE-COMPOSITION
-Status: active
+Status: complete
 Topics:
     - go
     - architecture
@@ -15,10 +15,11 @@ RelatedFiles:
       Note: Primary architecture analysis artifact for this ticket
 ExternalSources: []
 Summary: Research ticket capturing detailed EngineFactory module composition design and future implementation backlog.
-LastUpdated: 2026-02-20T10:33:11.066930067-05:00
+LastUpdated: 2026-02-21T15:58:09.471594532-05:00
 WhatFor: Preserve architecture analysis for moving from global module registries to explicit EngineFactory module composition.
 WhenToUse: Use when starting implementation of module ordering/dependency/conflict-aware EngineFactory APIs.
 ---
+
 
 
 # EngineFactory module composition and registration lifecycle

--- a/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/index.md
+++ b/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/index.md
@@ -11,13 +11,17 @@ DocType: index
 Intent: long-term
 Owners: []
 RelatedFiles:
-    - Path: 2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/design/01-enginefactory-withmodules-architecture-deep-dive.md
-      Note: Primary architecture analysis artifact for this ticket
+    - Path: ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/design/01-enginefactory-withmodules-architecture-deep-dive.md
+      Note: Original architecture investigation and dependency-solver oriented analysis
+    - Path: ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/design/02-pragmatic-mvp-api-for-module-composition-and-runtime-ownership.md
+      Note: Finalized no-compat v2 API design used for implementation
+    - Path: ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/reference/01-diary.md
+      Note: Step-by-step execution diary with commit-level implementation details
 ExternalSources: []
-Summary: Research ticket capturing detailed EngineFactory module composition design and future implementation backlog.
+Summary: Completed ticket for no-compat EngineFactory rewrite introducing explicit builder/factory/runtime lifecycle, module specs, runtime initializers, and migrated callsites.
 LastUpdated: 2026-02-21T15:58:09.471594532-05:00
-WhatFor: Preserve architecture analysis for moving from global module registries to explicit EngineFactory module composition.
-WhenToUse: Use when starting implementation of module ordering/dependency/conflict-aware EngineFactory APIs.
+WhatFor: Preserve both design rationale and implementation record for the completed EngineFactory no-compat composition rewrite.
+WhenToUse: Use when reviewing or extending explicit runtime composition APIs and lifecycle ownership in go-go-goja.
 ---
 
 
@@ -26,21 +30,24 @@ WhenToUse: Use when starting implementation of module ordering/dependency/confli
 
 ## Overview
 
-This ticket stores the detailed analysis and design brainstorming for introducing
-`EngineFactory.WithModules(...)` style composition with deterministic ordering,
-dependency checks, and conflict validation. It is intentionally scoped as
-pre-implementation architecture work so delivery can happen later under a clear
-technical plan.
+This ticket now captures both the architecture analysis and the completed
+no-backward-compatibility implementation that replaced legacy runtime wrappers
+with explicit builder/factory/runtime ownership.
+
+The shipped model introduces explicit module and runtime initializer contracts,
+immutable factory construction, and callsite migration across repl/demo/tests.
 
 ## Key Links
 
-- **Primary Design Doc**: `design/01-enginefactory-withmodules-architecture-deep-dive.md`
+- **Design Doc (initial)**: `design/01-enginefactory-withmodules-architecture-deep-dive.md`
+- **Design Doc (v2, implemented API)**: `design/02-pragmatic-mvp-api-for-module-composition-and-runtime-ownership.md`
+- **Implementation Diary**: `reference/01-diary.md`
 - **Related Files**: See frontmatter/linked docs for code references
 - **External Sources**: See frontmatter ExternalSources field
 
 ## Status
 
-Current status: **active**
+Current status: **complete**
 
 ## Topics
 

--- a/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/reference/01-diary.md
+++ b/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/reference/01-diary.md
@@ -10,13 +10,36 @@ Topics:
 DocType: reference
 Intent: long-term
 Owners: []
-RelatedFiles: []
+RelatedFiles:
+    - Path: go-go-goja/cmd/bun-demo/main.go
+      Note: Demo command migrated to builder/factory runtime flow
+    - Path: go-go-goja/cmd/repl/main.go
+      Note: REPL command migrated to owned runtime construction and close
+    - Path: go-go-goja/engine/factory.go
+      Note: New builder/factory API with explicit Build and NewRuntime lifecycle
+    - Path: go-go-goja/engine/factory_test.go
+      Note: Factory tests moved to builder-based API and validation
+    - Path: go-go-goja/engine/module_specs.go
+      Note: RuntimeContext
+    - Path: go-go-goja/engine/options.go
+      Note: Option pipeline renamed for builder settings
+    - Path: go-go-goja/engine/runtime.go
+      Note: Owned runtime struct and explicit Close semantics
+    - Path: go-go-goja/engine/runtime_test.go
+      Note: Runtime tests updated for explicit factory runtime creation
+    - Path: go-go-goja/perf/goja/bench_test.go
+      Note: Bench helper migrated to new runtime API and cleanup closure
+    - Path: go-go-goja/perf/goja/phase2_bench_test.go
+      Note: Remaining bench callsites updated for 3-value runtime helper and close handling
+    - Path: go-go-goja/pkg/repl/evaluators/javascript/evaluator.go
+      Note: Evaluator reset now closes/recreates owned runtime
 ExternalSources: []
 Summary: ""
 LastUpdated: 2026-02-21T15:47:38.4626097-05:00
 WhatFor: ""
 WhenToUse: ""
 ---
+
 
 # Diary
 
@@ -85,3 +108,95 @@ This step intentionally front-loads scope discipline so subsequent code commits 
 
 - Ticket path:
   - `go-go-goja/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/`
+
+## Step 2: Land no-compat engine API rewrite and migrate call sites
+
+I replaced the previous mixed constructor/wrapper model with a single builder -> factory -> runtime flow and migrated active callsites to use owned runtime lifecycle explicitly. This commit makes API shape deliberate: module registration is an explicit composition step, and runtime creation is a factory responsibility.
+
+This step also captured a real migration break in perf benchmarks, then fixed it before finalizing the commit. The failure was useful because it validated that old signatures were fully removed and stale usage was surfaced by tooling.
+
+### Prompt Context
+
+**User prompt (verbatim):** (see Step 1)
+
+**Assistant interpretation:** Implement the next task batch directly, commit incrementally, and keep ticket diary/changelog updated with concrete technical details.
+
+**Inferred user intent:** Drive execution instead of planning, with auditable progress and no backwards-compatibility detours.
+
+**Commit (code):** `4059db5` — "GC-05: replace legacy runtime wrappers with builder and runtime ownership"
+
+### What I did
+
+- Reworked engine API surface around:
+  - `NewBuilder(...)`
+  - fluent builder methods for require options, module specs, and runtime initializers
+  - `Build()` producing immutable factory
+  - `factory.NewRuntime(ctx)` returning owned runtime object
+- Added module composition contracts and explicit default-registry module spec.
+- Removed legacy runtime wrapper entry points and moved runtime teardown into explicit `Close(ctx)`.
+- Migrated callsites in demo/repl/evaluator/perf packages to the new API.
+- Updated engine and runtime tests to use builder/factory/runtime flow.
+- Fixed a benchmark typecheck break in `phase2_bench_test.go` caused by helper signature migration.
+
+### Why
+
+- The previous API mixed construction responsibilities and made module composition less explicit.
+- No-compat mode requires direct cutover so stale API usage fails fast and is corrected immediately.
+
+### What worked
+
+- Compile-time migration pressure caught remaining legacy call patterns.
+- Pre-commit lint/test hooks validated end-to-end engine + callsite consistency after fixes.
+
+### What didn't work
+
+- First commit attempt failed in pre-commit lint due old benchmark helper usage:
+  - Command: `git commit -m "GC-05: replace legacy runtime wrappers with builder and runtime ownership"`
+  - Error excerpts:
+    - `perf/goja/phase2_bench_test.go:191:13: assignment mismatch: 2 variables but newRuntime returns 3 values`
+    - `perf/goja/phase2_bench_test.go:203:12: assignment mismatch: 2 variables but newRuntime returns 3 values`
+    - `perf/goja/phase2_bench_test.go:217:12: assignment mismatch: 2 variables but newRuntime returns 3 values`
+- Resolution:
+  - Updated those callsites to accept cleanup closure and invoke/defer runtime close.
+  - Re-ran commit; hooks passed.
+
+### What I learned
+
+- Removing wrappers early is effective only if benchmark/test helpers are migrated in the same batch; otherwise API breakage appears as noisy late failures.
+- Explicit runtime ownership improves benchmark hygiene by preventing leaked event loop/runtime objects.
+
+### What was tricky to build
+
+- The sharp edge was mixed helper signatures across benchmark files. The root cause was partial migration of `newRuntime` consumers; symptoms were typecheck failures in pre-commit lint.
+- I addressed it by standardizing all benchmark callsites to the same `(vm, req, close)` contract and adding close calls where missing.
+
+### What warrants a second pair of eyes
+
+- `pkg/repl/evaluators/javascript/evaluator.go` reset semantics now close/recreate owned runtime; review for lifecycle correctness under repeated reset/use.
+- `engine/module_specs.go` default registry module strategy should be reviewed for desired default surface area.
+
+### What should be done in the future
+
+- Add a focused design follow-up on dependency resolution hooks and optional DAG validation in builder phase.
+
+### Code review instructions
+
+- Start with:
+  - `engine/factory.go`
+  - `engine/module_specs.go`
+  - `engine/runtime.go`
+  - `pkg/repl/evaluators/javascript/evaluator.go`
+- Then inspect migrated callsites:
+  - `cmd/repl/main.go`
+  - `cmd/bun-demo/main.go`
+  - `perf/goja/bench_test.go`
+  - `perf/goja/phase2_bench_test.go`
+- Validate by re-running repo hooks (lint + test) on staged files.
+
+### Technical details
+
+- New core flow:
+  - `builder := engine.NewBuilder()`
+  - `factory, _ := builder.WithModules(engine.DefaultRegistryModules()).Build()`
+  - `rt, _ := factory.NewRuntime(ctx)`
+  - `defer rt.Close(ctx)`

--- a/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/reference/01-diary.md
+++ b/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/reference/01-diary.md
@@ -200,3 +200,63 @@ This step also captured a real migration break in perf benchmarks, then fixed it
   - `factory, _ := builder.WithModules(engine.DefaultRegistryModules()).Build()`
   - `rt, _ := factory.NewRuntime(ctx)`
   - `defer rt.Close(ctx)`
+
+## Step 3: Close ticket execution checklist after migration commits
+
+I closed the remaining ticket checklist item for documentation because the diary and changelog now have per-step, per-commit entries for the implementation sequence. This step keeps the ticket state aligned with the actual code and commit history.
+
+With this closure, the no-compat runtime composition rewrite is fully tracked from planning to landed code and documentation artifacts.
+
+### Prompt Context
+
+**User prompt (verbatim):** (see Step 1)
+
+**Assistant interpretation:** Finish the remaining task bookkeeping and keep diary continuity while progressing step-by-step with commits.
+
+**Inferred user intent:** Ensure the ticket is not just coded but properly closed out in documentation.
+
+### What I did
+
+- Verified execution checklist state in `tasks.md`.
+- Added this closure diary step.
+- Marked remaining docs task as completed.
+
+### Why
+
+- The ticket required explicit documentary tracking per commit; leaving the final checkbox open would misrepresent completion state.
+
+### What worked
+
+- Existing step entries and changelog notes were sufficient to satisfy the docs requirement without additional code churn.
+
+### What didn't work
+
+- N/A.
+
+### What I learned
+
+- Keeping docs in lockstep with each code commit makes final closure straightforward and low-risk.
+
+### What was tricky to build
+
+- The only subtlety was ensuring closure reflects real completion criteria (per-step diary + concrete changelog links), not just checking a box mechanically.
+
+### What warrants a second pair of eyes
+
+- Confirm ticket reviewers agree that current diary granularity is sufficient for archival traceability.
+
+### What should be done in the future
+
+- Continue the same step/commit diary pattern for subsequent tickets to reduce context loss during handoffs.
+
+### Code review instructions
+
+- Review:
+  - `ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/tasks.md`
+  - `ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/changelog.md`
+  - `ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/reference/01-diary.md`
+
+### Technical details
+
+- Closure criterion used:
+  - task checklist aligned with landed commits and associated diary/changelog records.

--- a/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/reference/01-diary.md
+++ b/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/reference/01-diary.md
@@ -1,0 +1,87 @@
+---
+Title: Diary
+Ticket: GC-05-ENGINE-MODULE-COMPOSITION
+Status: active
+Topics:
+    - go
+    - architecture
+    - refactor
+    - tooling
+DocType: reference
+Intent: long-term
+Owners: []
+RelatedFiles: []
+ExternalSources: []
+Summary: ""
+LastUpdated: 2026-02-21T15:47:38.4626097-05:00
+WhatFor: ""
+WhenToUse: ""
+---
+
+# Diary
+
+## Goal
+
+Track the implementation work for the GC-05 no-compat EngineFactory rewrite, including API cut decisions, file-by-file changes, and commit-by-commit progress.
+
+## Step 1: Expand ticket tasks for execution mode (no wrappers)
+
+I converted the existing research backlog into an execution-oriented implementation checklist that matches the current direction: full API rewrite, no backwards compatibility wrappers, no dependency solver in this iteration.
+
+This step intentionally front-loads scope discipline so subsequent code commits can be small and auditable against explicit milestones.
+
+### Prompt Context
+
+**User prompt (verbatim):** "go ahead, add detailed tasks to the ticket (no backwards compatibility / wrapper), and then do the tasks one by one, committing as you go and continuing keeping your diary"
+
+**Assistant interpretation:** First update ticket tasks with a concrete no-compat plan, then start implementation with incremental commits while recording diary entries.
+
+**Inferred user intent:** Execute the rewrite immediately with transparent progress tracking and minimal ambiguity about scope.
+
+### What I did
+
+- Updated `tasks.md` to a concrete no-compat sequence:
+  - new builder and module/runtime contracts
+  - owned runtime lifecycle
+  - deletion of legacy API paths
+  - migration of all in-repo call sites
+  - test/doc updates
+- Created this diary document and added the first step entry.
+
+### Why
+
+- The previous task list was architecture-research-oriented and included dependency solver work not required for the current implementation pass.
+- Explicit no-wrapper tasks are necessary to prevent scope drift.
+
+### What worked
+
+- Task list now maps directly to executable code milestones.
+
+### What didn't work
+
+- N/A.
+
+### What I learned
+
+- Converting design goals to actionable tasks early reduces churn when doing multi-commit refactors.
+
+### What was tricky to build
+
+- Ensuring task wording is explicit about removals (legacy APIs) and not interpreted as additive/compat behavior.
+
+### What warrants a second pair of eyes
+
+- Confirm that task order is acceptable before irreversible API removals land.
+
+### What should be done in the future
+
+- Keep updating this diary after each code commit with exact files and rationale.
+
+### Code review instructions
+
+- Review `tasks.md` to confirm implementation order and no-compat policy are explicit.
+
+### Technical details
+
+- Ticket path:
+  - `go-go-goja/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/`

--- a/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/reference/01-diary.md
+++ b/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/reference/01-diary.md
@@ -33,12 +33,15 @@ RelatedFiles:
       Note: Remaining bench callsites updated for 3-value runtime helper and close handling
     - Path: go-go-goja/pkg/repl/evaluators/javascript/evaluator.go
       Note: Evaluator reset now closes/recreates owned runtime
+    - Path: go-go-goja/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/index.md
+      Note: Step 4 index normalization for completion-state accuracy
 ExternalSources: []
 Summary: ""
 LastUpdated: 2026-02-21T15:47:38.4626097-05:00
 WhatFor: ""
 WhenToUse: ""
 ---
+
 
 
 # Diary
@@ -260,3 +263,71 @@ With this closure, the no-compat runtime composition rewrite is fully tracked fr
 
 - Closure criterion used:
   - task checklist aligned with landed commits and associated diary/changelog records.
+
+## Step 4: Refresh ticket index to match completed implementation state
+
+I audited the ticket index after closure and found stale research-era wording that still described the work as pre-implementation and marked status text as active in the body. I updated the index metadata and overview to reflect what was actually shipped.
+
+This keeps the ticket self-consistent for handoff and future maintenance: readers now see the implemented v2 design, diary, and completion state from the first document they open.
+
+### Prompt Context
+
+**User prompt (verbatim):** "Make sure the documentation is updated appropriately"
+
+**Assistant interpretation:** Validate ticket documentation consistency post-implementation and correct stale or misleading documentation state.
+
+**Inferred user intent:** Ensure the ticket is accurate and review-ready, not only code-complete.
+
+### What I did
+
+- Ran a doc hygiene pass (`task list`, `doc list`, `doctor`) for GC-05.
+- Identified stale `index.md` content:
+  - summary still framed as future work
+  - body status said active
+  - key links omitted implemented v2 design and diary
+  - related files only referenced design/01
+- Updated `index.md` frontmatter and body to reflect completed no-compat rewrite and include key docs.
+
+### Why
+
+- Ticket index is the entrypoint; stale status/summary causes confusion and weakens traceability for interns/reviewers.
+
+### What worked
+
+- Existing ticket artifacts (tasks/changelog/diary/design v2) were already complete; only index normalization was needed.
+
+### What didn't work
+
+- `docmgr doctor` reported generic workspace warnings:
+  - `multiple_index` in dated parent folder
+  - `missing_numeric_prefix` for ticket `index.md`
+- These are structural conventions and not correctness blockers for this ticket content.
+
+### What I learned
+
+- Ticket closure does not automatically rewrite narrative sections in `index.md`; manual index sync remains necessary after major scope shifts.
+
+### What was tricky to build
+
+- The subtle part was distinguishing real ticket inconsistency from non-blocking doctor convention warnings. I treated only the semantic drift in ticket content as actionable.
+
+### What warrants a second pair of eyes
+
+- Confirm preferred policy for `index.md` naming/prefix conventions if you want doctor warnings reduced globally.
+
+### What should be done in the future
+
+- Add a lightweight “index sync after close” checklist item template to avoid stale summaries in future tickets.
+
+### Code review instructions
+
+- Review:
+  - `ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/index.md`
+  - `ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/reference/01-diary.md`
+
+### Technical details
+
+- Index updates included:
+  - summary/what-for/when-to-use rewrite for completed state
+  - key links for design/01, design/02, and diary
+  - status text normalization to `complete`.

--- a/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/reference/01-diary.md
+++ b/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/reference/01-diary.md
@@ -11,6 +11,8 @@ DocType: reference
 Intent: long-term
 Owners: []
 RelatedFiles:
+    - Path: go-go-goja/README.md
+      Note: Step 5 top-level docs modernization after no-compat API rewrite
     - Path: go-go-goja/cmd/bun-demo/main.go
       Note: Demo command migrated to builder/factory runtime flow
     - Path: go-go-goja/cmd/repl/main.go
@@ -41,6 +43,7 @@ LastUpdated: 2026-02-21T15:47:38.4626097-05:00
 WhatFor: ""
 WhenToUse: ""
 ---
+
 
 
 
@@ -331,3 +334,71 @@ This keeps the ticket self-consistent for handoff and future maintenance: reader
   - summary/what-for/when-to-use rewrite for completed state
   - key links for design/01, design/02, and diary
   - status text normalization to `complete`.
+
+## Step 5: Refresh root README for post-rewrite API reality
+
+I updated the repository README because it still taught removed runtime wrappers and outdated folder semantics. The doc now reflects the shipped no-compat runtime composition model and points readers to the current lifecycle contract.
+
+This prevents new contributors from copy-pasting obsolete `engine.New()` patterns and aligns onboarding docs with the code that actually exists.
+
+### Prompt Context
+
+**User prompt (verbatim):** "also update the README which probably hasn't been touched in a while."
+
+**Assistant interpretation:** Modernize README content to match current implementation state after the runtime API rewrite.
+
+**Inferred user intent:** Keep top-level documentation operationally accurate for new readers and future implementation work.
+
+**Commit (code):** `998a03b` — "docs: refresh README for builder/factory runtime API"
+
+### What I did
+
+- Updated `README.md` to:
+  - document `NewBuilder -> Build -> NewRuntime -> Close` as canonical flow
+  - remove/reframe references to removed wrappers (`engine.New`, `engine.NewWithOptions`, `engine.Open`)
+  - update folder layout descriptions for current commands/engine package
+  - add an explicit runtime API code example for current usage
+  - clarify module enablement language around `DefaultRegistryModules()`
+
+### Why
+
+- The README is the first integration surface for contributors; stale API guidance creates avoidable churn and incorrect implementations.
+
+### What worked
+
+- Targeted edits were sufficient; no additional code changes were needed.
+
+### What didn't work
+
+- N/A.
+
+### What I learned
+
+- API-cut tickets should reserve a final pass specifically for root README synchronization, not only ticket-local docs.
+
+### What was tricky to build
+
+- The main risk was making sure wording reflected strict no-compat reality while preserving practical onboarding examples.
+
+### What warrants a second pair of eyes
+
+- Confirm whether README should also include an advanced section on custom `ModuleSpec` / `RuntimeInitializer` authoring patterns.
+
+### What should be done in the future
+
+- Add a short release checklist item: “README examples compile against current public API.”
+
+### Code review instructions
+
+- Review:
+  - `README.md`
+  - `ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/reference/01-diary.md`
+
+### Technical details
+
+- Canonical sequence now documented:
+  - `engine.NewBuilder()`
+  - `WithModules(engine.DefaultRegistryModules())`
+  - `Build()`
+  - `factory.NewRuntime(ctx)`
+  - `rt.Close(ctx)`

--- a/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/tasks.md
+++ b/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/tasks.md
@@ -2,29 +2,29 @@
 
 ## TODO
 
-- [ ] Finalize no-compat rewrite scope and freeze migration policy (explicitly no wrappers, no legacy New/Open path).
-- [ ] Introduce canonical builder API in `engine`:
+- [x] Finalize no-compat rewrite scope and freeze migration policy (explicitly no wrappers, no legacy New/Open path).
+- [x] Introduce canonical builder API in `engine`:
   - `NewBuilder(...)`
   - `WithRequireOptions(...)`
   - `WithModules(...)`
   - `WithRuntimeInitializers(...)`
   - `Build()`
-- [ ] Implement module contracts without dependency solver:
+- [x] Implement module contracts without dependency solver:
   - `ModuleSpec` with stable `ID()` and `Register(*require.Registry)`.
   - `RuntimeInitializer` with stable `ID()` and `InitRuntime(*RuntimeContext)`.
   - duplicate-ID fail-fast validation for both sets.
-- [ ] Implement immutable built `Factory` and owned runtime lifecycle:
+- [x] Implement immutable built `Factory` and owned runtime lifecycle:
   - `Factory.NewRuntime(ctx)` returns `*Runtime` (VM, require, loop, owner runner).
   - `Runtime.Close(ctx)` shuts down owner and event loop safely.
-- [ ] Remove legacy runtime creation APIs and implicit module path:
+- [x] Remove legacy runtime creation APIs and implicit module path:
   - delete `engine.New()`, `engine.NewWithOptions(...)`, `engine.Open(...)`, and implicit `modules.EnableAll(...)` behavior.
   - keep only explicit composition through builder.
-- [ ] Migrate all in-repo call sites to new API:
+- [x] Migrate all in-repo call sites to new API:
   - `cmd/repl`
   - `cmd/bun-demo`
   - `pkg/repl/evaluators/javascript`
   - engine tests and perf benches.
-- [ ] Update tests for new API surface (no dependency solver assertions, only duplicate-ID and lifecycle semantics).
+- [x] Update tests for new API surface (no dependency solver assertions, only duplicate-ID and lifecycle semantics).
 - [ ] Update GC-05 ticket docs:
   - diary entries per implementation step/commit.
   - changelog entries tied to concrete code changes.

--- a/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/tasks.md
+++ b/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/tasks.md
@@ -25,6 +25,6 @@
   - `pkg/repl/evaluators/javascript`
   - engine tests and perf benches.
 - [x] Update tests for new API surface (no dependency solver assertions, only duplicate-ID and lifecycle semantics).
-- [ ] Update GC-05 ticket docs:
+- [x] Update GC-05 ticket docs:
   - diary entries per implementation step/commit.
   - changelog entries tied to concrete code changes.

--- a/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/tasks.md
+++ b/ttmp/2026/02/20/GC-05-ENGINE-MODULE-COMPOSITION--enginefactory-module-composition-and-registration-lifecycle/tasks.md
@@ -2,9 +2,29 @@
 
 ## TODO
 
-- [ ] Review GC-05 design deep-dive and choose final EngineFactory module lifecycle (constructor-only vs builder Build freeze)
-- [ ] Define EngineModule contract (ID, DependsOn, Register) and registration context shape
-- [ ] Implement deterministic dependency resolver with cycle/missing-dependency diagnostics
-- [ ] Add conflict detection for duplicate module IDs and registration keys with explicit policy
-- [ ] Introduce WithModules(...) API on EngineFactory builder and keep compatibility shim with current EnableAll path
-- [ ] Add tests for ordering, dependency failures, and deterministic module install plans
+- [ ] Finalize no-compat rewrite scope and freeze migration policy (explicitly no wrappers, no legacy New/Open path).
+- [ ] Introduce canonical builder API in `engine`:
+  - `NewBuilder(...)`
+  - `WithRequireOptions(...)`
+  - `WithModules(...)`
+  - `WithRuntimeInitializers(...)`
+  - `Build()`
+- [ ] Implement module contracts without dependency solver:
+  - `ModuleSpec` with stable `ID()` and `Register(*require.Registry)`.
+  - `RuntimeInitializer` with stable `ID()` and `InitRuntime(*RuntimeContext)`.
+  - duplicate-ID fail-fast validation for both sets.
+- [ ] Implement immutable built `Factory` and owned runtime lifecycle:
+  - `Factory.NewRuntime(ctx)` returns `*Runtime` (VM, require, loop, owner runner).
+  - `Runtime.Close(ctx)` shuts down owner and event loop safely.
+- [ ] Remove legacy runtime creation APIs and implicit module path:
+  - delete `engine.New()`, `engine.NewWithOptions(...)`, `engine.Open(...)`, and implicit `modules.EnableAll(...)` behavior.
+  - keep only explicit composition through builder.
+- [ ] Migrate all in-repo call sites to new API:
+  - `cmd/repl`
+  - `cmd/bun-demo`
+  - `pkg/repl/evaluators/javascript`
+  - engine tests and perf benches.
+- [ ] Update tests for new API surface (no dependency solver assertions, only duplicate-ID and lifecycle semantics).
+- [ ] Update GC-05 ticket docs:
+  - diary entries per implementation step/commit.
+  - changelog entries tied to concrete code changes.


### PR DESCRIPTION
This refactors the engine's public API for creating JavaScript runtimes. It
replaces the previous implicit constructors (`New`, `Open`, `NewWithOptions`) with a
new explicit builder pattern.

The goal is to provide clear, deterministic, and safe runtime composition and
lifecycle management.

**BREAKING CHANGE:** The previous top-level functions for creating a runtime
have been removed. All consumers must migrate to the new builder flow.

**Core Changes:**

*   **Builder Pattern:** A new `engine.NewBuilder()` is the entry point for
    configuring a runtime `Factory`.
*   **Explicit Composition:** Modules are now added explicitly via `builder.WithModules(...)`
    and `builder.WithRuntimeInitializers(...)` instead of being globally enabled.
*   **Owned Runtime:** The factory's `NewRuntime()` method now returns a `*Runtime`
    struct. This object owns the Goja VM, event loop, and a runtime owner for
    concurrency safety.
*   **Explicit Lifecycle:** The `Runtime` struct has a `Close()` method that
    must be called to shut down the event loop and release resources.

All internal call sites in commands, tests, and benchmarks have been updated to
use the new API, including proper `defer rt.Close()` calls.