### PR TITLE
feat(jsverbs): Create CLI commands from JavaScript functions

### DIFF
--- a/cmd/jsverbs-example/main.go
+++ b/cmd/jsverbs-example/main.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/go-go-golems/glazed/pkg/cli"
+	"github.com/go-go-golems/glazed/pkg/cmds/logging"
+	"github.com/go-go-golems/glazed/pkg/cmds/schema"
+	"github.com/go-go-golems/glazed/pkg/help"
+	help_cmd "github.com/go-go-golems/glazed/pkg/help/cmd"
+	"github.com/spf13/cobra"
+
+	sharedoc "github.com/go-go-golems/go-go-goja/pkg/doc"
+	"github.com/go-go-golems/go-go-goja/pkg/jsverbs"
+)
+
+func main() {
+	dir := discoverDirectory(os.Args[1:])
+
+	registry, err := jsverbs.ScanDir(dir)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	commands, err := registry.Commands()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	root := &cobra.Command{
+		Use:   "jsverbs-example",
+		Short: "Expose scanned JavaScript functions as Glazed commands",
+		Long: fmt.Sprintf(
+			"Scan %s for .js/.cjs files, infer verbs from top-level functions, and run them through goja + Glazed.",
+			registry.RootDir,
+		),
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return logging.InitLoggerFromCobra(cmd)
+		},
+	}
+	root.PersistentFlags().StringP("dir", "d", dir, "Directory scanned before command registration")
+	if err := logging.AddLoggingSectionToRootCommand(root, "jsverbs-example"); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	setDefaultFlagValue(root, "log-level", "error")
+	setDefaultFlagValue(root, "log-format", "text")
+
+	root.AddCommand(&cobra.Command{
+		Use:   "list",
+		Short: "List discovered JS verbs",
+		Run: func(cmd *cobra.Command, args []string) {
+			paths := make([]string, 0, len(registry.Verbs()))
+			for _, verb := range registry.Verbs() {
+				paths = append(paths, fmt.Sprintf("%s\t%s", verb.FullPath(), verb.SourceRef()))
+			}
+			sort.Strings(paths)
+			fmt.Fprintln(cmd.OutOrStdout(), strings.Join(paths, "\n"))
+		},
+	})
+
+	if err := cli.AddCommandsToRootCommand(
+		root,
+		commands,
+		nil,
+		cli.WithParserConfig(cli.CobraParserConfig{
+			ShortHelpSections: []string{schema.DefaultSlug},
+			MiddlewaresFunc:   cli.CobraCommandDefaultMiddlewares,
+		}),
+	); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	helpSystem := help.NewHelpSystem()
+	if err := sharedoc.AddDocToHelpSystem(helpSystem); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to load help docs: %v\n", err)
+	}
+	help_cmd.SetupCobraRootCommand(helpSystem, root)
+
+	if err := root.Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+func discoverDirectory(args []string) string {
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "--dir" || arg == "-d":
+			if i+1 < len(args) {
+				return args[i+1]
+			}
+		case strings.HasPrefix(arg, "--dir="):
+			return strings.TrimPrefix(arg, "--dir=")
+		}
+	}
+	return "."
+}
+
+func setDefaultFlagValue(root *cobra.Command, name string, value string) {
+	flag := root.PersistentFlags().Lookup(name)
+	if flag == nil {
+		return
+	}
+	flag.DefValue = value
+	_ = flag.Value.Set(value)
+}

--- a/go.mod
+++ b/go.mod
@@ -149,5 +149,6 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260203192932-546029d2fa20 // indirect
 	google.golang.org/grpc v1.78.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-go-golems/go-go-goja
 
-go 1.25.7
+go 1.25.8
 
 require (
 	dagger.io/dagger v0.19.9
@@ -10,6 +10,7 @@ require (
 	github.com/charmbracelet/x/ansi v0.11.3
 	github.com/dop251/goja v0.0.0-20250630131328-58d95d85e994
 	github.com/dop251/goja_nodejs v0.0.0-20240728170619-29b559befffc
+	github.com/fsnotify/fsnotify v1.9.0
 	github.com/go-go-golems/bobatea v0.1.1
 	github.com/go-go-golems/glazed v1.0.1
 	github.com/mattn/go-sqlite3 v1.14.32
@@ -19,6 +20,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/tree-sitter/go-tree-sitter v0.25.0
 	github.com/tree-sitter/tree-sitter-javascript v0.25.0
+	golang.org/x/text v0.34.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -58,7 +60,6 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
-	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-go-golems/geppetto v0.8.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
@@ -144,7 +145,6 @@ require (
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/term v0.40.0 // indirect
-	golang.org/x/text v0.34.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260128011058-8636f8732409 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260203192932-546029d2fa20 // indirect
 	google.golang.org/grpc v1.78.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -383,6 +383,8 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0 h1:0vLT13EuvQ0hNvakwLuFZ/jYrLp5F3kcWHXdRggjCE8=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=

--- a/go.sum
+++ b/go.sum
@@ -352,8 +352,6 @@ golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0 h1:R84qjqJb5nVJMxqWYb3np9L5Z
 golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0/go.mod h1:S9Xr4PYopiDyqSyp5NjCrhFrqg6A5zA2E/iPHPhqnS8=
 golang.org/x/image v0.25.0 h1:Y6uW6rH1y5y/LK1J8BPWZtr6yZ7hrsy6hFrXjgsc2fQ=
 golang.org/x/image v0.25.0/go.mod h1:tCAmOEGthTtkalusGp1g3xa2gke8J6c2N565dTyl9Rs=
-golang.org/x/net v0.50.0 h1:ucWh9eiCGyDR3vtzso0WMQinm2Dnt8cFMuQa9K33J60=
-golang.org/x/net v0.50.0/go.mod h1:UgoSli3F/pBgdJBHCTc+tp3gmrU4XswgGRgtnwWTfyM=
 golang.org/x/net v0.51.0 h1:94R/GTO7mt3/4wIKpcR5gkGmRLOuE/2hNGeWq/GBIFo=
 golang.org/x/net v0.51.0/go.mod h1:aamm+2QF5ogm02fjy5Bb7CQ0WMt1/WVM7FtyaTLlA9Y=
 golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=

--- a/pkg/doc/08-jsverbs-example-overview.md
+++ b/pkg/doc/08-jsverbs-example-overview.md
@@ -1,0 +1,94 @@
+---
+Title: "jsverbs-example overview"
+Slug: jsverbs-example-overview
+Short: "How the example runner scans JavaScript files, turns them into Glazed verbs, and executes them."
+Topics:
+- goja
+- glazed
+- javascript
+- commands
+Commands:
+- jsverbs-example
+- jsverbs-example list
+Flags:
+- --dir
+- --log-level
+IsTopLevel: true
+IsTemplate: false
+ShowPerDefault: true
+SectionType: Application
+---
+
+This page explains what `jsverbs-example` does and how to use it to validate JavaScript-backed commands quickly.
+
+## What the runner scans
+
+The runner walks a directory recursively and inspects `.js` and `.cjs` files. It extracts:
+
+- top-level function declarations,
+- top-level arrow functions assigned to variables,
+- `__package__`, `__section__`, and `__verb__` metadata,
+- and `doc\`...\`` prose blocks for long help.
+
+By default, public top-level functions become commands even without explicit `__verb__` metadata. Files under subdirectories become nested command groups.
+
+## Command shape
+
+Each discovered function is compiled into an ordinary Glazed command. Scalar parameters become Glazed fields, shared sections become flag groups, and the JavaScript result is converted back into rows:
+
+- object result: one row,
+- array of objects: one row per item,
+- primitive result: one row with a `value` column,
+- `Promise`: awaited before conversion.
+
+Some verbs can opt out of structured output entirely. When a verb declares `output: "text"`, the runner exposes it as a writer-style command and prints the returned string directly instead of building a table.
+
+Positional arguments are treated as required unless a default value is declared. That means `jsverbs-example basics echo` now fails with usage instead of silently producing no rows.
+
+## Typical workflow
+
+List what was discovered first:
+
+```bash
+jsverbs-example --dir ./testdata/jsverbs list
+```
+
+Run a simple command:
+
+```bash
+jsverbs-example --dir ./testdata/jsverbs basics greet Manuel --excited
+```
+
+Run a verb that writes plain text instead of structured rows:
+
+```bash
+jsverbs-example --dir ./testdata/jsverbs basics banner Manuel
+```
+
+Run a command that uses a shared section:
+
+```bash
+jsverbs-example --dir ./testdata/jsverbs basics list-issues go-go-golems/go-go-goja --state closed --labels bug --labels docs
+```
+
+## Logging
+
+The example runner exposes standard Glazed logging flags on the root command. The default log level is `error` so module-registration debug logs stay out of the way during normal use. Raise the level explicitly when debugging loader behavior:
+
+```bash
+jsverbs-example --log-level debug --dir ./testdata/jsverbs list
+```
+
+## Troubleshooting
+
+| Problem | Cause | Solution |
+| --- | --- | --- |
+| A command prints nothing | A required positional argument was omitted earlier and the function returned `undefined` | Re-run with the required positional argument or inspect `--help` |
+| Relative `require()` fails | The helper file is outside the scanned directory or uses an unsupported resolution path | Keep helper files under the scanned tree and use relative imports like `./helper` |
+| A function is not listed | It is not top-level, starts with `_`, or is only defined as an object method | Export it as a top-level function or add explicit metadata around a discoverable function |
+
+## See Also
+
+- `glaze help jsverbs-example-fixture-format`
+- `glaze help jsverbs-example-developer-guide`
+- `glaze help jsverbs-example-reference`

--- a/pkg/doc/08-jsverbs-example-overview.md
+++ b/pkg/doc/08-jsverbs-example-overview.md
@@ -21,6 +21,8 @@ SectionType: Application
 
 This page explains what `jsverbs-example` does and how to use it to validate JavaScript-backed commands quickly.
 
+The example runner itself still scans from a directory passed through `--dir`, but the underlying `pkg/jsverbs` package is now broader than that one CLI shape. The library can scan a real directory, a generic `fs.FS` such as an `embed.FS`, or raw in-memory source strings. The runner is therefore best thought of as the simplest interactive harness for the package, not as the complete boundary of what `jsverbs` supports.
+
 ## What the runner scans
 
 The runner walks a directory recursively and inspects `.js` and `.cjs` files. It extracts:
@@ -29,6 +31,8 @@ The runner walks a directory recursively and inspects `.js` and `.cjs` files. It
 - top-level arrow functions assigned to variables,
 - `__package__`, `__section__`, and `__verb__` metadata,
 - and `doc\`...\`` prose blocks for long help.
+
+Under the hood, the scanner now parses metadata literals directly from the tree-sitter AST instead of rewriting JavaScript object text into JSON. That means metadata support is intentionally strict: literal objects, arrays, strings, numbers, booleans, and `null` are supported, while dynamic expressions inside metadata are rejected. This is a deliberate design choice so command discovery stays deterministic and scanner failures are easier to explain.
 
 By default, public top-level functions become commands even without explicit `__verb__` metadata. Files under subdirectories become nested command groups.
 
@@ -44,6 +48,8 @@ Each discovered function is compiled into an ordinary Glazed command. Scalar par
 Some verbs can opt out of structured output entirely. When a verb declares `output: "text"`, the runner exposes it as a writer-style command and prints the returned string directly instead of building a table.
 
 Positional arguments are treated as required unless a default value is declared. That means `jsverbs-example basics echo` now fails with usage instead of silently producing no rows.
+
+The package also has a stricter error model now. Invalid metadata is recorded as scan diagnostics and, by default, scan functions fail with a `ScanError` instead of silently dropping the broken section or verb. That change matters because it turns missing-command debugging from guesswork into a direct scanner error.
 
 ## Typical workflow
 
@@ -71,6 +77,17 @@ Run a command that uses a shared section:
 jsverbs-example --dir ./testdata/jsverbs basics list-issues go-go-golems/go-go-goja --state closed --labels bug --labels docs
 ```
 
+If you are working inside Go rather than through the example binary, the package-level entrypoints are now:
+
+```go
+jsverbs.ScanDir(...)
+jsverbs.ScanFS(...)
+jsverbs.ScanSource(...)
+jsverbs.ScanSources(...)
+```
+
+That is worth remembering because the example runner is intentionally simpler than the package API. A future application can embed command files at build time or synthesize them in memory without first writing them to disk.
+
 ## Logging
 
 The example runner exposes standard Glazed logging flags on the root command. The default log level is `error` so module-registration debug logs stay out of the way during normal use. Raise the level explicitly when debugging loader behavior:
@@ -85,7 +102,8 @@ jsverbs-example --log-level debug --dir ./testdata/jsverbs list
 | --- | --- | --- |
 | A command prints nothing | A required positional argument was omitted earlier and the function returned `undefined` | Re-run with the required positional argument or inspect `--help` |
 | Relative `require()` fails | The helper file is outside the scanned directory or uses an unsupported resolution path | Keep helper files under the scanned tree and use relative imports like `./helper` |
-| A function is not listed | It is not top-level, starts with `_`, or is only defined as an object method | Export it as a top-level function or add explicit metadata around a discoverable function |
+| A function is not listed | It is not top-level, starts with `_`, is only defined as an object method, or metadata parsing failed | Export it as a top-level function and check the scanner error output for invalid metadata |
+| A `__verb__` block seems to be ignored | The metadata used dynamic JavaScript instead of static literals | Restrict metadata to literal objects, arrays, strings, numbers, booleans, and `null` |
 
 ## See Also
 

--- a/pkg/doc/09-jsverbs-example-fixture-format.md
+++ b/pkg/doc/09-jsverbs-example-fixture-format.md
@@ -19,6 +19,8 @@ SectionType: Example
 
 This page describes the metadata patterns supported by the current prototype so you can create fixture directories intentionally.
 
+The important recent change is that metadata is now parsed as a strict literal subset rather than by rewriting JavaScript object text into JSON. That makes the accepted fixture format narrower, but also far more predictable. If a metadata block uses dynamic JavaScript, the scanner now reports an error instead of silently guessing.
+
 ## Supported metadata
 
 ### `__package__({...})`
@@ -48,6 +50,26 @@ Verb metadata also supports output selection:
 - `output: "text"` turns the verb into a plain writer command
 - omitted `output` keeps the default structured Glazed row behavior
 
+Metadata values should be static literals. Supported literal shapes are:
+
+- object literals
+- array literals
+- quoted strings
+- template strings without `${...}` substitutions
+- numbers
+- `true`, `false`, and `null`
+
+Unsupported metadata shapes include:
+
+- function calls
+- identifiers used as values
+- spreads
+- computed object keys
+- template substitutions
+- other dynamic expressions
+
+That restriction is intentional. Metadata is part of command discovery, so it needs to behave like declarative configuration rather than executable code.
+
 ## Binding modes
 
 `bind` changes how a JavaScript parameter is populated.
@@ -55,6 +77,8 @@ Verb metadata also supports output selection:
 - `bind: "all"` passes every resolved Glazed value as one object.
 - `bind: "context"` passes execution metadata such as the command path, module path, root directory, and section maps.
 - `bind: "filters"` passes the values from the named section as one object.
+
+Bindings are now resolved through one shared internal binding plan used by both schema generation and runtime invocation. As a JavaScript author you do not need to know the internal type name, but you do benefit from the result: if a bind is invalid, the failure happens consistently instead of one phase accepting it while another phase mis-invokes the function.
 
 ## Example
 
@@ -94,7 +118,29 @@ __verb__("banner", {
 });
 ```
 
+## Non-directory sources
+
+Most examples use directory fixtures because they are easy to inspect and run manually. The package is no longer limited to that one source shape, though. The same metadata format works when files come from:
+
+- `ScanDir(...)`
+- `ScanFS(...)`
+- `ScanSource(...)`
+- `ScanSources(...)`
+
+That means the fixture format described here is also the format for embedded command trees and in-memory synthetic command files.
+
+## Scanner failures
+
+Malformed metadata is now surfaced as scanner diagnostics and usually returned as a `ScanError`. In practice that means fixture authors should expect invalid metadata to fail loudly.
+
+Typical causes:
+
+- using a dynamic expression in metadata,
+- binding to a section that does not exist,
+- declaring a verb for a function name that is not present in the file.
+
 ## See Also
 
 - `glaze help jsverbs-example-overview`
 - `glaze help jsverbs-example-developer-guide`
+- `glaze help jsverbs-example-reference`

--- a/pkg/doc/09-jsverbs-example-fixture-format.md
+++ b/pkg/doc/09-jsverbs-example-fixture-format.md
@@ -1,0 +1,100 @@
+---
+Title: "jsverbs-example fixture format"
+Slug: jsverbs-example-fixture-format
+Short: "Metadata and fixture patterns supported by the prototype JavaScript verb runner."
+Topics:
+- goja
+- glazed
+- metadata
+- fixtures
+Commands:
+- jsverbs-example
+Flags:
+- --dir
+IsTopLevel: false
+IsTemplate: false
+ShowPerDefault: true
+SectionType: Example
+---
+
+This page describes the metadata patterns supported by the current prototype so you can create fixture directories intentionally.
+
+## Supported metadata
+
+### `__package__({...})`
+
+Use this to set file-level grouping metadata such as a package name or extra parent verbs.
+
+### `__section__("slug", {...})`
+
+Use this to define shared Glazed sections with reusable fields. Commands opt into those sections through `sections: ["slug"]` or by binding a parameter to that section.
+
+### `__verb__("functionName", {...})`
+
+Use this to override the inferred command name, help text, parents, or fields. Field metadata currently supports:
+
+- `type`
+- `help`
+- `short`
+- `default`
+- `choices`
+- `required`
+- `argument`
+- `section`
+- `bind`
+
+Verb metadata also supports output selection:
+
+- `output: "text"` turns the verb into a plain writer command
+- omitted `output` keeps the default structured Glazed row behavior
+
+## Binding modes
+
+`bind` changes how a JavaScript parameter is populated.
+
+- `bind: "all"` passes every resolved Glazed value as one object.
+- `bind: "context"` passes execution metadata such as the command path, module path, root directory, and section maps.
+- `bind: "filters"` passes the values from the named section as one object.
+
+## Example
+
+```js
+__section__("filters", {
+  fields: {
+    state: { type: "choice", choices: ["open", "closed"], default: "open" }
+  }
+});
+
+function listIssues(repo, filters, meta) {
+  return [{ repo, state: filters.state, rootDir: meta.rootDir }];
+}
+
+__verb__("listIssues", {
+  sections: ["filters"],
+  fields: {
+    repo: { argument: true },
+    filters: { bind: "filters" },
+    meta: { bind: "context" }
+  }
+});
+```
+
+Text-output verbs look like this:
+
+```js
+function banner(name) {
+  return `=== ${name} ===\n`;
+}
+
+__verb__("banner", {
+  output: "text",
+  fields: {
+    name: { argument: true }
+  }
+});
+```
+
+## See Also
+
+- `glaze help jsverbs-example-overview`
+- `glaze help jsverbs-example-developer-guide`

--- a/pkg/doc/10-jsverbs-example-developer-guide.md
+++ b/pkg/doc/10-jsverbs-example-developer-guide.md
@@ -1,0 +1,427 @@
+---
+Title: "jsverbs-example developer guide"
+Slug: jsverbs-example-developer-guide
+Short: "Intern-friendly guide to how JavaScript verb scanning, command compilation, and runtime execution work in go-go-goja."
+Topics:
+- goja
+- glazed
+- developer-guide
+- javascript
+- commands
+- architecture
+Commands:
+- jsverbs-example
+- jsverbs-example list
+- jsverbs-example help
+Flags:
+- --dir
+- --log-level
+IsTopLevel: true
+IsTemplate: false
+ShowPerDefault: true
+SectionType: Tutorial
+---
+
+This page is the main onramp for a new developer working on the JavaScript-to-Glazed command path in `go-go-goja`.
+
+It explains the system from the outside in: what problem it solves, which files matter, how data flows through the scanner and runtime, where to start reading, how to add a new capability safely, and how to debug failures without guessing.
+
+The most important thing to understand up front is that this subsystem is not “a JavaScript runner with some CLI glue attached.” It is a command-construction pipeline. The JavaScript source is treated first as declarative input that describes commands, and only later as executable code that implements those commands. That distinction explains many of the design choices in the code. We scan source without executing it, convert discovered metadata into Glazed command descriptions, and only after the command line has been parsed do we enter the runtime and invoke a function.
+
+That means a new developer should think in two mental models at the same time. The first model is static: files, functions, sentinels, sections, fields, command paths. The second model is dynamic: runtime factories, `require()` loaders, argument marshalling, promise waiting, and output rendering. Most bugs happen when those two models drift apart. For example, a function may be discovered correctly at scan time but invoked with the wrong argument shape at runtime, or a piece of metadata may be parsed correctly but never applied when the Glazed command description is built.
+
+## Easy onramp
+
+This section tells you where to start if you are new and want useful progress in the first hour.
+
+### What this subsystem does
+
+The `jsverbs-example` command scans a directory of JavaScript files, discovers top-level functions, turns selected functions into Glazed commands, and executes those functions through `goja`.
+
+The key idea is simple:
+
+- JavaScript authors write ordinary functions.
+- Optional metadata sentinels such as `__verb__` and `__section__` refine how those functions should look as CLI commands.
+- Go code scans the source tree once, builds command descriptions, and later invokes the right function with parsed Glazed values.
+
+This is valuable because it lets a JavaScript author work in a natural style while still getting the operational benefits of Glazed: schema-driven parsing, grouped flags, help text, table output, alternate renderers, and a conventional Cobra command tree. The author does not need to hand-write Go commands for every function. Instead, they provide a narrow amount of metadata only where the defaults are not good enough.
+
+### The three most important source files
+
+If you only read three files first, read these:
+
+- `pkg/jsverbs/scan.go`
+- `pkg/jsverbs/command.go`
+- `pkg/jsverbs/runtime.go`
+
+Read them in that order.
+
+Why this order matters:
+
+- `scan.go` tells you what the system believes exists.
+- `command.go` tells you how that belief becomes a Glazed command.
+- `runtime.go` tells you how execution actually crosses the Go/JS boundary.
+
+### The fastest way to build intuition
+
+Run these commands from the workspace root:
+
+```bash
+go test ./go-go-goja/pkg/jsverbs ./go-go-goja/cmd/jsverbs-example
+go run ./go-go-goja/cmd/jsverbs-example --dir ./go-go-goja/testdata/jsverbs list
+go run ./go-go-goja/cmd/jsverbs-example --dir ./go-go-goja/testdata/jsverbs basics greet Manuel --excited
+go run ./go-go-goja/cmd/jsverbs-example --dir ./go-go-goja/testdata/jsverbs basics banner Manuel
+```
+
+These four commands show the whole lifecycle:
+
+- tests validate the scan and execution paths,
+- `list` shows discovery,
+- `greet` shows structured table output,
+- `banner` shows plain text writer output.
+
+If you are onboarding somebody new, these commands are worth running live while the source is open in another pane. The `list` command tells you what the scanner believes. The structured command tells you what the Glazed layer built. The text command tells you where the subsystem deliberately stops being table-oriented. That small sequence gives a faster mental picture than reading implementation files cold.
+
+### How to read the fixture tree
+
+The test fixture directory at `testdata/jsverbs` is the shortest path to understanding supported behavior.
+
+Use it as a map:
+
+- `basics.js` shows public functions, explicit verb metadata, shared sections, `bind: "all"`, `bind: "context"`, structured output, and text output.
+- `advanced/numbers.js` shows integer arguments, async results, and rest parameters.
+- `nested/with-helper.js` and `nested/sub/helper.js` show relative `require()` behavior.
+- `packaged.js` shows `__package__` metadata and automatic exposure of public functions.
+
+When you are unsure how a feature should behave, start by adding or changing a fixture first and then make the implementation satisfy it.
+
+This is not just a testing convenience. It is a design discipline. The fixture tree acts as the most concrete form of subsystem documentation because it shows what JavaScript authors are actually expected to write. A fixture is harder to misread than a prose sentence and easier to stabilize than an informal code comment. In practice, the safest development loop is: write or update a fixture, make the scanner see it, make the compiler shape it, and then make the runtime execute it.
+
+## System at a glance
+
+The system has four stages:
+
+```text
+JavaScript files
+    |
+    v
+scan.go
+  discover functions + sentinels
+    |
+    v
+command.go
+  build Glazed command descriptions
+    |
+    v
+runtime.go
+  invoke selected JS function in goja
+    |
+    v
+CLI output
+  structured rows or plain text
+```
+
+Each stage has one job:
+
+- scanning answers “what functions and metadata exist?”
+- command building answers “what CLI shape should each function have?”
+- runtime invocation answers “how do we call the function correctly?”
+- output handling answers “should this become rows or plain text?”
+
+It is useful to treat these as hard boundaries. Discovery should not depend on runtime execution. Runtime invocation should not have to rediscover command metadata. Output rendering should not mutate the meaning of the command itself. When the code respects those boundaries, changes are localized and reasoning stays tractable. When those boundaries blur, the subsystem becomes fragile because behavior starts depending on hidden coupling between phases.
+
+## File map
+
+This section explains which files exist so you do not waste time searching.
+
+### Core implementation
+
+- `pkg/jsverbs/model.go`
+  This defines the in-memory model: registry, file specs, verb specs, parameter specs, field specs, and output modes.
+- `pkg/jsverbs/scan.go`
+  This walks the filesystem, parses JavaScript with tree-sitter, extracts functions and sentinel metadata, and finalizes discovered verbs.
+- `pkg/jsverbs/command.go`
+  This turns `VerbSpec` values into real Glazed commands. It decides whether a verb becomes a `GlazeCommand` or a `WriterCommand`.
+- `pkg/jsverbs/runtime.go`
+  This builds a goja runtime, injects a registry overlay, maps parsed Glazed values back into JS arguments, waits on promises, and returns results to Go.
+
+These files are intentionally small enough to read in one sitting. That is a good property to preserve. If you add a feature and it feels like it needs to spread arbitrary logic across all files at once, stop and ask whether you are really adding a new concept or only patching over a mismatch. Good additions usually fit cleanly into one stage and then require only a narrow thread through the others.
+
+### Example CLI
+
+- `cmd/jsverbs-example/main.go`
+  This is the runnable entrypoint. It scans a directory, registers commands, sets up Glazed logging, and loads the help system.
+- `pkg/doc/*.md`
+  These are shared Glazed help pages for `go-go-goja`, including the `jsverbs` guide and reference.
+
+The example CLI is not throwaway scaffolding. It is the fastest manual integration harness in the repo for this functionality. If a change only passes package tests but feels awkward in `jsverbs-example`, the design is probably not finished.
+
+### Fixtures and tests
+
+- `testdata/jsverbs/*`
+  Example JavaScript trees used for automated validation and interactive experiments.
+- `pkg/jsverbs/jsverbs_test.go`
+  End-to-end tests for discovery and execution behavior.
+
+## Discovery model
+
+This section explains what the scanner accepts and why it is intentionally conservative.
+
+### Supported function shapes
+
+The scanner currently discovers:
+
+- top-level `function foo(...) { ... }`
+- top-level `const foo = (...) => { ... }`
+- top-level `const foo = function(...) { ... }`
+
+The scanner does not try to discover every valid JavaScript callable shape. It stays narrow because command registration must be stable and predictable.
+
+That means these are not the main path:
+
+- object methods,
+- nested functions,
+- dynamically assigned exports,
+- runtime-generated functions.
+
+This conservatism is deliberate. Command trees need to be explainable to humans. If discovery were too clever, a developer would no longer be able to predict which functions become commands without mentally executing the file. That would make debugging and code review worse. A slightly narrower discovery model is usually better than a broader but surprising one.
+
+### Supported sentinels
+
+The scanner currently understands:
+
+- `__package__({...})`
+- `__section__("slug", {...})`
+- `__verb__("functionName", {...})`
+- `doc\`...\``
+
+The key design decision is that these are treated as source metadata, not runtime APIs. The scanner reads them statically; the runtime later installs no-op definitions so requiring the source does not crash.
+
+That separation is important for security and correctness. We do not want discovery to execute arbitrary module top-level code just to learn what a command looks like. We also do not want JavaScript authors to think of sentinels as runtime hooks with side effects. They are effectively annotations embedded in real code.
+
+### Why tree-sitter is used
+
+The scanner uses tree-sitter because the system needs source-aware extraction without executing arbitrary JavaScript during discovery.
+
+That gives three important properties:
+
+- discovery happens without running user code,
+- function names and parameter lists come from syntax rather than brittle regexes,
+- metadata sentinels can be read from source in a deterministic way.
+
+Tree-sitter is not free; it adds a parser dependency and a source-model layer that a new developer must learn a bit. But the tradeoff is worth it here because the subsystem needs syntax awareness. Once you accept that requirement, a proper parser is much cheaper than inventing a homegrown partial parser through string operations and then slowly discovering edge cases one by one.
+
+## Command compilation
+
+This section explains how a discovered verb becomes a usable CLI command.
+
+This stage is where the subsystem starts feeling like “real Glazed” instead of an extraction experiment. By the time a `VerbSpec` reaches `command.go`, the problem is no longer “what did the JavaScript file contain?” but “what command interface should users see?” That is a different problem, and it is why `command.go` deserves to stay focused on schema construction and command semantics.
+
+### Structured output verbs
+
+Most verbs default to structured output. They compile into a Glazed command and their result is normalized like this:
+
+- object -> one row
+- array of objects -> many rows
+- primitive -> one row with `value`
+- `null` or `undefined` -> no rows
+
+This is the right default for data-oriented commands because users immediately get table, JSON, CSV, and other Glazed formatting behavior.
+
+This default also keeps the subsystem aligned with the broader Glazed philosophy: commands should prefer structured data when they naturally produce structured data. If the result is conceptually a record or list of records, preserving that shape gives users far more leverage than flattening it into ad hoc strings.
+
+### Text output verbs
+
+Some commands should act like classic CLI tools and print plain output directly. For those, the verb metadata can declare:
+
+```js
+__verb__("banner", {
+  output: "text"
+})
+```
+
+That changes compilation from `GlazeCommand` to `WriterCommand`.
+
+The runtime invocation is the same. Only the Go-side result handling changes:
+
+- strings are written directly,
+- `[]byte` is written directly,
+- other values are JSON-rendered as a fallback.
+
+That fallback is intentionally pragmatic rather than pure. In a perfect world, text verbs would always return strings. In practice, developers experiment, and having a JSON fallback keeps a text-output verb from becoming unusable the moment it returns an object during refactoring. It is better to see slightly ugly output than no output at all, especially while a feature is still moving.
+
+### Field inference and required arguments
+
+If a parameter has no explicit field metadata, the system infers a simple default:
+
+- identifier parameter -> string field
+- rest parameter -> string-list argument
+
+Positional arguments are treated as required unless a default value is declared. This avoids the earlier bad UX where missing arguments could lead to silent `undefined` results.
+
+This rule is worth remembering because it is the point where JavaScript permissiveness meets CLI strictness. JavaScript is happy to call a function with fewer arguments. A CLI should usually not be. The subsystem therefore chooses the CLI interpretation by default: if something is a positional argument, users should be told when it is missing.
+
+## Runtime model
+
+This section explains what happens when the user actually runs a discovered verb.
+
+The runtime layer is where most “this feels magical” reactions come from, because it has to preserve normal module semantics while still injecting enough bookkeeping for Go to call the right function. The easiest way to stay oriented is to remember that the runtime does not invent a second module system. It rides on top of the existing `require()` path and only adds a thin overlay.
+
+### Why the source overlay exists
+
+The runtime does not call a function by parsing the file again. Instead, it uses the normal `require()` pipeline and injects a small overlay around the source.
+
+That overlay does two things:
+
+- defines no-op sentinel functions such as `__verb__`,
+- records top-level discovered functions into `globalThis.__glazedVerbRegistry`.
+
+This matters because it preserves normal module behavior, especially relative `require()` paths, while still letting Go find the function object later.
+
+This is the key design choice that made the prototype practical. A runtime that evaluated stitched-together snippets or bypassed `require()` entirely would quickly break real JavaScript modules. By overlaying the actual source instead, the subsystem can keep relative imports, helper modules, and familiar CommonJS behavior intact.
+
+### Runtime sequence
+
+The rough runtime sequence is:
+
+```text
+build engine factory
+  -> create goja runtime
+  -> require the target JS file
+  -> look up function in __glazedVerbRegistry
+  -> convert parsed Glazed values into JS arguments
+  -> call function
+  -> await Promise if needed
+  -> normalize result for Glazed rows or writer output
+```
+
+### Parameter binding modes
+
+Bindings control how one JS parameter is populated.
+
+- no `bind`
+  The parameter is fed from a normal field or inferred argument.
+- `bind: "filters"`
+  The parameter receives the named section as an object.
+- `bind: "all"`
+  The parameter receives every resolved field value as one object.
+- `bind: "context"`
+  The parameter receives execution metadata such as command path, module path, root directory, full value map, and section map.
+
+These bindings are the bridge between Glazed’s section-based model and JavaScript’s natural object-parameter style.
+
+Bindings are also one of the most important readability tools available to the JavaScript author. If a function really wants a cohesive object like `filters` or a runtime context object, encoding that directly is clearer than pretending every value should arrive as a flat string parameter. A good binding makes both the JS source and the Go-side command model easier to understand.
+
+## Output choice guide
+
+This section helps a new developer choose between structured and text output without overthinking it.
+
+Choose structured output when:
+
+- the result is a record or list of records,
+- users may want JSON/CSV/table formatting,
+- the command behaves like data retrieval or listing.
+
+Choose text output when:
+
+- the command should print a banner, snippet, script, or prose block,
+- table formatting would make the result worse,
+- the command should behave like a classic writer command.
+
+If you are unsure, start with structured output. It is easier to downshift one verb to `output: "text"` than to recover Glazed structure later.
+
+That recommendation is partly about user value and partly about future flexibility. Structured output preserves information. Text output usually throws structure away. Once structure is gone, adding a better formatter later is harder because the command contract has already collapsed into prose.
+
+## How to add a new capability safely
+
+This section gives the preferred workflow for extending the subsystem.
+
+### If you want to support a new metadata field
+
+1. Add or update a fixture in `testdata/jsverbs`.
+2. Extend the model in `model.go` if needed.
+3. Parse the metadata in `scan.go`.
+4. Apply the metadata in `command.go` or `runtime.go`.
+5. Add assertions in `pkg/jsverbs/jsverbs_test.go`.
+6. Run the package tests and one real `go run` command.
+
+This sequence matters because it forces the new behavior to exist in all three forms that matter: source syntax, in-memory model, and user-facing command behavior. Skipping one of those tends to create half-finished features that technically parse but never become useful commands, or commands that work only in tests but are not documented for actual users.
+
+### If you want to support a new parameter shape
+
+Be careful here. Parameter extraction is where convenience can easily become ambiguity.
+
+Preferred order:
+
+1. define the exact supported syntax,
+2. add a fixture,
+3. decide whether the new shape is inferable or must require explicit `bind`,
+4. update `extractParameters` and argument building together,
+5. verify both structured and writer verbs still work.
+
+Parameter support looks deceptively local, but it is one of the few places where scanner, compiler, and runtime all have to agree. That is why this kind of change deserves extra care. A parameter shape that is easy to extract but hard to marshal, or easy to marshal but hard to explain to users, is usually not worth supporting.
+
+### If you want to support a new output mode
+
+Treat output mode as a command-compilation concern first, not a runtime concern.
+
+Ask:
+
+- does this verb still use Glazed parsing?
+- does it need Glazed formatting?
+- does it need a new command interface or only a new renderer?
+
+In many cases, a new output style should probably be implemented as a formatter on top of structured rows, not as a brand new command type.
+
+This is a good place to raise the technical bar. New output modes should earn their complexity. A subsystem with too many command kinds becomes hard to reason about because each one drags new assumptions into parsing, help text, and execution. If a formatter can solve the problem, prefer that. If it cannot, document clearly why a new command interface is justified.
+
+## Common debugging path
+
+This section explains how to debug without jumping randomly between files.
+
+The main habit to build here is phase isolation. Ask first whether the issue is in discovery, compilation, runtime invocation, or output rendering. Once you answer that, the search space collapses dramatically. Most time is wasted not on hard bugs, but on debugging the wrong phase.
+
+When a verb is missing:
+
+1. run `jsverbs-example --dir ... list`
+2. if it is absent, debug `scan.go`
+3. if it is present but malformed, debug `command.go`
+
+When a verb is listed but crashes:
+
+1. run with `--log-level debug`
+2. inspect the fixture file and relative imports
+3. debug `runtime.go`
+
+When a verb runs but output looks wrong:
+
+1. determine whether it is a structured or text verb
+2. for structured verbs, inspect row normalization in `command.go`
+3. for text verbs, inspect text rendering fallback in `command.go`
+
+## Maintenance checklist
+
+Use this checklist before considering a change complete:
+
+- fixture added or updated
+- automated test added or updated
+- help docs updated if the developer-facing behavior changed
+- `go test ./go-go-goja/pkg/jsverbs ./go-go-goja/cmd/jsverbs-example`
+- at least one manual `go run` validation for the changed path
+
+The manual run is not optional ceremony. This subsystem is deeply user-facing: command names, help text, grouped flags, runtime behavior, and output shape all show up at the CLI boundary. Package tests are necessary, but they are not a substitute for looking at the actual command once.
+
+## Troubleshooting
+
+| Problem | Cause | Solution |
+| --- | --- | --- |
+| A function should be exposed but is not listed | It is not top-level, starts with `_`, or is not one of the supported declaration forms | Move it to top level or add a supported declaration form |
+| Relative `require()` works in Node but not here | The helper file is outside the scanned tree or the path resolution assumption does not match the overlay loader | Keep helpers inside the scanned tree and verify the resolved module path |
+| A parameter gets `null` or empty values unexpectedly | The parameter was inferred differently than you expected or needed a section bind | Add explicit field metadata and, if needed, a `bind` |
+| A text verb prints JSON instead of raw text | The JS function returned a non-string value in `output: "text"` mode | Return a string or intentionally rely on the JSON fallback |
+
+## See Also
+
+- `glaze help jsverbs-example-overview`
+- `glaze help jsverbs-example-fixture-format`
+- `glaze help jsverbs-example-reference`

--- a/pkg/doc/10-jsverbs-example-developer-guide.md
+++ b/pkg/doc/10-jsverbs-example-developer-guide.md
@@ -30,6 +30,8 @@ The most important thing to understand up front is that this subsystem is not �
 
 That means a new developer should think in two mental models at the same time. The first model is static: files, functions, sentinels, sections, fields, command paths. The second model is dynamic: runtime factories, `require()` loaders, argument marshalling, promise waiting, and output rendering. Most bugs happen when those two models drift apart. For example, a function may be discovered correctly at scan time but invoked with the wrong argument shape at runtime, or a piece of metadata may be parsed correctly but never applied when the Glazed command description is built.
 
+The hardening pass after the initial prototype tightened exactly those drift-prone seams. Metadata parsing is stricter, scanner diagnostics are explicit, raw and `fs.FS` inputs are supported in addition to directory scanning, and the compile-time/runtime parameter semantics now flow through one shared binding plan. If you read older notes or code-review documents for this subsystem, keep that evolution in mind because some of the rough edges called out there have already been addressed.
+
 ## Easy onramp
 
 This section tells you where to start if you are new and want useful progress in the first hour.
@@ -51,6 +53,7 @@ This is valuable because it lets a JavaScript author work in a natural style whi
 If you only read three files first, read these:
 
 - `pkg/jsverbs/scan.go`
+- `pkg/jsverbs/binding.go`
 - `pkg/jsverbs/command.go`
 - `pkg/jsverbs/runtime.go`
 
@@ -59,7 +62,8 @@ Read them in that order.
 Why this order matters:
 
 - `scan.go` tells you what the system believes exists.
-- `command.go` tells you how that belief becomes a Glazed command.
+- `binding.go` tells you how that discovered metadata becomes one shared command/runtime contract.
+- `command.go` tells you how that contract becomes a Glazed command.
 - `runtime.go` tells you how execution actually crosses the Go/JS boundary.
 
 ### The fastest way to build intuition
@@ -93,13 +97,15 @@ Use it as a map:
 - `nested/with-helper.js` and `nested/sub/helper.js` show relative `require()` behavior.
 - `packaged.js` shows `__package__` metadata and automatic exposure of public functions.
 
+The fixture tree is still disk-based because it is meant to be browsed by humans and exercised by the example runner. The package itself is now broader than that. It can also scan a generic `fs.FS` or a raw list of in-memory source files. That matters when you move from “example runner” thinking to “library API” thinking. The fixture tree teaches the metadata format and runtime behavior; it does not define the full list of supported source origins anymore.
+
 When you are unsure how a feature should behave, start by adding or changing a fixture first and then make the implementation satisfy it.
 
 This is not just a testing convenience. It is a design discipline. The fixture tree acts as the most concrete form of subsystem documentation because it shows what JavaScript authors are actually expected to write. A fixture is harder to misread than a prose sentence and easier to stabilize than an informal code comment. In practice, the safest development loop is: write or update a fixture, make the scanner see it, make the compiler shape it, and then make the runtime execute it.
 
 ## System at a glance
 
-The system has four stages:
+The system has five stages:
 
 ```text
 JavaScript files
@@ -107,6 +113,10 @@ JavaScript files
     v
 scan.go
   discover functions + sentinels
+    |
+    v
+binding.go
+  resolve parameter + field + section binding plan
     |
     v
 command.go
@@ -124,6 +134,7 @@ CLI output
 Each stage has one job:
 
 - scanning answers “what functions and metadata exist?”
+- binding planning answers “what is the one agreed contract between schema and invocation?”
 - command building answers “what CLI shape should each function have?”
 - runtime invocation answers “how do we call the function correctly?”
 - output handling answers “should this become rows or plain text?”
@@ -137,13 +148,15 @@ This section explains which files exist so you do not waste time searching.
 ### Core implementation
 
 - `pkg/jsverbs/model.go`
-  This defines the in-memory model: registry, file specs, verb specs, parameter specs, field specs, and output modes.
+  This defines the in-memory model: registry, file specs, verb specs, parameter specs, field specs, diagnostics, source-file inputs, and output modes.
 - `pkg/jsverbs/scan.go`
-  This walks the filesystem, parses JavaScript with tree-sitter, extracts functions and sentinel metadata, and finalizes discovered verbs.
+  This walks input sources, parses JavaScript with tree-sitter, extracts functions and sentinel metadata, records diagnostics, and finalizes discovered verbs.
+- `pkg/jsverbs/binding.go`
+  This resolves one shared binding plan so schema generation and runtime invocation do not each invent their own interpretation of parameter semantics.
 - `pkg/jsverbs/command.go`
   This turns `VerbSpec` values into real Glazed commands. It decides whether a verb becomes a `GlazeCommand` or a `WriterCommand`.
 - `pkg/jsverbs/runtime.go`
-  This builds a goja runtime, injects a registry overlay, maps parsed Glazed values back into JS arguments, waits on promises, and returns results to Go.
+  This builds a goja runtime, injects a registry overlay, serves in-memory module source through the runtime loader, maps parsed Glazed values back into JS arguments, waits on promises, and returns results to Go.
 
 These files are intentionally small enough to read in one sitting. That is a good property to preserve. If you add a feature and it feels like it needs to spread arbitrary logic across all files at once, stop and ask whether you are really adding a new concept or only patching over a mismatch. Good additions usually fit cleanly into one stage and then require only a narrow thread through the others.
 
@@ -199,6 +212,8 @@ The key design decision is that these are treated as source metadata, not runtim
 
 That separation is important for security and correctness. We do not want discovery to execute arbitrary module top-level code just to learn what a command looks like. We also do not want JavaScript authors to think of sentinels as runtime hooks with side effects. They are effectively annotations embedded in real code.
 
+The scanner now enforces that the metadata attached to these sentinels is a strict literal subset. This is worth emphasizing because it changes how you should think about authoring metadata. The supported style is “declarative configuration written in JavaScript syntax,” not “arbitrary code that eventually produces an object.”
+
 ### Why tree-sitter is used
 
 The scanner uses tree-sitter because the system needs source-aware extraction without executing arbitrary JavaScript during discovery.
@@ -210,6 +225,28 @@ That gives three important properties:
 - metadata sentinels can be read from source in a deterministic way.
 
 Tree-sitter is not free; it adds a parser dependency and a source-model layer that a new developer must learn a bit. But the tradeoff is worth it here because the subsystem needs syntax awareness. Once you accept that requirement, a proper parser is much cheaper than inventing a homegrown partial parser through string operations and then slowly discovering edge cases one by one.
+
+That last sentence is no longer hypothetical. The subsystem originally used a JS-to-JSON rewrite shortcut for metadata objects. The hardening pass removed it and replaced it with AST literal parsing precisely because source-text rewriting was the wrong long-term abstraction once tree-sitter was already in the stack.
+
+## Source origins
+
+This section explains a change that is easy to miss if you only use `jsverbs-example`.
+
+The library now supports several input shapes:
+
+- `ScanDir(...)`
+- `ScanFS(...)`
+- `ScanSource(...)`
+- `ScanSources(...)`
+
+All of them normalize into the same internal `FileSpec` and runtime module-path model. That means a future consumer can:
+
+- scan a real directory,
+- scan an `embed.FS`,
+- synthesize command files in memory,
+- and still reuse the same runtime loader and command compiler.
+
+The runtime no longer depends on going back to disk after scanning. It loads source from the registry itself. That is a subtle but important shift because it makes the scanner the source of truth for module content, not just a discovery pass that happens before a second, unrelated disk read.
 
 ## Command compilation
 
@@ -261,6 +298,8 @@ Positional arguments are treated as required unless a default value is declared.
 
 This rule is worth remembering because it is the point where JavaScript permissiveness meets CLI strictness. JavaScript is happy to call a function with fewer arguments. A CLI should usually not be. The subsystem therefore chooses the CLI interpretation by default: if something is a positional argument, users should be told when it is missing.
 
+The current implementation now reaches that behavior through a shared binding plan rather than through duplicated logic in `command.go` and `runtime.go`. That matters for maintainability. If you change how a parameter should behave, the safest place to start is the binding-plan layer rather than editing compile-time and runtime code separately.
+
 ## Runtime model
 
 This section explains what happens when the user actually runs a discovered verb.
@@ -279,6 +318,8 @@ That overlay does two things:
 This matters because it preserves normal module behavior, especially relative `require()` paths, while still letting Go find the function object later.
 
 This is the key design choice that made the prototype practical. A runtime that evaluated stitched-together snippets or bypassed `require()` entirely would quickly break real JavaScript modules. By overlaying the actual source instead, the subsystem can keep relative imports, helper modules, and familiar CommonJS behavior intact.
+
+The overlay still exists in the hardened implementation, but the backing source no longer has to come from the host filesystem. The loader now serves source from the registry’s scanned files, which is what enables raw-source and `fs.FS` use cases while preserving the same relative-module behavior.
 
 ### Runtime sequence
 
@@ -312,6 +353,22 @@ These bindings are the bridge between Glazed’s section-based model and JavaScr
 
 Bindings are also one of the most important readability tools available to the JavaScript author. If a function really wants a cohesive object like `filters` or a runtime context object, encoding that directly is clearer than pretending every value should arrive as a flat string parameter. A good binding makes both the JS source and the Go-side command model easier to understand.
 
+From the Go side, bindings are now resolved once into a `VerbBindingPlan`. You do not need to memorize the exact struct fields to work on the package, but you should remember the architectural rule: schema generation and runtime invocation should read from the same resolved binding contract. If you find yourself teaching those two phases the same rule separately, you are probably regressing the design.
+
+## Diagnostics and failure handling
+
+This section covers a behavior change that improves day-to-day development substantially.
+
+Malformed metadata is no longer silently dropped. The scanner now records diagnostics on the registry and, by default, returns a `ScanError` when error-level diagnostics are present.
+
+In practice, that means:
+
+- invalid `__verb__` metadata now fails loudly,
+- unsupported dynamic expressions inside metadata are rejected explicitly,
+- callers can inspect diagnostics instead of guessing why a verb disappeared.
+
+This makes the package stricter, but in a way that saves engineering time. For generated command trees, explicit scanner failures are much easier to debug than missing commands with no explanation.
+
 ## Output choice guide
 
 This section helps a new developer choose between structured and text output without overthinking it.
@@ -341,9 +398,10 @@ This section gives the preferred workflow for extending the subsystem.
 1. Add or update a fixture in `testdata/jsverbs`.
 2. Extend the model in `model.go` if needed.
 3. Parse the metadata in `scan.go`.
-4. Apply the metadata in `command.go` or `runtime.go`.
-5. Add assertions in `pkg/jsverbs/jsverbs_test.go`.
-6. Run the package tests and one real `go run` command.
+4. If it changes parameter semantics, express it through `binding.go`.
+5. Apply the metadata in `command.go` or `runtime.go`.
+6. Add assertions in `pkg/jsverbs/jsverbs_test.go`.
+7. Run the package tests and one real `go run` command.
 
 This sequence matters because it forces the new behavior to exist in all three forms that matter: source syntax, in-memory model, and user-facing command behavior. Skipping one of those tends to create half-finished features that technically parse but never become useful commands, or commands that work only in tests but are not documented for actual users.
 
@@ -356,7 +414,7 @@ Preferred order:
 1. define the exact supported syntax,
 2. add a fixture,
 3. decide whether the new shape is inferable or must require explicit `bind`,
-4. update `extractParameters` and argument building together,
+4. update `extractParameters` and the shared binding plan together,
 5. verify both structured and writer verbs still work.
 
 Parameter support looks deceptively local, but it is one of the few places where scanner, compiler, and runtime all have to agree. That is why this kind of change deserves extra care. A parameter shape that is easy to extract but hard to marshal, or easy to marshal but hard to explain to users, is usually not worth supporting.

--- a/pkg/doc/11-jsverbs-example-reference.md
+++ b/pkg/doc/11-jsverbs-example-reference.md
@@ -25,6 +25,15 @@ Think of this page as the answer key for the developer guide. The guide explains
 
 ## Discovery rules
 
+Library entrypoints:
+
+- `ScanDir(root, ...)`
+- `ScanFS(fsys, root, ...)`
+- `ScanSource(path, source, ...)`
+- `ScanSources(files, ...)`
+
+The example runner uses `ScanDir(...)`, but the package itself is no longer limited to disk directories.
+
 Supported function declarations:
 
 - top-level `function name(...) {}`
@@ -51,6 +60,24 @@ This rule gives the subsystem a useful default: simple files can become command 
 The sentinels are statically extracted at scan time and installed as runtime no-ops during execution.
 
 That means the same token can matter in two different ways: at scan time it carries meaning for command construction, and at runtime it only needs to exist so requiring the source does not fail. New developers sometimes conflate those roles, so it is worth being explicit that most sentinel behavior is compile-time metadata, not dynamic runtime logic.
+
+Metadata values are parsed as a strict literal subset. Supported metadata values are:
+
+- object literals
+- array literals
+- quoted strings
+- template strings without substitutions
+- numbers
+- `true`, `false`, `null`
+
+Unsupported metadata values include:
+
+- function calls
+- identifiers as values
+- template substitutions
+- computed keys
+- spreads
+- other dynamic expressions
 
 ## `__package__` fields
 
@@ -154,6 +181,8 @@ Requiredness rule:
 
 That requiredness rule is one of the most visible user-facing defaults in the subsystem. It is there to make the generated CLI behave like a serious command, not like an unconstrained JavaScript function call.
 
+Parameters using object or array patterns are not treated as normal inferred positional values. They require an explicit `bind`, because the package now prefers one explicit binding contract over guesswork.
+
 ## Binding modes
 
 No bind:
@@ -180,6 +209,8 @@ No bind:
 - pass one object with values from that named section
 
 Bindings are where a lot of expressiveness comes from. They let the generated CLI remain idiomatic on the Go side while still letting JavaScript authors think in terms of cohesive objects instead of only flat parameter lists.
+
+Internally, bindings are resolved through a shared binding plan that is consumed by both command compilation and runtime invocation. The user-visible implication is simple: invalid binds should now fail consistently instead of becoming mismatched behavior between those two phases.
 
 ## Output modes
 
@@ -211,26 +242,38 @@ Behavior:
 
 Promise support matters because it allows the runtime path to remain usable for more realistic JavaScript helpers instead of only synchronous utility functions. At the same time, the waiting logic is intentionally simple and explicit so developers can reason about how long-running or failing async code surfaces back into the CLI.
 
+The current polling implementation is deliberately retained as version-1 behavior. It is documented as simple and temporary rather than as the final async design.
+
 ## Relative module loading
 
-Execution uses a source loader that reads the real file from disk and injects an overlay around it. The overlay captures top-level functions while preserving normal relative `require()` behavior.
+Execution uses a source loader that serves the source already stored in the registry and injects an overlay around it. The overlay captures top-level functions while preserving normal relative `require()` behavior.
 
 Resolution currently tries:
 
-- exact path
-- `.js`
-- `.cjs`
-- `index.js`
-- `index.cjs`
+- the registry-backed module path for scanned files
+- relative lookups resolved by the underlying `require()` resolver against that scanned module path
 
-The runtime keeps this resolution logic intentionally narrow. It is designed to support practical local module trees for command fixtures and experiments, not to become a full reimplementation of every Node resolution edge case.
+This means relative helpers still work for directory scans, `fs.FS` scans, and raw in-memory source sets, as long as the referenced helper module is part of the scanned source set.
+
+## Diagnostics
+
+The scanner records diagnostics on the registry and, by default, fails with `ScanError` when error diagnostics are present.
+
+Practical implications:
+
+- malformed metadata is not silently dropped anymore
+- callers can inspect `registry.Diagnostics`
+- callers can inspect `registry.ErrorDiagnostics()`
+- `ScanOptions.FailOnErrorDiagnostics` controls whether error diagnostics become a returned scan error
+
+This is one of the most important behavioral changes from the original prototype because it turns missing-command debugging into an explicit scanner contract.
 
 ## Testing pattern
 
 Preferred testing structure:
 
 - use `testdata/jsverbs` for fixtures
-- use `ScanDir(...)` to build a registry
+- use `ScanDir(...)`, `ScanFS(...)`, or `ScanSource(...)` depending on what source origin you want to validate
 - use `registry.Commands()` to compile commands
 - execute structured verbs through a capture processor
 - execute text verbs through a `strings.Builder`

--- a/pkg/doc/11-jsverbs-example-reference.md
+++ b/pkg/doc/11-jsverbs-example-reference.md
@@ -1,0 +1,256 @@
+---
+Title: "jsverbs-example reference"
+Slug: jsverbs-example-reference
+Short: "Reference for metadata, inference rules, bindings, output modes, and runtime behavior in the JavaScript verb prototype."
+Topics:
+- goja
+- glazed
+- reference
+- metadata
+- runtime
+Commands:
+- jsverbs-example
+Flags:
+- --dir
+- --log-level
+IsTopLevel: false
+IsTemplate: false
+ShowPerDefault: true
+SectionType: GeneralTopic
+---
+
+This page is a compact reference for the JavaScript verb subsystem. Use it after you already understand the main flow and need exact rules instead of a tutorial narrative.
+
+Think of this page as the answer key for the developer guide. The guide explains the shape of the system and why it exists. This page tells you the exact supported inputs and behaviors the current implementation promises. When you change behavior, this is one of the places that should move with the code so future readers can distinguish deliberate design from accidental current behavior.
+
+## Discovery rules
+
+Supported function declarations:
+
+- top-level `function name(...) {}`
+- top-level `const name = (...) => {}`
+- top-level `const name = function(...) {}`
+
+Ignored for command discovery:
+
+- nested functions
+- object methods
+- functions whose names start with `_`
+
+Public functions are auto-exposed unless an explicit `__verb__` definition overrides them.
+
+This rule gives the subsystem a useful default: simple files can become command trees without much ceremony. At the same time, explicit `__verb__` metadata remains the escape hatch when naming, grouping, or output semantics need to be different from the inferred default.
+
+## Recognized sentinels
+
+- `__package__({...})`
+- `__section__("slug", {...})`
+- `__verb__("functionName", {...})`
+- `doc\`...\``
+
+The sentinels are statically extracted at scan time and installed as runtime no-ops during execution.
+
+That means the same token can matter in two different ways: at scan time it carries meaning for command construction, and at runtime it only needs to exist so requiring the source does not fail. New developers sometimes conflate those roles, so it is worth being explicit that most sentinel behavior is compile-time metadata, not dynamic runtime logic.
+
+## `__package__` fields
+
+Currently used package metadata:
+
+- `name`
+- `short`
+- `long`
+- `parents`
+- `tags`
+
+Package metadata mainly affects default command grouping.
+
+In other words, package metadata shapes where commands live in the tree more than how the function itself is called. If you are debugging command hierarchy or unexpectedly nested verbs, package metadata is one of the first places to inspect.
+
+## `__section__` fields
+
+Supported section fields:
+
+- `title`
+- `name`
+- `description`
+- `fields`
+
+Section field definitions support the same field keys used under `__verb__`.
+
+Sections are the main mechanism for sharing schema across multiple verbs in one file. They are especially useful when several commands conceptually operate over the same group of filters or options and you want the command line shape to reflect that shared structure.
+
+## `__verb__` fields
+
+Supported verb-level fields:
+
+- `command`
+- `name`
+- `short`
+- `long`
+- `parents`
+- `tags`
+- `sections`
+- `useSections`
+- `fields`
+- `output`
+- `outputMode`
+- `mode`
+
+Output aliases:
+
+- `glaze`
+- `table`
+- `structured`
+- `text`
+- `raw`
+- `writer`
+- `plain`
+
+Multiple aliases exist mostly for ergonomics while the subsystem is still evolving. In practice, using one canonical spelling per codebase is easier to read. For now, `output: "text"` and the default structured mode are the clearest choices.
+
+## Field definition keys
+
+Supported field metadata keys:
+
+- `type`
+- `help`
+- `short`
+- `bind`
+- `section`
+- `default`
+- `choices`
+- `required`
+- `argument`
+- `arg`
+
+These keys are intentionally close to Glazed concepts. The subsystem is not inventing a separate CLI schema language; it is translating a small JavaScript-friendly metadata format into existing Glazed schema structures.
+
+## Field type mapping
+
+Supported field types currently map to Glazed like this:
+
+- `string` -> string field
+- `bool` or `boolean` -> bool field
+- `int` or `integer` -> integer field
+- `float` or `number` -> float field
+- `stringList`, `list`, `[]string` -> string-list field
+- `choice` -> choice field
+- `choiceList` -> choice-list field
+
+If `choices` is set and no type is provided, the system treats the field as `choice`.
+
+This is another example of the system preferring useful defaults over forcing constant ceremony. When the metadata already expresses a closed set of valid values, treating the field as a choice is usually what the author intended anyway.
+
+## Inference rules
+
+If a parameter has no explicit field metadata:
+
+- identifier parameter -> inferred string field
+- rest parameter -> inferred string-list argument
+
+Requiredness rule:
+
+- arguments are required by default unless a default value is supplied
+
+That requiredness rule is one of the most visible user-facing defaults in the subsystem. It is there to make the generated CLI behave like a serious command, not like an unconstrained JavaScript function call.
+
+## Binding modes
+
+No bind:
+
+- use a normal field or inferred field value
+
+`bind: "all"`:
+
+- pass one object containing every resolved field value
+
+`bind: "context"`:
+
+- pass one object containing:
+  - `verb`
+  - `function`
+  - `module`
+  - `sourceFile`
+  - `rootDir`
+  - `values`
+  - `sections`
+
+`bind: "<section>"`:
+
+- pass one object with values from that named section
+
+Bindings are where a lot of expressiveness comes from. They let the generated CLI remain idiomatic on the Go side while still letting JavaScript authors think in terms of cohesive objects instead of only flat parameter lists.
+
+## Output modes
+
+`glaze` mode:
+
+- command compiles as `GlazeCommand`
+- objects become rows
+- arrays become many rows
+- primitives become `{value: ...}`
+
+`text` mode:
+
+- command compiles as `WriterCommand`
+- strings are written directly
+- `[]byte` is written directly
+- all other values fall back to pretty JSON
+
+That JSON fallback is a guardrail rather than a recommendation. If a text verb consistently returns structured objects, it is usually a sign that the command should probably be a structured verb instead.
+
+## Promise handling
+
+If a JS function returns a `Promise`, the runtime polls promise state through the runtime owner and waits until the promise is fulfilled or rejected.
+
+Behavior:
+
+- fulfilled -> exported value continues through normal output handling
+- rejected -> command returns an error
+- pending with canceled context -> command stops with context error
+
+Promise support matters because it allows the runtime path to remain usable for more realistic JavaScript helpers instead of only synchronous utility functions. At the same time, the waiting logic is intentionally simple and explicit so developers can reason about how long-running or failing async code surfaces back into the CLI.
+
+## Relative module loading
+
+Execution uses a source loader that reads the real file from disk and injects an overlay around it. The overlay captures top-level functions while preserving normal relative `require()` behavior.
+
+Resolution currently tries:
+
+- exact path
+- `.js`
+- `.cjs`
+- `index.js`
+- `index.cjs`
+
+The runtime keeps this resolution logic intentionally narrow. It is designed to support practical local module trees for command fixtures and experiments, not to become a full reimplementation of every Node resolution edge case.
+
+## Testing pattern
+
+Preferred testing structure:
+
+- use `testdata/jsverbs` for fixtures
+- use `ScanDir(...)` to build a registry
+- use `registry.Commands()` to compile commands
+- execute structured verbs through a capture processor
+- execute text verbs through a `strings.Builder`
+
+That split in test style mirrors the split in command interfaces. If you add a new output behavior and the tests no longer read naturally, it is worth checking whether the command abstraction itself is still clean.
+
+## Help integration
+
+The example runner loads the shared `pkg/doc` help pages into its help system.
+
+That means:
+
+- adding a new `*.md` file in `pkg/doc` makes it reusable for other commands
+- `jsverbs-example` automatically benefits from the shared doc package
+- no extra registration code is needed unless the docs move to a different package
+
+This is a good pattern to preserve because it keeps reusable developer documentation in a package-level location instead of hiding it under one command. A new contributor should be able to discover implementation and help content close to the reusable library code, not only inside one example binary.
+
+## See Also
+
+- `glaze help jsverbs-example-overview`
+- `glaze help jsverbs-example-developer-guide`
+- `glaze help jsverbs-example-fixture-format`

--- a/pkg/jsverbs/binding.go
+++ b/pkg/jsverbs/binding.go
@@ -1,0 +1,169 @@
+package jsverbs
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/go-go-golems/glazed/pkg/cmds/schema"
+)
+
+type BindingMode string
+
+const (
+	BindingModePositional BindingMode = "positional"
+	BindingModeSection    BindingMode = "section"
+	BindingModeAll        BindingMode = "all"
+	BindingModeContext    BindingMode = "context"
+)
+
+type ParameterBinding struct {
+	Param       ParameterSpec
+	Field       *FieldSpec
+	Mode        BindingMode
+	SectionSlug string
+}
+
+type ExtraFieldBinding struct {
+	Name        string
+	Field       *FieldSpec
+	SectionSlug string
+}
+
+type VerbBindingPlan struct {
+	Verb               *VerbSpec
+	Parameters         []ParameterBinding
+	ExtraFields        []ExtraFieldBinding
+	ReferencedSections []string
+}
+
+func buildVerbBindingPlan(verb *VerbSpec) (*VerbBindingPlan, error) {
+	referencedSections := map[string]struct{}{}
+	for _, slug := range verb.UseSections {
+		referencedSections[slug] = struct{}{}
+	}
+	for _, fieldMeta := range verb.Fields {
+		if fieldMeta == nil {
+			continue
+		}
+		if fieldMeta.Section != "" {
+			referencedSections[fieldMeta.Section] = struct{}{}
+		}
+		switch bind := normalizeBind(fieldMeta.Bind); bind {
+		case "", "all", "context":
+		default:
+			referencedSections[bind] = struct{}{}
+		}
+	}
+
+	plan := &VerbBindingPlan{
+		Verb:       verb,
+		Parameters: make([]ParameterBinding, 0, len(verb.Params)),
+	}
+
+	usedFields := map[string]struct{}{}
+	for _, param := range verb.Params {
+		fieldSpec := verb.Field(param.Name)
+		if fieldSpec != nil {
+			usedFields[param.Name] = struct{}{}
+			fieldSpec = fieldSpec.Clone()
+		} else {
+			fieldSpec = inferFieldFromParam(param)
+		}
+		if fieldSpec == nil {
+			continue
+		}
+		if fieldSpec.Name == "" {
+			fieldSpec.Name = param.Name
+		}
+		binding, err := resolveParameterBinding(verb, param, fieldSpec)
+		if err != nil {
+			return nil, err
+		}
+		plan.Parameters = append(plan.Parameters, binding)
+	}
+
+	extraFieldNames := make([]string, 0, len(verb.Fields))
+	for name := range verb.Fields {
+		if _, ok := usedFields[name]; ok {
+			continue
+		}
+		extraFieldNames = append(extraFieldNames, name)
+	}
+	sort.Strings(extraFieldNames)
+	for _, name := range extraFieldNames {
+		fieldSpec := verb.Fields[name]
+		if fieldSpec == nil {
+			continue
+		}
+		fieldSpec = fieldSpec.Clone()
+		if fieldSpec.Name == "" {
+			fieldSpec.Name = name
+		}
+		if normalizeBind(fieldSpec.Bind) != "" {
+			continue
+		}
+		sectionSlug := schema.DefaultSlug
+		if fieldSpec.Section != "" {
+			sectionSlug = fieldSpec.Section
+		}
+		plan.ExtraFields = append(plan.ExtraFields, ExtraFieldBinding{
+			Name:        name,
+			Field:       fieldSpec,
+			SectionSlug: sectionSlug,
+		})
+	}
+
+	for slug := range referencedSections {
+		if _, ok := verb.File.Sections[slug]; !ok {
+			return nil, fmt.Errorf("%s references unknown section %q", verb.SourceRef(), slug)
+		}
+	}
+	plan.ReferencedSections = make([]string, 0, len(referencedSections))
+	for _, slug := range verb.File.SectionOrder {
+		if _, ok := referencedSections[slug]; ok {
+			plan.ReferencedSections = append(plan.ReferencedSections, slug)
+		}
+	}
+
+	return plan, nil
+}
+
+func resolveParameterBinding(verb *VerbSpec, param ParameterSpec, fieldSpec *FieldSpec) (ParameterBinding, error) {
+	binding := ParameterBinding{
+		Param:       param,
+		Field:       fieldSpec,
+		Mode:        BindingModePositional,
+		SectionSlug: schema.DefaultSlug,
+	}
+	switch bind := normalizeBind(fieldSpec.Bind); bind {
+	case "":
+		if param.Kind != ParameterIdentifier && param.Kind != ParameterUnknown {
+			return ParameterBinding{}, fmt.Errorf("%s parameter %q requires a bind because it is %s", verb.SourceRef(), param.Name, param.Kind)
+		}
+		if fieldSpec.Section != "" {
+			binding.SectionSlug = fieldSpec.Section
+		}
+	case "all":
+		binding.Mode = BindingModeAll
+		binding.SectionSlug = ""
+	case "context":
+		binding.Mode = BindingModeContext
+		binding.SectionSlug = ""
+	default:
+		binding.Mode = BindingModeSection
+		binding.SectionSlug = bind
+	}
+	return binding, nil
+}
+
+func normalizeBind(bind string) string {
+	switch cleaned := strings.TrimSpace(bind); cleaned {
+	case "":
+		return ""
+	case "all", "context":
+		return cleaned
+	default:
+		return cleanCommandWord(cleaned)
+	}
+}

--- a/pkg/jsverbs/command.go
+++ b/pkg/jsverbs/command.go
@@ -1,0 +1,513 @@
+package jsverbs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/go-go-golems/glazed/pkg/cmds"
+	"github.com/go-go-golems/glazed/pkg/cmds/fields"
+	"github.com/go-go-golems/glazed/pkg/cmds/schema"
+	"github.com/go-go-golems/glazed/pkg/cmds/values"
+	"github.com/go-go-golems/glazed/pkg/middlewares"
+	"github.com/go-go-golems/glazed/pkg/types"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+type Command struct {
+	*cmds.CommandDescription
+	registry *Registry
+	verb     *VerbSpec
+}
+
+type WriterCommand struct {
+	*cmds.CommandDescription
+	registry *Registry
+	verb     *VerbSpec
+}
+
+var _ cmds.GlazeCommand = (*Command)(nil)
+var _ cmds.WriterCommand = (*WriterCommand)(nil)
+
+func (r *Registry) Commands() ([]cmds.Command, error) {
+	commands := make([]cmds.Command, 0, len(r.verbs))
+	for _, verb := range r.verbs {
+		cmd, err := r.commandForVerb(verb)
+		if err != nil {
+			return nil, err
+		}
+		commands = append(commands, cmd)
+	}
+	return commands, nil
+}
+
+func (r *Registry) commandForVerb(verb *VerbSpec) (cmds.Command, error) {
+	description, err := r.buildDescription(verb)
+	if err != nil {
+		return nil, err
+	}
+	switch verb.OutputMode {
+	case OutputModeGlaze:
+		return &Command{
+			CommandDescription: description,
+			registry:           r,
+			verb:               verb,
+		}, nil
+	case OutputModeText:
+		return &WriterCommand{
+			CommandDescription: description,
+			registry:           r,
+			verb:               verb,
+		}, nil
+	default:
+		return nil, fmt.Errorf("%s has unsupported output mode %q", verb.SourceRef(), verb.OutputMode)
+	}
+}
+
+func (r *Registry) buildDescription(verb *VerbSpec) (*cmds.CommandDescription, error) {
+	sections := map[string]*schema.SectionImpl{}
+	ordered := []string{}
+
+	ensureSection := func(slug, title, description string) (*schema.SectionImpl, error) {
+		slug = strings.TrimSpace(slug)
+		if slug == "" {
+			slug = schema.DefaultSlug
+		}
+		if section, ok := sections[slug]; ok {
+			if section.Name == "" && title != "" {
+				section.Name = title
+			}
+			if section.Description == "" && description != "" {
+				section.Description = description
+			}
+			return section, nil
+		}
+		if title == "" {
+			if slug == schema.DefaultSlug {
+				title = "Arguments"
+			} else {
+				title = prettySectionTitle(slug)
+			}
+		}
+		section, err := schema.NewSection(slug, title, schema.WithDescription(description))
+		if err != nil {
+			return nil, err
+		}
+		sections[slug] = section
+		ordered = append(ordered, slug)
+		return section, nil
+	}
+
+	if _, err := ensureSection(schema.DefaultSlug, "Arguments", ""); err != nil {
+		return nil, err
+	}
+
+	referencedSections := map[string]struct{}{}
+	for _, section := range verb.UseSections {
+		referencedSections[section] = struct{}{}
+	}
+	for _, fieldMeta := range verb.Fields {
+		if fieldMeta == nil {
+			continue
+		}
+		if fieldMeta.Section != "" {
+			referencedSections[fieldMeta.Section] = struct{}{}
+		}
+		if bind := strings.TrimSpace(fieldMeta.Bind); bind != "" && bind != "all" && bind != "context" {
+			referencedSections[cleanCommandWord(bind)] = struct{}{}
+		}
+	}
+
+	for _, slug := range verb.File.SectionOrder {
+		if _, ok := referencedSections[slug]; !ok {
+			continue
+		}
+		spec := verb.File.Sections[slug]
+		section, err := ensureSection(spec.Slug, spec.Title, spec.Description)
+		if err != nil {
+			return nil, err
+		}
+		fieldNames := make([]string, 0, len(spec.Fields))
+		for name := range spec.Fields {
+			fieldNames = append(fieldNames, name)
+		}
+		sort.Strings(fieldNames)
+		for _, name := range fieldNames {
+			field, err := buildFieldDefinition(spec.Fields[name])
+			if err != nil {
+				return nil, fmt.Errorf("%s section %s field %s: %w", verb.SourceRef(), slug, name, err)
+			}
+			section.AddFields(field)
+		}
+	}
+
+	addField := func(sectionSlug string, fieldSpec *FieldSpec) error {
+		section, err := ensureSection(sectionSlug, "", "")
+		if err != nil {
+			return err
+		}
+		field, err := buildFieldDefinition(fieldSpec)
+		if err != nil {
+			return err
+		}
+		if field.IsArgument && sectionSlug != schema.DefaultSlug {
+			return fmt.Errorf("arguments are only supported in the default section (field %s in %s)", field.Name, sectionSlug)
+		}
+		section.AddFields(field)
+		return nil
+	}
+
+	usedFields := map[string]struct{}{}
+	for _, param := range verb.Params {
+		fieldSpec := verb.Field(param.Name)
+		if fieldSpec != nil {
+			usedFields[param.Name] = struct{}{}
+		}
+		if fieldSpec == nil {
+			fieldSpec = inferFieldFromParam(param)
+		}
+		if fieldSpec == nil {
+			continue
+		}
+		if bind := strings.TrimSpace(fieldSpec.Bind); bind != "" {
+			if param.Kind != ParameterIdentifier && param.Kind != ParameterUnknown {
+				continue
+			}
+			continue
+		}
+		if param.Kind != ParameterIdentifier && param.Kind != ParameterUnknown {
+			return nil, fmt.Errorf("%s parameter %q requires a bind because it is %s", verb.SourceRef(), param.Name, param.Kind)
+		}
+		sectionSlug := schema.DefaultSlug
+		if fieldSpec.Section != "" {
+			sectionSlug = fieldSpec.Section
+		}
+		fieldSpec = fieldSpec.Clone()
+		if fieldSpec.Name == "" {
+			fieldSpec.Name = param.Name
+		}
+		if err := addField(sectionSlug, fieldSpec); err != nil {
+			return nil, fmt.Errorf("%s field %s: %w", verb.SourceRef(), param.Name, err)
+		}
+	}
+
+	extraFieldNames := make([]string, 0, len(verb.Fields))
+	for name := range verb.Fields {
+		if _, ok := usedFields[name]; ok {
+			continue
+		}
+		extraFieldNames = append(extraFieldNames, name)
+	}
+	sort.Strings(extraFieldNames)
+	for _, name := range extraFieldNames {
+		fieldSpec := verb.Fields[name]
+		if fieldSpec == nil {
+			continue
+		}
+		if strings.TrimSpace(fieldSpec.Bind) != "" {
+			continue
+		}
+		sectionSlug := schema.DefaultSlug
+		if fieldSpec.Section != "" {
+			sectionSlug = fieldSpec.Section
+		}
+		fieldSpec = fieldSpec.Clone()
+		if fieldSpec.Name == "" {
+			fieldSpec.Name = name
+		}
+		if err := addField(sectionSlug, fieldSpec); err != nil {
+			return nil, fmt.Errorf("%s field %s: %w", verb.SourceRef(), name, err)
+		}
+	}
+
+	description := cmds.NewCommandDescription(
+		verb.Name,
+		cmds.WithShort(verb.Short),
+		cmds.WithLong(verb.Long),
+		cmds.WithParents(verb.Parents...),
+		cmds.WithSource("jsverbs:"+verb.SourceRef()),
+	)
+	for _, slug := range ordered {
+		description.Schema.Set(slug, sections[slug])
+	}
+	return description, nil
+}
+
+func inferFieldFromParam(param ParameterSpec) *FieldSpec {
+	field := &FieldSpec{Name: param.Name}
+	if param.Rest {
+		field.Argument = true
+		field.Type = "stringList"
+		return field
+	}
+	switch param.Kind {
+	case ParameterIdentifier, ParameterUnknown:
+		field.Type = "string"
+		return field
+	case ParameterObject, ParameterArray:
+		return field
+	}
+
+	return field
+}
+
+func buildFieldDefinition(spec *FieldSpec) (*fields.Definition, error) {
+	if spec == nil {
+		return nil, fmt.Errorf("field spec is nil")
+	}
+	name := strings.TrimSpace(spec.Name)
+	if name == "" {
+		return nil, fmt.Errorf("field name is empty")
+	}
+	fieldType, err := glazedFieldType(spec)
+	if err != nil {
+		return nil, err
+	}
+	options := []fields.Option{}
+	if spec.Help != "" {
+		options = append(options, fields.WithHelp(spec.Help))
+	}
+	if spec.Short != "" {
+		options = append(options, fields.WithShortFlag(spec.Short))
+	}
+	if spec.Required || (spec.Argument && spec.Default == nil) {
+		options = append(options, fields.WithRequired(true))
+	}
+	if spec.Argument {
+		options = append(options, fields.WithIsArgument(true))
+	}
+	if len(spec.Choices) > 0 {
+		options = append(options, fields.WithChoices(spec.Choices...))
+	}
+	if spec.Default != nil {
+		value, err := normalizeDefaultValue(spec.Default, fieldType)
+		if err != nil {
+			return nil, err
+		}
+		options = append(options, fields.WithDefault(value))
+	}
+	return fields.New(name, fieldType, options...), nil
+}
+
+func glazedFieldType(spec *FieldSpec) (fields.Type, error) {
+	typeName := strings.ToLower(strings.TrimSpace(spec.Type))
+	if typeName == "" && len(spec.Choices) > 0 {
+		typeName = "choice"
+	}
+	switch typeName {
+	case "", "string":
+		return fields.TypeString, nil
+	case "bool", "boolean":
+		return fields.TypeBool, nil
+	case "int", "integer":
+		return fields.TypeInteger, nil
+	case "float", "number":
+		return fields.TypeFloat, nil
+	case "stringlist", "list", "[]string":
+		return fields.TypeStringList, nil
+	case "choice":
+		return fields.TypeChoice, nil
+	case "choicelist":
+		return fields.TypeChoiceList, nil
+	default:
+		return "", fmt.Errorf("unsupported field type %q", spec.Type)
+	}
+}
+
+func normalizeDefaultValue(value interface{}, fieldType fields.Type) (interface{}, error) {
+	switch fieldType {
+	case fields.TypeString, fields.TypeChoice:
+		s, ok := value.(string)
+		if !ok {
+			return nil, fmt.Errorf("expected string default, got %T", value)
+		}
+		return s, nil
+	case fields.TypeBool:
+		b, ok := value.(bool)
+		if !ok {
+			return nil, fmt.Errorf("expected bool default, got %T", value)
+		}
+		return b, nil
+	case fields.TypeInteger:
+		switch v := value.(type) {
+		case float64:
+			return int(v), nil
+		case int:
+			return v, nil
+		case int64:
+			return v, nil
+		default:
+			return nil, fmt.Errorf("expected integer default, got %T", value)
+		}
+	case fields.TypeFloat:
+		switch v := value.(type) {
+		case float64:
+			return v, nil
+		case int:
+			return float64(v), nil
+		default:
+			return nil, fmt.Errorf("expected float default, got %T", value)
+		}
+	case fields.TypeStringList, fields.TypeChoiceList:
+		switch v := value.(type) {
+		case []interface{}:
+			out := make([]string, 0, len(v))
+			for _, item := range v {
+				s, ok := item.(string)
+				if !ok {
+					return nil, fmt.Errorf("expected string list default, got %T", item)
+				}
+				out = append(out, s)
+			}
+			return out, nil
+		case []string:
+			return append([]string{}, v...), nil
+		default:
+			return nil, fmt.Errorf("expected string list default, got %T", value)
+		}
+	case fields.TypeSecret,
+		fields.TypeStringFromFile,
+		fields.TypeStringFromFiles,
+		fields.TypeFile,
+		fields.TypeFileList,
+		fields.TypeObjectListFromFile,
+		fields.TypeObjectListFromFiles,
+		fields.TypeObjectFromFile,
+		fields.TypeStringListFromFile,
+		fields.TypeStringListFromFiles,
+		fields.TypeKeyValue,
+		fields.TypeDate,
+		fields.TypeIntegerList,
+		fields.TypeFloatList:
+		return value, nil
+	}
+
+	return value, nil
+}
+
+func (c *Command) RunIntoGlazeProcessor(ctx context.Context, parsedValues *values.Values, gp middlewares.Processor) error {
+	result, err := c.registry.invoke(ctx, c.verb, parsedValues)
+	if err != nil {
+		return err
+	}
+	rows, err := rowsFromResult(result)
+	if err != nil {
+		return err
+	}
+	for _, row := range rows {
+		if err := gp.AddRow(ctx, row); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *WriterCommand) RunIntoWriter(ctx context.Context, parsedValues *values.Values, w io.Writer) error {
+	result, err := c.registry.invoke(ctx, c.verb, parsedValues)
+	if err != nil {
+		return err
+	}
+	text, err := renderTextResult(result)
+	if err != nil {
+		return err
+	}
+	_, err = io.WriteString(w, text)
+	return err
+}
+
+func renderTextResult(result interface{}) (string, error) {
+	if result == nil {
+		return "", nil
+	}
+	switch v := result.(type) {
+	case string:
+		return v, nil
+	case []byte:
+		return string(v), nil
+	case fmt.Stringer:
+		return v.String(), nil
+	}
+
+	value := reflect.ValueOf(result)
+	if value.IsValid() && (value.Kind() == reflect.Slice || value.Kind() == reflect.Array) {
+		if value.Type().Elem().Kind() == reflect.Uint8 {
+			return string(value.Bytes()), nil
+		}
+	}
+
+	b, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+func rowsFromResult(result interface{}) ([]types.Row, error) {
+	if result == nil {
+		return nil, nil
+	}
+	if row, ok := toRow(result); ok {
+		return []types.Row{row}, nil
+	}
+	value := reflect.ValueOf(result)
+	if value.Kind() == reflect.Slice || value.Kind() == reflect.Array {
+		rows := make([]types.Row, 0, value.Len())
+		for i := 0; i < value.Len(); i++ {
+			item := value.Index(i).Interface()
+			if row, ok := toRow(item); ok {
+				rows = append(rows, row)
+			} else {
+				rows = append(rows, types.NewRow(types.MRP("value", item)))
+			}
+		}
+		return rows, nil
+	}
+
+	return []types.Row{types.NewRow(types.MRP("value", result))}, nil
+}
+
+func prettySectionTitle(slug string) string {
+	return cases.Title(language.English).String(strings.ReplaceAll(slug, "-", " "))
+}
+
+func toRow(value interface{}) (types.Row, bool) {
+	switch v := value.(type) {
+	case map[string]interface{}:
+		return types.NewRowFromMap(v), true
+	case map[string]string:
+		row := types.NewRow()
+		keys := make([]string, 0, len(v))
+		for key := range v {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			row.Set(key, v[key])
+		}
+		return row, true
+	default:
+		rv := reflect.ValueOf(value)
+		if !rv.IsValid() || rv.Kind() != reflect.Map || rv.Type().Key().Kind() != reflect.String {
+			return nil, false
+		}
+		row := types.NewRow()
+		iter := rv.MapRange()
+		keys := []string{}
+		valuesByKey := map[string]interface{}{}
+		for iter.Next() {
+			key := iter.Key().String()
+			keys = append(keys, key)
+			valuesByKey[key] = iter.Value().Interface()
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			row.Set(key, valuesByKey[key])
+		}
+		return row, true
+	}
+}

--- a/pkg/jsverbs/command.go
+++ b/pkg/jsverbs/command.go
@@ -70,6 +70,11 @@ func (r *Registry) commandForVerb(verb *VerbSpec) (cmds.Command, error) {
 }
 
 func (r *Registry) buildDescription(verb *VerbSpec) (*cmds.CommandDescription, error) {
+	plan, err := buildVerbBindingPlan(verb)
+	if err != nil {
+		return nil, err
+	}
+
 	sections := map[string]*schema.SectionImpl{}
 	ordered := []string{}
 
@@ -107,26 +112,7 @@ func (r *Registry) buildDescription(verb *VerbSpec) (*cmds.CommandDescription, e
 		return nil, err
 	}
 
-	referencedSections := map[string]struct{}{}
-	for _, section := range verb.UseSections {
-		referencedSections[section] = struct{}{}
-	}
-	for _, fieldMeta := range verb.Fields {
-		if fieldMeta == nil {
-			continue
-		}
-		if fieldMeta.Section != "" {
-			referencedSections[fieldMeta.Section] = struct{}{}
-		}
-		if bind := strings.TrimSpace(fieldMeta.Bind); bind != "" && bind != "all" && bind != "context" {
-			referencedSections[cleanCommandWord(bind)] = struct{}{}
-		}
-	}
-
-	for _, slug := range verb.File.SectionOrder {
-		if _, ok := referencedSections[slug]; !ok {
-			continue
-		}
+	for _, slug := range plan.ReferencedSections {
 		spec := verb.File.Sections[slug]
 		section, err := ensureSection(spec.Slug, spec.Title, spec.Description)
 		if err != nil {
@@ -162,66 +148,18 @@ func (r *Registry) buildDescription(verb *VerbSpec) (*cmds.CommandDescription, e
 		return nil
 	}
 
-	usedFields := map[string]struct{}{}
-	for _, param := range verb.Params {
-		fieldSpec := verb.Field(param.Name)
-		if fieldSpec != nil {
-			usedFields[param.Name] = struct{}{}
-		}
-		if fieldSpec == nil {
-			fieldSpec = inferFieldFromParam(param)
-		}
-		if fieldSpec == nil {
+	for _, binding := range plan.Parameters {
+		if binding.Mode != BindingModePositional {
 			continue
 		}
-		if bind := strings.TrimSpace(fieldSpec.Bind); bind != "" {
-			if param.Kind != ParameterIdentifier && param.Kind != ParameterUnknown {
-				continue
-			}
-			continue
-		}
-		if param.Kind != ParameterIdentifier && param.Kind != ParameterUnknown {
-			return nil, fmt.Errorf("%s parameter %q requires a bind because it is %s", verb.SourceRef(), param.Name, param.Kind)
-		}
-		sectionSlug := schema.DefaultSlug
-		if fieldSpec.Section != "" {
-			sectionSlug = fieldSpec.Section
-		}
-		fieldSpec = fieldSpec.Clone()
-		if fieldSpec.Name == "" {
-			fieldSpec.Name = param.Name
-		}
-		if err := addField(sectionSlug, fieldSpec); err != nil {
-			return nil, fmt.Errorf("%s field %s: %w", verb.SourceRef(), param.Name, err)
+		if err := addField(binding.SectionSlug, binding.Field); err != nil {
+			return nil, fmt.Errorf("%s field %s: %w", verb.SourceRef(), binding.Param.Name, err)
 		}
 	}
 
-	extraFieldNames := make([]string, 0, len(verb.Fields))
-	for name := range verb.Fields {
-		if _, ok := usedFields[name]; ok {
-			continue
-		}
-		extraFieldNames = append(extraFieldNames, name)
-	}
-	sort.Strings(extraFieldNames)
-	for _, name := range extraFieldNames {
-		fieldSpec := verb.Fields[name]
-		if fieldSpec == nil {
-			continue
-		}
-		if strings.TrimSpace(fieldSpec.Bind) != "" {
-			continue
-		}
-		sectionSlug := schema.DefaultSlug
-		if fieldSpec.Section != "" {
-			sectionSlug = fieldSpec.Section
-		}
-		fieldSpec = fieldSpec.Clone()
-		if fieldSpec.Name == "" {
-			fieldSpec.Name = name
-		}
-		if err := addField(sectionSlug, fieldSpec); err != nil {
-			return nil, fmt.Errorf("%s field %s: %w", verb.SourceRef(), name, err)
+	for _, extraField := range plan.ExtraFields {
+		if err := addField(extraField.SectionSlug, extraField.Field); err != nil {
+			return nil, fmt.Errorf("%s field %s: %w", verb.SourceRef(), extraField.Name, err)
 		}
 	}
 

--- a/pkg/jsverbs/jsverbs_test.go
+++ b/pkg/jsverbs/jsverbs_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"testing/fstest"
 
 	"github.com/go-go-golems/glazed/pkg/cmds"
 	"github.com/go-go-golems/glazed/pkg/cmds/runner"
@@ -128,6 +129,120 @@ func TestFixtureCommandsExecute(t *testing.T) {
 		rows := runCommand(t, commandMap["meta pkg-demo ping"], nil)
 		require.Equal(t, true, rows[0]["ok"])
 	})
+}
+
+func TestScanSourcesSupportsRawJS(t *testing.T) {
+	registry, err := ScanSources([]SourceFile{
+		{
+			Path: "inline.js",
+			Source: []byte(`
+function ping(name) {
+  return { greeting: "hi " + name };
+}
+
+__verb__("ping", {
+  fields: {
+    name: { argument: true }
+  }
+});
+`),
+		},
+	})
+	require.NoError(t, err)
+
+	commandMap := mustCommandMap(t, registry)
+	rows := runCommand(t, commandMap["inline ping"], map[string]map[string]interface{}{
+		"default": {
+			"name": "manuel",
+		},
+	})
+	require.Equal(t, "hi manuel", rows[0]["greeting"])
+}
+
+func TestScanFSSupportsVirtualFiles(t *testing.T) {
+	registry, err := ScanFS(fstest.MapFS{
+		"nested/entry.js": {
+			Data: []byte(`
+function render(prefix, target) {
+  const helper = require("./sub/helper");
+  return { value: helper.decorate(prefix, target) };
+}
+
+__verb__("render", {
+  fields: {
+    prefix: { argument: true },
+    target: { argument: true }
+  }
+});
+`),
+		},
+		"nested/sub/helper.js": {
+			Data: []byte(`exports.decorate = (prefix, target) => prefix + ":" + target;`),
+		},
+	}, ".", ScanOptions{
+		IncludePublicFunctions: true,
+		Extensions:             []string{".js"},
+		FailOnErrorDiagnostics: true,
+	})
+	require.NoError(t, err)
+
+	commandMap := mustCommandMap(t, registry)
+	rows := runCommand(t, commandMap["nested entry render"], map[string]map[string]interface{}{
+		"default": {
+			"prefix": "repo",
+			"target": "glazed",
+		},
+	})
+	require.Equal(t, "repo:glazed", rows[0]["value"])
+}
+
+func TestScanDiagnosticsSurfaceInvalidMetadata(t *testing.T) {
+	registry, err := ScanSource("broken.js", `
+function greet() {
+  return { ok: true };
+}
+
+__verb__("greet", {
+  short: helper()
+});
+`)
+	require.Error(t, err)
+	require.NotNil(t, registry)
+	require.Contains(t, err.Error(), "unsupported metadata literal")
+	require.Len(t, registry.ErrorDiagnostics(), 1)
+	require.Contains(t, registry.ErrorDiagnostics()[0].Message, "invalid __verb__ metadata")
+}
+
+func TestCommandsFailForUnknownBoundSection(t *testing.T) {
+	registry, err := ScanSource("broken.js", `
+function summarize(filters) {
+  return { ok: !!filters };
+}
+
+__verb__("summarize", {
+  fields: {
+    filters: { bind: "missing" }
+  }
+});
+`)
+	require.NoError(t, err)
+
+	_, err = registry.Commands()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `unknown section "missing"`)
+}
+
+func TestCommandsFailForObjectParamWithoutBind(t *testing.T) {
+	registry, err := ScanSource("broken.js", `
+function summarize({ owner }) {
+  return { owner };
+}
+`)
+	require.NoError(t, err)
+
+	_, err = registry.Commands()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "requires a bind")
 }
 
 func mustRegistry(t *testing.T) *Registry {

--- a/pkg/jsverbs/jsverbs_test.go
+++ b/pkg/jsverbs/jsverbs_test.go
@@ -1,0 +1,212 @@
+package jsverbs
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-go-golems/glazed/pkg/cmds"
+	"github.com/go-go-golems/glazed/pkg/cmds/runner"
+	"github.com/go-go-golems/glazed/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScanDirDiscoversExpectedPaths(t *testing.T) {
+	registry := mustRegistry(t)
+
+	paths := []string{}
+	for _, verb := range registry.Verbs() {
+		paths = append(paths, verb.FullPath())
+	}
+
+	require.ElementsMatch(t, []string{
+		"advanced numbers add",
+		"advanced numbers list-names",
+		"advanced numbers multiply",
+		"basics banner",
+		"basics echo",
+		"basics greet",
+		"basics list-issues",
+		"basics summarize",
+		"meta pkg-demo ping",
+		"nested with-helper render",
+	}, paths)
+}
+
+func TestFixtureCommandsExecute(t *testing.T) {
+	registry := mustRegistry(t)
+	commandMap := mustCommandMap(t, registry)
+
+	t.Run("greet", func(t *testing.T) {
+		rows := runCommand(t, commandMap["basics greet"], map[string]map[string]interface{}{
+			"default": {
+				"name":    "Manuel",
+				"excited": true,
+			},
+		})
+		require.Equal(t, "Hello, Manuel!", rows[0]["greeting"])
+	})
+
+	t.Run("echo primitive", func(t *testing.T) {
+		rows := runCommand(t, commandMap["basics echo"], map[string]map[string]interface{}{
+			"default": {
+				"value": "plain-text",
+			},
+		})
+		require.Equal(t, "plain-text", rows[0]["value"])
+	})
+
+	t.Run("writer output", func(t *testing.T) {
+		text := runWriterCommand(t, commandMap["basics banner"], map[string]map[string]interface{}{
+			"default": {
+				"name": "Manuel",
+			},
+		})
+		require.Equal(t, "=== Manuel ===\n", text)
+	})
+
+	t.Run("list issues uses shared section and context", func(t *testing.T) {
+		rows := runCommand(t, commandMap["basics list-issues"], map[string]map[string]interface{}{
+			"default": {
+				"repo": "go-go-golems/go-go-goja",
+			},
+			"filters": {
+				"state":  "closed",
+				"labels": []string{"bug", "docs"},
+			},
+		})
+		require.Equal(t, "go-go-golems/go-go-goja", rows[0]["repo"])
+		require.Equal(t, "closed", rows[0]["state"])
+		require.EqualValues(t, 2, rows[0]["labelCount"])
+		require.Equal(t, "decorated:go-go-golems/go-go-goja", rows[0]["helper"])
+		require.Equal(t, filepath.ToSlash(filepath.Join(repoRoot(t), "testdata", "jsverbs")), rows[0]["rootDir"])
+	})
+
+	t.Run("summarize bind all", func(t *testing.T) {
+		rows := runCommand(t, commandMap["basics summarize"], map[string]map[string]interface{}{
+			"default": {
+				"owner": "go-go-golems",
+				"repo":  "go-go-goja",
+			},
+		})
+		require.Equal(t, "go-go-golems/go-go-goja", rows[0]["joined"])
+	})
+
+	t.Run("async multiply", func(t *testing.T) {
+		rows := runCommand(t, commandMap["advanced numbers multiply"], map[string]map[string]interface{}{
+			"default": {
+				"a": 6,
+				"b": 7,
+			},
+		})
+		require.EqualValues(t, 42, rows[0]["product"])
+	})
+
+	t.Run("rest argument list", func(t *testing.T) {
+		rows := runCommand(t, commandMap["advanced numbers list-names"], map[string]map[string]interface{}{
+			"default": {
+				"names": []string{"alice", "bob", "charlie"},
+			},
+		})
+		require.Len(t, rows, 3)
+		require.Equal(t, "alice", rows[0]["name"])
+		require.Equal(t, "charlie", rows[2]["name"])
+	})
+
+	t.Run("relative require helper", func(t *testing.T) {
+		rows := runCommand(t, commandMap["nested with-helper render"], map[string]map[string]interface{}{
+			"default": {
+				"prefix": "repo",
+				"target": "glazed",
+			},
+		})
+		require.Equal(t, "repo:glazed", rows[0]["value"])
+	})
+
+	t.Run("package metadata auto expose", func(t *testing.T) {
+		rows := runCommand(t, commandMap["meta pkg-demo ping"], nil)
+		require.Equal(t, true, rows[0]["ok"])
+	})
+}
+
+func mustRegistry(t *testing.T) *Registry {
+	t.Helper()
+	registry, err := ScanDir(filepath.Join(repoRoot(t), "testdata", "jsverbs"))
+	require.NoError(t, err)
+	return registry
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	require.NoError(t, err)
+	return root
+}
+
+func mustCommandMap(t *testing.T, registry *Registry) map[string]cmds.Command {
+	t.Helper()
+	commands, err := registry.Commands()
+	require.NoError(t, err)
+	ret := map[string]cmds.Command{}
+	for i, command := range commands {
+		ret[registry.Verbs()[i].FullPath()] = command
+	}
+	return ret
+}
+
+func runCommand(t *testing.T, command cmds.Command, valuesBySection map[string]map[string]interface{}) []map[string]interface{} {
+	t.Helper()
+	parsedValues, err := runner.ParseCommandValues(command, runner.WithValuesForSections(valuesBySection))
+	require.NoError(t, err)
+
+	glazeCommand, ok := command.(cmds.GlazeCommand)
+	require.True(t, ok)
+
+	gp := &captureProcessor{}
+	err = glazeCommand.RunIntoGlazeProcessor(context.Background(), parsedValues, gp)
+	require.NoError(t, err)
+	err = gp.Close(context.Background())
+	require.NoError(t, err)
+
+	rows := make([]map[string]interface{}, 0, len(gp.rows))
+	for _, row := range gp.rows {
+		rows = append(rows, rowToMap(row))
+	}
+	return rows
+}
+
+func runWriterCommand(t *testing.T, command cmds.Command, valuesBySection map[string]map[string]interface{}) string {
+	t.Helper()
+	parsedValues, err := runner.ParseCommandValues(command, runner.WithValuesForSections(valuesBySection))
+	require.NoError(t, err)
+
+	writerCommand, ok := command.(cmds.WriterCommand)
+	require.True(t, ok)
+
+	var b strings.Builder
+	err = writerCommand.RunIntoWriter(context.Background(), parsedValues, &b)
+	require.NoError(t, err)
+	return b.String()
+}
+
+func rowToMap(row types.Row) map[string]interface{} {
+	ret := map[string]interface{}{}
+	for pair := row.Oldest(); pair != nil; pair = pair.Next() {
+		ret[pair.Key] = pair.Value
+	}
+	return ret
+}
+
+type captureProcessor struct {
+	rows []types.Row
+}
+
+func (c *captureProcessor) AddRow(_ context.Context, row types.Row) error {
+	c.rows = append(c.rows, row)
+	return nil
+}
+
+func (c *captureProcessor) Close(context.Context) error {
+	return nil
+}

--- a/pkg/jsverbs/model.go
+++ b/pkg/jsverbs/model.go
@@ -16,31 +16,76 @@ const (
 	ParameterUnknown    ParameterKind = "unknown"
 )
 
+type DiagnosticSeverity string
+
+const (
+	DiagnosticSeverityWarning DiagnosticSeverity = "warning"
+	DiagnosticSeverityError   DiagnosticSeverity = "error"
+)
+
+type Diagnostic struct {
+	Severity DiagnosticSeverity
+	Path     string
+	Symbol   string
+	Message  string
+}
+
+type ScanError struct {
+	Diagnostics []Diagnostic
+}
+
+func (e *ScanError) Error() string {
+	if e == nil || len(e.Diagnostics) == 0 {
+		return "jsverbs scan failed"
+	}
+	parts := make([]string, 0, len(e.Diagnostics))
+	for _, diagnostic := range e.Diagnostics {
+		location := diagnostic.Path
+		if diagnostic.Symbol != "" {
+			location += "#" + diagnostic.Symbol
+		}
+		if location == "" {
+			location = "jsverbs"
+		}
+		parts = append(parts, fmt.Sprintf("%s: %s", location, diagnostic.Message))
+	}
+	return strings.Join(parts, "; ")
+}
+
 type ScanOptions struct {
 	IncludePublicFunctions bool
 	Extensions             []string
+	FailOnErrorDiagnostics bool
 }
 
 func DefaultScanOptions() ScanOptions {
 	return ScanOptions{
 		IncludePublicFunctions: true,
 		Extensions:             []string{".js", ".cjs"},
+		FailOnErrorDiagnostics: true,
 	}
 }
 
+type SourceFile struct {
+	Path   string
+	Source []byte
+}
+
 type Registry struct {
-	RootDir    string
-	Files      []*FileSpec
-	verbs      []*VerbSpec
-	verbsByKey map[string]*VerbSpec
-	filesByAbs map[string]*FileSpec
-	options    ScanOptions
+	RootDir       string
+	Files         []*FileSpec
+	Diagnostics   []Diagnostic
+	verbs         []*VerbSpec
+	verbsByKey    map[string]*VerbSpec
+	filesByModule map[string]*FileSpec
+	options       ScanOptions
 }
 
 type FileSpec struct {
 	AbsPath        string
 	RelPath        string
 	ModulePath     string
+	Source         []byte
 	Package        PackageSpec
 	Functions      []*FunctionSpec
 	functionByName map[string]*FunctionSpec
@@ -118,6 +163,16 @@ func (r *Registry) Verbs() []*VerbSpec {
 func (r *Registry) Verb(fullPath string) (*VerbSpec, bool) {
 	v, ok := r.verbsByKey[fullPath]
 	return v, ok
+}
+
+func (r *Registry) ErrorDiagnostics() []Diagnostic {
+	ret := []Diagnostic{}
+	for _, diagnostic := range r.Diagnostics {
+		if diagnostic.Severity == DiagnosticSeverityError {
+			ret = append(ret, diagnostic)
+		}
+	}
+	return ret
 }
 
 func (v *VerbSpec) FullPath() string {

--- a/pkg/jsverbs/model.go
+++ b/pkg/jsverbs/model.go
@@ -1,0 +1,228 @@
+package jsverbs
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+type ParameterKind string
+
+const (
+	ParameterIdentifier ParameterKind = "identifier"
+	ParameterObject     ParameterKind = "object"
+	ParameterArray      ParameterKind = "array"
+	ParameterUnknown    ParameterKind = "unknown"
+)
+
+type ScanOptions struct {
+	IncludePublicFunctions bool
+	Extensions             []string
+}
+
+func DefaultScanOptions() ScanOptions {
+	return ScanOptions{
+		IncludePublicFunctions: true,
+		Extensions:             []string{".js", ".cjs"},
+	}
+}
+
+type Registry struct {
+	RootDir    string
+	Files      []*FileSpec
+	verbs      []*VerbSpec
+	verbsByKey map[string]*VerbSpec
+	filesByAbs map[string]*FileSpec
+	options    ScanOptions
+}
+
+type FileSpec struct {
+	AbsPath        string
+	RelPath        string
+	ModulePath     string
+	Package        PackageSpec
+	Functions      []*FunctionSpec
+	functionByName map[string]*FunctionSpec
+	SectionOrder   []string
+	Sections       map[string]*SectionSpec
+	VerbMeta       map[string]*VerbSpec
+	Docs           map[string]string
+}
+
+type PackageSpec struct {
+	Name    string
+	Short   string
+	Long    string
+	Parents []string
+	Tags    []string
+}
+
+type FunctionSpec struct {
+	Name   string
+	Params []ParameterSpec
+	Doc    string
+}
+
+type ParameterSpec struct {
+	Name string
+	Kind ParameterKind
+	Rest bool
+}
+
+type SectionSpec struct {
+	Slug        string
+	Title       string
+	Description string
+	Fields      map[string]*FieldSpec
+}
+
+type FieldSpec struct {
+	Name     string
+	Type     string
+	Help     string
+	Short    string
+	Bind     string
+	Section  string
+	Default  interface{}
+	Choices  []string
+	Required bool
+	Argument bool
+}
+
+type VerbSpec struct {
+	FunctionName string
+	Name         string
+	Short        string
+	Long         string
+	OutputMode   string
+	Parents      []string
+	Tags         []string
+	UseSections  []string
+	Fields       map[string]*FieldSpec
+	File         *FileSpec
+	Params       []ParameterSpec
+}
+
+const (
+	OutputModeGlaze = "glaze"
+	OutputModeText  = "text"
+)
+
+func (r *Registry) Verbs() []*VerbSpec {
+	ret := make([]*VerbSpec, 0, len(r.verbs))
+	ret = append(ret, r.verbs...)
+	return ret
+}
+
+func (r *Registry) Verb(fullPath string) (*VerbSpec, bool) {
+	v, ok := r.verbsByKey[fullPath]
+	return v, ok
+}
+
+func (v *VerbSpec) FullPath() string {
+	if len(v.Parents) == 0 {
+		return v.Name
+	}
+	return strings.Join(append(append([]string{}, v.Parents...), v.Name), " ")
+}
+
+func (v *VerbSpec) SourceRef() string {
+	if v == nil || v.File == nil {
+		return ""
+	}
+	return fmt.Sprintf("%s#%s", v.File.RelPath, v.FunctionName)
+}
+
+func (v *VerbSpec) Field(name string) *FieldSpec {
+	if v == nil || v.Fields == nil {
+		return nil
+	}
+	if field, ok := v.Fields[name]; ok {
+		return field
+	}
+	return nil
+}
+
+func (f *FieldSpec) Clone() *FieldSpec {
+	if f == nil {
+		return nil
+	}
+	ret := *f
+	ret.Choices = append([]string{}, f.Choices...)
+	return &ret
+}
+
+func (s *SectionSpec) Clone() *SectionSpec {
+	if s == nil {
+		return nil
+	}
+	ret := &SectionSpec{
+		Slug:        s.Slug,
+		Title:       s.Title,
+		Description: s.Description,
+		Fields:      map[string]*FieldSpec{},
+	}
+	fieldNames := make([]string, 0, len(s.Fields))
+	for name := range s.Fields {
+		fieldNames = append(fieldNames, name)
+	}
+	sort.Strings(fieldNames)
+	for _, name := range fieldNames {
+		ret.Fields[name] = s.Fields[name].Clone()
+	}
+	return ret
+}
+
+func cleanCommandWord(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	return kebabCase(s)
+}
+
+func kebabCase(s string) string {
+	s = filepath.ToSlash(strings.TrimSpace(s))
+	if s == "" {
+		return ""
+	}
+	var out []rune
+	var prevLower bool
+	for i, r := range s {
+		switch {
+		case r == '/' || r == '_' || r == ' ':
+			if len(out) > 0 && out[len(out)-1] != '-' {
+				out = append(out, '-')
+			}
+			prevLower = false
+		case r >= 'A' && r <= 'Z':
+			if i > 0 && prevLower && out[len(out)-1] != '-' {
+				out = append(out, '-')
+			}
+			out = append(out, r+'a'-'A')
+			prevLower = false
+		default:
+			out = append(out, r)
+			prevLower = (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')
+		}
+	}
+	return strings.Trim(strings.ReplaceAll(string(out), "--", "-"), "-")
+}
+
+func dedupeStrings(items []string) []string {
+	seen := map[string]struct{}{}
+	ret := make([]string, 0, len(items))
+	for _, item := range items {
+		item = cleanCommandWord(item)
+		if item == "" {
+			continue
+		}
+		if _, ok := seen[item]; ok {
+			continue
+		}
+		seen[item] = struct{}{}
+		ret = append(ret, item)
+	}
+	return ret
+}

--- a/pkg/jsverbs/runtime.go
+++ b/pkg/jsverbs/runtime.go
@@ -1,0 +1,300 @@
+package jsverbs
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/dop251/goja"
+	"github.com/dop251/goja_nodejs/require"
+	"github.com/go-go-golems/glazed/pkg/cmds/fields"
+	"github.com/go-go-golems/glazed/pkg/cmds/schema"
+	"github.com/go-go-golems/glazed/pkg/cmds/values"
+	"github.com/go-go-golems/go-go-goja/engine"
+)
+
+func (r *Registry) invoke(ctx context.Context, verb *VerbSpec, parsedValues *values.Values) (interface{}, error) {
+	factory, err := engine.NewBuilder().
+		WithRequireOptions(require.WithLoader(r.sourceLoader)).
+		WithModules(engine.DefaultRegistryModules()).
+		Build()
+	if err != nil {
+		return nil, err
+	}
+
+	runtime, err := factory.NewRuntime(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = runtime.Close(context.Background())
+	}()
+
+	args, err := buildArguments(parsedValues, verb, r.RootDir)
+	if err != nil {
+		return nil, err
+	}
+
+	ret, err := runtime.Owner.Call(ctx, "jsverbs.invoke", func(_ context.Context, vm *goja.Runtime) (interface{}, error) {
+		if _, err := runtime.Require.Require(verb.File.ModulePath); err != nil {
+			return nil, err
+		}
+		registryValue := vm.Get("__glazedVerbRegistry")
+		if registryValue == nil || goja.IsUndefined(registryValue) || goja.IsNull(registryValue) {
+			return nil, fmt.Errorf("js verb registry not initialized")
+		}
+		registryObject := registryValue.ToObject(vm)
+		entryValue := registryObject.Get(verb.File.ModulePath)
+		if entryValue == nil || goja.IsUndefined(entryValue) || goja.IsNull(entryValue) {
+			return nil, fmt.Errorf("js verb module entry missing for %s", verb.File.ModulePath)
+		}
+		entryObject := entryValue.ToObject(vm)
+		fnValue := entryObject.Get(verb.FunctionName)
+		fn, ok := goja.AssertFunction(fnValue)
+		if !ok {
+			return nil, fmt.Errorf("js function %s not captured for %s", verb.FunctionName, verb.File.RelPath)
+		}
+		jsArgs := make([]goja.Value, 0, len(args))
+		for _, arg := range args {
+			jsArgs = append(jsArgs, vm.ToValue(arg))
+		}
+		result, err := fn(goja.Undefined(), jsArgs...)
+		if err != nil {
+			return nil, err
+		}
+		if result == nil || goja.IsUndefined(result) || goja.IsNull(result) {
+			return nil, nil
+		}
+		if promise, ok := result.Export().(*goja.Promise); ok {
+			return promise, nil
+		}
+		return result.Export(), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if promise, ok := ret.(*goja.Promise); ok {
+		return waitForPromise(ctx, runtime, promise)
+	}
+	return ret, nil
+}
+
+func buildArguments(parsedValues *values.Values, verb *VerbSpec, rootDir string) ([]interface{}, error) {
+	sectionValues := map[string]map[string]interface{}{}
+	if parsedValues == nil {
+		parsedValues = values.New()
+	}
+	allValues := parsedValues.GetDataMap()
+
+	parsedValues.ForEach(func(slug string, value *values.SectionValues) {
+		sectionMap := map[string]interface{}{}
+		value.Fields.ForEach(func(_ string, fieldValue *fields.FieldValue) {
+			if fieldValue == nil || fieldValue.Definition == nil {
+				return
+			}
+			sectionMap[fieldValue.Definition.Name] = fieldValue.Value
+		})
+		sectionValues[slug] = sectionMap
+	})
+
+	args := make([]interface{}, 0, len(verb.Params))
+	for _, param := range verb.Params {
+		field := verb.Field(param.Name)
+		if field == nil {
+			field = inferFieldFromParam(param)
+		}
+		if field != nil {
+			switch bind := strings.TrimSpace(field.Bind); bind {
+			case "all":
+				args = append(args, allValues)
+				continue
+			case "context":
+				args = append(args, map[string]interface{}{
+					"verb":       verb.FullPath(),
+					"function":   verb.FunctionName,
+					"module":     verb.File.ModulePath,
+					"sourceFile": verb.File.AbsPath,
+					"rootDir":    rootDir,
+					"values":     allValues,
+					"sections":   sectionValues,
+				})
+				continue
+			case "":
+			default:
+				slug := cleanCommandWord(bind)
+				args = append(args, cloneMap(sectionValues[slug]))
+				continue
+			}
+		}
+		if param.Kind != ParameterIdentifier && param.Kind != ParameterUnknown {
+			return nil, fmt.Errorf("%s parameter %q requires a bind", verb.SourceRef(), param.Name)
+		}
+		sectionSlug := schema.DefaultSlug
+		if field != nil && field.Section != "" {
+			sectionSlug = field.Section
+		}
+		value := sectionValues[sectionSlug][param.Name]
+		if param.Rest {
+			rv := reflect.ValueOf(value)
+			if rv.IsValid() && (rv.Kind() == reflect.Slice || rv.Kind() == reflect.Array) {
+				for i := 0; i < rv.Len(); i++ {
+					args = append(args, rv.Index(i).Interface())
+				}
+				continue
+			}
+		}
+		args = append(args, value)
+	}
+	return args, nil
+}
+
+func (r *Registry) sourceLoader(path string) ([]byte, error) {
+	absPath, err := resolveModulePath(r.RootDir, path)
+	if err != nil {
+		return nil, require.ModuleFileDoesNotExistError
+	}
+	src, err := os.ReadFile(absPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, require.ModuleFileDoesNotExistError
+		}
+		return nil, err
+	}
+	return []byte(r.injectOverlay(path, absPath, string(src))), nil
+}
+
+func (r *Registry) injectOverlay(moduleKey, absPath, source string) string {
+	file := r.filesByAbs[absPath]
+	functionNames := []string{}
+	if file != nil {
+		for _, fn := range file.Functions {
+			functionNames = append(functionNames, fn.Name)
+		}
+		sort.Strings(functionNames)
+	}
+
+	var suffix strings.Builder
+	suffix.WriteString("\n")
+	suffix.WriteString(`globalThis.__glazedVerbRegistry = globalThis.__glazedVerbRegistry || {};` + "\n")
+	suffix.WriteString(`globalThis.__glazedVerbRegistry["`)
+	suffix.WriteString(moduleKey)
+	suffix.WriteString(`"] = {`)
+	for i, name := range functionNames {
+		if i > 0 {
+			suffix.WriteString(",")
+		}
+		suffix.WriteString(name)
+		suffix.WriteString(`: typeof `)
+		suffix.WriteString(name)
+		suffix.WriteString(` === "function" ? `)
+		suffix.WriteString(name)
+		suffix.WriteString(` : undefined`)
+	}
+	suffix.WriteString("};\n")
+
+	prelude := strings.Join([]string{
+		`globalThis.__glazedVerbRegistry = globalThis.__glazedVerbRegistry || {};`,
+		`globalThis.__package__ = globalThis.__package__ || function() {};`,
+		`globalThis.__section__ = globalThis.__section__ || function() {};`,
+		`globalThis.__verb__ = globalThis.__verb__ || function() {};`,
+		`globalThis.doc = globalThis.doc || function() { return ""; };`,
+		"",
+	}, "\n")
+
+	return injectPrelude(source, prelude) + suffix.String()
+}
+
+func injectPrelude(source, prelude string) string {
+	trimmed := strings.TrimLeft(source, "\ufeff \t\r\n")
+	if strings.HasPrefix(trimmed, `"use strict";`) || strings.HasPrefix(trimmed, `'use strict';`) {
+		if idx := strings.Index(source, "\n"); idx >= 0 {
+			return source[:idx+1] + prelude + source[idx+1:]
+		}
+	}
+	return prelude + source
+}
+
+func resolveModulePath(rootDir, modulePath string) (string, error) {
+	modulePath = filepath.FromSlash(strings.TrimSpace(modulePath))
+	if modulePath == "" {
+		return "", fmt.Errorf("module path is empty")
+	}
+	candidates := []string{}
+	if filepath.IsAbs(modulePath) {
+		candidates = append(candidates, modulePath)
+	} else {
+		candidates = append(candidates, filepath.Join(rootDir, modulePath))
+	}
+
+	expanded := []string{}
+	for _, candidate := range candidates {
+		expanded = append(expanded, candidate)
+		expanded = append(expanded, candidate+".js", candidate+".cjs")
+		expanded = append(expanded, filepath.Join(candidate, "index.js"))
+		expanded = append(expanded, filepath.Join(candidate, "index.cjs"))
+	}
+	for _, candidate := range expanded {
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("module %s not found", modulePath)
+}
+
+func waitForPromise(ctx context.Context, runtime *engine.Runtime, promise *goja.Promise) (interface{}, error) {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		ret, err := runtime.Owner.Call(ctx, "jsverbs.promise-state", func(_ context.Context, vm *goja.Runtime) (interface{}, error) {
+			return promiseSnapshot{
+				State:  promise.State(),
+				Result: promise.Result(),
+			}, nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		snapshot := ret.(promiseSnapshot)
+		switch snapshot.State {
+		case goja.PromiseStatePending:
+			time.Sleep(5 * time.Millisecond)
+		case goja.PromiseStateRejected:
+			return nil, fmt.Errorf("promise rejected: %s", valueString(snapshot.Result))
+		case goja.PromiseStateFulfilled:
+			if snapshot.Result == nil || goja.IsUndefined(snapshot.Result) || goja.IsNull(snapshot.Result) {
+				return nil, nil
+			}
+			return snapshot.Result.Export(), nil
+		}
+	}
+}
+
+type promiseSnapshot struct {
+	State  goja.PromiseState
+	Result goja.Value
+}
+
+func valueString(value goja.Value) string {
+	if value == nil || goja.IsUndefined(value) || goja.IsNull(value) {
+		return "undefined"
+	}
+	return value.String()
+}
+
+func cloneMap(in map[string]interface{}) map[string]interface{} {
+	out := map[string]interface{}{}
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}

--- a/pkg/jsverbs/runtime.go
+++ b/pkg/jsverbs/runtime.go
@@ -3,8 +3,6 @@ package jsverbs
 import (
 	"context"
 	"fmt"
-	"os"
-	"path/filepath"
 	"reflect"
 	"sort"
 	"strings"
@@ -13,7 +11,6 @@ import (
 	"github.com/dop251/goja"
 	"github.com/dop251/goja_nodejs/require"
 	"github.com/go-go-golems/glazed/pkg/cmds/fields"
-	"github.com/go-go-golems/glazed/pkg/cmds/schema"
 	"github.com/go-go-golems/glazed/pkg/cmds/values"
 	"github.com/go-go-golems/go-go-goja/engine"
 )
@@ -35,7 +32,11 @@ func (r *Registry) invoke(ctx context.Context, verb *VerbSpec, parsedValues *val
 		_ = runtime.Close(context.Background())
 	}()
 
-	args, err := buildArguments(parsedValues, verb, r.RootDir)
+	plan, err := buildVerbBindingPlan(verb)
+	if err != nil {
+		return nil, err
+	}
+	args, err := buildArguments(parsedValues, plan, r.RootDir)
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +86,7 @@ func (r *Registry) invoke(ctx context.Context, verb *VerbSpec, parsedValues *val
 	return ret, nil
 }
 
-func buildArguments(parsedValues *values.Values, verb *VerbSpec, rootDir string) ([]interface{}, error) {
+func buildArguments(parsedValues *values.Values, plan *VerbBindingPlan, rootDir string) ([]interface{}, error) {
 	sectionValues := map[string]map[string]interface{}{}
 	if parsedValues == nil {
 		parsedValues = values.New()
@@ -103,74 +104,54 @@ func buildArguments(parsedValues *values.Values, verb *VerbSpec, rootDir string)
 		sectionValues[slug] = sectionMap
 	})
 
-	args := make([]interface{}, 0, len(verb.Params))
-	for _, param := range verb.Params {
-		field := verb.Field(param.Name)
-		if field == nil {
-			field = inferFieldFromParam(param)
-		}
-		if field != nil {
-			switch bind := strings.TrimSpace(field.Bind); bind {
-			case "all":
-				args = append(args, allValues)
-				continue
-			case "context":
-				args = append(args, map[string]interface{}{
-					"verb":       verb.FullPath(),
-					"function":   verb.FunctionName,
-					"module":     verb.File.ModulePath,
-					"sourceFile": verb.File.AbsPath,
-					"rootDir":    rootDir,
-					"values":     allValues,
-					"sections":   sectionValues,
-				})
-				continue
-			case "":
-			default:
-				slug := cleanCommandWord(bind)
-				args = append(args, cloneMap(sectionValues[slug]))
-				continue
-			}
-		}
-		if param.Kind != ParameterIdentifier && param.Kind != ParameterUnknown {
-			return nil, fmt.Errorf("%s parameter %q requires a bind", verb.SourceRef(), param.Name)
-		}
-		sectionSlug := schema.DefaultSlug
-		if field != nil && field.Section != "" {
-			sectionSlug = field.Section
-		}
-		value := sectionValues[sectionSlug][param.Name]
-		if param.Rest {
-			rv := reflect.ValueOf(value)
-			if rv.IsValid() && (rv.Kind() == reflect.Slice || rv.Kind() == reflect.Array) {
-				for i := 0; i < rv.Len(); i++ {
-					args = append(args, rv.Index(i).Interface())
+	args := make([]interface{}, 0, len(plan.Parameters))
+	for _, binding := range plan.Parameters {
+		switch binding.Mode {
+		case BindingModeAll:
+			args = append(args, allValues)
+			continue
+		case BindingModeContext:
+			args = append(args, map[string]interface{}{
+				"verb":       plan.Verb.FullPath(),
+				"function":   plan.Verb.FunctionName,
+				"module":     plan.Verb.File.ModulePath,
+				"sourceFile": fileSourcePath(plan.Verb.File),
+				"rootDir":    rootDir,
+				"values":     allValues,
+				"sections":   sectionValues,
+			})
+			continue
+		case BindingModeSection:
+			args = append(args, cloneMap(sectionValues[binding.SectionSlug]))
+			continue
+		case BindingModePositional:
+			value := sectionValues[binding.SectionSlug][binding.Field.Name]
+			if binding.Param.Rest {
+				rv := reflect.ValueOf(value)
+				if rv.IsValid() && (rv.Kind() == reflect.Slice || rv.Kind() == reflect.Array) {
+					for i := 0; i < rv.Len(); i++ {
+						args = append(args, rv.Index(i).Interface())
+					}
+					continue
 				}
-				continue
 			}
+			args = append(args, value)
+		default:
+			return nil, fmt.Errorf("%s parameter %q has unsupported binding mode %q", plan.Verb.SourceRef(), binding.Param.Name, binding.Mode)
 		}
-		args = append(args, value)
 	}
 	return args, nil
 }
 
-func (r *Registry) sourceLoader(path string) ([]byte, error) {
-	absPath, err := resolveModulePath(r.RootDir, path)
-	if err != nil {
+func (r *Registry) sourceLoader(modulePath string) ([]byte, error) {
+	file := r.filesByModule[modulePath]
+	if file == nil {
 		return nil, require.ModuleFileDoesNotExistError
 	}
-	src, err := os.ReadFile(absPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, require.ModuleFileDoesNotExistError
-		}
-		return nil, err
-	}
-	return []byte(r.injectOverlay(path, absPath, string(src))), nil
+	return []byte(r.injectOverlay(modulePath, file, string(file.Source))), nil
 }
 
-func (r *Registry) injectOverlay(moduleKey, absPath, source string) string {
-	file := r.filesByAbs[absPath]
+func (r *Registry) injectOverlay(moduleKey string, file *FileSpec, source string) string {
 	functionNames := []string{}
 	if file != nil {
 		for _, fn := range file.Functions {
@@ -220,33 +201,9 @@ func injectPrelude(source, prelude string) string {
 	return prelude + source
 }
 
-func resolveModulePath(rootDir, modulePath string) (string, error) {
-	modulePath = filepath.FromSlash(strings.TrimSpace(modulePath))
-	if modulePath == "" {
-		return "", fmt.Errorf("module path is empty")
-	}
-	candidates := []string{}
-	if filepath.IsAbs(modulePath) {
-		candidates = append(candidates, modulePath)
-	} else {
-		candidates = append(candidates, filepath.Join(rootDir, modulePath))
-	}
-
-	expanded := []string{}
-	for _, candidate := range candidates {
-		expanded = append(expanded, candidate)
-		expanded = append(expanded, candidate+".js", candidate+".cjs")
-		expanded = append(expanded, filepath.Join(candidate, "index.js"))
-		expanded = append(expanded, filepath.Join(candidate, "index.cjs"))
-	}
-	for _, candidate := range expanded {
-		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
-			return candidate, nil
-		}
-	}
-	return "", fmt.Errorf("module %s not found", modulePath)
-}
-
+// waitForPromise intentionally uses polling for v1. It is simple, explicit, and
+// good enough for the current prototype, but should not be mistaken for the final
+// async bridge design.
 func waitForPromise(ctx context.Context, runtime *engine.Runtime, promise *goja.Promise) (interface{}, error) {
 	for {
 		select {
@@ -297,4 +254,14 @@ func cloneMap(in map[string]interface{}) map[string]interface{} {
 		out[key] = value
 	}
 	return out
+}
+
+func fileSourcePath(file *FileSpec) string {
+	if file == nil {
+		return ""
+	}
+	if file.AbsPath != "" {
+		return file.AbsPath
+	}
+	return file.RelPath
 }

--- a/pkg/jsverbs/scan.go
+++ b/pkg/jsverbs/scan.go
@@ -24,6 +24,13 @@ func ScanDir(root string, opts ...ScanOptions) (*Registry, error) {
 	if err != nil {
 		return nil, fmt.Errorf("resolve root: %w", err)
 	}
+	rootHandle, err := os.OpenRoot(absRoot)
+	if err != nil {
+		return nil, fmt.Errorf("open root %s: %w", absRoot, err)
+	}
+	defer func() {
+		_ = rootHandle.Close()
+	}()
 
 	inputs := []sourceInput{}
 	err = filepath.WalkDir(absRoot, func(filePath string, d fs.DirEntry, walkErr error) error {
@@ -43,13 +50,13 @@ func ScanDir(root string, opts ...ScanOptions) (*Registry, error) {
 		if !supportsExtension(filePath, options.Extensions) {
 			return nil
 		}
-		source, err := os.ReadFile(filePath)
-		if err != nil {
-			return fmt.Errorf("read %s: %w", filePath, err)
-		}
 		relPath, err := filepath.Rel(absRoot, filePath)
 		if err != nil {
 			return fmt.Errorf("relpath %s: %w", filePath, err)
+		}
+		source, err := rootHandle.ReadFile(relPath)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", filePath, err)
 		}
 		inputs = append(inputs, sourceInput{
 			AbsPath:    filePath,
@@ -616,10 +623,10 @@ func (e *extractor) nodeText(node *tree_sitter.Node) string {
 	start := node.StartByte()
 	end := node.EndByte()
 	srcLen := uint(len(e.src))
-	if end < start || uint(start) > srcLen || uint(end) > srcLen {
+	if end < start || start > srcLen || end > srcLen {
 		return ""
 	}
-	return string(e.src[int(start):int(end)])
+	return string(e.src[start:end])
 }
 
 func (e *extractor) templateRawText(tmplNode *tree_sitter.Node) string {

--- a/pkg/jsverbs/scan.go
+++ b/pkg/jsverbs/scan.go
@@ -1,0 +1,833 @@
+package jsverbs
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/pkg/errors"
+	tree_sitter "github.com/tree-sitter/go-tree-sitter"
+	tree_sitter_javascript "github.com/tree-sitter/tree-sitter-javascript/bindings/go"
+)
+
+func ScanDir(root string, opts ...ScanOptions) (*Registry, error) {
+	options := DefaultScanOptions()
+	if len(opts) > 0 {
+		options = opts[0]
+	}
+
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return nil, errors.Wrap(err, "resolve root")
+	}
+
+	registry := &Registry{
+		RootDir:    absRoot,
+		Files:      []*FileSpec{},
+		verbsByKey: map[string]*VerbSpec{},
+		filesByAbs: map[string]*FileSpec{},
+		options:    options,
+	}
+
+	err = filepath.WalkDir(absRoot, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		name := d.Name()
+		if d.IsDir() {
+			if name == "node_modules" || strings.HasPrefix(name, ".") {
+				if path == absRoot {
+					return nil
+				}
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !supportsExtension(path, options.Extensions) {
+			return nil
+		}
+		file, err := scanFile(absRoot, path, options)
+		if err != nil {
+			return err
+		}
+		if file == nil {
+			return nil
+		}
+		registry.Files = append(registry.Files, file)
+		registry.filesByAbs[file.AbsPath] = file
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Slice(registry.Files, func(i, j int) bool {
+		return registry.Files[i].RelPath < registry.Files[j].RelPath
+	})
+
+	if err := registry.finalizeVerbs(); err != nil {
+		return nil, err
+	}
+
+	return registry, nil
+}
+
+func supportsExtension(path string, extensions []string) bool {
+	ext := strings.ToLower(filepath.Ext(path))
+	for _, candidate := range extensions {
+		if strings.EqualFold(ext, candidate) {
+			return true
+		}
+	}
+	return false
+}
+
+func scanFile(rootDir, absPath string, options ScanOptions) (*FileSpec, error) {
+	src, err := os.ReadFile(absPath)
+	if err != nil {
+		return nil, errors.Wrapf(err, "read %s", absPath)
+	}
+	relPath, err := filepath.Rel(rootDir, absPath)
+	if err != nil {
+		return nil, errors.Wrapf(err, "relpath %s", absPath)
+	}
+	relPath = filepath.ToSlash(relPath)
+	modulePath := filepath.ToSlash(absPath)
+
+	parser := tree_sitter.NewParser()
+	defer parser.Close()
+	lang := tree_sitter.NewLanguage(tree_sitter_javascript.Language())
+	if err := parser.SetLanguage(lang); err != nil {
+		return nil, errors.Wrap(err, "set javascript language")
+	}
+
+	tree := parser.Parse(src, nil)
+	if tree == nil {
+		return nil, fmt.Errorf("parse %s: nil tree", relPath)
+	}
+	defer tree.Close()
+
+	file := &FileSpec{
+		AbsPath:        absPath,
+		RelPath:        relPath,
+		ModulePath:     modulePath,
+		Functions:      []*FunctionSpec{},
+		functionByName: map[string]*FunctionSpec{},
+		SectionOrder:   []string{},
+		Sections:       map[string]*SectionSpec{},
+		VerbMeta:       map[string]*VerbSpec{},
+		Docs:           map[string]string{},
+	}
+	e := &extractor{
+		src:     src,
+		path:    absPath,
+		relPath: relPath,
+		options: options,
+		file:    file,
+	}
+	e.extract(tree.RootNode())
+	return file, nil
+}
+
+func (r *Registry) finalizeVerbs() error {
+	for _, file := range r.Files {
+		for _, fn := range file.Functions {
+			if doc, ok := file.Docs[fn.Name]; ok && strings.TrimSpace(fn.Doc) == "" {
+				fn.Doc = strings.TrimSpace(doc)
+			}
+		}
+
+		explicitNames := make([]string, 0, len(file.VerbMeta))
+		for name := range file.VerbMeta {
+			explicitNames = append(explicitNames, name)
+		}
+		sort.Strings(explicitNames)
+
+		for _, functionName := range explicitNames {
+			verb := file.VerbMeta[functionName]
+			if err := r.finalizeVerb(file, verb); err != nil {
+				return err
+			}
+		}
+
+		if !r.options.IncludePublicFunctions {
+			continue
+		}
+		for _, fn := range file.Functions {
+			if strings.HasPrefix(fn.Name, "_") {
+				continue
+			}
+			if _, ok := file.VerbMeta[fn.Name]; ok {
+				continue
+			}
+			verb := &VerbSpec{
+				FunctionName: fn.Name,
+				Fields:       map[string]*FieldSpec{},
+				OutputMode:   OutputModeGlaze,
+			}
+			if err := r.finalizeVerb(file, verb); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (r *Registry) finalizeVerb(file *FileSpec, verb *VerbSpec) error {
+	fn, ok := file.functionByName[verb.FunctionName]
+	if !ok {
+		return fmt.Errorf("%s references unknown function %q", file.RelPath, verb.FunctionName)
+	}
+
+	verb.File = file
+	verb.Params = append([]ParameterSpec{}, fn.Params...)
+	if verb.Fields == nil {
+		verb.Fields = map[string]*FieldSpec{}
+	}
+	if verb.OutputMode == "" {
+		verb.OutputMode = OutputModeGlaze
+	}
+	if verb.Name == "" {
+		verb.Name = cleanCommandWord(fn.Name)
+	}
+	if verb.Name == "" {
+		return fmt.Errorf("%s function %q resolved to empty command name", file.RelPath, fn.Name)
+	}
+	if len(verb.Parents) == 0 {
+		verb.Parents = defaultParentsForFile(file)
+	} else {
+		verb.Parents = dedupeStrings(verb.Parents)
+	}
+	if strings.TrimSpace(verb.Long) == "" && strings.TrimSpace(fn.Doc) != "" {
+		verb.Long = strings.TrimSpace(fn.Doc)
+	}
+	if strings.TrimSpace(verb.Short) == "" {
+		verb.Short = fmt.Sprintf("Run %s from %s", fn.Name, file.RelPath)
+	}
+	verb.Tags = dedupeStrings(verb.Tags)
+	verb.UseSections = dedupeStrings(verb.UseSections)
+
+	fullPath := verb.FullPath()
+	if _, exists := r.verbsByKey[fullPath]; exists {
+		return fmt.Errorf("duplicate js verb path %q (%s)", fullPath, verb.SourceRef())
+	}
+	r.verbs = append(r.verbs, verb)
+	r.verbsByKey[fullPath] = verb
+	return nil
+}
+
+func defaultParentsForFile(file *FileSpec) []string {
+	parents := append([]string{}, file.Package.Parents...)
+	dir := filepath.Dir(file.RelPath)
+	if dir != "." {
+		for _, part := range strings.Split(filepath.ToSlash(dir), "/") {
+			part = cleanCommandWord(part)
+			if part != "" {
+				parents = append(parents, part)
+			}
+		}
+	}
+	group := file.Package.Name
+	if strings.TrimSpace(group) == "" {
+		base := strings.TrimSuffix(filepath.Base(file.RelPath), filepath.Ext(file.RelPath))
+		if base != "index" || len(parents) == 0 {
+			group = base
+		}
+	}
+	if group != "" {
+		parents = append(parents, group)
+	}
+	return dedupeStrings(parents)
+}
+
+type extractor struct {
+	src     []byte
+	path    string
+	relPath string
+	options ScanOptions
+	file    *FileSpec
+}
+
+func (e *extractor) extract(root *tree_sitter.Node) {
+	count := int(root.ChildCount())
+	for i := 0; i < count; i++ {
+		e.processTopLevel(root.Child(uint(i)))
+	}
+}
+
+func (e *extractor) processTopLevel(node *tree_sitter.Node) {
+	if node == nil {
+		return
+	}
+	switch node.Kind() {
+	case "expression_statement":
+		e.processTopLevel(node.Child(0))
+	case "call_expression":
+		e.handleCallExpression(node)
+	case "function_declaration":
+		e.handleFunctionDeclaration(node)
+	case "lexical_declaration", "variable_declaration", "export_statement":
+		count := int(node.ChildCount())
+		for i := 0; i < count; i++ {
+			e.processTopLevel(node.Child(uint(i)))
+		}
+	case "variable_declarator":
+		e.handleVariableDeclarator(node)
+	}
+}
+
+func (e *extractor) handleFunctionDeclaration(node *tree_sitter.Node) {
+	nameNode := node.ChildByFieldName("name")
+	if nameNode == nil || nameNode.Kind() != "identifier" {
+		return
+	}
+	e.addFunction(e.nodeText(nameNode), extractParameters(node, e.nodeText))
+}
+
+func (e *extractor) handleVariableDeclarator(node *tree_sitter.Node) {
+	nameNode := node.ChildByFieldName("name")
+	valueNode := node.ChildByFieldName("value")
+	if nameNode == nil || valueNode == nil || nameNode.Kind() != "identifier" {
+		return
+	}
+	switch valueNode.Kind() {
+	case "arrow_function", "function":
+		e.addFunction(e.nodeText(nameNode), extractParameters(valueNode, e.nodeText))
+	}
+}
+
+func (e *extractor) addFunction(name string, params []ParameterSpec) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return
+	}
+	if _, ok := e.file.functionByName[name]; ok {
+		return
+	}
+	fn := &FunctionSpec{Name: name, Params: params}
+	e.file.Functions = append(e.file.Functions, fn)
+	e.file.functionByName[name] = fn
+}
+
+func (e *extractor) handleCallExpression(node *tree_sitter.Node) {
+	fnNode := node.ChildByFieldName("function")
+	if fnNode == nil {
+		return
+	}
+	fnName := e.nodeText(fnNode)
+	if fnName == "doc" {
+		e.handleDocTemplate(node)
+		return
+	}
+	argsNode := node.ChildByFieldName("arguments")
+	if argsNode == nil {
+		return
+	}
+	switch fnName {
+	case "__package__":
+		e.handlePackage(argsNode)
+	case "__section__":
+		e.handleSection(argsNode)
+	case "__verb__":
+		e.handleVerb(argsNode)
+	}
+}
+
+func (e *extractor) handlePackage(argsNode *tree_sitter.Node) {
+	objectArg := e.firstObjectArg(argsNode)
+	if objectArg == nil {
+		return
+	}
+	data := map[string]interface{}{}
+	if err := e.unmarshalObject(objectArg, &data); err != nil {
+		return
+	}
+	e.file.Package = PackageSpec{
+		Name:    stringValue(data["name"]),
+		Short:   stringValue(data["short"]),
+		Long:    stringValue(data["long"]),
+		Parents: stringSlice(data["parents"]),
+		Tags:    stringSlice(data["tags"]),
+	}
+}
+
+func (e *extractor) handleSection(argsNode *tree_sitter.Node) {
+	name, objectNode := e.namedObjectArgs(argsNode)
+	if objectNode == nil {
+		return
+	}
+	data := map[string]interface{}{}
+	if err := e.unmarshalObject(objectNode, &data); err != nil {
+		return
+	}
+	if name == "" {
+		name = stringValue(data["name"])
+	}
+	slug := cleanCommandWord(name)
+	if slug == "" {
+		return
+	}
+	section := &SectionSpec{
+		Slug:        slug,
+		Title:       stringFirst(data["title"], data["name"]),
+		Description: stringFirst(data["description"], data["help"]),
+		Fields:      parseFieldMap(data),
+	}
+	if section.Title == "" {
+		section.Title = slug
+	}
+	if _, ok := e.file.Sections[slug]; !ok {
+		e.file.SectionOrder = append(e.file.SectionOrder, slug)
+	}
+	e.file.Sections[slug] = section
+}
+
+func (e *extractor) handleVerb(argsNode *tree_sitter.Node) {
+	name, objectNode := e.namedObjectArgs(argsNode)
+	if objectNode == nil {
+		return
+	}
+	data := map[string]interface{}{}
+	if err := e.unmarshalObject(objectNode, &data); err != nil {
+		return
+	}
+	if name == "" {
+		name = stringFirst(data["function"], data["name"])
+	}
+	functionName := strings.TrimSpace(name)
+	if functionName == "" {
+		return
+	}
+
+	verb := &VerbSpec{
+		FunctionName: functionName,
+		Name:         cleanCommandWord(stringValue(data["command"])),
+		Short:        stringValue(data["short"]),
+		Long:         stringValue(data["long"]),
+		OutputMode:   normalizeOutputMode(stringFirst(data["output"], data["outputMode"], data["mode"])),
+		Parents:      stringSlice(data["parents"]),
+		Tags:         stringSlice(data["tags"]),
+		UseSections:  stringSlice(firstNonNil(data["sections"], data["useSections"])),
+		Fields:       parseFieldMap(data),
+	}
+	if verb.Name == "" {
+		verb.Name = cleanCommandWord(stringValue(data["name"]))
+	}
+	e.file.VerbMeta[functionName] = verb
+}
+
+func (e *extractor) handleDocTemplate(node *tree_sitter.Node) {
+	var templateNode *tree_sitter.Node
+	for i := 0; i < int(node.ChildCount()); i++ {
+		child := node.Child(uint(i))
+		if child.Kind() == "template_string" {
+			templateNode = child
+			break
+		}
+	}
+	if templateNode == nil {
+		return
+	}
+	frontmatter, body := splitFrontmatter(e.templateRawText(templateNode))
+	prose := strings.TrimSpace(body)
+	if prose == "" {
+		return
+	}
+	meta := parseFrontmatter(frontmatter)
+	target := strings.TrimSpace(firstString(meta["verb"], meta["symbol"]))
+	if target == "" {
+		return
+	}
+	e.file.Docs[target] = prose
+}
+
+func (e *extractor) namedObjectArgs(argsNode *tree_sitter.Node) (string, *tree_sitter.Node) {
+	args := e.collectArgs(argsNode)
+	switch len(args) {
+	case 1:
+		if args[0].Kind() == "object" {
+			return "", args[0]
+		}
+	case 2:
+		return strings.Trim(e.nodeText(args[0]), `"'`+"`"), args[1]
+	}
+	return "", nil
+}
+
+func (e *extractor) collectArgs(argsNode *tree_sitter.Node) []*tree_sitter.Node {
+	ret := []*tree_sitter.Node{}
+	for i := 0; i < int(argsNode.ChildCount()); i++ {
+		child := argsNode.Child(uint(i))
+		switch child.Kind() {
+		case ",", "(", ")", "comment":
+			continue
+		default:
+			ret = append(ret, child)
+		}
+	}
+	return ret
+}
+
+func (e *extractor) firstObjectArg(argsNode *tree_sitter.Node) *tree_sitter.Node {
+	for _, arg := range e.collectArgs(argsNode) {
+		if arg.Kind() == "object" {
+			return arg
+		}
+	}
+	return nil
+}
+
+func (e *extractor) unmarshalObject(node *tree_sitter.Node, dst interface{}) error {
+	raw := e.nodeText(node)
+	data := jsObjectToJSON(raw)
+	return json.Unmarshal([]byte(data), dst)
+}
+
+func (e *extractor) nodeText(node *tree_sitter.Node) string {
+	if node == nil {
+		return ""
+	}
+	start := int(node.StartByte())
+	end := int(node.EndByte())
+	if start < 0 || end < start || end > len(e.src) {
+		return ""
+	}
+	return string(e.src[start:end])
+}
+
+func (e *extractor) templateRawText(tmplNode *tree_sitter.Node) string {
+	text := e.nodeText(tmplNode)
+	text = strings.TrimPrefix(text, "`")
+	text = strings.TrimSuffix(text, "`")
+	return text
+}
+
+func extractParameters(node *tree_sitter.Node, textFn func(*tree_sitter.Node) string) []ParameterSpec {
+	if node == nil {
+		return nil
+	}
+	if paramsNode := node.ChildByFieldName("parameters"); paramsNode != nil {
+		return collectParameterNodes(paramsNode, textFn)
+	}
+	if paramNode := node.ChildByFieldName("parameter"); paramNode != nil {
+		return []ParameterSpec{parseParameterNode(paramNode, textFn)}
+	}
+	return nil
+}
+
+func collectParameterNodes(paramsNode *tree_sitter.Node, textFn func(*tree_sitter.Node) string) []ParameterSpec {
+	params := []ParameterSpec{}
+	for i := 0; i < int(paramsNode.ChildCount()); i++ {
+		child := paramsNode.Child(uint(i))
+		switch child.Kind() {
+		case ",", "(", ")", "comment":
+			continue
+		default:
+			params = append(params, parseParameterNode(child, textFn))
+		}
+	}
+	return params
+}
+
+func parseParameterNode(node *tree_sitter.Node, textFn func(*tree_sitter.Node) string) ParameterSpec {
+	if node == nil {
+		return ParameterSpec{}
+	}
+	switch node.Kind() {
+	case "identifier":
+		return ParameterSpec{Name: textFn(node), Kind: ParameterIdentifier}
+	case "rest_pattern":
+		argument := node.ChildByFieldName("argument")
+		if argument == nil && node.NamedChildCount() > 0 {
+			argument = node.NamedChild(0)
+		}
+		param := parseParameterNode(argument, textFn)
+		param.Rest = true
+		return param
+	case "assignment_pattern":
+		left := node.ChildByFieldName("left")
+		if left == nil && node.NamedChildCount() > 0 {
+			left = node.NamedChild(0)
+		}
+		return parseParameterNode(left, textFn)
+	case "object_pattern":
+		return ParameterSpec{Name: textFn(node), Kind: ParameterObject}
+	case "array_pattern":
+		return ParameterSpec{Name: textFn(node), Kind: ParameterArray}
+	default:
+		return ParameterSpec{Name: textFn(node), Kind: ParameterUnknown}
+	}
+}
+
+func parseFieldMap(data map[string]interface{}) map[string]*FieldSpec {
+	rawFields, _ := firstMap(data["fields"], data["params"])
+	if len(rawFields) == 0 {
+		return map[string]*FieldSpec{}
+	}
+	ret := map[string]*FieldSpec{}
+	for name, raw := range rawFields {
+		fieldMap, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		field := &FieldSpec{
+			Name:     name,
+			Type:     stringValue(fieldMap["type"]),
+			Help:     stringFirst(fieldMap["help"], fieldMap["description"]),
+			Short:    stringValue(fieldMap["short"]),
+			Bind:     stringValue(fieldMap["bind"]),
+			Section:  cleanCommandWord(stringValue(fieldMap["section"])),
+			Default:  fieldMap["default"],
+			Choices:  stringSlice(fieldMap["choices"]),
+			Required: boolValue(fieldMap["required"]),
+			Argument: boolFirst(fieldMap["argument"], fieldMap["arg"]),
+		}
+		ret[name] = field
+	}
+	return ret
+}
+
+func jsObjectToJSON(js string) string {
+	return convertJSToJSON(js)
+}
+
+func convertJSToJSON(input string) string {
+	var sb strings.Builder
+	i := 0
+	n := len(input)
+
+	for i < n {
+		ch := input[i]
+		switch {
+		case ch == '/' && i+1 < n && input[i+1] == '/':
+			for i < n && input[i] != '\n' {
+				i++
+			}
+		case ch == '/' && i+1 < n && input[i+1] == '*':
+			i += 2
+			for i+1 < n && (input[i] != '*' || input[i+1] != '/') {
+				i++
+			}
+			i += 2
+		case ch == '\'':
+			sb.WriteByte('"')
+			i++
+			for i < n && input[i] != '\'' {
+				if input[i] == '"' {
+					sb.WriteByte('\\')
+				}
+				if input[i] == '\\' && i+1 < n {
+					if input[i+1] == '\'' {
+						sb.WriteByte('\'')
+						i += 2
+						continue
+					}
+					sb.WriteByte(input[i])
+					i++
+				}
+				sb.WriteByte(input[i])
+				i++
+			}
+			sb.WriteByte('"')
+			i++
+		case ch == '"':
+			sb.WriteByte(ch)
+			i++
+			for i < n && input[i] != '"' {
+				if input[i] == '\\' && i+1 < n {
+					sb.WriteByte(input[i])
+					i++
+				}
+				sb.WriteByte(input[i])
+				i++
+			}
+			sb.WriteByte('"')
+			i++
+		case ch == '`':
+			sb.WriteByte('"')
+			i++
+			for i < n && input[i] != '`' {
+				if input[i] == '"' {
+					sb.WriteByte('\\')
+				}
+				if input[i] == '\\' && i+1 < n {
+					sb.WriteByte(input[i])
+					i++
+				}
+				sb.WriteByte(input[i])
+				i++
+			}
+			sb.WriteByte('"')
+			i++
+		case isIdentStart(ch):
+			start := i
+			for i < n && isIdentPart(input[i]) {
+				i++
+			}
+			word := input[start:i]
+			j := i
+			for j < n && (input[j] == ' ' || input[j] == '\t') {
+				j++
+			}
+			if j < n && input[j] == ':' && word != "true" && word != "false" && word != "null" {
+				sb.WriteByte('"')
+				sb.WriteString(word)
+				sb.WriteByte('"')
+			} else {
+				sb.WriteString(word)
+			}
+		case ch == ',':
+			j := i + 1
+			for j < n && (input[j] == ' ' || input[j] == '\t' || input[j] == '\n' || input[j] == '\r') {
+				j++
+			}
+			if j < n && (input[j] == '}' || input[j] == ']') {
+				i++
+			} else {
+				sb.WriteByte(ch)
+				i++
+			}
+		default:
+			sb.WriteByte(ch)
+			i++
+		}
+	}
+
+	return sb.String()
+}
+
+func isIdentStart(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_' || c == '$'
+}
+
+func isIdentPart(c byte) bool {
+	return isIdentStart(c) || (c >= '0' && c <= '9')
+}
+
+func splitFrontmatter(text string) (string, string) {
+	text = strings.TrimSpace(text)
+	if !strings.HasPrefix(text, "---") {
+		return "", text
+	}
+	rest := text[3:]
+	end := strings.Index(rest, "\n---")
+	if end == -1 {
+		return "", text
+	}
+	return strings.TrimSpace(rest[:end]), strings.TrimSpace(rest[end+4:])
+}
+
+func parseFrontmatter(fm string) map[string]string {
+	ret := map[string]string{}
+	for _, line := range strings.Split(fm, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		idx := strings.Index(line, ":")
+		if idx == -1 {
+			continue
+		}
+		key := strings.TrimSpace(line[:idx])
+		value := strings.TrimSpace(line[idx+1:])
+		ret[key] = value
+	}
+	return ret
+}
+
+func firstMap(values ...interface{}) (map[string]interface{}, bool) {
+	for _, value := range values {
+		if m, ok := value.(map[string]interface{}); ok {
+			return m, true
+		}
+	}
+	return nil, false
+}
+
+func firstNonNil(values ...interface{}) interface{} {
+	for _, value := range values {
+		if value != nil {
+			return value
+		}
+	}
+	return nil
+}
+
+func firstString(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func stringFirst(values ...interface{}) string {
+	for _, value := range values {
+		if s := stringValue(value); s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+func stringValue(value interface{}) string {
+	switch v := value.(type) {
+	case string:
+		return strings.TrimSpace(v)
+	default:
+		return ""
+	}
+}
+
+func stringSlice(value interface{}) []string {
+	switch v := value.(type) {
+	case []interface{}:
+		ret := make([]string, 0, len(v))
+		for _, item := range v {
+			if s := stringValue(item); s != "" {
+				ret = append(ret, s)
+			}
+		}
+		return ret
+	case []string:
+		ret := make([]string, 0, len(v))
+		for _, item := range v {
+			if s := stringValue(item); s != "" {
+				ret = append(ret, s)
+			}
+		}
+		return ret
+	default:
+		return nil
+	}
+}
+
+func boolValue(value interface{}) bool {
+	b, _ := value.(bool)
+	return b
+}
+
+func boolFirst(values ...interface{}) bool {
+	for _, value := range values {
+		if b, ok := value.(bool); ok {
+			return b
+		}
+	}
+	return false
+}
+
+func normalizeOutputMode(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "glaze", "table", "structured":
+		return OutputModeGlaze
+	case "text", "raw", "writer", "plain":
+		return OutputModeText
+	default:
+		return strings.ToLower(strings.TrimSpace(value))
+	}
+}

--- a/pkg/jsverbs/scan.go
+++ b/pkg/jsverbs/scan.go
@@ -1,15 +1,15 @@
 package jsverbs
 
 import (
-	"encoding/json"
 	"fmt"
 	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 
-	"github.com/pkg/errors"
 	tree_sitter "github.com/tree-sitter/go-tree-sitter"
 	tree_sitter_javascript "github.com/tree-sitter/tree-sitter-javascript/bindings/go"
 )
@@ -22,47 +22,150 @@ func ScanDir(root string, opts ...ScanOptions) (*Registry, error) {
 
 	absRoot, err := filepath.Abs(root)
 	if err != nil {
-		return nil, errors.Wrap(err, "resolve root")
+		return nil, fmt.Errorf("resolve root: %w", err)
 	}
 
-	registry := &Registry{
-		RootDir:    absRoot,
-		Files:      []*FileSpec{},
-		verbsByKey: map[string]*VerbSpec{},
-		filesByAbs: map[string]*FileSpec{},
-		options:    options,
-	}
-
-	err = filepath.WalkDir(absRoot, func(path string, d fs.DirEntry, walkErr error) error {
+	inputs := []sourceInput{}
+	err = filepath.WalkDir(absRoot, func(filePath string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
 		name := d.Name()
 		if d.IsDir() {
-			if name == "node_modules" || strings.HasPrefix(name, ".") {
-				if path == absRoot {
+			if shouldSkipDir(name) {
+				if filePath == absRoot {
 					return nil
 				}
 				return filepath.SkipDir
 			}
 			return nil
 		}
-		if !supportsExtension(path, options.Extensions) {
+		if !supportsExtension(filePath, options.Extensions) {
 			return nil
 		}
-		file, err := scanFile(absRoot, path, options)
+		source, err := os.ReadFile(filePath)
 		if err != nil {
-			return err
+			return fmt.Errorf("read %s: %w", filePath, err)
 		}
-		if file == nil {
-			return nil
+		relPath, err := filepath.Rel(absRoot, filePath)
+		if err != nil {
+			return fmt.Errorf("relpath %s: %w", filePath, err)
 		}
-		registry.Files = append(registry.Files, file)
-		registry.filesByAbs[file.AbsPath] = file
+		inputs = append(inputs, sourceInput{
+			AbsPath:    filePath,
+			RelPath:    filepath.ToSlash(relPath),
+			ModulePath: modulePathFromRelative(relPath),
+			Source:     source,
+		})
 		return nil
 	})
 	if err != nil {
 		return nil, err
+	}
+
+	return scanInputs(absRoot, inputs, options)
+}
+
+func ScanFS(fsys fs.FS, root string, opts ...ScanOptions) (*Registry, error) {
+	options := DefaultScanOptions()
+	if len(opts) > 0 {
+		options = opts[0]
+	}
+	root = strings.TrimSpace(root)
+	if root == "" {
+		root = "."
+	}
+
+	inputs := []sourceInput{}
+	err := fs.WalkDir(fsys, root, func(filePath string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		name := d.Name()
+		if d.IsDir() {
+			if shouldSkipDir(name) {
+				if filePath == root {
+					return nil
+				}
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !supportsExtension(filePath, options.Extensions) {
+			return nil
+		}
+		source, err := fs.ReadFile(fsys, filePath)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", filePath, err)
+		}
+		relPath, err := filepath.Rel(root, filePath)
+		if err != nil {
+			return fmt.Errorf("relpath %s: %w", filePath, err)
+		}
+		inputs = append(inputs, sourceInput{
+			RelPath:    filepath.ToSlash(relPath),
+			ModulePath: modulePathFromRelative(relPath),
+			Source:     source,
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return scanInputs(root, inputs, options)
+}
+
+func ScanSource(filePath string, source string, opts ...ScanOptions) (*Registry, error) {
+	return ScanSources([]SourceFile{{Path: filePath, Source: []byte(source)}}, opts...)
+}
+
+func ScanSources(files []SourceFile, opts ...ScanOptions) (*Registry, error) {
+	options := DefaultScanOptions()
+	if len(opts) > 0 {
+		options = opts[0]
+	}
+
+	inputs := make([]sourceInput, 0, len(files))
+	for _, file := range files {
+		modulePath, err := normalizeModulePath(file.Path)
+		if err != nil {
+			return nil, err
+		}
+		inputs = append(inputs, sourceInput{
+			RelPath:    strings.TrimPrefix(modulePath, "/"),
+			ModulePath: modulePath,
+			Source:     append([]byte(nil), file.Source...),
+		})
+	}
+
+	return scanInputs("", inputs, options)
+}
+
+type sourceInput struct {
+	AbsPath    string
+	RelPath    string
+	ModulePath string
+	Source     []byte
+}
+
+func scanInputs(rootDir string, inputs []sourceInput, options ScanOptions) (*Registry, error) {
+	registry := &Registry{
+		RootDir:       rootDir,
+		Files:         []*FileSpec{},
+		Diagnostics:   []Diagnostic{},
+		verbsByKey:    map[string]*VerbSpec{},
+		filesByModule: map[string]*FileSpec{},
+		options:       options,
+	}
+
+	for _, input := range inputs {
+		file, err := scanInput(input, options, registry)
+		if err != nil {
+			return registry, err
+		}
+		registry.Files = append(registry.Files, file)
+		registry.filesByModule[file.ModulePath] = file
 	}
 
 	sort.Slice(registry.Files, func(i, j int) bool {
@@ -70,14 +173,18 @@ func ScanDir(root string, opts ...ScanOptions) (*Registry, error) {
 	})
 
 	if err := registry.finalizeVerbs(); err != nil {
-		return nil, err
+		return registry, err
+	}
+
+	if diagnostics := registry.ErrorDiagnostics(); len(diagnostics) > 0 && options.FailOnErrorDiagnostics {
+		return registry, &ScanError{Diagnostics: diagnostics}
 	}
 
 	return registry, nil
 }
 
-func supportsExtension(path string, extensions []string) bool {
-	ext := strings.ToLower(filepath.Ext(path))
+func supportsExtension(filePath string, extensions []string) bool {
+	ext := strings.ToLower(filepath.Ext(filePath))
 	for _, candidate := range extensions {
 		if strings.EqualFold(ext, candidate) {
 			return true
@@ -86,35 +193,29 @@ func supportsExtension(path string, extensions []string) bool {
 	return false
 }
 
-func scanFile(rootDir, absPath string, options ScanOptions) (*FileSpec, error) {
-	src, err := os.ReadFile(absPath)
-	if err != nil {
-		return nil, errors.Wrapf(err, "read %s", absPath)
-	}
-	relPath, err := filepath.Rel(rootDir, absPath)
-	if err != nil {
-		return nil, errors.Wrapf(err, "relpath %s", absPath)
-	}
-	relPath = filepath.ToSlash(relPath)
-	modulePath := filepath.ToSlash(absPath)
+func shouldSkipDir(name string) bool {
+	return name == "node_modules" || strings.HasPrefix(name, ".")
+}
 
+func scanInput(input sourceInput, options ScanOptions, registry *Registry) (*FileSpec, error) {
 	parser := tree_sitter.NewParser()
 	defer parser.Close()
 	lang := tree_sitter.NewLanguage(tree_sitter_javascript.Language())
 	if err := parser.SetLanguage(lang); err != nil {
-		return nil, errors.Wrap(err, "set javascript language")
+		return nil, fmt.Errorf("set javascript language: %w", err)
 	}
 
-	tree := parser.Parse(src, nil)
+	tree := parser.Parse(input.Source, nil)
 	if tree == nil {
-		return nil, fmt.Errorf("parse %s: nil tree", relPath)
+		return nil, fmt.Errorf("parse %s: nil tree", input.RelPath)
 	}
 	defer tree.Close()
 
 	file := &FileSpec{
-		AbsPath:        absPath,
-		RelPath:        relPath,
-		ModulePath:     modulePath,
+		AbsPath:        input.AbsPath,
+		RelPath:        filepath.ToSlash(input.RelPath),
+		ModulePath:     input.ModulePath,
+		Source:         append([]byte(nil), input.Source...),
 		Functions:      []*FunctionSpec{},
 		functionByName: map[string]*FunctionSpec{},
 		SectionOrder:   []string{},
@@ -122,14 +223,15 @@ func scanFile(rootDir, absPath string, options ScanOptions) (*FileSpec, error) {
 		VerbMeta:       map[string]*VerbSpec{},
 		Docs:           map[string]string{},
 	}
-	e := &extractor{
-		src:     src,
-		path:    absPath,
-		relPath: relPath,
-		options: options,
-		file:    file,
+
+	extractor := &extractor{
+		src:      input.Source,
+		relPath:  file.RelPath,
+		options:  options,
+		file:     file,
+		registry: registry,
 	}
-	e.extract(tree.RootNode())
+	extractor.extract(tree.RootNode())
 	return file, nil
 }
 
@@ -222,9 +324,9 @@ func (r *Registry) finalizeVerb(file *FileSpec, verb *VerbSpec) error {
 
 func defaultParentsForFile(file *FileSpec) []string {
 	parents := append([]string{}, file.Package.Parents...)
-	dir := filepath.Dir(file.RelPath)
+	dir := path.Dir(file.RelPath)
 	if dir != "." {
-		for _, part := range strings.Split(filepath.ToSlash(dir), "/") {
+		for _, part := range strings.Split(dir, "/") {
 			part = cleanCommandWord(part)
 			if part != "" {
 				parents = append(parents, part)
@@ -233,7 +335,7 @@ func defaultParentsForFile(file *FileSpec) []string {
 	}
 	group := file.Package.Name
 	if strings.TrimSpace(group) == "" {
-		base := strings.TrimSuffix(filepath.Base(file.RelPath), filepath.Ext(file.RelPath))
+		base := strings.TrimSuffix(path.Base(file.RelPath), path.Ext(file.RelPath))
 		if base != "index" || len(parents) == 0 {
 			group = base
 		}
@@ -245,17 +347,16 @@ func defaultParentsForFile(file *FileSpec) []string {
 }
 
 type extractor struct {
-	src     []byte
-	path    string
-	relPath string
-	options ScanOptions
-	file    *FileSpec
+	src      []byte
+	relPath  string
+	options  ScanOptions
+	file     *FileSpec
+	registry *Registry
 }
 
 func (e *extractor) extract(root *tree_sitter.Node) {
-	count := int(root.ChildCount())
-	for i := 0; i < count; i++ {
-		e.processTopLevel(root.Child(uint(i)))
+	for i := uint(0); i < root.ChildCount(); i++ {
+		e.processTopLevel(root.Child(i))
 	}
 }
 
@@ -271,9 +372,8 @@ func (e *extractor) processTopLevel(node *tree_sitter.Node) {
 	case "function_declaration":
 		e.handleFunctionDeclaration(node)
 	case "lexical_declaration", "variable_declaration", "export_statement":
-		count := int(node.ChildCount())
-		for i := 0; i < count; i++ {
-			e.processTopLevel(node.Child(uint(i)))
+		for i := uint(0); i < node.ChildCount(); i++ {
+			e.processTopLevel(node.Child(i))
 		}
 	case "variable_declarator":
 		e.handleVariableDeclarator(node)
@@ -340,10 +440,17 @@ func (e *extractor) handleCallExpression(node *tree_sitter.Node) {
 func (e *extractor) handlePackage(argsNode *tree_sitter.Node) {
 	objectArg := e.firstObjectArg(argsNode)
 	if objectArg == nil {
+		e.errorf("", "__package__ requires an object argument")
 		return
 	}
-	data := map[string]interface{}{}
-	if err := e.unmarshalObject(objectArg, &data); err != nil {
+	value, err := e.parseLiteralNode(objectArg)
+	if err != nil {
+		e.errorf("", "invalid __package__ metadata: %v", err)
+		return
+	}
+	data, ok := value.(map[string]interface{})
+	if !ok {
+		e.errorf("", "__package__ metadata must be an object")
 		return
 	}
 	e.file.Package = PackageSpec{
@@ -358,10 +465,17 @@ func (e *extractor) handlePackage(argsNode *tree_sitter.Node) {
 func (e *extractor) handleSection(argsNode *tree_sitter.Node) {
 	name, objectNode := e.namedObjectArgs(argsNode)
 	if objectNode == nil {
+		e.errorf(name, "__section__ requires a name and object metadata")
 		return
 	}
-	data := map[string]interface{}{}
-	if err := e.unmarshalObject(objectNode, &data); err != nil {
+	value, err := e.parseLiteralNode(objectNode)
+	if err != nil {
+		e.errorf(name, "invalid __section__ metadata: %v", err)
+		return
+	}
+	data, ok := value.(map[string]interface{})
+	if !ok {
+		e.errorf(name, "__section__ metadata must be an object")
 		return
 	}
 	if name == "" {
@@ -369,6 +483,7 @@ func (e *extractor) handleSection(argsNode *tree_sitter.Node) {
 	}
 	slug := cleanCommandWord(name)
 	if slug == "" {
+		e.errorf(name, "__section__ resolved to empty slug")
 		return
 	}
 	section := &SectionSpec{
@@ -389,10 +504,17 @@ func (e *extractor) handleSection(argsNode *tree_sitter.Node) {
 func (e *extractor) handleVerb(argsNode *tree_sitter.Node) {
 	name, objectNode := e.namedObjectArgs(argsNode)
 	if objectNode == nil {
+		e.errorf(name, "__verb__ requires a function name and object metadata")
 		return
 	}
-	data := map[string]interface{}{}
-	if err := e.unmarshalObject(objectNode, &data); err != nil {
+	value, err := e.parseLiteralNode(objectNode)
+	if err != nil {
+		e.errorf(name, "invalid __verb__ metadata: %v", err)
+		return
+	}
+	data, ok := value.(map[string]interface{})
+	if !ok {
+		e.errorf(name, "__verb__ metadata must be an object")
 		return
 	}
 	if name == "" {
@@ -400,6 +522,7 @@ func (e *extractor) handleVerb(argsNode *tree_sitter.Node) {
 	}
 	functionName := strings.TrimSpace(name)
 	if functionName == "" {
+		e.errorf(name, "__verb__ resolved to empty function name")
 		return
 	}
 
@@ -422,8 +545,8 @@ func (e *extractor) handleVerb(argsNode *tree_sitter.Node) {
 
 func (e *extractor) handleDocTemplate(node *tree_sitter.Node) {
 	var templateNode *tree_sitter.Node
-	for i := 0; i < int(node.ChildCount()); i++ {
-		child := node.Child(uint(i))
+	for i := uint(0); i < node.ChildCount(); i++ {
+		child := node.Child(i)
 		if child.Kind() == "template_string" {
 			templateNode = child
 			break
@@ -453,15 +576,20 @@ func (e *extractor) namedObjectArgs(argsNode *tree_sitter.Node) (string, *tree_s
 			return "", args[0]
 		}
 	case 2:
-		return strings.Trim(e.nodeText(args[0]), `"'`+"`"), args[1]
+		nameValue, err := e.parseLiteralNode(args[0])
+		if err == nil {
+			if name, ok := nameValue.(string); ok {
+				return name, args[1]
+			}
+		}
 	}
 	return "", nil
 }
 
 func (e *extractor) collectArgs(argsNode *tree_sitter.Node) []*tree_sitter.Node {
 	ret := []*tree_sitter.Node{}
-	for i := 0; i < int(argsNode.ChildCount()); i++ {
-		child := argsNode.Child(uint(i))
+	for i := uint(0); i < argsNode.ChildCount(); i++ {
+		child := argsNode.Child(i)
 		switch child.Kind() {
 		case ",", "(", ")", "comment":
 			continue
@@ -481,22 +609,17 @@ func (e *extractor) firstObjectArg(argsNode *tree_sitter.Node) *tree_sitter.Node
 	return nil
 }
 
-func (e *extractor) unmarshalObject(node *tree_sitter.Node, dst interface{}) error {
-	raw := e.nodeText(node)
-	data := jsObjectToJSON(raw)
-	return json.Unmarshal([]byte(data), dst)
-}
-
 func (e *extractor) nodeText(node *tree_sitter.Node) string {
 	if node == nil {
 		return ""
 	}
-	start := int(node.StartByte())
-	end := int(node.EndByte())
-	if start < 0 || end < start || end > len(e.src) {
+	start := node.StartByte()
+	end := node.EndByte()
+	srcLen := uint(len(e.src))
+	if end < start || uint(start) > srcLen || uint(end) > srcLen {
 		return ""
 	}
-	return string(e.src[start:end])
+	return string(e.src[int(start):int(end)])
 }
 
 func (e *extractor) templateRawText(tmplNode *tree_sitter.Node) string {
@@ -504,6 +627,106 @@ func (e *extractor) templateRawText(tmplNode *tree_sitter.Node) string {
 	text = strings.TrimPrefix(text, "`")
 	text = strings.TrimSuffix(text, "`")
 	return text
+}
+
+func (e *extractor) parseLiteralNode(node *tree_sitter.Node) (interface{}, error) {
+	if node == nil {
+		return nil, fmt.Errorf("literal node is nil")
+	}
+	switch node.Kind() {
+	case "object":
+		return e.parseObjectLiteral(node)
+	case "array":
+		return e.parseArrayLiteral(node)
+	case "string":
+		return decodeStringLiteral(e.nodeText(node))
+	case "template_string":
+		return e.parseTemplateLiteral(node)
+	case "number":
+		return strconv.ParseFloat(e.nodeText(node), 64)
+	case "true":
+		return true, nil
+	case "false":
+		return false, nil
+	case "null":
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("unsupported metadata literal %q", node.Kind())
+	}
+}
+
+func (e *extractor) parseObjectLiteral(node *tree_sitter.Node) (map[string]interface{}, error) {
+	ret := map[string]interface{}{}
+	for i := uint(0); i < node.NamedChildCount(); i++ {
+		child := node.NamedChild(i)
+		switch child.Kind() {
+		case "pair":
+			keyNode := child.ChildByFieldName("key")
+			valueNode := child.ChildByFieldName("value")
+			if keyNode == nil || valueNode == nil {
+				return nil, fmt.Errorf("object pair missing key or value")
+			}
+			key, err := e.parseObjectKey(keyNode)
+			if err != nil {
+				return nil, err
+			}
+			value, err := e.parseLiteralNode(valueNode)
+			if err != nil {
+				return nil, fmt.Errorf("field %q: %w", key, err)
+			}
+			ret[key] = value
+		case "comment":
+			continue
+		default:
+			return nil, fmt.Errorf("unsupported object element %q", child.Kind())
+		}
+	}
+	return ret, nil
+}
+
+func (e *extractor) parseArrayLiteral(node *tree_sitter.Node) ([]interface{}, error) {
+	ret := []interface{}{}
+	for i := uint(0); i < node.NamedChildCount(); i++ {
+		child := node.NamedChild(i)
+		if child.Kind() == "comment" {
+			continue
+		}
+		value, err := e.parseLiteralNode(child)
+		if err != nil {
+			return nil, err
+		}
+		ret = append(ret, value)
+	}
+	return ret, nil
+}
+
+func (e *extractor) parseObjectKey(node *tree_sitter.Node) (string, error) {
+	switch node.Kind() {
+	case "property_identifier", "identifier":
+		return e.nodeText(node), nil
+	case "string", "template_string":
+		value, err := e.parseLiteralNode(node)
+		if err != nil {
+			return "", err
+		}
+		s, ok := value.(string)
+		if !ok {
+			return "", fmt.Errorf("object key must resolve to string")
+		}
+		return s, nil
+	default:
+		return "", fmt.Errorf("unsupported object key %q", node.Kind())
+	}
+}
+
+func (e *extractor) parseTemplateLiteral(node *tree_sitter.Node) (string, error) {
+	for i := uint(0); i < node.NamedChildCount(); i++ {
+		child := node.NamedChild(i)
+		if child.Kind() != "string_fragment" {
+			return "", fmt.Errorf("template metadata strings cannot contain substitutions")
+		}
+	}
+	return e.templateRawText(node), nil
 }
 
 func extractParameters(node *tree_sitter.Node, textFn func(*tree_sitter.Node) string) []ParameterSpec {
@@ -521,8 +744,8 @@ func extractParameters(node *tree_sitter.Node, textFn func(*tree_sitter.Node) st
 
 func collectParameterNodes(paramsNode *tree_sitter.Node, textFn func(*tree_sitter.Node) string) []ParameterSpec {
 	params := []ParameterSpec{}
-	for i := 0; i < int(paramsNode.ChildCount()); i++ {
-		child := paramsNode.Child(uint(i))
+	for i := uint(0); i < paramsNode.ChildCount(); i++ {
+		child := paramsNode.Child(i)
 		switch child.Kind() {
 		case ",", "(", ")", "comment":
 			continue
@@ -591,123 +814,6 @@ func parseFieldMap(data map[string]interface{}) map[string]*FieldSpec {
 	return ret
 }
 
-func jsObjectToJSON(js string) string {
-	return convertJSToJSON(js)
-}
-
-func convertJSToJSON(input string) string {
-	var sb strings.Builder
-	i := 0
-	n := len(input)
-
-	for i < n {
-		ch := input[i]
-		switch {
-		case ch == '/' && i+1 < n && input[i+1] == '/':
-			for i < n && input[i] != '\n' {
-				i++
-			}
-		case ch == '/' && i+1 < n && input[i+1] == '*':
-			i += 2
-			for i+1 < n && (input[i] != '*' || input[i+1] != '/') {
-				i++
-			}
-			i += 2
-		case ch == '\'':
-			sb.WriteByte('"')
-			i++
-			for i < n && input[i] != '\'' {
-				if input[i] == '"' {
-					sb.WriteByte('\\')
-				}
-				if input[i] == '\\' && i+1 < n {
-					if input[i+1] == '\'' {
-						sb.WriteByte('\'')
-						i += 2
-						continue
-					}
-					sb.WriteByte(input[i])
-					i++
-				}
-				sb.WriteByte(input[i])
-				i++
-			}
-			sb.WriteByte('"')
-			i++
-		case ch == '"':
-			sb.WriteByte(ch)
-			i++
-			for i < n && input[i] != '"' {
-				if input[i] == '\\' && i+1 < n {
-					sb.WriteByte(input[i])
-					i++
-				}
-				sb.WriteByte(input[i])
-				i++
-			}
-			sb.WriteByte('"')
-			i++
-		case ch == '`':
-			sb.WriteByte('"')
-			i++
-			for i < n && input[i] != '`' {
-				if input[i] == '"' {
-					sb.WriteByte('\\')
-				}
-				if input[i] == '\\' && i+1 < n {
-					sb.WriteByte(input[i])
-					i++
-				}
-				sb.WriteByte(input[i])
-				i++
-			}
-			sb.WriteByte('"')
-			i++
-		case isIdentStart(ch):
-			start := i
-			for i < n && isIdentPart(input[i]) {
-				i++
-			}
-			word := input[start:i]
-			j := i
-			for j < n && (input[j] == ' ' || input[j] == '\t') {
-				j++
-			}
-			if j < n && input[j] == ':' && word != "true" && word != "false" && word != "null" {
-				sb.WriteByte('"')
-				sb.WriteString(word)
-				sb.WriteByte('"')
-			} else {
-				sb.WriteString(word)
-			}
-		case ch == ',':
-			j := i + 1
-			for j < n && (input[j] == ' ' || input[j] == '\t' || input[j] == '\n' || input[j] == '\r') {
-				j++
-			}
-			if j < n && (input[j] == '}' || input[j] == ']') {
-				i++
-			} else {
-				sb.WriteByte(ch)
-				i++
-			}
-		default:
-			sb.WriteByte(ch)
-			i++
-		}
-	}
-
-	return sb.String()
-}
-
-func isIdentStart(c byte) bool {
-	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_' || c == '$'
-}
-
-func isIdentPart(c byte) bool {
-	return isIdentStart(c) || (c >= '0' && c <= '9')
-}
-
 func splitFrontmatter(text string) (string, string) {
 	text = strings.TrimSpace(text)
 	if !strings.HasPrefix(text, "---") {
@@ -737,6 +843,55 @@ func parseFrontmatter(fm string) map[string]string {
 		ret[key] = value
 	}
 	return ret
+}
+
+func decodeStringLiteral(raw string) (string, error) {
+	if len(raw) < 2 {
+		return "", fmt.Errorf("invalid string literal")
+	}
+	switch raw[0] {
+	case '"':
+		value, err := strconv.Unquote(raw)
+		if err != nil {
+			return "", fmt.Errorf("decode string literal: %w", err)
+		}
+		return value, nil
+	case '\'':
+		return decodeSingleQuotedLiteral(raw)
+	default:
+		return "", fmt.Errorf("unsupported string literal %q", raw)
+	}
+}
+
+func decodeSingleQuotedLiteral(raw string) (string, error) {
+	if len(raw) < 2 || raw[0] != '\'' || raw[len(raw)-1] != '\'' {
+		return "", fmt.Errorf("invalid single-quoted literal")
+	}
+	var sb strings.Builder
+	for i := 1; i < len(raw)-1; i++ {
+		ch := raw[i]
+		if ch != '\\' {
+			sb.WriteByte(ch)
+			continue
+		}
+		i++
+		if i >= len(raw)-1 {
+			return "", fmt.Errorf("unterminated escape sequence")
+		}
+		switch raw[i] {
+		case '\\', '\'', '"', '`':
+			sb.WriteByte(raw[i])
+		case 'n':
+			sb.WriteByte('\n')
+		case 'r':
+			sb.WriteByte('\r')
+		case 't':
+			sb.WriteByte('\t')
+		default:
+			return "", fmt.Errorf("unsupported escape sequence \\%c", raw[i])
+		}
+	}
+	return sb.String(), nil
 }
 
 func firstMap(values ...interface{}) (map[string]interface{}, bool) {
@@ -830,4 +985,28 @@ func normalizeOutputMode(value string) string {
 	default:
 		return strings.ToLower(strings.TrimSpace(value))
 	}
+}
+
+func modulePathFromRelative(relPath string) string {
+	return "/" + strings.TrimPrefix(filepath.ToSlash(relPath), "/")
+}
+
+func normalizeModulePath(filePath string) (string, error) {
+	cleaned := path.Clean("/" + strings.TrimSpace(filepath.ToSlash(filePath)))
+	if cleaned == "/" || cleaned == "." {
+		return "", fmt.Errorf("module path is empty")
+	}
+	return cleaned, nil
+}
+
+func (e *extractor) errorf(symbol, format string, args ...interface{}) {
+	if e.registry == nil {
+		return
+	}
+	e.registry.Diagnostics = append(e.registry.Diagnostics, Diagnostic{
+		Severity: DiagnosticSeverityError,
+		Path:     e.relPath,
+		Symbol:   strings.TrimSpace(symbol),
+		Message:  fmt.Sprintf(format, args...),
+	})
 }

--- a/testdata/jsverbs/advanced/numbers.js
+++ b/testdata/jsverbs/advanced/numbers.js
@@ -1,0 +1,34 @@
+function add(a, b) {
+  return { sum: a + b };
+}
+
+__verb__("add", {
+  short: "Add two integers",
+  fields: {
+    a: { type: "int", argument: true },
+    b: { type: "int", argument: true }
+  }
+});
+
+const multiply = async (a, b) => {
+  return { product: a * b };
+};
+
+__verb__("multiply", {
+  short: "Multiply asynchronously",
+  fields: {
+    a: { type: "int", argument: true },
+    b: { type: "int", argument: true }
+  }
+});
+
+function listNames(...names) {
+  return names.map((name, index) => ({ index, name }));
+}
+
+__verb__("listNames", {
+  short: "Expand a list argument",
+  fields: {
+    names: { type: "stringList", argument: true }
+  }
+});

--- a/testdata/jsverbs/basics.js
+++ b/testdata/jsverbs/basics.js
@@ -1,0 +1,120 @@
+__section__("filters", {
+  title: "Filters",
+  description: "Shared filter flags",
+  fields: {
+    state: {
+      type: "choice",
+      choices: ["open", "closed"],
+      default: "open",
+      help: "Issue state"
+    },
+    labels: {
+      type: "stringList",
+      help: "Labels to filter on"
+    }
+  }
+});
+
+doc`---
+verb: greet
+---
+Greets one person and optionally adds an exclamation mark.`;
+
+function greet(name, excited) {
+  return {
+    greeting: excited ? `Hello, ${name}!` : `Hello, ${name}`
+  };
+}
+
+__verb__("greet", {
+  short: "Greet one person",
+  fields: {
+    name: {
+      argument: true,
+      help: "Person name"
+    },
+    excited: {
+      type: "bool",
+      short: "e",
+      help: "Add excitement"
+    }
+  }
+});
+
+const echo = (value) => value;
+
+__verb__("echo", {
+  short: "Return a primitive value",
+  fields: {
+    value: {
+      argument: true
+    }
+  }
+});
+
+function banner(name) {
+  return `=== ${name} ===\n`;
+}
+
+__verb__("banner", {
+  short: "Write plain text output",
+  output: "text",
+  fields: {
+    name: {
+      argument: true
+    }
+  }
+});
+
+function listIssues(repo, filters, meta) {
+  const helper = require("./support/helper");
+  return [
+    {
+      repo,
+      state: filters.state,
+      labelCount: (filters.labels || []).length,
+      helper: helper.decorate(repo),
+      rootDir: meta.rootDir
+    }
+  ];
+}
+
+__verb__("listIssues", {
+  short: "Use shared sections and context",
+  sections: ["filters"],
+  fields: {
+    repo: {
+      argument: true,
+      help: "Repository name"
+    },
+    filters: {
+      bind: "filters"
+    },
+    meta: {
+      bind: "context"
+    }
+  }
+});
+
+function summarize(options) {
+  return {
+    owner: options.owner,
+    repo: options.repo,
+    joined: options.owner + "/" + options.repo
+  };
+}
+
+__verb__("summarize", {
+  short: "Bind all parsed values into one object",
+  fields: {
+    options: {
+      bind: "all"
+    },
+    owner: {
+      help: "Repository owner"
+    },
+    repo: {
+      help: "Repository name"
+    }
+  }
+});

--- a/testdata/jsverbs/nested/sub/helper.js
+++ b/testdata/jsverbs/nested/sub/helper.js
@@ -1,0 +1,5 @@
+module.exports = {
+  render(prefix, target) {
+    return prefix + ":" + target;
+  }
+};

--- a/testdata/jsverbs/nested/with-helper.js
+++ b/testdata/jsverbs/nested/with-helper.js
@@ -1,0 +1,12 @@
+const render = (prefix, target) => {
+  const helper = require("./sub/helper");
+  return { value: helper.render(prefix, target) };
+};
+
+__verb__("render", {
+  short: "Use a relative require",
+  fields: {
+    prefix: { argument: true },
+    target: { argument: true }
+  }
+});

--- a/testdata/jsverbs/packaged.js
+++ b/testdata/jsverbs/packaged.js
@@ -1,0 +1,9 @@
+__package__({
+  name: "pkg-demo",
+  parents: ["meta"],
+  short: "Package metadata demo"
+});
+
+function ping() {
+  return { ok: true };
+}

--- a/testdata/jsverbs/support/helper.js
+++ b/testdata/jsverbs/support/helper.js
@@ -1,0 +1,5 @@
+module.exports = {
+  decorate(value) {
+    return "decorated:" + value;
+  }
+};

--- a/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/.meta/sources.yaml
+++ b/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/.meta/sources.yaml
@@ -1,0 +1,3 @@
+- type: local
+  path: /tmp/goja-js.md
+  lastFetched: 2026-03-16T13:56:35.761310481-04:00

--- a/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/README.md
+++ b/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/README.md
@@ -1,0 +1,21 @@
+# Add Glazed command exporting from JavaScript
+
+This is the document workspace for ticket GOJA-04-JS-GLAZED-EXPORTS.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr doc add --ticket GOJA-04-JS-GLAZED-EXPORTS --doc-type design-doc --title "My Design"`
+- Import sources: `docmgr import file --ticket GOJA-04-JS-GLAZED-EXPORTS --file /path/to/doc.md`
+- Update metadata: `docmgr meta update --ticket GOJA-04-JS-GLAZED-EXPORTS --field Status --value review`

--- a/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/changelog.md
+++ b/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/changelog.md
@@ -45,3 +45,13 @@ Finished the diary and ticket bookkeeping, passed docmgr doctor cleanly, and upl
 - /home/manuel/workspaces/2026-03-16/add-glazed-js-layer/go-go-goja/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/changelog.md — Ticket changelog reflecting final delivery state
 - /home/manuel/workspaces/2026-03-16/add-glazed-js-layer/go-go-goja/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/reference/01-diary.md — Completed chronological diary including validation and upload results
 
+
+## 2026-03-16
+
+Added a full origin/main postmortem and code review for the jsverbs prototype, covering architecture, intern onboarding, and cleanup priorities.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-03-16/add-glazed-js-layer/go-go-goja/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/design-doc/02-js-verbs-prototype-postmortem-and-code-review.md — New postmortem and code review deliverable
+- /home/manuel/workspaces/2026-03-16/add-glazed-js-layer/go-go-goja/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/reference/01-diary.md — Diary updated to capture the postmortem step and review rationale
+

--- a/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/changelog.md
+++ b/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/changelog.md
@@ -1,0 +1,47 @@
+# Changelog
+
+## 2026-03-16
+
+- Initial workspace created
+
+
+## 2026-03-16
+
+Created GOJA-04 ticket workspace, added primary docs, and imported the source proposal note into sources/local.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-03-16/add-glazed-js-layer/go-go-goja/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/index.md — Ticket workspace and index for the new research ticket
+- /home/manuel/workspaces/2026-03-16/add-glazed-js-layer/go-go-goja/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/sources/local/goja-js.md — Imported source note preserved inside the ticket
+
+
+## 2026-03-16
+
+Mapped the current go-go-goja and Glazed seams and wrote the primary design guide for a repo-native jsverbs subsystem.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-03-16/add-glazed-js-layer/glazed/pkg/cmds/cmds.go — Existing Glazed command model used as the compilation target
+- /home/manuel/workspaces/2026-03-16/add-glazed-js-layer/go-go-goja/pkg/jsdoc/extract/extract.go — Existing static extraction precedent used as a design anchor
+- /home/manuel/workspaces/2026-03-16/add-glazed-js-layer/go-go-goja/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/design-doc/01-js-to-glazed-command-exporting-design-and-implementation-guide.md — Primary architecture and implementation guide
+
+
+## 2026-03-16
+
+Added and ran a ticket-local overlay-loader experiment proving that appended registry code can capture top-level functions while preserving relative require behavior.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-03-16/add-glazed-js-layer/go-go-goja/engine/factory.go — Factory seam used by the experiment
+- /home/manuel/workspaces/2026-03-16/add-glazed-js-layer/go-go-goja/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/scripts/jsverb_overlay_experiment.go — Runtime experiment validating the core loader assumption
+
+
+## 2026-03-16
+
+Finished the diary and ticket bookkeeping, passed docmgr doctor cleanly, and uploaded the ticket bundle to reMarkable under /ai/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-03-16/add-glazed-js-layer/go-go-goja/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/changelog.md — Ticket changelog reflecting final delivery state
+- /home/manuel/workspaces/2026-03-16/add-glazed-js-layer/go-go-goja/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/reference/01-diary.md — Completed chronological diary including validation and upload results
+

--- a/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/design-doc/01-js-to-glazed-command-exporting-design-and-implementation-guide.md
+++ b/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/design-doc/01-js-to-glazed-command-exporting-design-and-implementation-guide.md
@@ -1,0 +1,1080 @@
+---
+Title: JS-to-Glazed command exporting design and implementation guide
+Ticket: GOJA-04-JS-GLAZED-EXPORTS
+Status: active
+Topics:
+    - analysis
+    - architecture
+    - goja
+    - glazed
+    - js-bindings
+    - tooling
+DocType: design-doc
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: glazed/pkg/cmds/cmds.go
+      Note: Core Glazed command interfaces and descriptions targeted by compilation
+    - Path: glazed/pkg/cmds/loaders/loaders.go
+      Note: Dynamic command loader interface and recursive directory loading flow
+    - Path: go-go-goja/engine/factory.go
+      Note: Goja runtime factory lifecycle and require option composition used by JS verb execution
+    - Path: go-go-goja/engine/module_specs.go
+      Note: Default module registration model and explicit engine composition seam
+    - Path: go-go-goja/pkg/jsdoc/extract/extract.go
+      Note: Static tree-sitter extraction precedent and helper source for jsverbs discovery
+    - Path: go-go-goja/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/scripts/jsverb_overlay_experiment.go
+      Note: Ticket-local proof that an overlay loader can capture top-level functions without breaking relative require
+    - Path: go-go-goja/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/sources/local/01-goja-js.md
+      Note: Imported source proposal that this design doc interprets and refines
+ExternalSources:
+    - local:01-goja-js.md
+Summary: Grounded design guide for adding JS-defined Glazed commands in go-go-goja using static tree-sitter extraction, normalized verb metadata, Glazed command compilation, and runtime overlay invocation.
+LastUpdated: 2026-03-16T14:35:00-04:00
+WhatFor: Give a new engineer enough context to understand the current go-go-goja and Glazed architecture, evaluate the imported proposal, and implement a new JS-to-Glazed command layer without guessing.
+WhenToUse: Use when implementing or reviewing a feature that exposes JavaScript functions as Glazed commands in go-go-goja.
+---
+
+
+# JS-to-Glazed command exporting design and implementation guide
+
+## Executive Summary
+
+The imported source note in `sources/local/01-goja-js.md` is directionally correct: the repository already has the two main ingredients needed for this feature. First, `go-go-goja` already has a static, tree-sitter-backed sentinel extractor in `pkg/jsdoc/extract/extract.go:23-389`. Second, `glazed` already has a command model and registration path that can accept dynamically produced commands through `pkg/cmds/loaders/loaders.go:23-182`, `pkg/cmds/cmds.go:17-379`, and `pkg/cli/cobra.go:410-451`.
+
+My grounded interpretation is that this ticket should create a new `pkg/jsverbs` subsystem inside `go-go-goja`, not extend `pkg/jsdoc` in place and not move the feature into `glazed`. The extraction and runtime concerns belong with the Goja integration layer, while the output target is still ordinary Glazed commands. The right architecture is:
+
+1. statically scan JavaScript for exported command candidates and sentinel metadata,
+2. normalize that data into an internal verb registry,
+3. compile each normalized verb into an ordinary Glazed command description plus runtime wrapper,
+4. invoke the matching JavaScript function through a runtime overlay loader that preserves normal CommonJS behavior.
+
+The main design refinement relative to the imported note is that the implementation should be explicit about the seam boundaries that already exist in this repo. The existing `pkg/jsdoc` package proves out AST walking, literal decoding, prose attachment, and allowed-root enforcement. The existing `engine.Factory` and `require.WithLoader(...)` hooks prove out runtime customization. The existing Glazed interfaces prove out how command registration, section parsing, and structured output should look. The new work is therefore mostly about composition and model design, not about inventing brand new primitives.
+
+## Problem Statement And Scope
+
+The requested outcome is: define commands in JavaScript, discover them without executing arbitrary JS at startup, compile them into normal Glazed commands, and execute the corresponding JavaScript function at runtime through Goja.
+
+The feature needs to satisfy four constraints that are visible in the current codebase:
+
+- Discovery must be static and deterministic.
+  Evidence: `pkg/jsdoc/extract/extract.go:38-56` parses source into a tree-sitter AST and walks nodes without executing the file.
+- Runtime behavior must fit the explicit runtime lifecycle used by `engine.Factory` and `engine.Runtime`.
+  Evidence: `engine/factory.go:90-179` builds an immutable factory and creates runtime instances with `VM`, `Require`, `Loop`, and `Owner`.
+- The result must be ordinary Glazed commands, not a parallel command system.
+  Evidence: `glazed/pkg/cmds/cmds.go:17-379` defines the command description and `GlazeCommand` interfaces; `glazed/pkg/cli/cobra.go:410-451` adds built commands into the Cobra tree.
+- File loading and path handling must respect allowed roots and repository-local module root conventions.
+  Evidence: `pkg/jsdoc/extract/scopedfs.go:20-106` already protects static parsing, and `engine/module_roots.go:11-118` already derives module roots from script paths.
+
+In scope for this ticket:
+
+- static JS discovery,
+- command metadata sentinels,
+- Glazed schema compilation,
+- runtime binding and invocation,
+- result adaptation into Glazed rows,
+- tests, docs, and developer-facing integration guidance.
+
+Out of scope for v1:
+
+- sandboxing untrusted JavaScript,
+- streaming Glazed rows directly from JS,
+- TypeScript type generation for JS verb metadata,
+- class-method command exposure,
+- arbitrary comment parsing,
+- watch-mode reload behavior.
+
+## Grounded Interpretation Of The Imported Note
+
+The imported note proposes a sibling `pkg/jsverbs` package beside `pkg/jsdoc`, a sentinel family such as `__package__`, `__section__`, and `__verb__`, a two-phase extractor/normalizer pipeline, and runtime invocation through an overlay source loader. After inspecting the repo, I think those are the right large-grain choices.
+
+What the imported note gets right:
+
+- `pkg/jsverbs` should live in `go-go-goja`, not `glazed`.
+  Reason: the parsing and runtime seams live in `go-go-goja`; `glazed` should continue to consume ordinary commands.
+- Sentinel-based metadata is a better fit than full JSDoc comment parsing.
+  Reason: `pkg/jsdoc/extract/extract.go:159-317` already relies on explicit sentinels and `doc` templates rather than free-form comment parsing.
+- The architecture should be split into extraction, normalization, compilation, and runtime.
+  Reason: the current codebase already benefits from those boundaries. `pkg/jsdoc/model/store.go:3-89` keeps storage/index concerns separate from parsing, and Glazed keeps command description separate from runtime parsing/execution.
+- Runtime overlay loading is viable.
+  Reason: the ticket-local experiment in `scripts/jsverb_overlay_experiment.go` successfully captured top-level functions through appended source while preserving relative `require("./helper.js")`.
+
+Where the imported note needs repo-specific refinement:
+
+- The note talks about compiling into `cmds.CommandDescription + schema.Section + fields.Definition`, which is correct, but the real integration point is a concrete `cmds.Command` implementation that also satisfies `cmds.GlazeCommand`.
+  Evidence: `glazed/pkg/cmds/cmds.go:336-379`.
+- The note suggests a clean `LoadCommandsFromFS` integration. In this repo that means implementing `glazed/pkg/cmds/loaders.CommandLoader`.
+  Evidence: `glazed/pkg/cmds/loaders/loaders.go:23-29`.
+- The note treats section values abstractly. In this repo runtime bindings should work from `values.Values` and `values.SectionValues`.
+  Evidence: `glazed/pkg/cmds/values/section-values.go:155-301`.
+- The note proposes reusing `__doc__` prose. That is sensible, but the current `pkg/jsdoc` package only models docs, not functions. The new package should therefore reuse helper ideas, not directly reuse the current `FileDoc` model.
+  Evidence: `pkg/jsdoc/model/model.go:17-70`.
+
+My conclusion is:
+
+- keep the imported note's overall architecture,
+- implement it in a repo-native way using the existing Goja and Glazed seams,
+- treat `pkg/jsdoc` as a precedent and helper source, not as the destination package for command logic.
+
+## Current-State Architecture
+
+### 1. Goja runtime composition
+
+`engine.FactoryBuilder` composes runtime settings before build time, validates them, and freezes them into a reusable `Factory` (`engine/factory.go:15-29`, `engine/factory.go:90-132`). `Factory.NewRuntime(...)` then creates a `goja.Runtime`, starts an event loop, creates a `runtimeowner.Runner`, enables the `require` registry, enables console support, and runs runtime initializers (`engine/factory.go:134-179`).
+
+That matters for this ticket because the JS-command runtime should not sidestep this machinery. A generated JS verb command should create a runtime through the factory, not through ad-hoc `goja.New()` calls. That preserves:
+
+- opt-in module registration via `engine.DefaultRegistryModules()` (`engine/module_specs.go:64-82`),
+- require customization via `engine.WithRequireOptions(...)` (`engine/options.go:13-20`),
+- owned lifecycle via `engine.Runtime` (`engine/runtime.go:21-49`),
+- loop ownership and cross-goroutine safety via `pkg/runtimeowner/runner.go:27-225`.
+
+### 2. JS static extraction precedent
+
+The strongest precedent is `pkg/jsdoc/extract/extract.go`. It already shows how this repo parses JavaScript source with tree-sitter, walks the top-level AST, identifies sentinel calls, attaches line numbers, and decodes simple object literals into Go models (`pkg/jsdoc/extract/extract.go:38-56`, `pkg/jsdoc/extract/extract.go:96-205`, `pkg/jsdoc/extract/extract.go:271-389`).
+
+Key reusable ideas from that package:
+
+- parser construction and AST walking,
+- sentinel detection via `call_expression`,
+- lightweight JS-object-to-JSON literal decoding,
+- `doc` tagged-template frontmatter parsing,
+- 1-based source line preservation,
+- allowed-root enforcement via `ScopedFS`.
+
+Key things that are too `jsdoc`-specific to reuse directly:
+
+- `FileDoc`, `Package`, `SymbolDoc`, and `Example` as the main output model,
+- `DocStore` indexing rules,
+- the assumption that only documentation sentinels matter and function declarations do not.
+
+This is why a sibling package is preferable to extending `pkg/jsdoc` in place.
+
+### 3. Glazed command plumbing
+
+Glazed already has the exact runtime types this feature should target:
+
+- `cmds.CommandDescription` carries `Name`, `Short`, `Long`, `Schema`, `Parents`, and `Source` (`glazed/pkg/cmds/cmds.go:17-35`).
+- `schema.SectionImpl` groups field definitions and knows how to register them on Cobra (`glazed/pkg/cmds/schema/section-impl.go:10-127`, `glazed/pkg/cmds/schema/section-impl.go:216-258`).
+- `fields.Definition` already supports names, types, help text, defaults, choices, requiredness, arguments, and short flags (`glazed/pkg/cmds/fields/definitions.go:16-84`).
+- The legal Glazed type strings are already enumerated in `glazed/pkg/cmds/fields/field-type.go:7-47`.
+- Parsed values arrive at runtime as `values.Values`, grouped by section slug (`glazed/pkg/cmds/values/section-values.go:155-301`).
+- `cli.BuildCobraCommandFromCommand(...)` and `cli.AddCommandsToRootCommand(...)` already wire dynamic commands into the Cobra tree (`glazed/pkg/cli/cobra.go:379-451`).
+
+This is a major simplification. The JS-command layer does not need to invent flag parsing, help layout, or CLI registration. It only needs to compile into the existing target types.
+
+### 4. Existing CLI precedent inside go-go-goja
+
+The `cmd/goja-jsdoc` command is the best local precedent for "new reusable subsystem plus thin Glazed CLI wrapper." Its `extract` command builds a `cmds.CommandDescription`, decodes values through the default section, and delegates into a package-level implementation (`cmd/goja-jsdoc/extract_command.go:19-95`).
+
+That suggests a good shape for future user-facing JS-command tooling:
+
+- keep the reusable logic in `pkg/jsverbs/...`,
+- keep any CLI integration thin,
+- avoid embedding the business logic directly in Cobra command setup.
+
+## Design Goals
+
+The design should optimize for these goals:
+
+1. Preserve static discovery.
+   Startup should not execute user JS just to discover commands.
+2. Preserve Glazed normality.
+   Generated commands should look like normal Glazed commands to the rest of the system.
+3. Preserve CommonJS behavior.
+   Relative `require()` inside command source files should keep working.
+4. Reuse the current runtime lifecycle.
+   Command execution should go through `engine.Factory`, `Runtime`, and `runtimeowner`.
+5. Keep metadata near the JS code.
+   Sentinel metadata should live in the same file as the functions it describes.
+6. Fail loudly on collisions and unsupported syntax.
+   Discovery should be deterministic and explicit.
+
+## Proposed Package Layout
+
+I recommend the following package layout inside `go-go-goja/pkg`:
+
+```text
+pkg/
+  jsverbs/
+    model/
+      raw.go
+      model.go
+      diagnostics.go
+      registry.go
+
+    extract/
+      extract.go
+      functions.go
+      literals.go
+      templates.go
+
+    normalize/
+      normalize.go
+      merge_jsdoc.go
+
+    compile/
+      glazed.go
+      bindings.go
+      help.go
+
+    runtime/
+      command.go
+      loader.go
+      invoke.go
+      marshal.go
+      adapt.go
+      context.go
+
+    loaders/
+      loader.go
+```
+
+Reasoning for this split:
+
+- `model/` keeps extraction output and normalized runtime contracts distinct.
+- `extract/` remains static and syntax-oriented.
+- `normalize/` is where semantic rules, defaults, inheritance, and collision checks should live.
+- `compile/` is explicitly Glazed-facing.
+- `runtime/` is explicitly Goja-facing.
+- `loaders/` is the Glazed `CommandLoader` adapter.
+
+This is consistent with the way the repo already separates extraction, model, and consumer-specific behavior in `pkg/jsdoc`.
+
+## Authoring Model
+
+### Sentinel family
+
+I agree with the imported note that the command system should use explicit sentinels rather than comment parsing.
+
+Recommended sentinel set:
+
+- `__package__(...)`
+  File-level metadata and default command grouping.
+- `__section__(...)`
+  Shared or reusable flag sections.
+- `__verb__(...)`
+  Per-function command metadata.
+- `doc\`...\``
+  Long-form prose and frontmatter for command help.
+
+This is additive to the existing `jsdoc` style. A future implementation may optionally merge in `__doc__` summaries and parameter descriptions, but command extraction should not require `__doc__`.
+
+### Minimal authoring example
+
+```js
+__package__({
+  name: "math",
+  title: "Math tools",
+  description: "Small math utilities exposed as CLI verbs."
+});
+
+__verb__("clamp", {
+  short: "Clamp a number to a range",
+  params: {
+    value: { type: "float", positional: true, help: "Input value" },
+    min: { type: "float", positional: true, help: "Lower bound" },
+    max: { type: "float", positional: true, help: "Upper bound" }
+  }
+});
+
+doc`
+---
+verb: clamp
+---
+
+Clamp a value to the inclusive range [min, max].
+`;
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function lerp(a, b, t = 0.5) {
+  return a + (b - a) * t;
+}
+```
+
+### Public function discovery rules
+
+For v1 I recommend discovering these top-level forms:
+
+- `function foo(...) {}`
+- `async function foo(...) {}`
+- `const foo = (...) => {}`
+- `const foo = async (...) => {}`
+- `const foo = function (...) {}`
+- exported variants of the same forms if they appear in source
+
+Do not auto-expose:
+
+- nested functions,
+- class methods,
+- anonymous expressions,
+- names starting with `_`.
+
+Inference based on current Glazed loader behavior:
+
+Because `LoadCommandsFromFS` recursively scans directories (`glazed/pkg/cmds/loaders/loaders.go:109-182`), accidental command exposure would be confusing. I therefore recommend one loader option for strict mode:
+
+```go
+type LoaderOptions struct {
+    RequireVerbSentinel bool
+}
+```
+
+Default behavior can remain auto-expose-public-functions, but hosts should be able to opt into strict sentinel-only behavior.
+
+## Core Data Model
+
+### Raw extraction model
+
+```go
+type RawFileSpec struct {
+    FilePath       string
+    Package        *RawPackage
+    SharedSections []*RawSection
+    VerbOverlays   []*RawVerb
+    Functions      []*FunctionDecl
+    DocBlocks      []*RawDocBlock
+    Diagnostics    []Diagnostic
+}
+
+type FunctionDecl struct {
+    Name       string
+    Async      bool
+    Kind       FunctionKind
+    Params     []*FunctionParam
+    SourceFile string
+    Line       int
+}
+
+type FunctionParam struct {
+    Name          string
+    IsDestructured bool
+    DefaultLiteral any
+}
+```
+
+### Normalized model
+
+```go
+type Registry struct {
+    Verbs       []*VerbSpec
+    ByPath      map[string]*VerbSpec
+    Diagnostics []Diagnostic
+}
+
+type VerbSpec struct {
+    FunctionName string
+    CommandName  string
+    Parents      []string
+    Short        string
+    Long         string
+    Hidden       bool
+    Sections     []*SectionSpec
+    Bindings     []*BindingSpec
+    SourceFile   string
+    Line         int
+}
+
+type SectionSpec struct {
+    Slug        string
+    Name        string
+    Description string
+    Prefix      string
+    Fields      []*FieldSpec
+}
+
+type FieldSpec struct {
+    Name       string
+    Type       string
+    Help       string
+    Default    any
+    Choices    []string
+    Required   bool
+    ShortFlag  string
+    Positional bool
+}
+
+type BindingSpec struct {
+    ParamName   string
+    Kind        BindingKind // flag | section | all | context
+    SectionSlug string
+    FieldName   string
+}
+```
+
+Why this split matters:
+
+- extraction can stay deterministic and syntax-only,
+- normalization can accumulate semantic diagnostics,
+- compilation can focus only on Glazed targets,
+- runtime can rely on a stable binding contract.
+
+## Discovery, Normalization, Compilation, Runtime
+
+### High-level architecture diagram
+
+```text
+JavaScript source files
+        |
+        v
++---------------------+
+| jsverbs/extract     |
+| - tree-sitter walk  |
+| - function capture  |
+| - sentinel capture  |
+| - doc block capture |
++---------------------+
+        |
+        v
++---------------------+
+| jsverbs/normalize   |
+| - defaults          |
+| - path rules        |
+| - collision checks  |
+| - binding plan      |
++---------------------+
+        |
+        +-----------------------------+
+        |                             |
+        v                             v
++---------------------+      +----------------------+
+| jsverbs/compile     |      | jsverbs/runtime      |
+| -> Glazed command   |      | -> call JS function  |
+| descriptions        |      | -> adapt results     |
++---------------------+      +----------------------+
+        |
+        v
++---------------------+
+| Glazed/Cobra tree   |
++---------------------+
+```
+
+### Phase A: extraction
+
+Implementation notes:
+
+- Reuse the tree-sitter parser setup from `pkg/jsdoc/extract/extract.go:38-56`.
+- Reuse the literal-decoding helper style from `pkg/jsdoc/extract/extract.go:385-519`, but move any reusable pieces into `pkg/jsverbs/extract/literals.go`.
+- Extend the AST walker to capture function declarations and variable declarators in addition to sentinel calls.
+
+Pseudocode:
+
+```pseudo
+function ExtractFile(path, src):
+  tree = parseJavaScript(src)
+  raw = new RawFileSpec(path)
+
+  for node in root.children:
+    switch node.kind:
+      case call_expression:
+        maybeCapturePackage(node)
+        maybeCaptureSection(node)
+        maybeCaptureVerb(node)
+        maybeCaptureDocTemplate(node)
+      case function_declaration:
+        captureFunction(node)
+      case lexical_declaration:
+        captureVariableFunctionForms(node)
+      case export_statement:
+        recurseIntoExport(node)
+
+  return raw
+```
+
+### Phase B: normalization
+
+Normalization should:
+
+1. compute command paths,
+2. infer default field definitions from JS parameters,
+3. merge explicit overrides,
+4. attach shared sections,
+5. merge help text and prose,
+6. validate collisions and unsupported shapes,
+7. produce a final `Registry`.
+
+Important normalization rules:
+
+- command path = discovered parents from directory + optional package path + verb leaf,
+- default field name = kebab-case parameter name,
+- no JS default literal means required field,
+- destructured parameters are invalid unless explicitly bound as `section` or `all`,
+- duplicate command paths are hard errors,
+- duplicate short flags are hard errors,
+- positional arguments must stay in the default section.
+
+### Phase C: Glazed compilation
+
+Compilation should be intentionally boring:
+
+- `VerbSpec.CommandName` -> `cmds.CommandDescription.Name`
+- `VerbSpec.Parents` -> `cmds.WithParents(...)`
+- `VerbSpec.Short` and `Long` -> help text
+- `SectionSpec` -> `schema.NewSection(...)`
+- `FieldSpec` -> `fields.New(...)`
+- positional fields -> `fields.WithIsArgument(true)`
+
+Compilation pseudocode:
+
+```pseudo
+function CompileVerb(verbSpec):
+  sections = []
+  for each sectionSpec in verbSpec.sections:
+    section = schema.NewSection(sectionSpec.slug, sectionSpec.name, ...)
+    for each fieldSpec in sectionSpec.fields:
+      def = fields.New(fieldSpec.name, fieldSpec.type, ...)
+      if fieldSpec.positional:
+        def.IsArgument = true
+      section.AddFields(def)
+    sections.append(section)
+
+  desc = cmds.NewCommandDescription(
+    verbSpec.commandName,
+    WithShort(verbSpec.short),
+    WithLong(verbSpec.long),
+    WithParents(verbSpec.parents...),
+    WithSections(sections...),
+    WithSource("jsverbs/" + verbSpec.sourceFile),
+  )
+
+  return JSVerbCommand{CommandDescription: desc, Verb: verbSpec}
+```
+
+### Phase D: runtime invocation
+
+Runtime should construct a real `cmds.GlazeCommand` implementation. That command should:
+
+1. create a fresh runtime from `engine.Factory`,
+2. install sentinel no-ops,
+3. require the target file through an overlay source loader,
+4. fetch the target function from a global registry inserted by the overlay,
+5. convert parsed Glazed values into JS call arguments,
+6. call the JS function,
+7. adapt the result into Glazed rows.
+
+Runtime diagram:
+
+```text
+parsed Glazed values
+        |
+        v
++------------------------+
+| JSVerbCommand.Run...   |
+| create runtime         |
++------------------------+
+        |
+        v
++------------------------+
+| require.WithLoader     |
+| overlay source         |
+| - sentinel no-ops      |
+| - original source      |
+| - registry appendix    |
++------------------------+
+        |
+        v
++------------------------+
+| globalThis registry    |
+| function lookup        |
++------------------------+
+        |
+        v
++------------------------+
+| JS invocation          |
+| result adaptation      |
++------------------------+
+        |
+        v
+Glazed rows
+```
+
+## Overlay Loader Design
+
+### Why the overlay is needed
+
+The imported note is correct that CommonJS top-level functions are not automatically exported. Requiring a file normally only gives `module.exports`, not arbitrary top-level declarations.
+
+The overlay strategy is the cleanest repo-native answer because:
+
+- `engine.WithRequireOptions(...)` already accepts `require.WithLoader(...)` (`engine/options.go:13-20`),
+- `cmd/bun-demo/main.go:21-58` already proves that custom source loaders are a supported pattern here,
+- the overlay preserves CommonJS semantics instead of rewriting `module.exports`.
+
+### Experiment result
+
+I validated the overlay idea with `ttmp/.../scripts/jsverb_overlay_experiment.go`.
+
+Observed result:
+
+```json
+{
+  "hiddenType": "func(goja.FunctionCall) goja.Value",
+  "listIssues": "repo:openai/openai",
+  "moduleExports": {
+    "exported": true
+  },
+  "registryKeys": [
+    "listIssues",
+    "hidden"
+  ]
+}
+```
+
+What this proves:
+
+- appended code in the same module scope can still reference top-level function and `const` declarations,
+- relative `require("./helper.js")` continues to work,
+- the overlay can register functions without mutating `module.exports`.
+
+Operational note:
+
+- Running `go run` from the repo root initially failed because the top-level `go.work` file advertises lower Go versions than some modules require.
+- The experiment ran successfully with `GOWORK=off`.
+
+That exact failure should be preserved in the diary because it affects future ticket-local experiments.
+
+## Binding Model
+
+Each JS parameter should compile into one of four runtime binding modes.
+
+### `bind: "flag"`
+
+Default mode. One Glazed field becomes one JS argument.
+
+Example:
+
+```js
+function echo(text, upper = false) {}
+```
+
+Runtime:
+
+- `text` <- string or positional argument,
+- `upper` <- bool flag.
+
+### `bind: "section"`
+
+One JS parameter receives an object built from one Glazed section.
+
+Example:
+
+```js
+function listIssues(repo, auth) {}
+```
+
+Where:
+
+```js
+auth = {
+  token: "...",
+  baseUrl: "https://api.github.com"
+}
+```
+
+Recommendation:
+
+- JS object keys should be camelCase,
+- CLI flags should remain kebab-case,
+- normalization should own this name conversion.
+
+### `bind: "all"`
+
+One JS parameter receives a grouped object of all resolved sections.
+
+Suggested shape:
+
+```js
+{
+  default: { ... },
+  auth: { ... },
+  glazed: { ... },
+  commandSettings: { ... }
+}
+```
+
+### `bind: "context"`
+
+One JS parameter receives runtime metadata rather than user-provided flags.
+
+Suggested shape:
+
+```js
+{
+  verb: {
+    name: "list-issues",
+    functionName: "listIssues",
+    sourceFile: "github/issues.js",
+    path: ["github", "list-issues"]
+  },
+  sections: { ... },
+  cwd: "/current/dir"
+}
+```
+
+Keep this intentionally small in v1.
+
+## Help Text And JSDoc Merging
+
+I recommend a layered help strategy rather than making `jsverbs` depend on `jsdoc` authoring everywhere.
+
+Merge order:
+
+1. `__verb__.short`
+2. matching `__doc__.summary` if available
+3. humanized function name
+
+For flag help:
+
+1. explicit `__verb__.params[param].help`
+2. matching `__doc__.params[].description`
+3. empty string
+
+For long help:
+
+1. `doc` block with `verb: <name>` frontmatter
+2. matching `__doc__.prose`
+3. package prose
+
+This gives a nice migration path:
+
+- command authors can stay fully command-centric,
+- existing jsdocex-style docs can enrich help without becoming mandatory.
+
+## Security And Allowed Roots
+
+This feature must make an explicit trust-boundary statement: it is not a sandbox for untrusted JavaScript.
+
+Static discovery should reuse the defensive posture already present in `pkg/jsdoc/extract/scopedfs.go:20-106`:
+
+- reject absolute paths,
+- reject traversal,
+- reject symlink escapes,
+- require all parsed files to stay inside the configured root.
+
+Runtime execution should mirror that intent:
+
+- only load files under an explicitly provisioned root,
+- only expose native modules that the host registered on the engine factory,
+- never imply that "Goja means safe."
+
+## API Sketch
+
+### Top-level package API
+
+```go
+package jsverbs
+
+type Loader struct {
+    factory *engine.Factory
+    rootDir string
+    opts    LoaderOptions
+}
+
+func NewLoader(factory *engine.Factory, rootDir string, opts ...LoaderOption) (*Loader, error)
+
+func (l *Loader) Discover(ctx context.Context) (*model.Registry, error)
+```
+
+### Glazed loader adapter
+
+```go
+package loaders
+
+type JSVerbLoader struct {
+    Factory *engine.Factory
+    RootDir string
+    Opts    Options
+}
+
+func (l *JSVerbLoader) LoadCommands(
+    f fs.FS,
+    entryName string,
+    options []cmds.CommandDescriptionOption,
+    aliasOptions []alias.Option,
+) ([]cmds.Command, error)
+
+func (l *JSVerbLoader) IsFileSupported(f fs.FS, fileName string) bool
+```
+
+### Runtime command wrapper
+
+```go
+type JSVerbCommand struct {
+    *cmds.CommandDescription
+    Verb    *model.VerbSpec
+    Factory *engine.Factory
+    RootDir string
+}
+
+func (c *JSVerbCommand) RunIntoGlazeProcessor(
+    ctx context.Context,
+    parsedValues *values.Values,
+    gp middlewares.Processor,
+) error
+```
+
+## Detailed Implementation Plan
+
+### Phase 1: extraction package
+
+Files:
+
+- `pkg/jsverbs/model/raw.go`
+- `pkg/jsverbs/extract/extract.go`
+- `pkg/jsverbs/extract/functions.go`
+- `pkg/jsverbs/extract/literals.go`
+- `pkg/jsverbs/extract/templates.go`
+
+Tasks:
+
+1. Copy the parser/bootstrap approach from `pkg/jsdoc/extract/extract.go`.
+2. Add function-declaration discovery.
+3. Add `__section__` and `__verb__` literal parsing.
+4. Preserve line numbers and source file paths.
+5. Add extraction diagnostics instead of silent drops where possible.
+
+Tests:
+
+- top-level function discovery,
+- arrow and function-expression discovery,
+- underscore-private exclusion,
+- sentinel extraction,
+- doc block attachment,
+- line-number correctness.
+
+### Phase 2: normalization package
+
+Files:
+
+- `pkg/jsverbs/model/model.go`
+- `pkg/jsverbs/model/diagnostics.go`
+- `pkg/jsverbs/model/registry.go`
+- `pkg/jsverbs/normalize/normalize.go`
+- `pkg/jsverbs/normalize/merge_jsdoc.go`
+
+Tasks:
+
+1. Build command paths from directory and package context.
+2. Infer fields from function parameters.
+3. Attach shared sections.
+4. Compile binding plans.
+5. Detect collisions and unsupported cases.
+
+Tests:
+
+- duplicate command path detection,
+- duplicate short flags,
+- default type inference,
+- destructuring rejection,
+- `bind: section`, `bind: all`, `bind: context`,
+- package-path overrides.
+
+### Phase 3: Glazed compilation
+
+Files:
+
+- `pkg/jsverbs/compile/glazed.go`
+- `pkg/jsverbs/compile/bindings.go`
+- `pkg/jsverbs/compile/help.go`
+
+Tasks:
+
+1. Map section specs to `schema.Section`.
+2. Map fields to `fields.Definition`.
+3. Construct `cmds.CommandDescription`.
+4. Preserve `Parents` and `Source`.
+5. Generate stable short and long help text.
+
+Tests:
+
+- field type compilation,
+- positional argument ordering,
+- prefixed section flags,
+- help-merge precedence.
+
+### Phase 4: runtime package
+
+Files:
+
+- `pkg/jsverbs/runtime/command.go`
+- `pkg/jsverbs/runtime/loader.go`
+- `pkg/jsverbs/runtime/invoke.go`
+- `pkg/jsverbs/runtime/marshal.go`
+- `pkg/jsverbs/runtime/adapt.go`
+- `pkg/jsverbs/runtime/context.go`
+
+Tasks:
+
+1. Build overlay loader around `require.WithLoader(...)`.
+2. Install sentinel no-ops.
+3. Register discovered top-level functions in a runtime-global registry.
+4. Resolve the selected function by file and name.
+5. Marshal section values into JS arguments.
+6. Adapt sync and async results into rows.
+
+Tests:
+
+- relative require survives overlay,
+- top-level function capture,
+- object-param section binding,
+- all-sections binding,
+- context binding,
+- primitive/object/list result adaptation,
+- promise resolution if async support is enabled.
+
+### Phase 5: Glazed loader integration
+
+Files:
+
+- `pkg/jsverbs/loaders/loader.go`
+- optionally a small example command under `cmd/`
+
+Tasks:
+
+1. Implement `glazed/pkg/cmds/loaders.CommandLoader`.
+2. Return multiple commands per JS file when necessary.
+3. Integrate with `loaders.LoadCommandsFromFS(...)`.
+4. Document how host apps attach the loader.
+
+Minimal host example:
+
+```go
+factory, err := engine.NewBuilder().
+    WithModules(engine.DefaultRegistryModules()).
+    Build()
+if err != nil {
+    return err
+}
+
+loader := jsverbsloaders.NewJSVerbLoader(factory, rootDir)
+
+commands, err := loaders.LoadCommandsFromFS(
+    os.DirFS(rootDir),
+    ".",
+    "jsverbs",
+    loader,
+    nil,
+    nil,
+)
+if err != nil {
+    return err
+}
+
+return cli.AddCommandsToRootCommand(rootCmd, commands, nil)
+```
+
+## Test And Validation Strategy
+
+Unit tests:
+
+- extractor tests using small inline JS snippets,
+- normalizer tests using raw fixtures,
+- compiler tests over normalized specs,
+- runtime loader and invocation tests using in-memory source maps,
+- result adapter tests for primitives, objects, arrays, and nulls.
+
+Integration tests:
+
+- one directory with multiple JS verbs,
+- nested package paths,
+- duplicate path failure,
+- host command registration through `LoadCommandsFromFS(...)`,
+- smoke test executing a generated Glazed command and asserting rows.
+
+Manual validation:
+
+1. Create a sample JS directory with `__package__`, `__section__`, `__verb__`, and plain top-level functions.
+2. Discover and register commands into a small Cobra root.
+3. Run:
+   - positional-argument command,
+   - prefixed-section command,
+   - async-return command,
+   - malformed-file failure case.
+4. Confirm help text, command paths, and row output.
+
+## Risks, Alternatives, And Open Questions
+
+### Risks
+
+- Accidental command exposure if auto-discovery is too permissive.
+- Complexity creep if `jsverbs` tries to subsume every `jsdoc` behavior instead of staying command-focused.
+- Binding ambiguity for destructured parameters and nested objects.
+- Runtime/debug confusion if overlay-generated source is not easy to inspect in errors.
+
+### Recommended mitigations
+
+- provide strict sentinel-only mode,
+- accumulate file-local diagnostics before failing,
+- include source file and line in every normalized verb,
+- keep the overlay source builder small and testable,
+- write the generated overlaid source to temp files in debug mode when needed.
+
+### Alternatives considered
+
+#### 1. Sidecar YAML or JSON command descriptors
+
+Rejected because metadata drift is likely and the repo already favors code-local metadata.
+
+#### 2. Extending `pkg/jsdoc` directly
+
+Rejected because documentation and command exposure are related but distinct concerns. `pkg/jsdoc` should remain focused on documentation extraction and export.
+
+#### 3. Runtime-only introspection
+
+Rejected because it would require executing JS during discovery, which conflicts with the repository's existing static-extraction precedent and makes failure modes less deterministic.
+
+### Open questions
+
+1. Should v1 auto-expose public top-level functions by default, or require `__verb__` unless explicitly opted out?
+2. Should `__section__` be file-scoped only in v1, or support package-wide reuse across files?
+3. Should async support await native promises immediately in v1, or land after sync commands are stable?
+4. Should `jsverbs` merge with `jsdoc` only when a separate `DocStore` is available, or directly parse `__doc__` in the same pass?
+
+## File-Level Guidance For A New Intern
+
+If you are implementing this ticket from scratch, start in this order:
+
+1. Read `go-go-goja/pkg/jsdoc/extract/extract.go`.
+   Learn how the repo already uses tree-sitter and simple JS-literal decoding.
+2. Read `go-go-goja/engine/factory.go`, `engine/runtime.go`, and `pkg/runtimeowner/runner.go`.
+   Learn how runtimes are constructed and why you should not bypass the factory.
+3. Read `glazed/pkg/cmds/cmds.go`, `glazed/pkg/cmds/schema/section-impl.go`, `glazed/pkg/cmds/fields/definitions.go`, and `glazed/pkg/cmds/values/section-values.go`.
+   Learn the command/section/field/value model you are compiling into.
+4. Read `glazed/pkg/cmds/loaders/loaders.go` and `glazed/pkg/cli/cobra.go`.
+   Learn how dynamically discovered commands get attached to Cobra.
+5. Run `ttmp/.../scripts/jsverb_overlay_experiment.go`.
+   Learn why the overlay loader approach works before you write production code.
+
+## References
+
+- Imported proposal:
+  - `ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/sources/local/01-goja-js.md`
+- Ticket-local experiment:
+  - `ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/scripts/jsverb_overlay_experiment.go`
+- Goja runtime composition:
+  - `engine/factory.go:15-179`
+  - `engine/runtime.go:21-49`
+  - `engine/module_specs.go:14-82`
+  - `engine/module_roots.go:11-118`
+  - `pkg/runtimeowner/runner.go:27-225`
+- JS extraction precedent:
+  - `pkg/jsdoc/extract/extract.go:23-584`
+  - `pkg/jsdoc/extract/scopedfs.go:20-106`
+  - `pkg/jsdoc/model/model.go:17-70`
+  - `pkg/jsdoc/model/store.go:3-89`
+  - `cmd/goja-jsdoc/extract_command.go:19-95`
+  - `cmd/goja-jsdoc/doc/01-jsdoc-system.md:35-259`
+- Glazed command target types:
+  - `../glazed/pkg/cmds/cmds.go:17-379`
+  - `../glazed/pkg/cmds/loaders/loaders.go:23-182`
+  - `../glazed/pkg/cmds/schema/section-impl.go:10-279`
+  - `../glazed/pkg/cmds/fields/definitions.go:16-84`
+  - `../glazed/pkg/cmds/fields/field-type.go:7-47`
+  - `../glazed/pkg/cmds/fields/cobra.go:54-280`
+  - `../glazed/pkg/cmds/values/section-values.go:155-301`
+  - `../glazed/pkg/cli/cobra-parser.go:91-260`
+  - `../glazed/pkg/cli/cobra.go:379-451`
+  - `../glazed/pkg/cmds/runner/run.go:39-92`

--- a/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/design-doc/02-js-verbs-prototype-postmortem-and-code-review.md
+++ b/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/design-doc/02-js-verbs-prototype-postmortem-and-code-review.md
@@ -1,0 +1,1179 @@
+---
+Title: JS verbs prototype postmortem and code review
+Ticket: GOJA-04-JS-GLAZED-EXPORTS
+Status: active
+Topics:
+    - analysis
+    - architecture
+    - goja
+    - glazed
+    - js-bindings
+    - tooling
+DocType: design-doc
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: cmd/jsverbs-example/main.go
+      Note: |-
+        Example runner bootstrapping and help/logging integration reviewed in detail here
+        Example runner bootstrap and logging/help integration reviewed for CLI ergonomics
+    - Path: pkg/doc/doc.go
+      Note: Shared Glazed help loader used by the example runner
+    - Path: pkg/jsverbs/command.go
+      Note: |-
+        Command-compilation and output-adaptation logic reviewed in detail here
+        Command compilation and output adaptation code reviewed for duplicated policy and ergonomics
+    - Path: pkg/jsverbs/jsverbs_test.go
+      Note: |-
+        Test coverage and test-shape analysis for the prototype
+        Test coverage reviewed for happy-path strength and failure-path gaps
+    - Path: pkg/jsverbs/runtime.go
+      Note: |-
+        Runtime invocation and overlay-loader implementation reviewed in detail here
+        Runtime bridge reviewed for overlay loader
+    - Path: pkg/jsverbs/scan.go
+      Note: |-
+        Static scanner and metadata normalization logic reviewed in detail here
+        Static scanner and metadata parsing code reviewed for brittleness and cleanup opportunities
+ExternalSources: []
+Summary: Detailed postmortem and code review of the jsverbs prototype added since origin/main, covering architecture, strengths, weaknesses, non-idiomatic choices, cleanup priorities, and intern-oriented implementation guidance.
+LastUpdated: 2026-03-16T16:24:34.516454875-04:00
+WhatFor: Provide an evidence-backed review of the jsverbs prototype that explains both how it works and where it should be cleaned up before being treated as production-quality infrastructure.
+WhenToUse: Use when onboarding a new engineer to the jsverbs prototype, reviewing the current implementation against Go and Glazed idioms, or planning the next cleanup/refactor pass.
+---
+
+
+# JS verbs prototype postmortem and code review
+
+## Executive Summary
+
+This document reviews everything added on the current branch since `origin/main`, which at the time of writing is one feature commit:
+
+- `4e4e893` - `Add jsverbs prototype runner and shared docs`
+
+The new code introduces a proof-of-concept subsystem in `pkg/jsverbs` that scans JavaScript files, discovers top-level functions and metadata sentinels, compiles them into Glazed commands, and executes them through a goja runtime with a source-overlay loader. The branch also adds an example runner in `cmd/jsverbs-example`, fixture coverage in `testdata/jsverbs`, shared Glazed help pages under `pkg/doc`, and ticket-local research artifacts under `ttmp/.../GOJA-04-JS-GLAZED-EXPORTS--...`.
+
+The prototype is useful and directionally correct. It proves that the overall product shape is viable:
+
+- static JS discovery can produce a usable command registry,
+- command descriptions can be derived from JS metadata and Glazed schemas,
+- runtime invocation can bridge Go and JavaScript without hand-written Go commands,
+- relative `require()` still works when source is wrapped by an overlay loader.
+
+At the same time, the prototype is still obviously a prototype. The code works, the tests cover the happy path well enough for exploration, and the help/docs are much better than average for a spike, but several parts are not yet production-grade. The major concerns are not deprecated APIs or obvious syntax mistakes. We already cleaned those up. The real problems are structural:
+
+1. the scanner silently ignores malformed metadata,
+2. the metadata parser relies on a handwritten JS-object-to-JSON conversion pass,
+3. command-compilation logic and runtime argument-binding logic have to stay manually synchronized,
+4. the runtime creates a fresh engine factory for every invocation,
+5. promise waiting is implemented as polling,
+6. the example runner bootstraps command discovery with manual pre-parse argument inspection.
+
+For a new intern, the right mindset is this:
+
+- treat the current implementation as a strong feasibility prototype,
+- trust the tested flows,
+- do not mistake the current internal shape for the final architecture,
+- focus first on making metadata handling stricter and cleaner before adding more features.
+
+## Scope and Review Method
+
+This review covers all branch changes relative to `origin/main`, with primary attention on executable code and the shared help/documentation path. The changed code surface is:
+
+- `cmd/jsverbs-example/main.go`
+- `pkg/jsverbs/model.go`
+- `pkg/jsverbs/scan.go`
+- `pkg/jsverbs/command.go`
+- `pkg/jsverbs/runtime.go`
+- `pkg/jsverbs/jsverbs_test.go`
+- `pkg/doc/08-jsverbs-example-overview.md`
+- `pkg/doc/09-jsverbs-example-fixture-format.md`
+- `pkg/doc/10-jsverbs-example-developer-guide.md`
+- `pkg/doc/11-jsverbs-example-reference.md`
+- `testdata/jsverbs/...`
+
+This review also references pre-existing framework seams because those explain whether the new code is idiomatic and where future cleanup should attach:
+
+- `go-go-goja/engine/factory.go`
+- `glazed/pkg/cmds/cmds.go`
+- `glazed/pkg/cli/cobra.go`
+- `glazed/pkg/cmds/logging/init.go`
+- `go-go-goja/pkg/doc/doc.go`
+
+The analysis method was:
+
+1. inspect the exact `origin/main...HEAD` diff,
+2. read the new code with line anchors,
+3. compare the implementation choices against existing Goja and Glazed extension seams,
+4. identify correctness, maintainability, and idiomatic-Go concerns,
+5. turn that into a cleanup-oriented postmortem for a new engineer.
+
+## Easy Onramp For A New Intern
+
+If you are seeing this subsystem for the first time, start with a very simple mental model:
+
+- `scan.go` answers: "What commands exist in this JS tree?"
+- `command.go` answers: "How should those commands look to Glazed and Cobra?"
+- `runtime.go` answers: "How do we actually call the JS function once the user ran the command?"
+- `main.go` answers: "How does the example binary expose all of that at the CLI?"
+
+Read in exactly that order.
+
+Then run these commands from the workspace root:
+
+```bash
+go test ./go-go-goja/pkg/jsverbs ./go-go-goja/cmd/jsverbs-example
+go run ./go-go-goja/cmd/jsverbs-example --dir ./go-go-goja/testdata/jsverbs list
+go run ./go-go-goja/cmd/jsverbs-example --dir ./go-go-goja/testdata/jsverbs basics greet Manuel --excited
+go run ./go-go-goja/cmd/jsverbs-example --dir ./go-go-goja/testdata/jsverbs basics banner Manuel
+go run ./go-go-goja/cmd/jsverbs-example --dir ./go-go-goja/testdata/jsverbs help jsverbs-example-developer-guide
+```
+
+Those commands show the entire lifecycle:
+
+- `list` shows what the scanner discovered,
+- `greet` shows a structured Glazed command,
+- `banner` shows text-mode output,
+- `help ...` shows how the shared `pkg/doc` docs are wired in.
+
+After that, open these files side by side:
+
+- `pkg/jsverbs/scan.go`
+- `pkg/jsverbs/command.go`
+- `pkg/jsverbs/runtime.go`
+- `testdata/jsverbs/basics.js`
+- `pkg/jsverbs/jsverbs_test.go`
+
+That combination is enough to understand almost every branch-specific design choice.
+
+## What The System Is
+
+The subsystem can be viewed as a four-stage pipeline:
+
+```text
+JS source files
+    |
+    v
+[scan.go]
+Static extraction of:
+- top-level functions
+- __package__
+- __section__
+- __verb__
+- doc`...`
+    |
+    v
+[model.go]
+Normalized in-memory registry:
+- FileSpec
+- FunctionSpec
+- VerbSpec
+- SectionSpec
+- FieldSpec
+    |
+    v
+[command.go]
+Compilation into Glazed commands:
+- CommandDescription
+- GlazeCommand or WriterCommand
+    |
+    v
+[runtime.go]
+Per-invocation goja runtime:
+- custom require loader
+- overlay prelude/suffix
+- argument marshalling
+- function call
+- result adaptation
+```
+
+That architecture is sensible because it respects the difference between discovery and execution.
+
+The static stage answers "what is the command tree?" without running user code.
+The runtime stage answers "how do we invoke one chosen function?" only after the CLI has already parsed arguments.
+
+This separation is one of the best parts of the prototype. It matches how Glazed works. A Glazed command needs a schema and description before execution. The JS cannot be treated only as dynamic runtime code because the CLI surface has to exist before the command is invoked.
+
+## Architecture Walkthrough With File References
+
+### 1. Registry model
+
+The central data model lives in `pkg/jsverbs/model.go`.
+
+Important types:
+
+- `Registry`
+- `FileSpec`
+- `FunctionSpec`
+- `VerbSpec`
+- `SectionSpec`
+- `FieldSpec`
+- `ParameterSpec`
+
+Why this matters:
+
+- `Registry` is the stable boundary between scanning and command creation.
+- `VerbSpec` is the real "unit of command" in the subsystem.
+- `FieldSpec` and `SectionSpec` are the bridge between JS metadata and Glazed schema definitions.
+
+Relevant code:
+
+- `Registry` and `FileSpec`: `pkg/jsverbs/model.go:31-51`
+- `VerbSpec`: `pkg/jsverbs/model.go:93-105`
+- output mode constants: `pkg/jsverbs/model.go:107-110`
+
+This model is mostly clean. It is simple value-carrying state with a few helper methods. That is idiomatic enough and easy to reason about.
+
+### 2. Static scanner
+
+The scanner lives in `pkg/jsverbs/scan.go`.
+
+The top-level flow is:
+
+1. walk the directory tree,
+2. read JS files,
+3. parse them with tree-sitter JavaScript,
+4. collect top-level function declarations and metadata sentinel calls,
+5. normalize those into `FileSpec`,
+6. finalize all discovered verbs into the registry.
+
+Relevant code:
+
+- directory walk and parser setup: `pkg/jsverbs/scan.go:17-133`
+- finalize discovered verbs: `pkg/jsverbs/scan.go:136-220`
+- top-level extractor dispatch: `pkg/jsverbs/scan.go:255-338`
+- sentinel handlers: `pkg/jsverbs/scan.go:340-446`
+- parameter parsing: `pkg/jsverbs/scan.go:509-563`
+- metadata object conversion: `pkg/jsverbs/scan.go:594-833`
+
+This file is doing the most work and is also the least elegant part of the implementation. That is not surprising. Scanners often start out as a mixture of syntax walking, normalization, and fallback heuristics. But it is the first place that should be cleaned up.
+
+### 3. Command compiler
+
+The command compiler lives in `pkg/jsverbs/command.go`.
+
+Its job is:
+
+1. turn `VerbSpec` into a `cmds.CommandDescription`,
+2. build Glazed sections and fields,
+3. choose whether a verb becomes a structured `GlazeCommand` or a text `WriterCommand`,
+4. adapt JS return values into rows or text.
+
+Relevant code:
+
+- command wrapper types: `pkg/jsverbs/command.go:22-35`
+- registry-to-command conversion: `pkg/jsverbs/command.go:37-70`
+- schema assembly: `pkg/jsverbs/command.go:72-239`
+- field inference and definition building: `pkg/jsverbs/command.go:241-390`
+- structured output path: `pkg/jsverbs/command.go:393-408`
+- text output path: `pkg/jsverbs/command.go:410-447`
+- row conversion helpers: `pkg/jsverbs/command.go:450-513`
+
+This file is conceptually sound, but it currently owns too many policies at once:
+
+- section existence,
+- field inference,
+- defaults normalization,
+- runtime output shape adaptation,
+- some cross-checks on parameter binding.
+
+It works, but it is dense. A new contributor can still follow it, but only by reading it carefully from top to bottom.
+
+### 4. Runtime bridge
+
+The runtime bridge lives in `pkg/jsverbs/runtime.go`.
+
+Its job is:
+
+1. create a goja runtime factory,
+2. load the JS module through a custom loader,
+3. inject a prelude and suffix so sentinel symbols exist and top-level functions are captured,
+4. build JS arguments from parsed Glazed values,
+5. call the correct function,
+6. wait for promise completion if needed.
+
+Relevant code:
+
+- runtime construction and call path: `pkg/jsverbs/runtime.go:21-86`
+- argument binding: `pkg/jsverbs/runtime.go:88-155`
+- custom loader and overlay injection: `pkg/jsverbs/runtime.go:157-221`
+- module resolution: `pkg/jsverbs/runtime.go:223-248`
+- promise waiting: `pkg/jsverbs/runtime.go:250-300`
+
+This file proves the feasibility of the runtime approach. It also contains one of the most important design insights of the branch: the static registry does not need to rewrite modules permanently. It only needs a runtime loader that temporarily decorates source.
+
+### 5. Example runner and shared docs
+
+The example runner lives in `cmd/jsverbs-example/main.go`. It loads shared docs from `pkg/doc`.
+
+Relevant code:
+
+- runner bootstrap: `cmd/jsverbs-example/main.go:20-88`
+- manual directory discovery: `cmd/jsverbs-example/main.go:91-104`
+- shared help loader: `pkg/doc/doc.go:8-12`
+
+The binary is good enough as a manual test harness and demo vehicle. It is not yet the final product shape, but it does its job.
+
+## What Went Well
+
+This prototype has several strong points that should be preserved even if the internal code is refactored.
+
+### The architecture is split along the right seams
+
+The split between scanner, registry, compiler, and runtime is good. That maps well onto the surrounding framework APIs:
+
+- `engine.NewBuilder()` and `Factory.NewRuntime(...)` already separate runtime composition from runtime instantiation in `engine/factory.go:31-179`.
+- `cmds.NewCommandDescription(...)` expects schema-first command construction in `glazed/pkg/cmds/cmds.go:221-232`.
+- `cli.AddCommandsToRootCommand(...)` and the Glazed Cobra run path expect commands to exist before execution in `glazed/pkg/cli/cobra.go:232-260`.
+
+This is the main reason the prototype feels coherent even where the internals are rough.
+
+### The end-to-end experience is real, not mocked
+
+The tests and example runner exercise the actual stack:
+
+- JS fixtures are scanned from disk,
+- Glazed parses their arguments,
+- goja executes them,
+- helper modules are resolved through `require()`,
+- output is rendered through structured rows or text.
+
+That matters. Many spikes stop at an in-memory proof or fake data model. This one crosses the whole boundary.
+
+### Shared help pages were moved to the right place
+
+The docs now live under `pkg/doc`, and `pkg/doc/doc.go:8-12` exposes them through a package-level loader.
+
+That is a good move because:
+
+- the docs describe reusable library behavior, not only one example binary,
+- other commands can load the same help bundle,
+- the example binary stays lightweight.
+
+### Tests cover the most important happy paths
+
+`pkg/jsverbs/jsverbs_test.go` covers:
+
+- explicit metadata,
+- inferred public functions,
+- section binding,
+- `bind: "all"`,
+- `bind: "context"`,
+- async promise return,
+- rest parameters,
+- relative helper imports,
+- package metadata grouping,
+- text output mode.
+
+For a first implementation pass, that is decent coverage.
+
+## Primary Findings
+
+This section is the core code review. Findings are ordered from highest leverage / highest risk to lower-severity cleanup items.
+
+### Finding 1: Metadata parse failures are silently ignored
+
+Severity: high
+
+Where to look:
+
+- `pkg/jsverbs/scan.go:340-420`
+- `pkg/jsverbs/scan.go:484-488`
+
+Problem:
+
+The scanner swallows metadata parsing errors for `__package__`, `__section__`, and `__verb__`. If the metadata object cannot be converted or unmarshaled, the handler simply returns. That means the command may disappear, partially degrade, or fall back to inferred behavior without telling the author what happened.
+
+Example:
+
+```go
+data := map[string]interface{}{}
+if err := e.unmarshalObject(objectNode, &data); err != nil {
+    return
+}
+```
+
+Why it matters:
+
+- Silent fallback is hostile to users and maintainers.
+- A typo in metadata can turn into a missing or malformed command with no explanation.
+- The more metadata features we add, the worse this failure mode becomes.
+
+Why it is non-idiomatic:
+
+In Go, especially in infrastructure code, silent error suppression is usually only acceptable for truly optional best-effort behavior. This metadata is not optional in the same sense. It defines the command contract. Silent failure here creates hidden state transitions.
+
+Recommended cleanup:
+
+- Collect scanner diagnostics rather than dropping them.
+- Either:
+  - fail the entire scan on invalid metadata, or
+  - record structured warnings and expose them in `Registry`.
+
+Preferred shape:
+
+```text
+ScanDir
+  -> Registry
+     -> Files
+     -> Verbs
+     -> Diagnostics []Diagnostic
+```
+
+Pseudocode:
+
+```go
+type Diagnostic struct {
+    Severity string
+    File     string
+    Symbol   string
+    Message  string
+}
+
+func (e *extractor) handleVerb(argsNode *tree_sitter.Node) {
+    name, objectNode := e.namedObjectArgs(argsNode)
+    if objectNode == nil {
+        e.warn("verb sentinel requires object argument")
+        return
+    }
+
+    data := map[string]interface{}{}
+    if err := e.unmarshalObject(objectNode, &data); err != nil {
+        e.errorf("invalid __verb__ metadata for %s: %v", name, err)
+        return
+    }
+
+    ...
+}
+```
+
+Intern guidance:
+
+- If you make only one cleanup, make it this one first.
+- Strict errors will save far more engineering time than adding one more metadata feature.
+
+### Finding 2: The scanner uses a handwritten JS-object-to-JSON converter
+
+Severity: high
+
+Where to look:
+
+- `pkg/jsverbs/scan.go:594-700`
+- `pkg/jsverbs/scan.go:703-833`
+
+Problem:
+
+The metadata parser extracts raw source text for JS object literals, then runs it through `convertJSToJSON(...)`, then unmarshals JSON into Go maps.
+
+This is clever and pragmatic, but also brittle. It is not a real JavaScript value parser. It relies on source-text rewriting rules that will eventually diverge from actual JavaScript grammar.
+
+Why it matters:
+
+- It can mis-handle edge cases such as template expressions, regex literals, computed properties, spread, nested expressions, or more complicated strings.
+- It makes metadata support feel larger than it really is. Every new JS syntax shape becomes a parser-maintenance problem.
+- It encourages "just one more special case" growth.
+
+Why it is inelegant:
+
+The code already has tree-sitter parse trees. Converting syntax back into text and then reparsing that text with a handmade converter is a classic smell. It means the code has access to a structured syntax tree but is not fully using it.
+
+A new contributor reading this code will immediately ask: "If we already parsed the AST, why are we reparsing object literals through string munging?"
+
+That is the right question.
+
+What the prototype got right:
+
+- It kept the behavior local to metadata parsing.
+- It made the happy path work quickly.
+- It avoided premature overengineering.
+
+But the next pass should improve this area.
+
+Cleanup options:
+
+1. Best medium-term option:
+   Walk object and array AST nodes directly and convert them to Go values.
+
+2. Acceptable short-term option:
+   Keep the current approach, but reject unsupported syntax loudly and document the allowed metadata subset explicitly.
+
+Preferred rule:
+
+- metadata should be static and literal-only,
+- dynamic expressions inside `__verb__` or `__section__` should be errors, not heuristically accepted.
+
+Pseudocode:
+
+```go
+func parseLiteralNode(node *tree_sitter.Node) (interface{}, error) {
+    switch node.Kind() {
+    case "object":
+        return parseObject(node)
+    case "array":
+        return parseArray(node)
+    case "string", "template_string":
+        return parseString(node)
+    case "true":
+        return true, nil
+    case "false":
+        return false, nil
+    case "number":
+        return parseNumber(node)
+    case "null":
+        return nil, nil
+    default:
+        return nil, fmt.Errorf("unsupported non-literal metadata node: %s", node.Kind())
+    }
+}
+```
+
+### Finding 3: Schema construction and runtime argument binding are manually duplicated
+
+Severity: high
+
+Where to look:
+
+- schema logic: `pkg/jsverbs/command.go:110-226`
+- runtime binding logic: `pkg/jsverbs/runtime.go:106-153`
+
+Problem:
+
+The same conceptual policy exists in two different forms:
+
+- `command.go` decides which fields and sections exist and when a parameter requires a bind.
+- `runtime.go` decides how those same binds and sections become JS arguments.
+
+That means the subsystem depends on two independently-written interpretations of the same command model staying synchronized.
+
+Why it matters:
+
+- Drift bugs will be subtle.
+- One side may accept a parameter shape that the other side cannot invoke correctly.
+- Adding new parameter kinds or bind modes becomes risky.
+
+This is the classic prototype risk: the model is conceptually singular, but operationally duplicated.
+
+Example of the problem shape:
+
+```text
+VerbSpec + FieldSpec
+    |
+    +--> buildDescription() chooses sections/fields/requirements
+    |
+    +--> buildArguments() chooses argument objects and binds
+```
+
+A better shape is:
+
+```text
+VerbSpec
+    |
+    v
+BindingPlan
+    |
+    +--> schema builder uses it
+    +--> runtime binder uses it
+```
+
+Recommended cleanup:
+
+Introduce an explicit intermediate plan, for example:
+
+- `ParameterBindingPlan`
+- `VerbExecutionPlan`
+- `ResolvedFieldPlan`
+
+This plan would contain:
+
+- source parameter name,
+- parameter kind,
+- resolved Glazed field name,
+- section slug,
+- bind mode,
+- argument/index order,
+- whether the value is positional, section-bound, context-bound, or all-values-bound.
+
+Pseudocode:
+
+```go
+type BoundParameter struct {
+    ParamName   string
+    ParamKind   ParameterKind
+    FieldName   string
+    SectionSlug string
+    BindMode    string // positional, section, all, context
+    Rest        bool
+}
+
+type VerbPlan struct {
+    Verb       *VerbSpec
+    Sections   []*schema.SectionImpl
+    Parameters []BoundParameter
+}
+```
+
+Then:
+
+- `buildDescription()` consumes `VerbPlan.Sections`
+- `buildArguments()` consumes `VerbPlan.Parameters`
+
+That would make future behavior changes much safer.
+
+### Finding 4: A new engine factory is built on every invocation
+
+Severity: medium-high
+
+Where to look:
+
+- `pkg/jsverbs/runtime.go:21-30`
+- comparison seam: `go-go-goja/engine/factory.go:31-179`
+
+Problem:
+
+Each command invocation does:
+
+1. `engine.NewBuilder()`
+2. `WithRequireOptions(...)`
+3. `WithModules(engine.DefaultRegistryModules())`
+4. `Build()`
+5. `NewRuntime(ctx)`
+
+That means both the require registry and module registration plan are rebuilt for every command execution.
+
+Why it matters:
+
+- unnecessary overhead,
+- unnecessary allocation churn,
+- harder testing and configuration,
+- harder future extension if callers want custom modules or runtime initializers.
+
+Why it is non-idiomatic relative to the existing engine API:
+
+`engine/factory.go` is already designed around an immutable built `Factory` that can create many runtimes. The prototype is rebuilding the composition instead of reusing it.
+
+This is exactly the kind of thing an initial spike does, and exactly the kind of thing we should clean before hardening.
+
+Better shape:
+
+- `Registry` or a higher-level runner should own a prepared `Factory`.
+- `invoke()` should only ask for `factory.NewRuntime(ctx)`.
+
+Pseudocode:
+
+```go
+type RuntimeProvider interface {
+    NewRuntime(ctx context.Context) (*engine.Runtime, error)
+}
+
+type Registry struct {
+    RootDir string
+    ...
+    runtimeFactory *engine.Factory
+}
+
+func (r *Registry) prepareRuntimeFactory() error {
+    factory, err := engine.NewBuilder().
+        WithRequireOptions(require.WithLoader(r.sourceLoader)).
+        WithModules(engine.DefaultRegistryModules()...).
+        Build()
+    if err != nil {
+        return err
+    }
+    r.runtimeFactory = factory
+    return nil
+}
+```
+
+That would improve performance and make dependency injection easier.
+
+### Finding 5: Promise completion is implemented as polling with `time.Sleep`
+
+Severity: medium
+
+Where to look:
+
+- `pkg/jsverbs/runtime.go:250-280`
+
+Problem:
+
+`waitForPromise(...)` loops, checks promise state via `runtime.Owner.Call(...)`, and sleeps for `5 * time.Millisecond` while pending.
+
+This is functional, but inelegant and inefficient. It is a polling bridge, not an event-driven bridge.
+
+Why it matters:
+
+- polling adds latency and jitter,
+- frequent command calls can stack unnecessary wakeups,
+- the pattern is harder to reason about when async behavior gets more complex.
+
+Why it is acceptable for a prototype:
+
+- it is straightforward,
+- it keeps the logic local,
+- it is easy to debug,
+- it handles context cancellation.
+
+But it should still be called what it is: a temporary bridge.
+
+Future cleanup:
+
+- investigate whether the event loop or promise job queue can expose a less polling-heavy synchronization mechanism,
+- or explicitly label this as "prototype polling" in code comments so nobody mistakes it for final architecture.
+
+At minimum, if polling remains, add a comment that explains the reason and tradeoff.
+
+### Finding 6: The example runner uses manual pre-parse discovery of `--dir`
+
+Severity: medium
+
+Where to look:
+
+- `cmd/jsverbs-example/main.go:20-27`
+- `cmd/jsverbs-example/main.go:91-104`
+
+Problem:
+
+The example runner scans the target directory before Cobra parses flags, so it manually inspects `os.Args` to find `--dir`. That is why `discoverDirectory(...)` exists.
+
+This works, but it is not very elegant:
+
+- it duplicates a small amount of flag-parsing behavior,
+- the command tree is fixed before Cobra owns the CLI state,
+- changing the scanning root is a bootstrap concern rather than a normal parsed configuration path.
+
+Why it happened:
+
+This is a real constraint. The command tree must exist before Cobra can execute subcommands, so the scan root has to be known before command registration.
+
+That means the code is not "wrong", but it is awkward.
+
+Possible improvements:
+
+1. Keep it, but comment clearly that this is a bootstrap phase and intentionally pre-Cobra.
+2. Introduce a tiny bootstrap command that builds the actual command tree after parsing only root-level bootstrap flags.
+3. Separate the example runner into:
+   - bootstrap options,
+   - registry builder,
+   - root command factory.
+
+For an example binary, option 1 is acceptable. For a production binary, option 2 or 3 would be cleaner.
+
+### Finding 7: Error style and helper style are inconsistent
+
+Severity: medium-low
+
+Where to look:
+
+- `pkg/jsverbs/scan.go:12`
+- `pkg/jsverbs/scan.go:25`, `92`, `96`, `105`
+- rest of new package uses mostly `fmt.Errorf`
+
+Problem:
+
+`scan.go` mixes `github.com/pkg/errors` wrapping with the rest of the package's `fmt.Errorf(... %w ...)` style.
+
+That is not a correctness bug, but it is an avoidable inconsistency in new code. In a small new package, style drift is a signal that the code was assembled incrementally rather than shaped as one coherent unit.
+
+Recommendation:
+
+- standardize on `fmt.Errorf(... %w ...)` unless the repository strongly prefers `pkg/errors` in newly-written code.
+
+This is low priority compared with the scanner and binding issues, but worth cleaning when touching the file.
+
+### Finding 8: The scanner creates a fresh parser per file
+
+Severity: low
+
+Where to look:
+
+- `pkg/jsverbs/scan.go:101-112`
+
+Problem:
+
+`scanFile(...)` constructs a new tree-sitter parser and language setup for every file.
+
+This is simpler than managing parser reuse, and for a small fixture tree it is fine, but it is not ideal for larger trees.
+
+Why it is probably okay for now:
+
+- the subsystem is still exploratory,
+- scan sizes are likely small,
+- clarity is better than premature pooling.
+
+Future cleanup:
+
+- if scan volume grows, reuse a parser per scan run or hide parser setup inside a dedicated scanner object.
+
+### Finding 9: The test suite is good on happy paths but weak on failure modes
+
+Severity: low-to-medium
+
+Where to look:
+
+- `pkg/jsverbs/jsverbs_test.go:15-212`
+
+What is covered well:
+
+- happy-path discovery,
+- successful structured commands,
+- successful writer commands,
+- section binds,
+- async returns,
+- helper imports.
+
+What is missing:
+
+- malformed `__verb__` metadata,
+- invalid field types,
+- duplicate command paths,
+- unsupported metadata shapes,
+- failure diagnostics,
+- promise rejection behavior,
+- invalid `bind` references,
+- object/array pattern parameters without binds,
+- runtime loader failure messages.
+
+This matters because the weakest part of the implementation is metadata strictness, and the tests do not yet pin that behavior down.
+
+Recommended additions:
+
+- a `testdata/jsverbs-invalid/` tree,
+- scanner-diagnostic tests,
+- command-compilation failure tests,
+- promise rejection test,
+- invalid bind test.
+
+## Findings Summary Table
+
+| Area | Current state | Why it is a problem | Recommended next move |
+| --- | --- | --- | --- |
+| Metadata errors | Silent drop | Hidden behavior changes | Add diagnostics or fail-fast |
+| Metadata parsing | Handwritten JS-to-JSON conversion | Brittle and hard to extend | Parse AST literals directly |
+| Schema vs runtime | Duplicated policies | Drift risk | Introduce binding plan |
+| Runtime factory | Built per invocation | Wasteful and harder to configure | Cache factory or inject provider |
+| Promises | Polling loop | Inefficient, temporary shape | Replace or document as prototype |
+| Runner bootstrap | Manual `os.Args` scan | Awkward CLI bootstrap | Keep with comment or split bootstrap |
+| Error style | Mixed wrapping styles | Inconsistent package style | Standardize |
+| Parser lifecycle | New parser per file | Extra overhead | Reuse later if needed |
+| Tests | Happy-path focused | Weak contract around failures | Add failure fixtures |
+
+## Deprecated APIs And Non-Idiomatic Choices
+
+This section exists because the user explicitly asked for special attention to deprecated and non-idiomatic code.
+
+### Deprecated APIs
+
+Good news:
+
+- the obvious deprecated call (`strings.Title`) was already removed and replaced with `golang.org/x/text/cases`,
+- the logging setup uses `logging.InitLoggerFromCobra(...)`, which is the correct current direction according to `glazed/pkg/cmds/logging/init.go:148-220`,
+- this branch does not currently introduce known deprecated APIs in the new jsverbs path.
+
+So the real critique is not "deprecated API usage". It is "prototype-grade internal architecture".
+
+### Non-idiomatic patterns worth calling out
+
+The main non-idiomatic choices are:
+
+- silently swallowing parse errors for contract-defining metadata,
+- using manual text rewriting where AST-based literal parsing is available,
+- duplicating command semantics across compile-time and runtime code paths,
+- rebuilding immutable factories per invocation,
+- polling promises with `time.Sleep`,
+- pre-parsing `os.Args` to bootstrap the command tree.
+
+None of those are embarrassing in a spike. But they should be treated as debt, not as patterns to cargo-cult into future packages.
+
+## Intern-Friendly Data Flow
+
+This is the simplest way to understand execution.
+
+### Static phase
+
+```text
+ScanDir(root)
+  -> WalkDir(root)
+  -> read file
+  -> tree-sitter parse
+  -> find:
+       function greet(name, excited)
+       __verb__("greet", {...})
+       __section__("filters", {...})
+       doc`...`
+  -> build FileSpec
+  -> finalize VerbSpec
+```
+
+### Command-registration phase
+
+```text
+Registry.Commands()
+  -> for each VerbSpec
+      -> buildDescription(verb)
+      -> choose:
+           OutputModeGlaze -> Command
+           OutputModeText  -> WriterCommand
+```
+
+### Runtime phase
+
+```text
+Run command
+  -> Glazed parses CLI args into values.Values
+  -> jsverbs.invoke(...)
+  -> buildArguments(parsedValues, verb, rootDir)
+  -> require(module)
+  -> overlay captures top-level functions
+  -> call selected function
+  -> if Promise: wait
+  -> adapt result to rows or text
+```
+
+### Concrete example
+
+For `testdata/jsverbs/basics.js`:
+
+```text
+JS:
+  function listIssues(repo, filters, meta) { ... }
+  __verb__("listIssues", {
+    sections: ["filters"],
+    fields: {
+      repo: { argument: true },
+      filters: { bind: "filters" },
+      meta: { bind: "context" }
+    }
+  })
+
+CLI:
+  jsverbs-example basics list-issues my/repo --state closed --labels bug
+
+Go path:
+  ScanDir -> VerbSpec
+  Commands -> CommandDescription with default + filters sections
+  ParseCommandValues -> values.Values
+  buildArguments -> ["my/repo", {"state":"closed","labels":["bug"]}, contextMap]
+  goja function call
+  rowsFromResult -> Glazed rows
+```
+
+That is the whole subsystem in one example.
+
+## Where The Current Design Matches Existing Framework Idioms
+
+The following decisions are good because they align with existing framework seams rather than inventing entirely separate infrastructure.
+
+### It compiles to ordinary Glazed commands
+
+This is exactly right. `glazed/pkg/cmds/cmds.go:17-35` defines `CommandDescription` as the command-registration contract. The prototype uses that instead of creating a parallel command abstraction.
+
+That means:
+
+- Glazed help and schemas work,
+- Glazed output modes work,
+- Cobra integration works,
+- future Glazed middlewares can still apply.
+
+### It uses the go-go-goja engine builder instead of bypassing it
+
+The runtime bridge uses `engine.NewBuilder()` and `Factory.NewRuntime(...)` from `engine/factory.go:31-179`.
+
+That is the correct seam. Even though the current implementation rebuilds the factory too often, it still integrates through the intended extension point:
+
+- custom require options,
+- default native modules,
+- future runtime initializers.
+
+### It reuses the shared help system pattern
+
+The docs live in `pkg/doc`, and `pkg/doc/doc.go:8-12` exposes them through `LoadSectionsFromFS(...)`. That matches the general Glazed help-loading pattern.
+
+This is a good example of a prototype that managed to land docs in a reusable place instead of burying them inside the example binary.
+
+## Where The Current Design Does Not Yet Feel Production-Ready
+
+This section is intentionally blunt. These are the areas that still feel like a successful branch-local experiment rather than a hardened subsystem.
+
+### The scanner feels permissive in the wrong places
+
+The scanner is strict about some structural facts, like duplicate command paths in `pkg/jsverbs/scan.go:214-220`, but permissive about the more user-visible failure mode: invalid metadata input.
+
+That is backwards. Users can recover from explicit, well-scoped errors. They struggle with silent behavior changes.
+
+### The model contract is under-specified
+
+There is an implicit contract among:
+
+- `ParameterSpec`,
+- `FieldSpec`,
+- `buildDescription(...)`,
+- `buildArguments(...)`.
+
+That contract exists in code, but not in one explicit data structure. That makes review and extension harder than it should be.
+
+### Runtime composition is not injected
+
+The current code bakes in:
+
+- default native modules,
+- overlay loader wiring,
+- factory construction strategy.
+
+That is okay for an example, but not yet ideal for a reusable package. Eventually this should be injectable or at least configurable.
+
+## Cleanup Roadmap
+
+If we want to harden this subsystem without rewriting it from scratch, this is the order I would recommend.
+
+### Phase 1: Make metadata handling explicit and strict
+
+Goals:
+
+- no silent metadata failures,
+- no unsupported dynamic metadata shapes slipping through,
+- clear error messages.
+
+Changes:
+
+- add scanner diagnostics,
+- fail fast on invalid `__verb__`, `__section__`, `__package__`,
+- document the supported literal subset,
+- add tests for failure cases.
+
+### Phase 2: Extract a shared binding plan
+
+Goals:
+
+- remove duplicated policy,
+- make compile-time and runtime semantics provably aligned.
+
+Changes:
+
+- introduce `VerbPlan` or `BindingPlan`,
+- derive sections and runtime argument mapping from the same plan,
+- centralize bind validation there.
+
+### Phase 3: Harden runtime composition
+
+Goals:
+
+- reduce per-call overhead,
+- improve configurability,
+- make runtime behavior more testable.
+
+Changes:
+
+- prepare and reuse an `engine.Factory`,
+- optionally inject runtime factory or modules,
+- keep overlay loader logic but isolate it behind a small runtime adapter object.
+
+### Phase 4: Replace or clearly isolate polling-based promise waiting
+
+Goals:
+
+- remove temporary-feeling async glue,
+- improve clarity around cancellation and promise completion.
+
+Changes:
+
+- investigate event-driven alternatives,
+- or keep polling but isolate/document it as temporary.
+
+### Phase 5: Refine the example runner
+
+Goals:
+
+- cleaner bootstrap,
+- easier reuse by other binaries,
+- less command-tree setup awkwardness.
+
+Changes:
+
+- split bootstrap config from registry build,
+- maybe expose a `NewRootCommand(registry *Registry)` helper,
+- comment the pre-parse `--dir` bootstrap constraint clearly if it remains.
+
+## Suggested Refactor Shape
+
+One possible future package layout:
+
+```text
+pkg/jsverbs/
+  model.go
+  scan.go
+  metadata_parse.go
+  diagnostics.go
+  plan.go
+  command_build.go
+  runtime_invoke.go
+  runtime_loader.go
+  registry.go
+  jsverbs_test.go
+```
+
+What this buys us:
+
+- scanner concerns become smaller,
+- metadata parsing becomes independently testable,
+- binding-plan logic has one home,
+- runtime loader and runtime invocation stop competing for space in one file.
+
+This does not need to happen immediately. But if the package grows, the current file sizes already justify this direction:
+
+- `scan.go`: 833 lines
+- `command.go`: 513 lines
+- `runtime.go`: 300 lines
+
+That is manageable today, but clearly trending toward "too much per file".
+
+## What A New Intern Should Change First
+
+If you are the new engineer assigned to this package, do not start by adding more metadata features.
+
+Start here:
+
+1. add scanner diagnostics and fail-fast behavior,
+2. add failure-path tests,
+3. extract binding-plan logic,
+4. only then add new parameter shapes or metadata.
+
+That order matters because otherwise every new feature will deepen the weakest part of the implementation.
+
+## Review Checklist For The Next Iteration
+
+Use this checklist before calling the subsystem "ready for broader adoption":
+
+- invalid metadata fails loudly and points to the right file/symbol,
+- supported metadata syntax is explicit and tested,
+- one binding plan feeds both schema generation and runtime invocation,
+- runtime factory construction is reused or injected,
+- promise waiting is documented or improved,
+- example runner bootstrap behavior is clearly explained,
+- failure fixtures exist alongside happy-path fixtures,
+- help docs stay in `pkg/doc` and describe the real current contract.
+
+## Final Assessment
+
+The jsverbs branch is a successful feasibility spike with unusually good documentation for a spike. It proves the product direction and gives the team a real end-to-end artifact to discuss.
+
+The main lesson from the postmortem is not that the design direction was wrong. It is that the next cleanup pass should target contract clarity, not more surface area. The architecture is good enough to continue. The internals are just still wearing prototype clothes.
+
+If we harden metadata parsing, unify binding policy, and stop rebuilding runtime composition on every call, this can become a strong reusable subsystem rather than a one-off example.
+
+## References
+
+- `go-go-goja/pkg/jsverbs/model.go`
+- `go-go-goja/pkg/jsverbs/scan.go`
+- `go-go-goja/pkg/jsverbs/command.go`
+- `go-go-goja/pkg/jsverbs/runtime.go`
+- `go-go-goja/pkg/jsverbs/jsverbs_test.go`
+- `go-go-goja/cmd/jsverbs-example/main.go`
+- `go-go-goja/pkg/doc/doc.go`
+- `go-go-goja/testdata/jsverbs/basics.js`
+- `go-go-goja/testdata/jsverbs/advanced/numbers.js`
+- `go-go-goja/engine/factory.go`
+- `glazed/pkg/cmds/cmds.go`
+- `glazed/pkg/cli/cobra.go`
+- `glazed/pkg/cmds/logging/init.go`
+- `go-go-goja/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/reference/01-diary.md`
+- `go-go-goja/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/design-doc/01-js-to-glazed-command-exporting-design-and-implementation-guide.md`

--- a/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/index.md
+++ b/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/index.md
@@ -13,11 +13,13 @@ DocType: index
 Intent: long-term
 Owners: []
 RelatedFiles:
-    - Path: go-go-goja/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/design-doc/01-js-to-glazed-command-exporting-design-and-implementation-guide.md
+    - Path: ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/design-doc/01-js-to-glazed-command-exporting-design-and-implementation-guide.md
       Note: Primary deliverable for the ticket
-    - Path: go-go-goja/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/reference/01-diary.md
+    - Path: ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/design-doc/02-js-verbs-prototype-postmortem-and-code-review.md
+      Note: Postmortem and code review deliverable for the prototype branch
+    - Path: ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/reference/01-diary.md
       Note: Chronological investigation diary
-    - Path: go-go-goja/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/sources/local/01-goja-js.md
+    - Path: ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/sources/local/01-goja-js.md
       Note: Imported source note that motivated the design work
 ExternalSources:
     - local:01-goja-js.md
@@ -26,6 +28,7 @@ LastUpdated: 2026-03-16T13:56:35.761467442-04:00
 WhatFor: Track the analysis and implementation planning work for exposing JavaScript-defined functions as ordinary Glazed commands in go-go-goja.
 WhenToUse: Use when reviewing or implementing JS-to-Glazed command discovery, compilation, and runtime invocation in this repository.
 ---
+
 
 
 

--- a/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/index.md
+++ b/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/index.md
@@ -1,0 +1,73 @@
+---
+Title: Add Glazed command exporting from JavaScript
+Ticket: GOJA-04-JS-GLAZED-EXPORTS
+Status: active
+Topics:
+    - analysis
+    - architecture
+    - goja
+    - glazed
+    - js-bindings
+    - tooling
+DocType: index
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: go-go-goja/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/design-doc/01-js-to-glazed-command-exporting-design-and-implementation-guide.md
+      Note: Primary deliverable for the ticket
+    - Path: go-go-goja/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/reference/01-diary.md
+      Note: Chronological investigation diary
+    - Path: go-go-goja/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/sources/local/01-goja-js.md
+      Note: Imported source note that motivated the design work
+ExternalSources:
+    - local:01-goja-js.md
+Summary: Research ticket for designing a repo-native JS-to-Glazed command layer in go-go-goja, grounded in the current jsdoc extractor, Goja engine factory, and Glazed command system.
+LastUpdated: 2026-03-16T13:56:35.761467442-04:00
+WhatFor: Track the analysis and implementation planning work for exposing JavaScript-defined functions as ordinary Glazed commands in go-go-goja.
+WhenToUse: Use when reviewing or implementing JS-to-Glazed command discovery, compilation, and runtime invocation in this repository.
+---
+
+
+
+# Add Glazed command exporting from JavaScript
+
+## Overview
+
+This ticket captures the design work for a new `pkg/jsverbs`-style subsystem in `go-go-goja`. The goal is to discover JavaScript command definitions statically, normalize them into a registry, compile them into regular Glazed commands, and invoke the matching JavaScript function at runtime through the existing Goja engine/runtime seams.
+
+The imported source note from `sources/local/01-goja-js.md` is preserved in the ticket, but the primary deliverable here is a grounded repository-specific interpretation: which current packages provide the extraction/runtime/CLI seams already, what needs to be added, what the risks are, and how an intern should implement and validate the work.
+
+## Key Links
+
+- **Related Files**: See frontmatter RelatedFiles field
+- **External Sources**: See frontmatter ExternalSources field
+
+## Status
+
+Current status: **active**
+
+## Topics
+
+- analysis
+- architecture
+- goja
+- glazed
+- js-bindings
+- tooling
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/reference/01-diary.md
+++ b/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/reference/01-diary.md
@@ -259,6 +259,128 @@ I therefore created a ticket-local experiment rather than treating the note as a
 
 **Commit (code):** N/A
 
+## Step 5: Postmortem The Prototype Against origin/main
+
+After the prototype and docs were committed, the next useful step was not more feature work. It was to stop and inspect what we had actually built since `origin/main`, with special attention to inelegant code, non-idiomatic patterns, and places where the prototype shape should not calcify into the final architecture.
+
+This step produced a new long-form postmortem/code review document aimed at a new intern. The goal was to explain the subsystem clearly while also being candid about what is solid, what is brittle, and what should be cleaned up first.
+
+### Prompt Context
+
+**User prompt (verbatim):**
+
+```text
+Ok, let's do a full post mortem and post mortem review of the code we wrote since origin/main. Create a detailed postmortem and review, especially vs inelegant code, deprecated stuff, non idiomatic code, etc...
+
+Create a detailed postmortem/code review that is very detailed for a new intern, explaining all the parts of the system needed to understand what it is, with prose paragraphs and bullet point sand pseudocode and diagrams and api references and file
+  references.
+  It should be very clear and detailed. Store in the ticket and the nupload to remarkable.
+```
+
+**Assistant interpretation:** Compare the current branch against `origin/main`, read the newly-added jsverbs code and docs as a complete subsystem, identify the main architectural and idiomatic issues, write a detailed intern-facing postmortem/review into the existing ticket, and upload the updated ticket bundle to reMarkable.
+
+**Inferred user intent:** Capture the real lessons of the implementation while the context is still fresh, so future engineers inherit a grounded review rather than only a design guide.
+
+**Commit (code):** `4e4e893` — `Add jsverbs prototype runner and shared docs`
+
+### What I did
+
+- Fetched `origin/main` and diffed the branch against it.
+- Confirmed the branch delta was the single committed jsverbs prototype plus docs and ticket artifacts.
+- Read the core implementation files with line anchors:
+  - `pkg/jsverbs/scan.go`
+  - `pkg/jsverbs/command.go`
+  - `pkg/jsverbs/runtime.go`
+  - `pkg/jsverbs/model.go`
+  - `pkg/jsverbs/jsverbs_test.go`
+  - `cmd/jsverbs-example/main.go`
+- Read framework seams used by the prototype:
+  - `go-go-goja/engine/factory.go`
+  - `glazed/pkg/cmds/cmds.go`
+  - `glazed/pkg/cli/cobra.go`
+  - `glazed/pkg/cmds/logging/init.go`
+  - `go-go-goja/pkg/doc/doc.go`
+- Added a new design doc:
+  - `design-doc/02-js-verbs-prototype-postmortem-and-code-review.md`
+- Wrote the postmortem with:
+  - architecture explanation,
+  - findings ordered by severity,
+  - cleanup roadmap,
+  - diagrams and pseudocode,
+  - intern-oriented onramp guidance.
+
+### Why
+
+- The prototype was already functional, but branch-local success is not the same thing as a clean long-term design.
+- Doing the review immediately after implementation catches prototype assumptions before they become entrenched.
+- The user explicitly wanted scrutiny around inelegant and non-idiomatic code, not just a celebratory summary.
+
+### What worked
+
+- The branch delta was compact enough that a full origin/main review was tractable in one pass.
+- The code had enough tests and docs to make a detailed review evidence-based instead of speculative.
+- The new postmortem identified a short list of high-leverage cleanup targets rather than producing a vague "could be cleaner" report.
+
+### What didn't work
+
+- Nothing failed materially in this step.
+- The hardest part was not tooling; it was deciding which prototype shortcuts were acceptable spike tradeoffs and which ones needed to be called out as real debt.
+
+### What I learned
+
+- The overall architecture is sound; the biggest issues are contract clarity and internal shape, not feature direction.
+- The most important cleanup is making metadata parsing explicit and strict.
+- The next most important cleanup is removing the duplication between schema-building and runtime argument binding.
+
+### What was tricky to build
+
+- The review needed to serve two goals at once: explain the subsystem to a new intern and also critique it sharply. Those goals can conflict if the doc becomes either too tutorial-like or too terse.
+- I resolved that by first describing the actual runtime/data flow, then layering the findings on top of that shared explanation.
+
+### What warrants a second pair of eyes
+
+- Whether the scanner should become fully fail-fast or support a first-class diagnostics mode.
+- Whether a shared `BindingPlan` layer is the right abstraction name and shape.
+- Whether the runtime factory should live on `Registry`, on a separate runner object, or behind an injected provider.
+
+### What should be done in the future
+
+- Implement the cleanup roadmap in the new postmortem doc in order:
+  1. metadata strictness,
+  2. failure-path tests,
+  3. shared binding plan,
+  4. runtime factory reuse,
+  5. promise bridge cleanup.
+
+### Code review instructions
+
+- Start with the new postmortem:
+  - `ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/design-doc/02-js-verbs-prototype-postmortem-and-code-review.md`
+- Then review the referenced implementation files in this order:
+  - `pkg/jsverbs/scan.go`
+  - `pkg/jsverbs/command.go`
+  - `pkg/jsverbs/runtime.go`
+  - `cmd/jsverbs-example/main.go`
+- Validate the claims against the actual branch delta:
+  - `git diff --stat origin/main...HEAD`
+
+### Technical details
+
+- Diff commands used:
+
+```bash
+git -C /home/manuel/workspaces/2026-03-16/add-glazed-js-layer/go-go-goja fetch origin main
+git -C /home/manuel/workspaces/2026-03-16/add-glazed-js-layer/go-go-goja diff --stat origin/main...HEAD
+git -C /home/manuel/workspaces/2026-03-16/add-glazed-js-layer/go-go-goja diff --name-only origin/main...HEAD
+git -C /home/manuel/workspaces/2026-03-16/add-glazed-js-layer/go-go-goja log --oneline --reverse origin/main..HEAD
+```
+
+- Core review output:
+
+```text
+ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/design-doc/02-js-verbs-prototype-postmortem-and-code-review.md
+```
+
 ### What I did
 
 - Added:

--- a/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/reference/01-diary.md
+++ b/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/reference/01-diary.md
@@ -1,0 +1,533 @@
+---
+Title: Diary
+Ticket: GOJA-04-JS-GLAZED-EXPORTS
+Status: active
+Topics:
+    - analysis
+    - architecture
+    - goja
+    - glazed
+    - js-bindings
+    - tooling
+DocType: reference
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: glazed/pkg/cmds/cmds.go
+      Note: Glazed command target that shaped the investigation
+    - Path: go-go-goja/engine/factory.go
+      Note: Runtime factory seam discussed while evaluating execution strategy
+    - Path: go-go-goja/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/design-doc/01-js-to-glazed-command-exporting-design-and-implementation-guide.md
+      Note: Primary design deliverable described by the diary
+    - Path: go-go-goja/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/scripts/jsverb_overlay_experiment.go
+      Note: Ticket-local runtime experiment captured in the diary
+    - Path: go-go-goja/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/sources/local/goja-js.md
+      Note: Imported source note that triggered the investigation
+ExternalSources:
+    - local:01-goja-js.md
+Summary: Chronological diary for the GOJA-04 research ticket, covering ticket setup, source-note import, repository investigation, and runtime overlay experimentation for JS-defined Glazed commands.
+LastUpdated: 2026-03-16T14:45:00-04:00
+WhatFor: Preserve the exact investigation flow, commands, failures, and reasoning used to build the GOJA-04 design guide.
+WhenToUse: Use when reviewing the research process behind the JS-to-Glazed command exporting proposal or continuing the implementation later.
+---
+
+
+# Diary
+
+## Goal
+
+This diary records the end-to-end investigation for `GOJA-04-JS-GLAZED-EXPORTS`: create the ticket, import and read the source note, map the real repository architecture, validate the key runtime assumption with an experiment, and turn that into an intern-friendly design and implementation guide.
+
+The focus is not just what was written, but why the chosen interpretation is grounded in the current `go-go-goja` and `glazed` code instead of being a loose restatement of the imported proposal.
+
+## Step 1: Create The Ticket Workspace And Import The Source Note
+
+I started by creating a new docmgr ticket because the user explicitly asked for the work to live inside a ticket and to keep a detailed diary there. That gave me a stable workspace for docs, scripts, imported sources, and later upload packaging.
+
+I also imported `/tmp/goja-js.md` immediately so the source note would be preserved inside the ticket instead of remaining as an external scratch file. This mattered because the final design doc needed to reference the note as evidence and interpret it in repository-local terms.
+
+### Prompt Context
+
+**User prompt (verbatim):**
+
+```text
+Create a new ticket to add glazed exporting commands from JS, and import /tmp/goja-js.md using docmgr import file --file /tmp/goja-js.md --ticket ... and read it in detail, and then write up your own grounded interpretation of the ticket and using jsdocex nd all. Feel free to build and run experiments in the scripts/ folder of the ticket. Keep a detailed diary.
+
+Create a detailed analysis / design / implementation guide that is very detailed for a new intern, explaining all the parts of the system needed to understand what it is, with prose paragraphs and bullet point sand pseudocode and diagrams and api references and file
+  references.
+  It should be very clear and detailed. Store in the ticket and the nupload to remarkable.
+```
+
+**Assistant interpretation:** Create a new `docmgr` ticket, import the provided markdown source note, study it carefully, investigate the relevant code paths in `go-go-goja` and `glazed`, write a detailed design/analysis guide plus diary into the ticket, and deliver the ticket bundle to reMarkable.
+
+**Inferred user intent:** Produce a durable research-quality implementation guide for a future engineer, not just an ephemeral chat answer.
+
+**Commit (code):** N/A
+
+### What I did
+
+- Ran `docmgr status --summary-only` to confirm the docs root and current ticket landscape.
+- Read the `ticket-research-docmgr-remarkable`, `docmgr`, `diary`, and `remarkable-upload` skill instructions.
+- Read `/tmp/goja-js.md` in full before creating any final interpretation.
+- Created the ticket:
+  - `docmgr ticket create-ticket --ticket GOJA-04-JS-GLAZED-EXPORTS --title "Add Glazed command exporting from JavaScript" --topics analysis,architecture,goja,glazed,js-bindings,tooling`
+- Added the primary docs:
+  - `docmgr doc add --ticket GOJA-04-JS-GLAZED-EXPORTS --doc-type design-doc --title "JS-to-Glazed command exporting design and implementation guide"`
+  - `docmgr doc add --ticket GOJA-04-JS-GLAZED-EXPORTS --doc-type reference --title "Diary"`
+- Imported the source note:
+  - `docmgr import file --file /tmp/goja-js.md --ticket GOJA-04-JS-GLAZED-EXPORTS`
+
+### Why
+
+- The ticket workspace was needed before any research output could be stored or uploaded.
+- Importing the note early guaranteed the ticket would retain the original proposal as a source artifact.
+- Establishing the ticket ID first made it possible to put experiments in the ticket-local `scripts/` folder, as requested.
+
+### What worked
+
+- `docmgr` created the ticket and document scaffolding cleanly.
+- The imported note landed in:
+  - `ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/sources/local/01-goja-js.md`
+- The ticket naming fit the existing `GOJA-01`, `GOJA-02`, `GOJA-03` sequence for jsdocex-related work.
+
+### What didn't work
+
+- Nothing failed in this step.
+
+### What I learned
+
+- The repo already had a natural ticket slot for this work: `GOJA-04` follows the completed `GOJA-01..03` jsdoc tickets.
+- The imported note was already detailed enough to propose a concrete subsystem (`pkg/jsverbs`), but not yet grounded in actual repository seams.
+
+### What was tricky to build
+
+- The only subtle part was choosing the ticket identity and scope so it matched the earlier `goja-jsdoc` tickets without implying that this was merely another exporter for the existing doc system.
+- I resolved that by naming the ticket around "Glazed command exporting from JavaScript" instead of around jsdoc alone.
+
+### What warrants a second pair of eyes
+
+- Whether `GOJA-04-JS-GLAZED-EXPORTS` is the final preferred ticket slug if the team wants slightly different naming around "verbs", "commands", or "loader".
+
+### What should be done in the future
+
+- Keep future implementation experiments under the ticket-local `scripts/` directory so the ticket remains continuation-friendly.
+
+### Code review instructions
+
+- Start at the ticket root:
+  - `ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/`
+- Confirm the imported source note exists under `sources/local/`.
+- Confirm the design doc and diary live under `design-doc/` and `reference/`.
+
+### Technical details
+
+- Ticket creation command:
+
+```bash
+docmgr ticket create-ticket \
+  --ticket GOJA-04-JS-GLAZED-EXPORTS \
+  --title "Add Glazed command exporting from JavaScript" \
+  --topics analysis,architecture,goja,glazed,js-bindings,tooling
+```
+
+- Import command:
+
+```bash
+docmgr import file --file /tmp/goja-js.md --ticket GOJA-04-JS-GLAZED-EXPORTS
+```
+
+## Step 2: Map The Current go-go-goja And Glazed Architecture
+
+After the ticket setup, I shifted into evidence gathering. The imported note made several architectural claims, but the user specifically asked for my own grounded interpretation, so I needed to prove where the real seams already were in the current repositories.
+
+This step was mostly repository reading and architecture mapping. I focused on the code that would either constrain the new feature or make it easier: the existing jsdoc extractor, the Goja runtime factory, Glazed command compilation, dynamic command loaders, and value/section parsing.
+
+### Prompt Context
+
+**User prompt (verbatim):** (same as Step 1)
+
+**Assistant interpretation:** Build a repository-specific understanding of how JS-defined commands would have to fit into the existing runtime and CLI infrastructure.
+
+**Inferred user intent:** Avoid speculative design by anchoring the guide to actual file-level evidence.
+
+**Commit (code):** N/A
+
+### What I did
+
+- Listed the workspace structure and confirmed the relevant repos were:
+  - `go-go-goja/`
+  - `glazed/`
+- Queried existing ticket names with:
+  - `docmgr ticket list`
+- Read the key `go-go-goja` files:
+  - `pkg/jsdoc/extract/extract.go`
+  - `pkg/jsdoc/extract/scopedfs.go`
+  - `pkg/jsdoc/model/model.go`
+  - `pkg/jsdoc/model/store.go`
+  - `engine/factory.go`
+  - `engine/runtime.go`
+  - `engine/module_specs.go`
+  - `engine/module_roots.go`
+  - `modules/common.go`
+  - `modules/glazehelp/glazehelp.go`
+  - `pkg/runtimeowner/runner.go`
+  - `cmd/goja-jsdoc/extract_command.go`
+  - `cmd/goja-jsdoc/doc/01-jsdoc-system.md`
+- Read the key `glazed` files:
+  - `pkg/cmds/cmds.go`
+  - `pkg/cmds/loaders/loaders.go`
+  - `pkg/cmds/schema/section-impl.go`
+  - `pkg/cmds/fields/definitions.go`
+  - `pkg/cmds/fields/field-type.go`
+  - `pkg/cmds/fields/cobra.go`
+  - `pkg/cmds/values/section-values.go`
+  - `pkg/cli/cobra-parser.go`
+  - `pkg/cli/cobra.go`
+  - `pkg/cmds/runner/run.go`
+
+### Why
+
+- I needed to separate what the imported note proposed from what the current codebase already supports.
+- The design guide was supposed to explain "all the parts of the system needed to understand what it is", so I needed both the Goja half and the Glazed half.
+
+### What worked
+
+- The codebase already has a strong precedent for static JS extraction in `pkg/jsdoc/extract`.
+- The Goja runtime factory already accepts `require.WithLoader(...)` through `engine.WithRequireOptions(...)`.
+- Glazed already has a dynamic command loader interface and a registration path that can add multiple commands into a Cobra tree.
+
+### What didn't work
+
+- One search command failed because I used an unmatched shell quote while searching for backtick-containing patterns:
+
+```text
+zsh:1: unmatched "
+```
+
+- I reran that search with safer quoting and continued.
+
+### What I learned
+
+- The imported proposal's `pkg/jsverbs` direction is compatible with the current repo layout.
+- `pkg/jsdoc` provides a reusable extraction precedent, but its data model is documentation-centric and should not be stretched into the command runtime model.
+- The actual compilation target is not just `CommandDescription`; it is a concrete `cmds.Command` implementation that also satisfies `cmds.GlazeCommand`.
+
+### What was tricky to build
+
+- The tricky part here was separating "similar enough to reuse" from "same problem, reuse directly".
+- `pkg/jsdoc/extract` is reusable in spirit, parser setup, and helper style, but not as the final package where command-specific models should live.
+
+### What warrants a second pair of eyes
+
+- The exact future boundary between `pkg/jsdoc` helper reuse and new `pkg/jsverbs` helper ownership.
+- Whether the team prefers a small shared internal helper package for JS sentinel parsing later, or wants duplication first and refactor later.
+
+### What should be done in the future
+
+- During implementation, keep extraction helpers and runtime helpers separate from day one.
+- Add tests that explicitly prove the intended seam boundaries, especially around binding plans and result adaptation.
+
+### Code review instructions
+
+- Review the architecture evidence in the final design doc against the source files listed above.
+- Check that each major design claim points back to at least one of those files.
+
+### Technical details
+
+- Useful evidence-gathering commands:
+
+```bash
+rg -n 'CommandLoader|LoadCommandsFromFS|RunIntoGlazeProcessor' glazed/pkg glazed/cmd -S
+rg -n 'WithLoader|DefaultRegistryModules|ScopedFS|ParseFSFile' go-go-goja -S
+nl -ba go-go-goja/pkg/jsdoc/extract/extract.go | sed -n '1,620p'
+nl -ba glazed/pkg/cmds/cmds.go | sed -n '1,420p'
+```
+
+## Step 3: Validate The Overlay Loader Runtime Assumption
+
+The imported note's most important non-trivial claim was that a custom source loader could append a registry block to a CommonJS module and still see top-level functions without breaking normal relative `require()` behavior. That claim was plausible, but it was still an assumption until I ran it in this repo.
+
+I therefore created a ticket-local experiment rather than treating the note as authoritative. The experiment stayed out of product code and lived in the ticket's `scripts/` directory, exactly as the user invited.
+
+### Prompt Context
+
+**User prompt (verbatim):** (same as Step 1)
+
+**Assistant interpretation:** Build and run a focused experiment in the ticket-local `scripts/` directory if doing so reduces design uncertainty.
+
+**Inferred user intent:** Verify key runtime assumptions instead of hand-waving over them in the analysis doc.
+
+**Commit (code):** N/A
+
+### What I did
+
+- Added:
+  - `ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/scripts/jsverb_overlay_experiment.go`
+- The script:
+  - builds an in-memory module map,
+  - wraps `entry.js` with a preamble and appended registry block,
+  - loads it through `require.WithLoader(...)`,
+  - verifies that `listIssues` can still be called from the injected registry,
+  - verifies that `require("./helper.js")` still works,
+  - prints a JSON summary of the result.
+- First I ran:
+
+```bash
+go run ./ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/scripts/jsverb_overlay_experiment.go
+```
+
+- That failed because the top-level `go.work` file declares a lower Go version than several modules require.
+- I reran with:
+
+```bash
+GOWORK=off go run ./ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/scripts/jsverb_overlay_experiment.go
+```
+
+- That succeeded and produced the expected JSON output.
+
+### Why
+
+- The overlay loader approach is the key runtime mechanism in the imported note.
+- If it had failed, the design doc would have needed a different execution strategy.
+
+### What worked
+
+- The appended registry block could still access both a top-level function declaration and a top-level `const` function value.
+- `module.exports` still worked independently.
+- Relative `require("./helper.js")` still resolved correctly through the custom loader.
+
+### What didn't work
+
+- Running the experiment without isolating from the top-level workspace failed with this exact error:
+
+```text
+go: module ../glazed listed in go.work file requires go >= 1.25.7, but go.work lists go 1.25; to update it:
+	go work use
+go: module . listed in go.work file requires go >= 1.25.7, but go.work lists go 1.25; to update it:
+	go work use
+go: module ../geppetto listed in go.work file requires go >= 1.25.8, but go.work lists go 1.25; to update it:
+	go work use
+go: module ../pinocchio listed in go.work file requires go >= 1.26.1, but go.work lists go 1.25; to update it:
+	go work use
+```
+
+### What I learned
+
+- The imported note's overlay-loader approach is viable in the current repository.
+- `GOWORK=off` is the correct escape hatch for ticket-local Go experiments in this workspace when the shared `go.work` file is out of sync with module-level `go` requirements.
+
+### What was tricky to build
+
+- The tricky part was making sure the experiment proved the right thing and not something adjacent.
+- I specifically avoided mutating `module.exports` for function capture, because the proposal's value is that it preserves ordinary CommonJS behavior while still exposing top-level functions through a side registry.
+
+### What warrants a second pair of eyes
+
+- Whether production code should register every discovered top-level function into the registry or only the selected function for the target command.
+- Whether a debug mode should materialize the overlaid source for easier stack traces and troubleshooting.
+
+### What should be done in the future
+
+- Reuse this experiment structure as the basis for future runtime tests under a real `pkg/jsverbs/runtime` package.
+- Add an automated unit test equivalent once implementation starts.
+
+### Code review instructions
+
+- Read the experiment file top to bottom.
+- Re-run:
+
+```bash
+cd go-go-goja
+GOWORK=off go run ./ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/scripts/jsverb_overlay_experiment.go
+```
+
+- Verify the JSON output shows:
+  - `moduleExports.exported == true`
+  - `listIssues == "repo:openai/openai"`
+  - `registryKeys` includes `listIssues`
+
+### Technical details
+
+- Successful output:
+
+```json
+{
+  "hiddenType": "func(goja.FunctionCall) goja.Value",
+  "listIssues": "repo:openai/openai",
+  "moduleExports": {
+    "exported": true
+  },
+  "registryKeys": [
+    "listIssues",
+    "hidden"
+  ]
+}
+```
+
+## Step 4: Finish The Deliverables, Pass Doctor, And Upload The Ticket Bundle
+
+With the architecture work and experiment finished, I switched into delivery mode. This step was about turning the ticket from "good draft" into "clean deliverable": update the docs, remove scaffold noise, relate the right files, make `docmgr doctor` pass cleanly, then bundle the ticket docs to reMarkable.
+
+This step also surfaced the final mechanical issues that are easy to miss in research tickets: imported source files do not arrive with docmgr frontmatter, generated task files contain placeholders, and remote listings can be slightly inconsistent if you probe the exact path too early after upload.
+
+### Prompt Context
+
+**User prompt (verbatim):** (same as Step 1)
+
+**Assistant interpretation:** Complete the ticket end to end, not just the analysis writing: finish the diary, clean the bookkeeping, validate the docs, and upload the result to reMarkable.
+
+**Inferred user intent:** Receive a durable, reviewable ticket bundle that is already validated and delivered.
+
+**Commit (code):** N/A
+
+### What I did
+
+- Cleaned up ticket scaffolding:
+  - removed the default `Add tasks here` line from `tasks.md`
+  - filled the `index.md` overview and summary
+- Added the main design guide and the first three diary steps.
+- Related files to the index, design doc, and diary with `docmgr doc relate`.
+- Added topic vocabulary entries:
+  - `docmgr vocab add --category topics --slug glazed --description "Glazed command and CLI framework topics"`
+  - `docmgr vocab add --category topics --slug js-bindings --description "JavaScript-facing bindings and interop topics"`
+- Normalized the imported source note so `docmgr doctor` would accept it:
+  - renamed `sources/local/goja-js.md` to `sources/local/01-goja-js.md`
+  - added ticket-style frontmatter to the imported note
+  - updated references in `index.md`, the design doc, and the diary
+- Ran `docmgr doctor --ticket GOJA-04-JS-GLAZED-EXPORTS --stale-after 30` until it passed cleanly.
+- Verified reMarkable prerequisites:
+  - `remarquee status`
+  - `remarquee cloud account --non-interactive`
+- Ran the safe upload flow:
+  - dry-run bundle upload
+  - real bundle upload
+  - remote listing checks under `/ai/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS`
+
+### Why
+
+- The ticket-research workflow explicitly requires a clean `docmgr doctor` run before upload.
+- The user asked for the result to be stored in the ticket and uploaded to reMarkable, so stopping after the design doc would have left the work half-finished.
+
+### What worked
+
+- After normalizing the imported source note and adding the missing vocabulary, `docmgr doctor` passed cleanly:
+
+```text
+## Doctor Report (1 findings)
+
+### GOJA-04-JS-GLAZED-EXPORTS
+
+- ✅ All checks passed
+```
+
+- The reMarkable bundle dry-run succeeded and showed the expected input set.
+- The real upload succeeded:
+
+```text
+OK: uploaded GOJA-04 JS-to-Glazed command exporting guide.pdf -> /ai/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS
+```
+
+- Directory verification succeeded once I listed the parent and then the remote folder with a trailing slash:
+
+```text
+[d]	GOJA-04-JS-GLAZED-EXPORTS
+```
+
+```text
+[f]	GOJA-04 JS-to-Glazed command exporting guide
+```
+
+### What didn't work
+
+- The first `docmgr doctor` run failed before cleanup. It reported:
+
+```text
+1) [warning] Unknown vocabulary value for Topics
+File: /home/manuel/workspaces/2026-03-16/add-glazed-js-layer/go-go-goja/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/index.md
+Field: Topics
+Value: "glazed,js-bindings"
+Known values: goja, analysis, migration, tooling, go, tui, inspector, refactor, ui, architecture, bobatea, repl, security
+
+1) [error] YAML/frontmatter syntax error
+File: /home/manuel/workspaces/2026-03-16/add-glazed-js-layer/go-go-goja/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/sources/local/goja-js.md
+Problem: frontmatter delimiters '---' not found
+```
+
+- The first direct listing of the target folder also failed:
+
+```text
+Error: no matches for 'GOJA-04-JS-GLAZED-EXPORTS'
+```
+
+- I resolved that by checking the parent directory and then listing the exact folder with a trailing slash after the upload had settled.
+
+### What I learned
+
+- Imported source files need to be normalized if we want strict `docmgr doctor` compliance inside a ticket.
+- `docmgr doctor` is useful precisely because it catches the non-obvious ticket hygiene issues that prose review will miss.
+- `remarquee cloud ls` is a good verification step, but listing the parent directory first is more reliable than assuming the exact folder path will resolve immediately.
+
+### What was tricky to build
+
+- The trickiest part of this step was not writing content; it was making the imported source note both preserved and doctor-clean.
+- I chose to keep the original note content intact while wrapping it in frontmatter and renaming it with a numeric prefix. That satisfied docmgr without throwing away the imported source artifact the user explicitly asked me to store.
+
+### What warrants a second pair of eyes
+
+- Whether future ticket imports under `sources/local/` should be normalized automatically by a helper script instead of handled manually per ticket.
+- Whether the team wants a standard convention for reMarkable bundle contents on research tickets (for example always include `tasks.md` and `changelog.md`, or only include index/design/diary).
+
+### What should be done in the future
+
+- Consider a tiny ticket-local helper or docmgr feature for converting imported markdown files into doctor-clean source docs automatically.
+- Reuse the same bundle upload pattern for similar research tickets.
+
+### Code review instructions
+
+- Re-run validation:
+
+```bash
+docmgr doctor --ticket GOJA-04-JS-GLAZED-EXPORTS --stale-after 30
+```
+
+- Verify the uploaded folder exists:
+
+```bash
+remarquee cloud ls /ai/2026/03/16 --long --non-interactive | rg GOJA-04
+remarquee cloud ls /ai/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS/ --long --non-interactive
+```
+
+- Review the final ticket docs:
+  - `index.md`
+  - `design-doc/01-js-to-glazed-command-exporting-design-and-implementation-guide.md`
+  - `reference/01-diary.md`
+
+### Technical details
+
+- Dry-run upload command:
+
+```bash
+remarquee upload bundle --dry-run \
+  /home/manuel/workspaces/2026-03-16/add-glazed-js-layer/go-go-goja/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/index.md \
+  /home/manuel/workspaces/2026-03-16/add-glazed-js-layer/go-go-goja/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/design-doc/01-js-to-glazed-command-exporting-design-and-implementation-guide.md \
+  /home/manuel/workspaces/2026-03-16/add-glazed-js-layer/go-go-goja/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/reference/01-diary.md \
+  /home/manuel/workspaces/2026-03-16/add-glazed-js-layer/go-go-goja/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/tasks.md \
+  /home/manuel/workspaces/2026-03-16/add-glazed-js-layer/go-go-goja/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/changelog.md \
+  --name "GOJA-04 JS-to-Glazed command exporting guide" \
+  --remote-dir "/ai/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS" \
+  --toc-depth 2
+```
+
+- Real upload command:
+
+```bash
+remarquee upload bundle \
+  /home/manuel/workspaces/2026-03-16/add-glazed-js-layer/go-go-goja/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/index.md \
+  /home/manuel/workspaces/2026-03-16/add-glazed-js-layer/go-go-goja/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/design-doc/01-js-to-glazed-command-exporting-design-and-implementation-guide.md \
+  /home/manuel/workspaces/2026-03-16/add-glazed-js-layer/go-go-goja/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/reference/01-diary.md \
+  /home/manuel/workspaces/2026-03-16/add-glazed-js-layer/go-go-goja/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/tasks.md \
+  /home/manuel/workspaces/2026-03-16/add-glazed-js-layer/go-go-goja/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/changelog.md \
+  --name "GOJA-04 JS-to-Glazed command exporting guide" \
+  --remote-dir "/ai/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS" \
+  --toc-depth 2
+```

--- a/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/scripts/jsverb_overlay_experiment.go
+++ b/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/scripts/jsverb_overlay_experiment.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/dop251/goja"
+	"github.com/dop251/goja_nodejs/require"
+	"github.com/go-go-golems/go-go-goja/engine"
+)
+
+func main() {
+	sources := map[string]string{
+		"entry.js": `
+const helper = require("./helper.js");
+
+function listIssues(repo) {
+  return helper.prefix(repo);
+}
+
+const hidden = () => "hidden";
+
+module.exports = {
+  exported: true
+};
+`,
+		"helper.js": `
+module.exports = {
+  prefix(value) {
+    return "repo:" + value;
+  }
+};
+`,
+	}
+
+	loader := func(path string) ([]byte, error) {
+		cleaned := strings.TrimPrefix(path, "./")
+		src, ok := sources[cleaned]
+		if !ok {
+			return nil, require.ModuleFileDoesNotExistError
+		}
+		if cleaned == "entry.js" {
+			src = injectOverlay(cleaned, src, []string{"listIssues", "hidden"})
+		}
+		return []byte(src), nil
+	}
+
+	factory, err := engine.NewBuilder(
+		engine.WithRequireOptions(require.WithLoader(loader)),
+	).Build()
+	if err != nil {
+		panic(err)
+	}
+
+	rt, err := factory.NewRuntime(context.Background())
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		_ = rt.Close(context.Background())
+	}()
+
+	mod, err := rt.Require.Require("./entry.js")
+	if err != nil {
+		panic(err)
+	}
+
+	registryValue := rt.VM.Get("__glazedVerbRegistry")
+	registryObject := registryValue.ToObject(rt.VM)
+	entryValue := registryObject.Get("entry.js")
+	entryObject := entryValue.ToObject(rt.VM)
+
+	listIssuesValue := entryObject.Get("listIssues")
+	listIssuesFn, ok := goja.AssertFunction(listIssuesValue)
+	if !ok {
+		panic("listIssues was not captured as a function")
+	}
+
+	out, err := listIssuesFn(goja.Undefined(), rt.VM.ToValue("openai/openai"))
+	if err != nil {
+		panic(err)
+	}
+
+	result := map[string]any{
+		"moduleExports": mod.Export(),
+		"registryKeys":  objectKeys(entryObject),
+		"listIssues":    out.Export(),
+		"hiddenType":    entryObject.Get("hidden").ExportType().String(),
+	}
+
+	b, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(string(b))
+}
+
+func injectOverlay(modulePath string, source string, functionNames []string) string {
+	var b strings.Builder
+	b.WriteString(`
+globalThis.__glazedVerbRegistry = globalThis.__glazedVerbRegistry || {};
+globalThis.__package__ = globalThis.__package__ || function() {};
+globalThis.__section__ = globalThis.__section__ || function() {};
+globalThis.__verb__ = globalThis.__verb__ || function() {};
+globalThis.doc = globalThis.doc || function() { return ""; };
+`)
+	b.WriteString(source)
+	b.WriteString("\n")
+	b.WriteString(`globalThis.__glazedVerbRegistry["`)
+	b.WriteString(modulePath)
+	b.WriteString(`"] = {`)
+	for i, name := range functionNames {
+		if i > 0 {
+			b.WriteString(",")
+		}
+		b.WriteString(name)
+		b.WriteString(`: typeof `)
+		b.WriteString(name)
+		b.WriteString(` === "function" ? `)
+		b.WriteString(name)
+		b.WriteString(` : undefined`)
+	}
+	b.WriteString("};\n")
+	return b.String()
+}
+
+func objectKeys(obj *goja.Object) []string {
+	keys := make([]string, 0, len(obj.Keys()))
+	keys = append(keys, obj.Keys()...)
+	return keys
+}

--- a/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/sources/local/01-goja-js.md
+++ b/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/sources/local/01-goja-js.md
@@ -1,0 +1,786 @@
+---
+Title: Imported source note: goja-js
+Ticket: GOJA-04-JS-GLAZED-EXPORTS
+Status: active
+Topics:
+    - analysis
+    - architecture
+    - goja
+    - glazed
+    - js-bindings
+    - tooling
+DocType: reference
+Intent: long-term
+Owners: []
+RelatedFiles: []
+ExternalSources:
+    - local:/tmp/goja-js.md
+Summary: Imported source note proposing a jsdocex-style static metadata system that compiles JavaScript functions into ordinary Glazed commands.
+LastUpdated: 2026-03-16T14:52:00-04:00
+WhatFor: Preserve the original proposal text inside the ticket so the grounded design guide can reference and refine it.
+WhenToUse: Use when reviewing the original unedited proposal that motivated GOJA-04.
+---
+
+JSDoc itself is comment-block based, but your repo already has a tree-sitter sentinel extractor (`pkg/jsdoc/extract`) rather than a free-form comment parser. Goja is a pure-Go ECMAScript 5.1+ runtime, and Glazed already gives you a rich command model with fields, sections, and multiple output modes. So the right cut here is not “teach JSDoc new tricks.” It is “build a sibling jsdocex-style static metadata system for CLI verbs, then compile that into ordinary Glazed commands.” ([JSDoc][1])
+
+The key idea is simple: every public top-level JS function becomes a candidate verb; optional sentinel metadata next to the function refines the command path, flags, sections, help text, and binding rules; then the runner turns that into `cmds.CommandDescription + schema.Section + fields.Definition`, which means the rest of the Glazed machinery stays boring and reliable instead of mutating into a many-headed parser goblin.
+
+## Core proposal
+
+Add a new subsystem, `pkg/jsverbs`, parallel to `pkg/jsdoc`.
+
+It should do four things:
+
+1. Statically scan JS files without executing them.
+2. Discover public top-level functions and CLI metadata sentinels.
+3. Normalize that into a `VerbRegistry`.
+4. Compile each discovered verb into a regular Glazed command that invokes the matching JS function at runtime.
+
+The most important design decision is this:
+
+**Use explicit sentinel calls and tagged templates, not comment parsing.**
+
+That preserves the jsdocex feel, keeps extraction deterministic, and lets the metadata be shaped like Glazed’s actual schema model instead of squeezing CLI structure through comment tags.
+
+## User-facing authoring model
+
+I would use this sentinel family:
+
+* `__package__(...)` for file/module-level metadata
+* `__section__(...)` for reusable flag sections
+* `__verb__(...)` for per-function CLI metadata
+* `doc\`...`` for long-form prose/help text
+
+Runtime should inject no-op implementations for these symbols so the same file can be executed normally.
+
+### Minimal example
+
+```js
+__package__({
+  name: "math",
+  title: "Math tools",
+  description: "Small math utilities exposed as CLI verbs."
+});
+
+__verb__("clamp", {
+  short: "Clamp a number to a range",
+  params: {
+    value: { type: "float", positional: true, help: "Input value" },
+    min:   { type: "float", positional: true, help: "Lower bound" },
+    max:   { type: "float", positional: true, help: "Upper bound" }
+  }
+});
+
+doc`
+---
+verb: clamp
+---
+
+Clamp a value to the inclusive range [min, max].
+`;
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function lerp(a, b, t = 0.5) {
+  return a + (b - a) * t;
+}
+```
+
+That yields:
+
+* `math clamp <value> <min> <max>`
+* `math lerp --a ... --b ... --t ...`
+
+`clamp` is customized. `lerp` is auto-exposed from the signature.
+
+### Shared section example
+
+```js
+__package__({
+  name: "github",
+  title: "GitHub tools",
+  defaultSections: ["auth"]
+});
+
+__section__("auth", {
+  title: "Authentication",
+  prefix: "gh",
+  flags: [
+    { name: "token", type: "string", required: true, help: "GitHub token" },
+    { name: "base-url", type: "string", default: "https://api.github.com", help: "API base URL" }
+  ]
+});
+
+__verb__("listIssues", {
+  name: "list-issues",
+  short: "List issues for a repository",
+  useSections: ["auth"],
+  params: {
+    repo:  { positional: true, help: "owner/repo" },
+    state: { type: "choice", choices: ["open", "closed", "all"], default: "open" },
+    auth:  { bind: "section", section: "auth" },
+    ctx:   { bind: "context" }
+  }
+});
+
+async function listIssues(repo, state = "open", auth, ctx) {
+  // auth = { token, baseUrl }
+  // ctx contains runner metadata + resolved section values
+  return [];
+}
+```
+
+That yields a verb roughly like:
+
+```bash
+runner github list-issues openai/openai --state open --gh-token $TOKEN
+```
+
+## Sentinel schemas
+
+Use JSON-ish object literals only. No computed keys, spreads, function values, interpolations, or other jazz-hands.
+
+```ts
+type PackageDef = {
+  name?: string;              // slash-separated package path, default = file stem
+  title?: string;
+  description?: string;
+  defaultSections?: string[]; // shared sections auto-attached to all verbs in file
+  hidden?: boolean;           // hide package/group from auto-attach helpers
+};
+
+type SectionDef = {
+  name: string;               // unique within file/package
+  title?: string;
+  description?: string;
+  prefix?: string;            // Glazed section prefix
+  flags: FlagDef[];
+};
+
+type FlagDef = {
+  name: string;               // CLI field name, e.g. "base-url"
+  short?: string;             // short flag
+  type?: string;              // existing glazed field type strings
+  help?: string;
+  default?: any;
+  choices?: string[];
+  required?: boolean;
+  positional?: boolean;       // compile as argument instead of flag
+};
+
+type ParamOverride = {
+  name?: string;              // flag name override
+  section?: string;           // section slug; default = "default"
+  short?: string;
+  type?: string;
+  help?: string;
+  default?: any;
+  choices?: string[];
+  required?: boolean;
+  positional?: boolean;
+  bind?: "flag" | "section" | "all" | "context";
+};
+
+type VerbDef = {
+  name?: string;              // CLI leaf name; default = kebab-case(functionName)
+  short?: string;
+  aliases?: string[];
+  hidden?: boolean;
+  useSections?: string[];     // attach shared sections
+  sections?: SectionDef[];    // inline, verb-local sections
+  params?: Record<string, ParamOverride>;
+};
+```
+
+## Public function discovery rules
+
+The extractor should recognize these top-level forms:
+
+* `function foo(...) {}`
+* `async function foo(...) {}`
+* `const foo = (...) => {}`
+* `const foo = async (...) => {}`
+* `const foo = function(...) {}`
+* `export function foo(...) {}` if present in source
+
+It should **not** expose:
+
+* nested functions
+* class methods
+* anonymous expressions
+* names starting with `_` unless explicitly decorated with `__verb__`
+
+That last rule is important. Without it, helper functions become accidental commands and the CLI turns into a raccoon nest.
+
+## Parameter inference
+
+Every public top-level function becomes a candidate verb even with no `__verb__` metadata.
+
+Default inference rules:
+
+* parameter name → field name using kebab-case
+* no JS default → required field
+* `= true/false` → `bool`
+* `= 1` → `int`
+* `= 1.5` → `float`
+* `= "x"` → `string`
+* `= ["a", "b"]` → `stringList`
+* `= [1, 2]` → `intList`
+* `= [1.5, 2.5]` → `floatList`
+* unknown / unsupported default literal → field type falls back to `string`
+
+Destructured params are where dragons sleep. For v1:
+
+* destructured params are **not auto-exposed**
+* if a function uses destructuring, the user must bind that parameter as `bind: "all"` or `bind: "section"`
+
+Example:
+
+```js
+function good(name, verbose = false) {}
+function alsoGood(auth, ctx) {} // if bound via metadata
+function nope({ name, age }) {} // error unless explicitly bound
+```
+
+## Binding model
+
+This is the most important runtime contract.
+
+Each JS function parameter gets a binding plan.
+
+### `bind: "flag"` (default)
+
+The parameter receives one scalar value from one Glazed field.
+
+Example:
+
+```js
+function echo(text, upper = false) {}
+```
+
+becomes:
+
+* `text` ← `--text` or positional argument if marked so
+* `upper` ← `--upper`
+
+### `bind: "section"`
+
+The parameter receives one section object.
+
+Example:
+
+```js
+__section__("auth", { ... });
+
+__verb__("fetchData", {
+  useSections: ["auth"],
+  params: {
+    auth: { bind: "section", section: "auth" }
+  }
+});
+
+function fetchData(auth) {}
+```
+
+At runtime:
+
+```js
+auth = {
+  token: "...",
+  baseUrl: "..."
+}
+```
+
+I would materialize object keys in `camelCase`, with the original field names available only in raw metadata if needed. CLI flags can stay kebab-case; JS objects should not.
+
+### `bind: "all"`
+
+The parameter receives all resolved section values.
+
+```js
+function main(all) {}
+```
+
+At runtime:
+
+```js
+all = {
+  default: { ... },
+  auth: { ... },
+  glazed: { ... },   // if included
+  command: { ... }   // if included
+}
+```
+
+### `bind: "context"`
+
+The parameter receives runner context, not user flags.
+
+Suggested shape:
+
+```js
+{
+  verb: {
+    name: "list-issues",
+    functionName: "listIssues",
+    sourceFile: "github/issues.js",
+    path: ["github", "list-issues"]
+  },
+  sections: { ... },      // same grouped values as bind:"all"
+  cwd: "/current/dir"
+}
+```
+
+Keep this small in v1. Do not dump the full process environment in there by default unless you enjoy accidental footguns.
+
+## Command path strategy
+
+When a directory is provisioned, every discovered verb gets a stable command path.
+
+I would compute it like this:
+
+1. Start with relative directory parents from the provisioned root.
+2. Add package parents from `__package__.name`, split by `/`.
+3. If no package name was declared, use the file stem as the package segment.
+4. Use `__verb__.name` or kebab-case of the function name as the leaf command.
+
+Examples:
+
+* `scripts/math.js` with `function clamp()` → `math clamp`
+* `scripts/github/issues.js` with `__package__({name:"github"})` and `function listIssues()` → `github list-issues`
+* `scripts/admin/users/list.js` with no package override and `function run()` → `admin users list run`
+
+Collision rules:
+
+* duplicate full command path = hard error
+* duplicate shared section name within file/package = hard error
+* duplicate local section names within a verb = hard error
+
+You want discovery to fail loudly and early, not quietly choose one command and leave future-you in a swamp.
+
+## Help and documentation merge
+
+This system should play nicely with the existing jsdoc-style metadata instead of pretending it lives on a different planet.
+
+Recommended merge order:
+
+* command short help:
+
+  1. `__verb__.short`
+  2. matching `__doc__.summary`
+  3. humanized function name
+
+* flag help:
+
+  1. `__verb__.params[param].help`
+  2. matching `__doc__.params[].description`
+  3. empty string
+
+* long help:
+
+  1. `doc` template with `verb: <functionName>`
+  2. matching jsdoc symbol prose
+  3. package prose as preamble
+
+That lets users keep existing symbol docs and only add CLI-specific bits where needed.
+
+## Extraction architecture
+
+I would split this into two phases.
+
+### Phase A: raw extraction
+
+Produce a raw file model:
+
+```go
+type RawFileSpec struct {
+    FilePath       string
+    Package        *RawPackage
+    SharedSections []*RawSection
+    VerbOverlays   []*RawVerb
+    Functions      []*FunctionDecl
+    ProseBlocks    []*RawDocBlock
+}
+```
+
+With:
+
+```go
+type FunctionDecl struct {
+    Name       string
+    Async      bool
+    Params     []*FunctionParam
+    Kind       FunctionKind
+    SourceFile string
+    Line       int
+}
+```
+
+This phase only parses syntax and literals. It does not decide command paths yet.
+
+### Phase B: normalization
+
+Normalize raw data into a runtime/compiler model:
+
+```go
+type VerbSpec struct {
+    FunctionName string
+    CommandName  string
+    Parents      []string
+    Short        string
+    Long         string
+    Hidden       bool
+    Sections     []*SectionSpec
+    Bindings     []*BindingSpec
+    SourceFile   string
+    Line         int
+}
+```
+
+`BindingSpec` is the contract between extraction and execution:
+
+```go
+type BindingSpec struct {
+    ParamName   string
+    Kind        BindingKind
+    SectionSlug string
+    FieldName   string
+    Required    bool
+}
+```
+
+This split matters. It keeps the tree-sitter pass dumb and deterministic, and it moves all semantic rules—collisions, inheritance, default sections, help merge, binding rules—into a pure normalization layer that is easy to test.
+
+## Reuse existing repo patterns
+
+I would not invent a parallel loader framework.
+
+Glazed already has `pkg/cmds/loaders.CommandLoader` and a recursive directory-loading flow. Use that.
+
+The JS loader should implement the same interface and return **multiple commands per file**.
+
+That means a host program can provision a directory roughly like this:
+
+```go
+factory, err := engine.NewBuilder().
+    WithModules(engine.DefaultRegistryModules()).
+    Build()
+if err != nil {
+    return err
+}
+
+loader := jsverbsloaders.NewJSVerbLoader(
+    factory,
+    jsverbsloaders.WithRoot(rootDir),
+)
+
+commands, err := loaders.LoadCommandsFromFS(
+    os.DirFS(rootDir),
+    ".",
+    "js",
+    loader,
+    nil,
+    nil,
+)
+if err != nil {
+    return err
+}
+
+return cli.AddCommandsToRootCommand(rootCmd, commands, nil)
+```
+
+That is the cleanest part of this design: the JS side is dynamic, but the host still deals in ordinary `[]cmds.Command`.
+
+## Compiling to Glazed
+
+Each normalized `VerbSpec` compiles into:
+
+* one `cmds.CommandDescription`
+* zero or more `schema.Section`
+* one concrete `JSVerbCommand` implementing `cmds.GlazeCommand`
+
+Compilation rules:
+
+* `VerbSpec.CommandName` → `CommandDescription.Name`
+* `VerbSpec.Parents` → `CommandDescription.Parents`
+* `Short/Long` → help text
+* each `SectionSpec` → `schema.NewSection(...)`
+* each flag → `fields.New(...)`
+* `positional: true` compiles to `IsArgument`
+* shared sections are attached before local sections
+* default scalar params go into `schema.DefaultSlug`
+
+Do **not** invent a second field type system. The JS metadata `type` should accept the existing Glazed field type strings directly.
+
+## Runtime invocation design
+
+Each generated command is backed by a `JSVerbCommand`:
+
+```go
+type JSVerbCommand struct {
+    *cmds.CommandDescription
+    Verb    *model.VerbSpec
+    Factory *engine.Factory
+    RootDir string
+}
+```
+
+It implements `RunIntoGlazeProcessor`.
+
+### Invocation flow
+
+1. Create a fresh runtime from the factory.
+2. Install sentinel no-ops.
+3. Require the target script through an overlay loader.
+4. Resolve the selected top-level function.
+5. Build JS call args from the binding plan.
+6. Call the function.
+7. Convert the result to rows.
+
+### Why an overlay loader
+
+This bit is crucial.
+
+Top-level functions in a CommonJS module are not automatically exported. So the runner needs a way to call them **without requiring the user to write `module.exports = { ... }`**.
+
+The clean answer is:
+
+* load the target file through a custom `require.WithLoader(...)`
+* for command source files, return:
+
+```text
+[preamble with sentinel no-ops]
+[original source]
+[appendix that registers discovered top-level functions in a runtime-global registry]
+```
+
+Example appendix:
+
+```js
+globalThis.__glazedVerbRegistry = globalThis.__glazedVerbRegistry || {};
+globalThis.__glazedVerbRegistry["github/issues.js"] = {
+  listIssues: typeof listIssues === "function" ? listIssues : undefined
+};
+```
+
+Then after `require("./github/issues.js")`, Go reads:
+
+```go
+globalThis.__glazedVerbRegistry["github/issues.js"]["listIssues"]
+```
+
+This keeps relative `require("./other-file")` working, because the file still executes as a real module. It also avoids mutating `module.exports`, which gets weird fast if a script reassigns it to something exotic.
+
+## Result adaptation
+
+All generated commands should implement `cmds.GlazeCommand`.
+
+Default result adapter:
+
+* `undefined` / `null` → no rows
+* plain object → one row
+* array of plain objects → one row per object
+* array of primitives → one row per value, using `value`
+* primitive → one row with field `value`
+
+Examples:
+
+```js
+return { id: 1, name: "alice" }         // 1 row
+return [{id:1}, {id:2}]                 // 2 rows
+return "hello"                          // 1 row: { value: "hello" }
+return 42                               // 1 row: { value: 42 }
+```
+
+For v1, that is enough. Later, add a native `glazed` JS module for streaming rows directly if needed.
+
+## Async support
+
+Support both sync and async functions.
+
+Runtime behavior:
+
+* if return value is not a Promise, adapt directly
+* if it is a Promise, await settlement through the existing event-loop/owned-runtime machinery, then adapt the resolved value
+
+That gives you `async function` support without changing the command model.
+
+## Validation and diagnostics
+
+Discovery should return structured diagnostics with file and line numbers.
+
+Reject these with clear errors:
+
+* `__verb__("foo")` but no matching top-level function `foo`
+* `params.limit` override when function has no `limit` parameter
+* `bind:"section"` without `section`
+* `useSections:["auth"]` when `auth` is not defined
+* destructured param without explicit binding
+* unsupported metadata literal form
+* duplicate command path
+* duplicate short flag within one command
+* positional flag inside a non-default section if you do not want to support that in v1
+
+I would make normalization accumulate all file-local diagnostics before failing, so the user gets one useful report instead of a single whack-a-mole error.
+
+## Security model
+
+Important plain statement: this is **not** a sandbox for untrusted code.
+
+Good practices:
+
+* discovery never executes JS
+* scanning is limited to an allowed root
+* path traversal is rejected
+* command execution only loads scripts under the provisioned root
+* native modules exposed to JS are explicit and whitelisted by the engine factory
+
+Bad fantasy to avoid:
+
+* “it’s in Goja so it must be safe”
+* no, the JS can still do whatever the host runtime and native modules allow
+
+So the design should borrow the allowed-root pattern already used in the jsdoc extractor, but it should still document that executing third-party scripts is a trust boundary.
+
+## Proposed package layout
+
+```text
+pkg/
+  jsverbs/
+    model/
+      raw.go          // RawFileSpec, RawPackage, RawVerb, RawSection
+      model.go        // VerbSpec, SectionSpec, BindingSpec, Registry
+      store.go        // indexes, collision checks
+
+    extract/
+      extract.go      // tree-sitter extraction
+      functions.go    // top-level function discovery
+      literals.go     // JS literal -> JSON-ish decoding
+      templates.go    // doc frontmatter parsing
+
+    normalize/
+      normalize.go    // raw -> normalized registry
+      merge_docs.go   // optional merge with jsdoc summaries/prose
+
+    compile/
+      glazed.go       // VerbSpec -> CommandDescription + Sections
+      bindings.go     // Binding plan compilation
+
+    runtime/
+      command.go      // JSVerbCommand
+      loader.go       // overlay source loader
+      invoke.go       // call selected function
+      marshal.go      // glazed values -> JS args
+      adapt.go        // JS return -> rows
+      context.go      // runner context object
+
+    loaders/
+      loader.go       // implements glazed loaders.CommandLoader
+      attach.go       // optional root attachment helper
+```
+
+If you want to avoid premature abstraction, skip a shared `pkg/jssentinel` package initially. Start with `pkg/jsverbs/extract`, copy the few helpers you need from `pkg/jsdoc/extract`, and factor later once tests prove the stable seams.
+
+## Implementation plan
+
+### Step 1: model + extraction
+
+Build raw extractor first.
+
+Tests:
+
+* simple top-level function discovery
+* arrow/function-expression discovery
+* `_private` exclusion
+* `__package__`, `__section__`, `__verb__` literal parsing
+* `doc` block attachment
+* line number/source file capture
+
+### Step 2: normalization
+
+Convert raw data into final `VerbSpec`.
+
+Tests:
+
+* package path defaults
+* file-stem fallback
+* default section creation from params
+* section reuse
+* param override merge
+* collision detection
+* destructuring validation
+
+### Step 3: Glazed compilation
+
+Compile into `CommandDescription` and sections.
+
+Tests:
+
+* flag names/types/defaults
+* positional args
+* section prefixes
+* short flag collisions
+* help text precedence
+
+### Step 4: runtime invocation
+
+Implement overlay loader + function lookup + binding + result adapter.
+
+Tests:
+
+* call top-level declaration
+* call arrow function
+* section-bound object param
+* `bind:"all"`
+* `bind:"context"`
+* relative `require()` still works
+* async function returns Promise
+* row adaptation
+
+### Step 5: directory loader
+
+Implement `loaders.CommandLoader`.
+
+Tests:
+
+* one file with multiple verbs
+* recursive directory scan
+* duplicate paths across files
+* source metadata on commands
+
+### Step 6: optional polish
+
+* merge with `__doc__` for help text
+* package/group command help
+* watch mode / hot reload for long-lived hosts
+* native `glazed` JS module for streaming rows
+
+## Design choices I would explicitly reject
+
+### 1. Sidecar YAML for JS commands
+
+It works, but it drifts. Metadata next to code is the whole point here.
+
+### 2. Full JSDoc comment parsing
+
+That is a much bigger parser problem for much less payoff. You already have a sentinel-based extraction style. Use it.
+
+### 3. Runtime-only introspection
+
+Do not execute every script at startup just to discover commands. That is slower, less predictable, and much harder to secure or debug.
+
+## Bottom line
+
+The clean design is:
+
+* **static sentinel extraction**
+* **auto-discovery of public top-level functions**
+* **normalization into a command registry**
+* **compilation into ordinary Glazed commands**
+* **runtime invocation through an overlay loader that exposes top-level functions without requiring explicit exports**
+
+That gives you the jsdocex authoring feel, preserves locality of metadata, fits the Glazed command model, and avoids turning startup into a dynamic-code séance.
+
+[1]: https://jsdoc.app/ "https://jsdoc.app/"

--- a/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/tasks.md
+++ b/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/tasks.md
@@ -7,3 +7,4 @@
 - [x] Run a ticket-local overlay-loader experiment to validate runtime assumptions
 - [x] Write the detailed design/analysis/implementation guide and diary
 - [x] Relate files, validate with docmgr doctor, and upload the bundle to reMarkable
+- [x] Write detailed postmortem/code review for the jsverbs prototype and upload it

--- a/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/tasks.md
+++ b/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/tasks.md
@@ -1,0 +1,9 @@
+# Tasks
+
+## TODO
+
+- [x] Create ticket workspace, primary docs, and import the source note
+- [x] Map the current go-go-goja + Glazed architecture relevant to JS-defined commands
+- [x] Run a ticket-local overlay-loader experiment to validate runtime assumptions
+- [x] Write the detailed design/analysis/implementation guide and diary
+- [x] Relate files, validate with docmgr doctor, and upload the bundle to reMarkable

--- a/ttmp/2026/03/16/GOJA-05-JSVERBS-HARDENING--harden-jsverbs-scanner-sources-diagnostics-and-binding-plan/README.md
+++ b/ttmp/2026/03/16/GOJA-05-JSVERBS-HARDENING--harden-jsverbs-scanner-sources-diagnostics-and-binding-plan/README.md
@@ -1,0 +1,21 @@
+# Harden jsverbs scanner, sources, diagnostics, and binding plan
+
+This is the document workspace for ticket GOJA-05-JSVERBS-HARDENING.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr doc add --ticket GOJA-05-JSVERBS-HARDENING --doc-type design-doc --title "My Design"`
+- Import sources: `docmgr import file --ticket GOJA-05-JSVERBS-HARDENING --file /path/to/doc.md`
+- Update metadata: `docmgr meta update --ticket GOJA-05-JSVERBS-HARDENING --field Status --value review`

--- a/ttmp/2026/03/16/GOJA-05-JSVERBS-HARDENING--harden-jsverbs-scanner-sources-diagnostics-and-binding-plan/changelog.md
+++ b/ttmp/2026/03/16/GOJA-05-JSVERBS-HARDENING--harden-jsverbs-scanner-sources-diagnostics-and-binding-plan/changelog.md
@@ -1,0 +1,18 @@
+# Changelog
+
+## 2026-03-16
+
+- Initial workspace created
+
+
+## 2026-03-16
+
+Implemented the jsverbs hardening pass: strict AST metadata parsing, diagnostics, raw/fs source support, shared binding planning, standardized errors, and failure-path tests.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-03-16/add-glazed-js-layer/go-go-goja/pkg/jsverbs/binding.go — New shared binding plan introduced
+- /home/manuel/workspaces/2026-03-16/add-glazed-js-layer/go-go-goja/pkg/jsverbs/jsverbs_test.go — Expanded success and failure coverage
+- /home/manuel/workspaces/2026-03-16/add-glazed-js-layer/go-go-goja/pkg/jsverbs/runtime.go — Runtime loader refactored to in-memory module serving with v1 polling note
+- /home/manuel/workspaces/2026-03-16/add-glazed-js-layer/go-go-goja/pkg/jsverbs/scan.go — Scanner rewritten around strict literal parsing and diagnostics
+

--- a/ttmp/2026/03/16/GOJA-05-JSVERBS-HARDENING--harden-jsverbs-scanner-sources-diagnostics-and-binding-plan/design-doc/01-jsverbs-hardening-plan-and-implementation-guide.md
+++ b/ttmp/2026/03/16/GOJA-05-JSVERBS-HARDENING--harden-jsverbs-scanner-sources-diagnostics-and-binding-plan/design-doc/01-jsverbs-hardening-plan-and-implementation-guide.md
@@ -1,0 +1,449 @@
+---
+Title: jsverbs hardening plan and implementation guide
+Ticket: GOJA-05-JSVERBS-HARDENING
+Status: active
+Topics:
+    - architecture
+    - goja
+    - glazed
+    - js-bindings
+    - tooling
+    - refactor
+DocType: design-doc
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: pkg/jsverbs/binding.go
+      Note: |-
+        Shared binding plan used by both schema generation and runtime invocation
+        Shared schema/runtime binding contract introduced in this ticket
+    - Path: pkg/jsverbs/command.go
+      Note: |-
+        Command compilation now consumes the shared binding plan
+        Command compilation updated to consume binding plan
+    - Path: pkg/jsverbs/jsverbs_test.go
+      Note: |-
+        Added raw-source, fs-backed, and failure-path coverage
+        New raw-source
+    - Path: pkg/jsverbs/model.go
+      Note: |-
+        New source and diagnostic model for the hardened jsverbs package
+        Expanded registry model with diagnostics and source-file abstractions
+    - Path: pkg/jsverbs/runtime.go
+      Note: |-
+        Runtime loader now serves in-memory sources and documents polling as v1 behavior
+        Runtime source loader moved to in-memory registry-backed module serving
+    - Path: pkg/jsverbs/scan.go
+      Note: |-
+        Strict AST literal parsing, scan diagnostics, and multi-source scanning entrypoints
+        Strict AST literal parser and multi-source scanning entrypoints
+ExternalSources: []
+Summary: Hardening pass for jsverbs that replaced js-to-json rewriting with strict AST literal parsing, added diagnostics and multi-source scanning, unified binding logic, standardized errors, and expanded failure-path tests.
+LastUpdated: 2026-03-16T16:43:22.752967662-04:00
+WhatFor: Document the follow-up hardening work that turns the first jsverbs prototype into a stricter and more reusable package-level implementation.
+WhenToUse: Use when reviewing or extending the hardened jsverbs package, especially around scanner input sources, diagnostics, or command/runtime binding behavior.
+---
+
+
+# jsverbs hardening plan and implementation guide
+
+## Executive Summary
+
+This ticket is the first cleanup pass after the initial jsverbs prototype. The original spike proved the concept, but it still had several prototype-level weaknesses:
+
+- metadata parsing relied on rewriting JS object text into fake JSON,
+- malformed metadata was silently dropped,
+- the package only scanned directories on disk,
+- schema generation and runtime argument binding had parallel hand-maintained logic,
+- error style was inconsistent,
+- failure-path tests were thin.
+
+This hardening pass addresses those issues directly. The result is still recognizably the same subsystem, but it is a cleaner subsystem:
+
+- metadata is now parsed from the tree-sitter AST rather than through `jsObjectToJSON`,
+- scanner diagnostics are recorded and surfaced as `ScanError`,
+- jsverbs can now scan from disk directories, generic `fs.FS` trees, and raw in-memory source strings,
+- runtime loading no longer depends on disk reads after scanning,
+- compile-time schema generation and runtime invocation now share one binding plan,
+- promise polling is intentionally kept as version-1 behavior and clearly marked that way,
+- new tests cover raw-source inputs, fs-backed inputs, and several error cases.
+
+The package is still a v1 prototype, but it is now much clearer about what is static data, what is runtime behavior, and where errors should appear.
+
+## Problem Statement
+
+The first jsverbs prototype had the right architecture direction but the wrong internal pressure points. The most important problem was not that the package lacked features. It was that the parts of the system closest to the user contract were also the least strict.
+
+That showed up in several places:
+
+1. scanner metadata parsing was text-based and heuristic,
+2. invalid metadata could silently disappear,
+3. the runtime loader still assumed disk-backed files,
+4. `command.go` and `runtime.go` each encoded their own interpretation of parameter bindings,
+5. test coverage emphasized the success path more than the failure path.
+
+For a package that generates command surfaces from source code, that is the wrong tradeoff. The scanner and binding logic need to be the most explicit parts of the implementation, not the loosest.
+
+## What Changed
+
+### 1. The package now supports multiple source origins
+
+Before:
+
+- `ScanDir(root string, ...)`
+
+Now:
+
+- `ScanDir(root string, ...)`
+- `ScanFS(fsys fs.FS, root string, ...)`
+- `ScanSource(path string, source string, ...)`
+- `ScanSources(files []SourceFile, ...)`
+
+Relevant files:
+
+- `pkg/jsverbs/model.go`
+- `pkg/jsverbs/scan.go`
+
+The key design choice here is that all of these inputs normalize into the same internal model:
+
+```text
+Source origin
+  -> sourceInput
+  -> FileSpec{
+       RelPath,
+       ModulePath,
+       Source,
+       ...
+     }
+```
+
+That means runtime loading no longer needs to care whether code originally came from the host filesystem, an embedded filesystem, or a raw string in memory.
+
+### 2. The runtime loader now serves in-memory scanned sources
+
+Before, `runtime.go` loaded source from disk again using real file paths.
+
+Now, the registry stores scanned source bytes on each `FileSpec`, and the runtime loader resolves modules from `Registry.filesByModule`.
+
+That gives the subsystem a clean virtual-module story:
+
+- `ModulePath` is the canonical runtime path,
+- `Source` is the canonical runtime source,
+- `AbsPath` is only extra metadata when a source really came from disk.
+
+This is what makes `ScanFS` and `ScanSource` practical instead of superficial.
+
+### 3. Metadata parsing now walks AST literals directly
+
+The old path was:
+
+```text
+tree-sitter object node
+  -> raw source text
+  -> jsObjectToJSON(...)
+  -> json.Unmarshal(...)
+  -> map[string]any
+```
+
+The new path is:
+
+```text
+tree-sitter literal node
+  -> parseLiteralNode(...)
+     -> parseObjectLiteral(...)
+     -> parseArrayLiteral(...)
+     -> decode string / number / bool / null
+  -> map[string]any / []any / scalar
+```
+
+Supported metadata literals are intentionally narrow:
+
+- objects
+- arrays
+- quoted strings
+- template strings without substitutions
+- numbers
+- `true`, `false`, `null`
+
+Unsupported metadata shapes now fail explicitly:
+
+- calls
+- identifiers as values
+- spreads
+- computed keys
+- template substitutions
+- other dynamic expressions
+
+That is the right boundary. Metadata should be static data, not code.
+
+### 4. The scanner now records diagnostics
+
+The registry now carries `Diagnostics []Diagnostic`, and scan failures surface through `ScanError`.
+
+That gives the package a more honest contract:
+
+- invalid metadata is no longer silently ignored,
+- callers can inspect diagnostics,
+- strict callers still get an error by default.
+
+This is especially important for future CLIs or editors that may want to show scan feedback without immediately crashing.
+
+### 5. Schema generation and runtime binding now share one plan
+
+The new file `pkg/jsverbs/binding.go` introduces a shared binding plan.
+
+That plan resolves:
+
+- parameter -> field,
+- parameter -> section,
+- parameter -> bind mode,
+- extra verb fields that exist only in the schema,
+- which shared sections are required.
+
+`command.go` uses the plan to build Glazed sections and fields.
+`runtime.go` uses the same plan to build JS call arguments.
+
+That removes the previous "parallel interpretations" problem where compile-time and runtime had to stay synchronized by convention.
+
+### 6. Promise polling remains, but is now explicitly marked as v1
+
+The implementation still polls promises. That was requested and is reasonable for now.
+
+The important change is not behavioral. It is communicative. `waitForPromise(...)` is now documented as intentionally simple version-1 behavior so future readers do not mistake it for the final async bridge design.
+
+### 7. Error style is now standardized
+
+The new package code now uses standard `fmt.Errorf(... %w ...)` wrapping rather than mixing in `github.com/pkg/errors`.
+
+That makes the package more internally consistent and more in line with normal modern Go style.
+
+## Architecture Diagram
+
+```text
+ScanDir / ScanFS / ScanSource / ScanSources
+    |
+    v
+[scan.go]
+- walk inputs
+- parse with tree-sitter
+- parse strict metadata literals
+- record diagnostics
+    |
+    v
+[model.go]
+Registry + FileSpec + VerbSpec + Diagnostic
+    |
+    v
+[binding.go]
+VerbBindingPlan
+- parameter bindings
+- shared sections
+- extra fields
+    |
+    +-----------------------------+
+    |                             |
+    v                             v
+[command.go]                 [runtime.go]
+build Glazed schema          build JS arguments
+and command wrappers         and execute function
+```
+
+## API Reference
+
+### Scanning APIs
+
+#### `ScanDir`
+
+Use when the JS lives on disk in a normal directory tree.
+
+```go
+registry, err := jsverbs.ScanDir("./testdata/jsverbs")
+```
+
+#### `ScanFS`
+
+Use when the JS is packaged in an `embed.FS` or any other `fs.FS`.
+
+```go
+registry, err := jsverbs.ScanFS(embeddedFiles, ".", jsverbs.DefaultScanOptions())
+```
+
+#### `ScanSource`
+
+Use when you only have one JS source string.
+
+```go
+registry, err := jsverbs.ScanSource("inline.js", sourceText)
+```
+
+#### `ScanSources`
+
+Use when you want to construct a virtual module tree from in-memory files.
+
+```go
+registry, err := jsverbs.ScanSources([]jsverbs.SourceFile{
+    {Path: "entry.js", Source: []byte(entry)},
+    {Path: "lib/helper.js", Source: []byte(helper)},
+})
+```
+
+### Diagnostics
+
+The package now exposes:
+
+- `Diagnostic`
+- `DiagnosticSeverity`
+- `ScanError`
+- `Registry.ErrorDiagnostics()`
+
+That means callers can choose between:
+
+- fail-fast usage,
+- or tooling/editor usage that inspects diagnostics.
+
+### Binding Plan
+
+The new shared types are:
+
+- `BindingMode`
+- `ParameterBinding`
+- `ExtraFieldBinding`
+- `VerbBindingPlan`
+
+These are intentionally internal package mechanics right now, but they are the conceptual center of the hardening pass.
+
+## Intern Onramp
+
+If you are new to the hardened version of jsverbs, read these files in order:
+
+1. `pkg/jsverbs/model.go`
+2. `pkg/jsverbs/scan.go`
+3. `pkg/jsverbs/binding.go`
+4. `pkg/jsverbs/command.go`
+5. `pkg/jsverbs/runtime.go`
+6. `pkg/jsverbs/jsverbs_test.go`
+
+Why this order works:
+
+- `model.go` tells you what data the package believes in,
+- `scan.go` tells you how that data is discovered,
+- `binding.go` tells you how parameters become a single shared execution/schema contract,
+- `command.go` and `runtime.go` then become much easier to understand because they are consumers of that plan rather than inventors of parallel rules.
+
+## Design Decisions
+
+### Decision 1: Use a virtual module path as the runtime identity
+
+Rationale:
+
+- it works for disk, `embed.FS`, and raw strings,
+- it preserves relative `require()` semantics,
+- it separates runtime identity from host filesystem identity.
+
+Tradeoff:
+
+- extra normalization logic is required up front,
+- but the runtime becomes much cleaner afterward.
+
+### Decision 2: Keep metadata literal support intentionally small
+
+Rationale:
+
+- metadata should be declarative,
+- strict parsing keeps the scanner maintainable,
+- explicit failure is better than heuristic acceptance.
+
+Tradeoff:
+
+- some dynamic JS patterns are rejected,
+- but that is a deliberate boundary, not a missing feature.
+
+### Decision 3: Keep promise polling for now
+
+Rationale:
+
+- the user explicitly wanted it kept,
+- it is simple and easy to debug,
+- it avoids a larger async bridge design detour in this ticket.
+
+Tradeoff:
+
+- it is not the final async story,
+- so the code now says that clearly.
+
+### Decision 4: Prefer one binding plan over repeated helper logic
+
+Rationale:
+
+- compile-time schema behavior and runtime argument behavior must not drift,
+- one plan is easier to test than two coupled functions.
+
+Tradeoff:
+
+- introduces one extra internal concept,
+- but removes a larger maintenance risk.
+
+## Alternatives Considered
+
+### Alternative: keep js-to-json and just add diagnostics
+
+Rejected because it would preserve the most brittle part of the old scanner while only improving the error surface.
+
+### Alternative: add `embed.FS` support by extracting embedded files to disk first
+
+Rejected because it would keep the runtime tied to disk paths and would not solve the raw-string source case cleanly.
+
+### Alternative: only factor out a few shared helpers instead of a binding plan
+
+Rejected because helper extraction would reduce duplication but would not create one explicit contract for parameter binding semantics.
+
+## Testing Strategy
+
+The hardened package now validates:
+
+- existing fixture discovery and command execution,
+- raw-string scanning via `ScanSource` / `ScanSources`,
+- generic `fs.FS` scanning via `ScanFS`,
+- invalid metadata diagnostics,
+- invalid bind references,
+- unsupported object-pattern parameters without binds.
+
+That testing mix is important because it covers both:
+
+- new feature paths,
+- and the exact failure surfaces that used to be vague or silent.
+
+## Remaining Gaps
+
+This ticket deliberately does not do everything.
+
+Still open or future-worthy:
+
+- a public incremental `Registry.AddSource(...)` API if callers want to mutate an existing registry instead of building from `ScanSources`,
+- richer warning-level diagnostics beyond hard errors,
+- package docs/help pages that describe the new source APIs explicitly,
+- a less polling-heavy async bridge in a future version.
+
+## Implementation Status
+
+The requested items from the ticket have been implemented:
+
+- strict AST literal parsing instead of js-to-json rewriting,
+- scan diagnostics,
+- raw source support,
+- `fs.FS` support suitable for `embed.FS`,
+- shared schema/runtime binding plan,
+- explicit v1 polling comment,
+- unified `fmt.Errorf` error style,
+- failure-path tests.
+
+## References
+
+- `go-go-goja/pkg/jsverbs/model.go`
+- `go-go-goja/pkg/jsverbs/scan.go`
+- `go-go-goja/pkg/jsverbs/binding.go`
+- `go-go-goja/pkg/jsverbs/command.go`
+- `go-go-goja/pkg/jsverbs/runtime.go`
+- `go-go-goja/pkg/jsverbs/jsverbs_test.go`
+- `go-go-goja/cmd/jsverbs-example/main.go`
+- `go-go-goja/ttmp/2026/03/16/GOJA-04-JS-GLAZED-EXPORTS--add-glazed-command-exporting-from-javascript/design-doc/02-js-verbs-prototype-postmortem-and-code-review.md`

--- a/ttmp/2026/03/16/GOJA-05-JSVERBS-HARDENING--harden-jsverbs-scanner-sources-diagnostics-and-binding-plan/index.md
+++ b/ttmp/2026/03/16/GOJA-05-JSVERBS-HARDENING--harden-jsverbs-scanner-sources-diagnostics-and-binding-plan/index.md
@@ -1,0 +1,67 @@
+---
+Title: Harden jsverbs scanner, sources, diagnostics, and binding plan
+Ticket: GOJA-05-JSVERBS-HARDENING
+Status: active
+Topics:
+    - architecture
+    - goja
+    - glazed
+    - js-bindings
+    - tooling
+    - refactor
+DocType: index
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: ttmp/2026/03/16/GOJA-05-JSVERBS-HARDENING--harden-jsverbs-scanner-sources-diagnostics-and-binding-plan/design-doc/01-jsverbs-hardening-plan-and-implementation-guide.md
+      Note: Primary deliverable for the jsverbs hardening implementation
+    - Path: ttmp/2026/03/16/GOJA-05-JSVERBS-HARDENING--harden-jsverbs-scanner-sources-diagnostics-and-binding-plan/reference/01-diary.md
+      Note: Chronological implementation diary for the hardening pass
+ExternalSources: []
+Summary: ""
+LastUpdated: 2026-03-16T16:43:22.502901605-04:00
+WhatFor: ""
+WhenToUse: ""
+---
+
+
+# Harden jsverbs scanner, sources, diagnostics, and binding plan
+
+## Overview
+
+<!-- Provide a brief overview of the ticket, its goals, and current status -->
+
+## Key Links
+
+- **Related Files**: See frontmatter RelatedFiles field
+- **External Sources**: See frontmatter ExternalSources field
+
+## Status
+
+Current status: **active**
+
+## Topics
+
+- architecture
+- goja
+- glazed
+- js-bindings
+- tooling
+- refactor
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/2026/03/16/GOJA-05-JSVERBS-HARDENING--harden-jsverbs-scanner-sources-diagnostics-and-binding-plan/reference/01-diary.md
+++ b/ttmp/2026/03/16/GOJA-05-JSVERBS-HARDENING--harden-jsverbs-scanner-sources-diagnostics-and-binding-plan/reference/01-diary.md
@@ -1,0 +1,193 @@
+---
+Title: Diary
+Ticket: GOJA-05-JSVERBS-HARDENING
+Status: active
+Topics:
+    - architecture
+    - goja
+    - glazed
+    - js-bindings
+    - tooling
+    - refactor
+DocType: reference
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: go-go-goja/pkg/jsverbs/scan.go
+      Note: Scanner refactor from text-rewrite metadata parsing to strict AST literal parsing
+    - Path: go-go-goja/pkg/jsverbs/binding.go
+      Note: Shared binding plan added during the hardening pass
+    - Path: go-go-goja/pkg/jsverbs/runtime.go
+      Note: Runtime loader moved to in-memory source serving and kept polling with explicit v1 documentation
+    - Path: go-go-goja/pkg/jsverbs/jsverbs_test.go
+      Note: New failure-path and source-origin coverage added in this ticket
+    - Path: go-go-goja/ttmp/2026/03/16/GOJA-05-JSVERBS-HARDENING--harden-jsverbs-scanner-sources-diagnostics-and-binding-plan/design-doc/01-jsverbs-hardening-plan-and-implementation-guide.md
+      Note: Primary design and implementation guide for the hardening pass
+ExternalSources: []
+Summary: Chronological diary for the jsverbs hardening pass that added strict metadata parsing, diagnostics, multi-source scanning, a shared binding plan, and failure-path tests.
+LastUpdated: 2026-03-16T16:43:22.758921591-04:00
+WhatFor: Preserve the reasoning, commands, and implementation path for the follow-up jsverbs hardening work after the initial prototype ticket.
+WhenToUse: Use when reviewing how the jsverbs hardening pass was implemented or continuing similar cleanup work later.
+---
+
+# Diary
+
+## Goal
+
+This diary records the follow-up hardening pass for jsverbs after the initial prototype. The goal of the step was not to expand surface area arbitrarily, but to clean the weakest internal seams: metadata parsing, source loading, diagnostics, binding logic, error consistency, and missing failure-path tests.
+
+## Step 1: Create The Follow-Up Ticket And Harden The Package
+
+The follow-up work started from a clear implementation list provided by the user: remove the js-to-json rewrite, support raw strings and `embed.FS`-style scanning, add diagnostics, unify binding logic, keep promise polling but mark it as v1, standardize errors, and add failure-path tests. That was cohesive enough to treat as a single hardening ticket rather than an unstructured patch series.
+
+I created a new ticket first so the implementation, rationale, and later validation evidence would have a clean home separate from the original design/research ticket. After that, I refactored the package around a virtual module-path model so that all source origins could share the same runtime loader and command discovery path.
+
+### Prompt Context
+
+**User prompt (verbatim):**
+
+```text
+ok, so there's that to fix,
+
+- then i also want to add adding a raw JS string to the registry, in case we don't load from a dir
+- I also want to load from an embed.FS
+- scan diagnostics
+- get clear schema + runtime binding logic
+- keep polling as it is and mark it as a first version
+- unify error style
+- add error case failure tests
+
+So create a new ticket, add detailed tasks for all of this, is then go through them
+```
+
+**Assistant interpretation:** Create a follow-up hardening ticket for jsverbs, turn the requested cleanup items into explicit ticket tasks, implement the scanner/runtime/model refactor in code, validate it with tests and manual runs, and document the result in the new ticket.
+
+**Inferred user intent:** Move the jsverbs package from prototype-grade internals toward a cleaner version-1 implementation without changing the overall product direction.
+
+**Commit (code):** `4e4e893` — `Add jsverbs prototype runner and shared docs`
+
+### What I did
+
+- Created a new ticket:
+  - `GOJA-05-JSVERBS-HARDENING`
+- Added tasks for:
+  - strict AST literal parsing,
+  - diagnostics,
+  - raw source + `fs.FS` support,
+  - shared binding plan,
+  - v1 polling note,
+  - unified error style,
+  - failure-path tests.
+- Refactored the package model in `pkg/jsverbs/model.go` to add:
+  - `SourceFile`,
+  - `Diagnostic`,
+  - `ScanError`,
+  - in-memory source bytes on `FileSpec`,
+  - module-path keyed file lookup on `Registry`.
+- Replaced the scanner in `pkg/jsverbs/scan.go` so it now:
+  - supports `ScanDir`, `ScanFS`, `ScanSource`, and `ScanSources`,
+  - parses metadata literals directly from the tree-sitter AST,
+  - records diagnostics instead of silently dropping bad metadata.
+- Added `pkg/jsverbs/binding.go` so both command compilation and runtime invocation now consume the same binding plan.
+- Updated `pkg/jsverbs/runtime.go` to:
+  - load source from the registry rather than from disk,
+  - work with virtual module paths for raw and fs-backed sources,
+  - keep polling with an explicit version-1 comment.
+- Added tests in `pkg/jsverbs/jsverbs_test.go` for:
+  - raw JS string scanning,
+  - `fs.FS` scanning,
+  - invalid metadata diagnostics,
+  - invalid bound sections,
+  - unsupported object-pattern parameters without binds.
+- Validated with:
+  - `go test ./go-go-goja/pkg/jsverbs`
+  - `go test ./go-go-goja/cmd/jsverbs-example`
+  - `go run ./go-go-goja/cmd/jsverbs-example --dir ./go-go-goja/testdata/jsverbs list`
+  - `go run ./go-go-goja/cmd/jsverbs-example --dir ./go-go-goja/testdata/jsverbs basics list-issues go-go-golems/go-go-goja --state closed --labels bug --labels docs`
+
+### Why
+
+- The old scanner and runtime had the right broad architecture but the wrong kinds of shortcuts in the places closest to the user contract.
+- Supporting raw sources and `fs.FS` cleanly required a source model change anyway, so it made sense to fix diagnostics and runtime loading around the same underlying abstraction.
+- Binding-plan cleanup was worth doing in the same pass because scanner strictness without compile/runtime alignment would still leave a major drift risk in place.
+
+### What worked
+
+- The virtual module-path model simplified more than one problem at once:
+  - runtime loading,
+  - raw source support,
+  - fs-backed support,
+  - relative `require()` behavior.
+- The direct AST literal parser was smaller and easier to reason about than the previous text-to-JSON rewrite.
+- The shared binding plan made the compile/runtime contract much easier to explain.
+- The failure tests caught the exact behavior that the user wanted tightened.
+
+### What didn't work
+
+- My first refactor attempt changed `engine.DefaultRegistryModules()` to a variadic form in `runtime.go`, but the actual API returns a single composite `ModuleSpec`. The initial test run failed with:
+
+```text
+cannot use engine.DefaultRegistryModules() (value of interface type engine.ModuleSpec) as []engine.ModuleSpec value in argument to ...WithModules
+```
+
+- I fixed that by restoring the non-variadic call.
+
+### What I learned
+
+- The best way to add raw string and `embed.FS` support was not a special-case code path. It was making the registry itself the source of truth for runtime source bytes.
+- A strict literal parser is less code than a permissive text-rewrite system once the package already has an AST.
+- The shared binding plan is the real center of gravity for future jsverbs changes. It is the place where command schema and runtime invocation should keep meeting.
+
+### What was tricky to build
+
+- The main tricky part was making the source model generic enough for all three input origins without breaking the relative `require()` behavior already proven by the first prototype.
+- The key insight was to use canonical module paths like `/nested/entry.js` as the runtime identity, while keeping `AbsPath` only as optional source metadata for disk-backed inputs.
+- That preserved the old runtime behavior while decoupling runtime loading from the host filesystem.
+
+### What warrants a second pair of eyes
+
+- The exact literal subset supported by the new metadata parser.
+- Whether the current `ScanError` / diagnostics balance is the right API for callers that may want non-fatal warnings later.
+- Whether a public incremental `Registry.AddSource(...)` API is still worth adding even though `ScanSource` and `ScanSources` now cover the main non-directory use cases.
+
+### What should be done in the future
+
+- Consider updating shared jsverbs help docs under `pkg/doc` so they explicitly document `ScanFS`, `ScanSource`, diagnostics, and the stricter metadata rules.
+- If async command complexity grows, revisit the polling bridge.
+- Consider a richer diagnostics API if editors or interactive tools want warning-level feedback without failing the scan.
+
+### Code review instructions
+
+- Start with:
+  - `pkg/jsverbs/model.go`
+  - `pkg/jsverbs/scan.go`
+  - `pkg/jsverbs/binding.go`
+  - `pkg/jsverbs/runtime.go`
+- Then confirm the new behaviors through:
+  - `pkg/jsverbs/jsverbs_test.go`
+- Finally, verify the example runner still works with:
+  - `go run ./go-go-goja/cmd/jsverbs-example --dir ./go-go-goja/testdata/jsverbs list`
+
+### Technical details
+
+- New scanning entrypoints:
+
+```go
+ScanDir(root string, opts ...ScanOptions)
+ScanFS(fsys fs.FS, root string, opts ...ScanOptions)
+ScanSource(path string, source string, opts ...ScanOptions)
+ScanSources(files []SourceFile, opts ...ScanOptions)
+```
+
+- New diagnostic types:
+
+```go
+type Diagnostic struct { ... }
+type ScanError struct { Diagnostics []Diagnostic }
+```
+
+- New shared binding-plan file:
+
+```text
+pkg/jsverbs/binding.go
+```

--- a/ttmp/2026/03/16/GOJA-05-JSVERBS-HARDENING--harden-jsverbs-scanner-sources-diagnostics-and-binding-plan/tasks.md
+++ b/ttmp/2026/03/16/GOJA-05-JSVERBS-HARDENING--harden-jsverbs-scanner-sources-diagnostics-and-binding-plan/tasks.md
@@ -1,0 +1,11 @@
+# Tasks
+
+## TODO
+
+- [x] Replace js-to-json source rewriting with strict AST literal parsing for metadata objects and arrays
+- [x] Add scan diagnostics and surface invalid metadata instead of silently dropping it
+- [x] Unify new jsverbs package error style around standard fmt.Errorf wrapping
+- [x] Keep promise polling as v1 behavior but document it clearly in code and docs
+- [x] Extract a shared binding plan so schema generation and runtime argument binding follow one contract
+- [x] Add failure-path tests for malformed metadata, invalid binds, and scanner/runtime error cases
+- [x] Add jsverbs source inputs for raw JS strings and embed.FS-backed scanning/loading

--- a/ttmp/vocabulary.yaml
+++ b/ttmp/vocabulary.yaml
@@ -25,6 +25,10 @@ topics:
       description: Read-eval-print loop interfaces and behavior
     - slug: security
       description: Security-focused engineering work such as trust boundaries, validation, and policy enforcement.
+    - slug: js-bindings
+      description: JavaScript-facing bindings and interop topics
+    - slug: glazed
+      description: Glazed command and CLI framework topics
 docTypes:
     - slug: index
       description: Ticket index documents


### PR DESCRIPTION
This pull request introduces a new system, `jsverbs`, for automatically
generating `glazed` CLI commands from JavaScript files. This allows developers
to expose JS functions as full-featured command-line verbs with minimal Go
boilerplate.

### Key Features:

- **File Scanning:** Recursively scans directories for `.js` and `.cjs` files
  to discover potential commands. Top-level functions are automatically
  identified as verbs.

- **Metadata Syntax:** A simple, JS-native syntax is introduced to configure
  the generated commands:
  - `__verb__(name, {...})`: Defines command metadata, including fields,
    arguments, and help text.
  - `__section__(name, {...})`: Creates reusable groups of flags (sections).
  - `__package__({...})`: Sets file-level metadata for command grouping.

- **Flexible Parameter Binding:** Provides `bind` options to control how CLI
  values are passed to JS functions:
  - `bind: "filters"`: Passes values from a named section as an object.
  - `bind: "context"`: Provides execution context (e.g., command path).
  - `bind: "all"`: Passes all resolved parameters as a single object.

- **Output Handling:**
  - Automatically converts JS return values (objects, arrays of objects,
    Promises) into structured `glazed` output (tables, JSON, YAML).
  - Supports `output: "text"` for commands that should return raw string
    output.

- **Example Implementation:**
  - Includes a new `jsverbs-example` command that demonstrates how to use the
    `jsverbs` package to build a CLI application.

- **Comprehensive Documentation:**
  - Adds detailed documentation covering the overview, fixture format, and a
    developer guide for the new system.