### PR TITLE
feat(engine): Add granular module configuration via middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,30 @@ go run ./cmd/goja-repl run ./testdata/yaml.js
 
 The `run` verb creates a fresh runtime, enables default native modules, derives module roots from the script path, executes the file, and closes the runtime.
 
+### Module Security Flags
+
+You can control which native modules are loaded using persistent CLI flags:
+
+```bash
+# Safe mode: only data-only modules (crypto, events, path, time, timer)
+go run ./cmd/goja-repl --safe-mode run ./script.js
+
+# Whitelist: only specific modules
+go run ./cmd/goja-repl --enable-module fs,path run ./script.js
+
+# Blacklist: all except specific modules
+go run ./cmd/goja-repl --disable-module fs,exec run ./script.js
+```
+
+These flags apply to all commands that build a runtime (`run`, `tui`, `eval`, `create`, etc.).
+
 ### Runtime API quick example (current)
 
 ```go
 ctx := context.Background()
 
 factory, err := engine.NewBuilder().
-    WithModules(engine.DefaultRegistryModules()).
+    UseModuleMiddleware(engine.MiddlewareSafe()).
     Build()
 if err != nil {
     return err
@@ -93,7 +110,10 @@ if err != nil {
 ```
 
 Notes:
-- `DefaultRegistryModules()` enables modules that registered themselves through `modules.Register(...)`.
+- `UseModuleMiddleware(engine.MiddlewareSafe())` enables only data-safe modules.
+- Use `UseModuleMiddleware(engine.MiddlewareOnly("fs", "path"))` for a whitelist.
+- Use `UseModuleMiddleware(engine.MiddlewareExclude("exec"))` for a blacklist.
+- The old `WithModules(engine.DefaultRegistryModules())` is deprecated; omit the middleware to load all modules (the default).
 - `rt` bundles `VM`, `Require`, `Loop`, and `Owner` for explicit lifecycle control.
 
 ## TypeScript Declaration Generation
@@ -180,7 +200,18 @@ Say we want to expose a simplistic `uuid` module that exports a single `v4()` fu
        _ "github.com/go-go-golems/go-go-goja/modules/uuid" // ← new module here
    )
    ```
-   The blank import is only required once. At runtime, enabling `engine.DefaultRegistryModules()` makes registered modules available to `require(...)`.
+   The blank import is only required once. At runtime, the default behavior (no middleware) makes all registered modules available to `require(...)`. Use `UseModuleMiddleware` to restrict the sandbox:
+
+   ```go
+   // All modules (default)
+   engine.NewBuilder()
+
+   // Safe mode only
+   engine.NewBuilder().UseModuleMiddleware(engine.MiddlewareSafe())
+
+   // Specific modules
+   engine.NewBuilder().UseModuleMiddleware(engine.MiddlewareOnly("uuid"))
+   ```
 4. **Profit**
    ```js
    const { v4 } = require("uuid");
@@ -204,12 +235,18 @@ For Go-level tests, prefer constructing a runtime directly instead of shelling o
 ```go
 ctx := context.Background()
 
+// Safe mode (data-only modules)
 factory, err := engine.NewBuilder().
-    WithModules(engine.DefaultRegistryModules()).
+    UseModuleMiddleware(engine.MiddlewareSafe()).
     Build()
 if err != nil {
     t.Fatal(err)
 }
+
+// Or, to test a specific module:
+// factory, err := engine.NewBuilder().
+//     UseModuleMiddleware(engine.MiddlewareOnly("fs")).
+//     Build()
 
 rt, err := factory.NewRuntime(ctx)
 if err != nil {

--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ go run ./cmd/goja-repl --safe-mode run ./script.js
 # Whitelist: only specific modules
 go run ./cmd/goja-repl --enable-module fs,path run ./script.js
 
+# Whitelist in the TUI; db is an alias for the database module
+go run ./cmd/goja-repl tui --enable-module db
+
 # Blacklist: all except specific modules
 go run ./cmd/goja-repl --disable-module fs,exec run ./script.js
 ```

--- a/cmd/bun-demo/main.go
+++ b/cmd/bun-demo/main.go
@@ -44,7 +44,7 @@ func main() {
 
 	builder := pluginSetup.WithBuilder(engine.NewBuilder().
 		WithRequireOptions(require.WithLoader(embeddedSourceLoader)).
-		WithModules(engine.DefaultRegistryModules()))
+		UseModuleMiddleware(engine.MiddlewareSafe()))
 
 	factory, err := builder.Build()
 	if err != nil {

--- a/cmd/goja-repl/cmd_run.go
+++ b/cmd/goja-repl/cmd_run.go
@@ -91,7 +91,7 @@ func runScriptFile(ctx context.Context, opts runScriptOptions) error {
 		return fmt.Errorf("script file not found %q: %w", scriptPath, err)
 	}
 
-	builder := engine.NewBuilder().WithModules(engine.DefaultRegistryModules())
+	builder := engine.NewBuilder().UseModuleMiddleware(engine.MiddlewareSafe())
 	if opts.UseModuleRoots {
 		requireOpt, err := engine.RequireOptionWithModuleRootsFromScript(scriptPath, engine.DefaultModuleRootsOptions())
 		if err != nil {

--- a/cmd/goja-repl/cmd_run.go
+++ b/cmd/goja-repl/cmd_run.go
@@ -55,6 +55,9 @@ type runScriptOptions struct {
 	File               string
 	PluginDirs         []string
 	AllowPluginModules []string
+	EnableModules      []string
+	DisableModules     []string
+	SafeMode           bool
 	UseModuleRoots     bool
 }
 
@@ -71,6 +74,9 @@ func (c *runCommand) Run(ctx context.Context, vals *values.Values) error {
 	if c.opts != nil {
 		opts.PluginDirs = c.opts.PluginDirs
 		opts.AllowPluginModules = c.opts.AllowPluginModules
+		opts.EnableModules = c.opts.EnableModules
+		opts.DisableModules = c.opts.DisableModules
+		opts.SafeMode = c.opts.SafeMode
 	}
 	return runScriptFile(ctx, opts)
 }
@@ -91,7 +97,14 @@ func runScriptFile(ctx context.Context, opts runScriptOptions) error {
 		return fmt.Errorf("script file not found %q: %w", scriptPath, err)
 	}
 
-	builder := engine.NewBuilder().UseModuleMiddleware(engine.MiddlewareSafe())
+	builder := engine.NewBuilder()
+	if opts.SafeMode {
+		builder = builder.UseModuleMiddleware(engine.MiddlewareSafe())
+	} else if len(opts.EnableModules) > 0 {
+		builder = builder.UseModuleMiddleware(engine.MiddlewareOnly(opts.EnableModules...))
+	} else if len(opts.DisableModules) > 0 {
+		builder = builder.UseModuleMiddleware(engine.MiddlewareExclude(opts.DisableModules...))
+	}
 	if opts.UseModuleRoots {
 		requireOpt, err := engine.RequireOptionWithModuleRootsFromScript(scriptPath, engine.DefaultModuleRootsOptions())
 		if err != nil {

--- a/cmd/goja-repl/root.go
+++ b/cmd/goja-repl/root.go
@@ -120,7 +120,7 @@ func (s commandSupport) newAppWithOptions(options appSupportOptions) (*replapi.A
 		}
 	}
 	pluginSetup := host.NewRuntimeSetup(s.opts.PluginDirs, s.opts.AllowPluginModules)
-	builder := engine.NewBuilder().WithModules(engine.DefaultRegistryModules())
+	builder := engine.NewBuilder().UseModuleMiddleware(engine.MiddlewareSafe())
 	if options.helpSystem != nil {
 		builder = builder.WithRuntimeModuleRegistrars(docaccessruntime.NewRegistrar(docaccessruntime.Config{
 			HelpSources: []docaccessruntime.HelpSource{{

--- a/cmd/goja-repl/root.go
+++ b/cmd/goja-repl/root.go
@@ -29,6 +29,9 @@ type rootOptions struct {
 	DBPath             string
 	PluginDirs         []string
 	AllowPluginModules []string
+	EnableModules      []string
+	DisableModules     []string
+	SafeMode           bool
 }
 
 func newRootCommand(out io.Writer) (*cobra.Command, error) {
@@ -46,6 +49,9 @@ func newRootCommand(out io.Writer) (*cobra.Command, error) {
 	root.PersistentFlags().StringVar(&opts.DBPath, "db-path", "goja-repl.sqlite", "SQLite path for persistent REPL state")
 	root.PersistentFlags().StringSliceVar(&opts.PluginDirs, "plugin-dir", nil, fmt.Sprintf("plugin directory (defaults to %s/... when omitted)", host.DefaultDiscoveryRoot()))
 	root.PersistentFlags().StringSliceVar(&opts.AllowPluginModules, "allow-plugin-module", nil, "allow only the listed plugin module names")
+	root.PersistentFlags().StringSliceVar(&opts.EnableModules, "enable-module", nil, "enable only these native modules (comma-separated)")
+	root.PersistentFlags().StringSliceVar(&opts.DisableModules, "disable-module", nil, "disable these native modules (comma-separated)")
+	root.PersistentFlags().BoolVar(&opts.SafeMode, "safe-mode", false, "load only data-only modules (crypto, events, path, time, timer)")
 	if err := logging.AddLoggingSectionToRootCommand(root, "goja-repl"); err != nil {
 		return nil, err
 	}
@@ -103,6 +109,22 @@ type appSupportOptions struct {
 	helpSystem *help.HelpSystem
 }
 
+func (s commandSupport) moduleMiddleware() engine.ModuleMiddleware {
+	if s.opts == nil {
+		return nil
+	}
+	if s.opts.SafeMode {
+		return engine.MiddlewareSafe()
+	}
+	if len(s.opts.EnableModules) > 0 {
+		return engine.MiddlewareOnly(s.opts.EnableModules...)
+	}
+	if len(s.opts.DisableModules) > 0 {
+		return engine.MiddlewareExclude(s.opts.DisableModules...)
+	}
+	return nil
+}
+
 func (s commandSupport) newApp() (*replapi.App, *repldb.Store, error) {
 	return s.newAppWithOptions(appSupportOptions{
 		profile:   replapi.ProfilePersistent,
@@ -120,7 +142,10 @@ func (s commandSupport) newAppWithOptions(options appSupportOptions) (*replapi.A
 		}
 	}
 	pluginSetup := host.NewRuntimeSetup(s.opts.PluginDirs, s.opts.AllowPluginModules)
-	builder := engine.NewBuilder().UseModuleMiddleware(engine.MiddlewareSafe())
+	builder := engine.NewBuilder()
+	if mw := s.moduleMiddleware(); mw != nil {
+		builder = builder.UseModuleMiddleware(mw)
+	}
 	if options.helpSystem != nil {
 		builder = builder.WithRuntimeModuleRegistrars(docaccessruntime.NewRegistrar(docaccessruntime.Config{
 			HelpSources: []docaccessruntime.HelpSource{{

--- a/cmd/goja-repl/root_test.go
+++ b/cmd/goja-repl/root_test.go
@@ -297,6 +297,22 @@ func TestRunCommandEnableModule(t *testing.T) {
 	}
 }
 
+func TestRunCommandEnableDatabaseAlias(t *testing.T) {
+	script := filepath.Join(t.TempDir(), "test.js")
+	if err := os.WriteFile(script, []byte(`const db = require("db"); if (typeof db.query !== "function") throw new Error("missing query");`), 0644); err != nil {
+		t.Fatalf("write test script: %v", err)
+	}
+
+	err := runScriptFile(context.Background(), runScriptOptions{
+		File:           script,
+		EnableModules:  []string{"db"},
+		UseModuleRoots: true,
+	})
+	if err != nil {
+		t.Fatalf("execute run with --enable-module db: %v", err)
+	}
+}
+
 func TestRunCommandEnableModuleOnly(t *testing.T) {
 	script := filepath.Join(t.TempDir(), "test.js")
 	if err := os.WriteFile(script, []byte(`require("fs"); require("os");`), 0644); err != nil {

--- a/cmd/goja-repl/root_test.go
+++ b/cmd/goja-repl/root_test.go
@@ -242,3 +242,76 @@ func TestParseTUIProfile(t *testing.T) {
 		t.Fatal("expected invalid profile to fail")
 	}
 }
+
+func TestRunCommandSafeModeDisablesFs(t *testing.T) {
+	script := filepath.Join(t.TempDir(), "test.js")
+	if err := os.WriteFile(script, []byte(`require("fs");`), 0644); err != nil {
+		t.Fatalf("write test script: %v", err)
+	}
+
+	err := runScriptFile(context.Background(), runScriptOptions{
+		File:           script,
+		SafeMode:       true,
+		UseModuleRoots: true,
+	})
+	if err == nil {
+		t.Fatal("expected fs require to fail in safe mode")
+	}
+	if !strings.Contains(err.Error(), "Invalid module") {
+		t.Fatalf("expected Invalid module error, got %v", err)
+	}
+}
+
+func TestRunCommandDisableModule(t *testing.T) {
+	script := filepath.Join(t.TempDir(), "test.js")
+	if err := os.WriteFile(script, []byte(`require("fs");`), 0644); err != nil {
+		t.Fatalf("write test script: %v", err)
+	}
+
+	err := runScriptFile(context.Background(), runScriptOptions{
+		File:           script,
+		DisableModules: []string{"fs"},
+		UseModuleRoots: true,
+	})
+	if err == nil {
+		t.Fatal("expected fs require to fail when disabled")
+	}
+	if !strings.Contains(err.Error(), "Invalid module") {
+		t.Fatalf("expected Invalid module error, got %v", err)
+	}
+}
+
+func TestRunCommandEnableModule(t *testing.T) {
+	script := filepath.Join(t.TempDir(), "test.js")
+	if err := os.WriteFile(script, []byte(`require("fs");`), 0644); err != nil {
+		t.Fatalf("write test script: %v", err)
+	}
+
+	err := runScriptFile(context.Background(), runScriptOptions{
+		File:           script,
+		EnableModules:  []string{"fs"},
+		UseModuleRoots: true,
+	})
+	if err != nil {
+		t.Fatalf("execute run with --enable-module fs: %v", err)
+	}
+}
+
+func TestRunCommandEnableModuleOnly(t *testing.T) {
+	script := filepath.Join(t.TempDir(), "test.js")
+	if err := os.WriteFile(script, []byte(`require("fs"); require("os");`), 0644); err != nil {
+		t.Fatalf("write test script: %v", err)
+	}
+
+	err := runScriptFile(context.Background(), runScriptOptions{
+		File:           script,
+		EnableModules:  []string{"fs"},
+		UseModuleRoots: true,
+	})
+	if err == nil {
+		t.Fatal("expected os require to fail when not enabled")
+	}
+	if !strings.Contains(err.Error(), "Invalid module") {
+		t.Fatalf("expected Invalid module error, got %v", err)
+	}
+}

--- a/engine/factory.go
+++ b/engine/factory.go
@@ -71,7 +71,8 @@ func (b *FactoryBuilder) WithModules(mods ...ModuleSpec) *FactoryBuilder {
 	return b
 }
 
-// UseModuleMiddleware appends module-selection middlewares. When middlewares are
+// UseModuleMiddleware appends module-selection middlewares. A plain builder with
+// no explicit modules enables all default-registry modules; when middlewares are
 // present, the builder evaluates the pipeline at Build() time and converts the
 // resulting module names into NativeModuleSpec registrations. This is the
 // preferred way to control which default-registry modules are loaded.
@@ -131,7 +132,11 @@ func (b *FactoryBuilder) Build() (*Factory, error) {
 	}
 
 	// Evaluate module middleware pipeline and convert selected names to specs.
-	if len(b.moduleMiddlewares) > 0 {
+	// A plain NewBuilder().Build() preserves the historical default of exposing
+	// all default-registry modules. Calling UseModuleMiddleware narrows or
+	// transforms that selection; explicit WithModules(...) remains explicit and
+	// does not auto-append the default registry.
+	if len(b.moduleMiddlewares) > 0 || len(b.modules) == 0 {
 		selector := SelectAll
 		for i := len(b.moduleMiddlewares) - 1; i >= 0; i-- {
 			selector = b.moduleMiddlewares[i](selector)

--- a/engine/factory.go
+++ b/engine/factory.go
@@ -21,6 +21,7 @@ type FactoryBuilder struct {
 	settings builderSettings
 
 	modules                 []ModuleSpec
+	moduleMiddlewares       []ModuleMiddleware
 	runtimeModuleRegistrars []RuntimeModuleRegistrar
 	runtimeInitializers     []RuntimeInitializer
 	built                   bool
@@ -70,6 +71,20 @@ func (b *FactoryBuilder) WithModules(mods ...ModuleSpec) *FactoryBuilder {
 	return b
 }
 
+// UseModuleMiddleware appends module-selection middlewares. When middlewares are
+// present, the builder evaluates the pipeline at Build() time and converts the
+// resulting module names into NativeModuleSpec registrations. This is the
+// preferred way to control which default-registry modules are loaded.
+//
+// Middlewares are applied in order: the first middleware wraps the subsequent
+// ones. Override middlewares (Safe, Only) replace the selection; transform
+// middlewares (Exclude, Add, Custom) modify the result of the next handler.
+func (b *FactoryBuilder) UseModuleMiddleware(mw ...ModuleMiddleware) *FactoryBuilder {
+	b.assertMutable()
+	b.moduleMiddlewares = append(b.moduleMiddlewares, mw...)
+	return b
+}
+
 // WithRuntimeModuleRegistrars appends runtime-scoped module registration hooks.
 func (b *FactoryBuilder) WithRuntimeModuleRegistrars(registrars ...RuntimeModuleRegistrar) *FactoryBuilder {
 	b.assertMutable()
@@ -114,6 +129,19 @@ func (b *FactoryBuilder) Build() (*Factory, error) {
 		}
 		modules_ = append(modules_, mod)
 	}
+
+	// Evaluate module middleware pipeline and convert selected names to specs.
+	if len(b.moduleMiddlewares) > 0 {
+		selector := SelectAll
+		for i := len(b.moduleMiddlewares) - 1; i >= 0; i-- {
+			selector = b.moduleMiddlewares[i](selector)
+		}
+		selected := sortedUnique(selector(allRegisteredModuleNames()))
+		for _, name := range selected {
+			modules_ = append(modules_, DefaultRegistryModule(name))
+		}
+	}
+
 	runtimeRegistrars := make([]RuntimeModuleRegistrar, 0, len(b.runtimeModuleRegistrars))
 	for i, registrar := range b.runtimeModuleRegistrars {
 		if registrar == nil {

--- a/engine/granular_modules_test.go
+++ b/engine/granular_modules_test.go
@@ -76,6 +76,7 @@ func TestHostAccessModulesRequireExplicitSelection(t *testing.T) {
 	}
 }
 
+//nolint:staticcheck // Tests the deprecated DefaultRegistryModule function directly.
 func TestDefaultRegistryModuleEnablesOneHostModule(t *testing.T) {
 	factory, err := NewBuilder().WithModules(DefaultRegistryModule("fs")).Build()
 	if err != nil {
@@ -107,6 +108,7 @@ func TestDefaultRegistryModuleEnablesOneHostModule(t *testing.T) {
 	}
 }
 
+//nolint:staticcheck // Tests the deprecated DefaultRegistryModulesNamed function directly.
 func TestDefaultRegistryModulesNamedEnablesSelectedHostModules(t *testing.T) {
 	factory, err := NewBuilder().WithModules(DefaultRegistryModulesNamed("fs", "os")).Build()
 	if err != nil {

--- a/engine/granular_modules_test.go
+++ b/engine/granular_modules_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestDataOnlyModulesAreEnabledByDefault(t *testing.T) {
-	factory, err := NewBuilder().Build()
+	factory, err := NewBuilder().UseModuleMiddleware(MiddlewareSafe()).Build()
 	if err != nil {
 		t.Fatalf("build factory: %v", err)
 	}
@@ -45,8 +45,39 @@ func TestDataOnlyModulesAreEnabledByDefault(t *testing.T) {
 	}
 }
 
-func TestHostAccessModulesRequireExplicitSelection(t *testing.T) {
+func TestDefaultBuilderEnablesAllDefaultRegistryModules(t *testing.T) {
 	factory, err := NewBuilder().Build()
+	if err != nil {
+		t.Fatalf("build factory: %v", err)
+	}
+	rt, err := factory.NewRuntime(context.Background())
+	if err != nil {
+		t.Fatalf("new runtime: %v", err)
+	}
+	defer func() { _ = rt.Close(context.Background()) }()
+
+	ret, err := rt.Owner.Call(context.Background(), "default-modules-present", func(_ context.Context, vm *goja.Runtime) (any, error) {
+		value, runErr := vm.RunString(`
+			function canRequire(name) {
+				try { require(name); return true; } catch (e) { return false; }
+			}
+			JSON.stringify({ fs: canRequire("fs"), nodeFs: canRequire("node:fs"), os: canRequire("os"), nodeOs: canRequire("node:os"), exec: canRequire("exec"), database: canRequire("database"), db: canRequire("db") });
+		`)
+		if runErr != nil {
+			return nil, runErr
+		}
+		return value.String(), nil
+	})
+	if err != nil {
+		t.Fatalf("run default module smoke: %v", err)
+	}
+	if ret != `{"fs":true,"nodeFs":true,"os":true,"nodeOs":true,"exec":true,"database":true,"db":true}` {
+		t.Fatalf("default module availability = %v", ret)
+	}
+}
+
+func TestSafeMiddlewareRestrictsHostAccessModules(t *testing.T) {
+	factory, err := NewBuilder().UseModuleMiddleware(MiddlewareSafe()).Build()
 	if err != nil {
 		t.Fatalf("build factory: %v", err)
 	}
@@ -61,7 +92,7 @@ func TestHostAccessModulesRequireExplicitSelection(t *testing.T) {
 			function canRequire(name) {
 				try { require(name); return true; } catch (e) { return false; }
 			}
-			JSON.stringify({ fs: canRequire("fs"), nodeFs: canRequire("node:fs"), os: canRequire("os"), nodeOs: canRequire("node:os"), exec: canRequire("exec"), database: canRequire("database") });
+			JSON.stringify({ fs: canRequire("fs"), nodeFs: canRequire("node:fs"), os: canRequire("os"), nodeOs: canRequire("node:os"), exec: canRequire("exec"), database: canRequire("database"), db: canRequire("db") });
 		`)
 		if runErr != nil {
 			return nil, runErr
@@ -71,7 +102,7 @@ func TestHostAccessModulesRequireExplicitSelection(t *testing.T) {
 	if err != nil {
 		t.Fatalf("run host absent smoke: %v", err)
 	}
-	if ret != `{"fs":false,"nodeFs":false,"os":false,"nodeOs":false,"exec":false,"database":false}` {
+	if ret != `{"fs":false,"nodeFs":false,"os":false,"nodeOs":false,"exec":false,"database":false,"db":false}` {
 		t.Fatalf("host module availability = %v", ret)
 	}
 }

--- a/engine/module_middleware.go
+++ b/engine/module_middleware.go
@@ -1,0 +1,192 @@
+package engine
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/go-go-golems/go-go-goja/modules"
+)
+
+// ModuleSelector chooses which modules to register from a set of available names.
+type ModuleSelector func(available []string) []string
+
+// ModuleMiddleware wraps a selector. The standard pattern is f(next) returns a new
+// selector. This gives explicit control flow: each middleware decides whether to
+// call next, short-circuit, modify before/after, etc.
+type ModuleMiddleware func(next ModuleSelector) ModuleSelector
+
+// SelectAll is the identity selector — includes all available modules.
+func SelectAll(available []string) []string { return available }
+
+// MiddlewareSafe returns only data-safe modules. It is an override middleware:
+// it does NOT call next, replacing the entire selection.
+func MiddlewareSafe() ModuleMiddleware {
+	return func(next ModuleSelector) ModuleSelector {
+		return func(available []string) []string {
+			_ = next
+			return intersect(available, dataOnlyDefaultRegistryModuleNames)
+		}
+	}
+}
+
+// MiddlewareOnly returns only the named modules. It is an override middleware:
+// it does NOT call next, replacing the entire selection.
+func MiddlewareOnly(names ...string) ModuleMiddleware {
+	trimmed := make([]string, 0, len(names))
+	for _, name := range names {
+		if t := strings.TrimSpace(name); t != "" {
+			trimmed = append(trimmed, t)
+		}
+	}
+	return func(next ModuleSelector) ModuleSelector {
+		return func(available []string) []string {
+			_ = next
+			expanded := expandDefaultRegistryModuleNames(trimmed)
+			return intersect(available, expanded)
+		}
+	}
+}
+
+// MiddlewareExclude calls next first, then removes the named modules from the
+// result. It is a transform middleware.
+func MiddlewareExclude(names ...string) ModuleMiddleware {
+	trimmed := make([]string, 0, len(names))
+	for _, name := range names {
+		if t := strings.TrimSpace(name); t != "" {
+			trimmed = append(trimmed, t)
+		}
+	}
+	return func(next ModuleSelector) ModuleSelector {
+		return func(available []string) []string {
+			selected := next(available)
+			expanded := expandDefaultRegistryModuleNames(trimmed)
+			return filterOut(selected, expanded)
+		}
+	}
+}
+
+// MiddlewareAdd calls next first, then appends the named modules (if they exist
+// in the available set). It is a transform middleware.
+func MiddlewareAdd(names ...string) ModuleMiddleware {
+	trimmed := make([]string, 0, len(names))
+	for _, name := range names {
+		if t := strings.TrimSpace(name); t != "" {
+			trimmed = append(trimmed, t)
+		}
+	}
+	return func(next ModuleSelector) ModuleSelector {
+		return func(available []string) []string {
+			selected := next(available)
+			expanded := expandDefaultRegistryModuleNames(trimmed)
+			// Only add names that are actually available
+			valid := intersect(available, expanded)
+			return appendUnique(selected, valid)
+		}
+	}
+}
+
+// MiddlewareCustom calls next first, then applies an arbitrary transformation.
+// It is a transform middleware.
+func MiddlewareCustom(fn func(selected []string) []string) ModuleMiddleware {
+	return func(next ModuleSelector) ModuleSelector {
+		return func(available []string) []string {
+			return fn(next(available))
+		}
+	}
+}
+
+// Pipeline composes middlewares left-to-right: the first middleware in the list
+// executes first, wrapping the subsequent ones.
+func Pipeline(mws ...ModuleMiddleware) ModuleMiddleware {
+	return func(next ModuleSelector) ModuleSelector {
+		handler := next
+		for i := len(mws) - 1; i >= 0; i-- {
+			handler = mws[i](handler)
+		}
+		return handler
+	}
+}
+
+// allRegisteredModuleNames returns all module names from the default registry.
+func allRegisteredModuleNames() []string {
+	mods := modules.ListDefaultModules()
+	names := make([]string, 0, len(mods))
+	for _, m := range mods {
+		if m != nil {
+			names = append(names, m.Name())
+		}
+	}
+	return names
+}
+
+// intersect returns elements in a that are also in b.
+func intersect(a, b []string) []string {
+	set := make(map[string]struct{}, len(b))
+	for _, v := range b {
+		set[v] = struct{}{}
+	}
+	ret := make([]string, 0)
+	seen := make(map[string]struct{})
+	for _, v := range a {
+		if _, ok := set[v]; !ok {
+			continue
+		}
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		ret = append(ret, v)
+	}
+	return ret
+}
+
+// filterOut returns elements in a that are NOT in b.
+func filterOut(a, b []string) []string {
+	set := make(map[string]struct{}, len(b))
+	for _, v := range b {
+		set[v] = struct{}{}
+	}
+	ret := make([]string, 0)
+	seen := make(map[string]struct{})
+	for _, v := range a {
+		if _, ok := set[v]; ok {
+			continue
+		}
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		ret = append(ret, v)
+	}
+	return ret
+}
+
+// appendUnique appends elements from src to dst, skipping duplicates.
+func appendUnique(dst, src []string) []string {
+	seen := make(map[string]struct{}, len(dst))
+	for _, v := range dst {
+		seen[v] = struct{}{}
+	}
+	for _, v := range src {
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		dst = append(dst, v)
+	}
+	return dst
+}
+
+// sortedUnique returns a sorted deduplicated copy of the slice.
+func sortedUnique(src []string) []string {
+	seen := make(map[string]struct{}, len(src))
+	for _, v := range src {
+		seen[v] = struct{}{}
+	}
+	ret := make([]string, 0, len(seen))
+	for v := range seen {
+		ret = append(ret, v)
+	}
+	sort.Strings(ret)
+	return ret
+}

--- a/engine/module_middleware_test.go
+++ b/engine/module_middleware_test.go
@@ -1,0 +1,250 @@
+package engine
+
+import (
+	"sort"
+	"testing"
+)
+
+func TestMiddlewareSafe(t *testing.T) {
+	available := []string{"crypto", "events", "fs", "os", "exec", "path", "time", "timer", "yaml"}
+	mw := MiddlewareSafe()
+	selected := mw(SelectAll)(available)
+
+	want := []string{"crypto", "events", "path", "time", "timer"}
+	if !slicesEqual(selected, want) {
+		t.Fatalf("MiddlewareSafe() = %v, want %v", selected, want)
+	}
+}
+
+func TestMiddlewareSafeIgnoresNext(t *testing.T) {
+	// Safe is an override middleware — it should ignore whatever next returns.
+	available := []string{"crypto", "events", "fs", "os"}
+	mw := MiddlewareSafe()
+	// next returns everything, but Safe should still only return safe modules.
+	selected := mw(SelectAll)(available)
+	want := []string{"crypto", "events"}
+	if !slicesEqual(selected, want) {
+		t.Fatalf("MiddlewareSafe() override failed: got %v, want %v", selected, want)
+	}
+}
+
+func TestMiddlewareOnly(t *testing.T) {
+	available := []string{"crypto", "events", "fs", "os", "exec", "path"}
+	mw := MiddlewareOnly("fs", "path")
+	selected := mw(SelectAll)(available)
+
+	want := []string{"fs", "path"}
+	if !slicesEqual(selected, want) {
+		t.Fatalf("MiddlewareOnly() = %v, want %v", selected, want)
+	}
+}
+
+func TestMiddlewareOnlyWithAliases(t *testing.T) {
+	available := []string{"crypto", "node:crypto", "fs", "node:fs"}
+	mw := MiddlewareOnly("crypto")
+	selected := mw(SelectAll)(available)
+
+	// expandDefaultRegistryModuleNames adds node:crypto as an alias.
+	want := []string{"crypto", "node:crypto"}
+	if !slicesEqual(selected, want) {
+		t.Fatalf("MiddlewareOnly with alias = %v, want %v", selected, want)
+	}
+}
+
+func TestMiddlewareOnlyIgnoresUnknown(t *testing.T) {
+	available := []string{"crypto", "fs"}
+	mw := MiddlewareOnly("fs", "nonexistent")
+	selected := mw(SelectAll)(available)
+
+	want := []string{"fs"}
+	if !slicesEqual(selected, want) {
+		t.Fatalf("MiddlewareOnly unknown = %v, want %v", selected, want)
+	}
+}
+
+func TestMiddlewareExclude(t *testing.T) {
+	available := []string{"crypto", "events", "fs", "os", "exec", "path"}
+	mw := MiddlewareExclude("fs", "exec")
+	selected := mw(SelectAll)(available)
+
+	want := []string{"crypto", "events", "os", "path"}
+	if !slicesEqual(selected, want) {
+		t.Fatalf("MiddlewareExclude() = %v, want %v", selected, want)
+	}
+}
+
+func TestMiddlewareAdd(t *testing.T) {
+	available := []string{"crypto", "events", "fs", "os", "path"}
+	mw := MiddlewareAdd("fs")
+	selected := mw(func(a []string) []string {
+		// Simulate a prior filter that removed fs.
+		return []string{"crypto", "events", "path"}
+	})(available)
+
+	want := []string{"crypto", "events", "path", "fs"}
+	if !slicesEqual(selected, want) {
+		t.Fatalf("MiddlewareAdd() = %v, want %v", selected, want)
+	}
+}
+
+func TestMiddlewareAddSkipsUnavailable(t *testing.T) {
+	available := []string{"crypto", "events"}
+	mw := MiddlewareAdd("fs") // fs is not in available
+	selected := mw(SelectAll)(available)
+
+	want := []string{"crypto", "events"}
+	if !slicesEqual(selected, want) {
+		t.Fatalf("MiddlewareAdd unavailable = %v, want %v", selected, want)
+	}
+}
+
+func TestMiddlewareCustom(t *testing.T) {
+	available := []string{"fs", "os", "exec"}
+	mw := MiddlewareCustom(func(selected []string) []string {
+		sort.Strings(selected)
+		return selected
+	})
+	selected := mw(SelectAll)(available)
+
+	want := []string{"exec", "fs", "os"}
+	if !slicesEqual(selected, want) {
+		t.Fatalf("MiddlewareCustom() = %v, want %v", selected, want)
+	}
+}
+
+func TestPipelineOrder(t *testing.T) {
+	available := []string{"crypto", "events", "fs", "os", "exec", "yaml", "path", "time", "timer"}
+
+	// Safe is an override middleware — it short-circuits everything after it.
+	// So Pipeline(Safe, Add(fs), Exclude(yaml)) is equivalent to just Safe.
+	mw := Pipeline(
+		MiddlewareSafe(),
+		MiddlewareAdd("fs"),
+		MiddlewareExclude("yaml"),
+	)
+	selected := mw(SelectAll)(available)
+	want := []string{"crypto", "events", "path", "time", "timer"}
+	if !slicesEqual(selected, want) {
+		t.Fatalf("Pipeline safe+add+exclude = %v, want %v", selected, want)
+	}
+}
+
+func TestPipelineAddThenSafe(t *testing.T) {
+	available := []string{"crypto", "events", "fs", "os", "exec", "path"}
+
+	// Add fs → Safe
+	// Add runs first, calls Safe (override → returns safe only).
+	// Add appends fs to the safe-only result.
+	mw := Pipeline(
+		MiddlewareAdd("fs"),
+		MiddlewareSafe(),
+	)
+	selected := mw(SelectAll)(available)
+	want := []string{"crypto", "events", "path", "fs"}
+	if !slicesEqual(selected, want) {
+		t.Fatalf("Pipeline add+safe = %v, want %v", selected, want)
+	}
+}
+
+func TestIntersect(t *testing.T) {
+	a := []string{"a", "b", "c", "d"}
+	b := []string{"b", "d", "e"}
+	got := intersect(a, b)
+	want := []string{"b", "d"}
+	if !slicesEqual(got, want) {
+		t.Fatalf("intersect = %v, want %v", got, want)
+	}
+}
+
+func TestIntersectDeduplicates(t *testing.T) {
+	a := []string{"a", "a", "b"}
+	b := []string{"a", "b", "b"}
+	got := intersect(a, b)
+	want := []string{"a", "b"}
+	if !slicesEqual(got, want) {
+		t.Fatalf("intersect dedup = %v, want %v", got, want)
+	}
+}
+
+func TestFilterOut(t *testing.T) {
+	a := []string{"a", "b", "c", "d"}
+	b := []string{"b", "d"}
+	got := filterOut(a, b)
+	want := []string{"a", "c"}
+	if !slicesEqual(got, want) {
+		t.Fatalf("filterOut = %v, want %v", got, want)
+	}
+}
+
+func TestFilterOutDeduplicates(t *testing.T) {
+	a := []string{"a", "a", "b", "c"}
+	b := []string{"a"}
+	got := filterOut(a, b)
+	want := []string{"b", "c"}
+	if !slicesEqual(got, want) {
+		t.Fatalf("filterOut dedup = %v, want %v", got, want)
+	}
+}
+
+func TestAppendUnique(t *testing.T) {
+	dst := []string{"a", "b"}
+	src := []string{"b", "c"}
+	got := appendUnique(dst, src)
+	want := []string{"a", "b", "c"}
+	if !slicesEqual(got, want) {
+		t.Fatalf("appendUnique = %v, want %v", got, want)
+	}
+}
+
+func TestMiddlewareOnlyForSafePlusExtra(t *testing.T) {
+	// To get safe modules + one extra, use MiddlewareOnly with explicit list.
+	available := []string{"crypto", "events", "fs", "os", "exec", "path"}
+	mw := MiddlewareOnly("crypto", "events", "path", "time", "timer", "fs")
+	selected := mw(SelectAll)(available)
+	want := []string{"crypto", "events", "fs", "path"}
+	if !slicesEqual(selected, want) {
+		t.Fatalf("MiddlewareOnly safe+fs = %v, want %v", selected, want)
+	}
+}
+
+func TestSortedUnique(t *testing.T) {
+	got := sortedUnique([]string{"b", "a", "b", "c", "a"})
+	want := []string{"a", "b", "c"}
+	if !slicesEqual(got, want) {
+		t.Fatalf("sortedUnique = %v, want %v", got, want)
+	}
+}
+
+func TestAllRegisteredModuleNames(t *testing.T) {
+	names := allRegisteredModuleNames()
+	if len(names) == 0 {
+		t.Fatal("allRegisteredModuleNames() returned empty slice")
+	}
+	// Verify at least some known modules are present.
+	has := func(name string) bool {
+		for _, n := range names {
+			if n == name {
+				return true
+			}
+		}
+		return false
+	}
+	if !has("fs") {
+		t.Fatal("expected fs in registered module names")
+	}
+	if !has("crypto") {
+		t.Fatal("expected crypto in registered module names")
+	}
+}
+
+func slicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/engine/module_middleware_test.go
+++ b/engine/module_middleware_test.go
@@ -51,6 +51,17 @@ func TestMiddlewareOnlyWithAliases(t *testing.T) {
 	}
 }
 
+func TestMiddlewareOnlyWithDatabaseAlias(t *testing.T) {
+	available := []string{"database", "db", "fs"}
+	mw := MiddlewareOnly("db")
+	selected := mw(SelectAll)(available)
+
+	want := []string{"database", "db"}
+	if !slicesEqual(selected, want) {
+		t.Fatalf("MiddlewareOnly with database alias = %v, want %v", selected, want)
+	}
+}
+
 func TestMiddlewareOnlyIgnoresUnknown(t *testing.T) {
 	available := []string{"crypto", "fs"}
 	mw := MiddlewareOnly("fs", "nonexistent")

--- a/engine/module_specs.go
+++ b/engine/module_specs.go
@@ -98,10 +98,13 @@ func (s defaultRegistryModulesSpec) Register(reg *require.Registry) error {
 }
 
 // DefaultRegistryModules returns a ModuleSpec that registers every module from
-// go-go-goja/modules.DefaultRegistry. Prefer DefaultRegistryModule(name) or
-// DefaultRegistryModulesNamed(...) when embedding untrusted or semi-trusted
-// JavaScript, because the full default registry includes host-access modules
-// such as fs, os, exec, and database.
+// go-go-goja/modules.DefaultRegistry.
+//
+// Deprecated: Use UseModuleMiddleware with the appropriate middleware instead.
+// For example:
+//
+//	engine.NewBuilder().UseModuleMiddleware(engine.MiddlewareSafe())
+//	engine.NewBuilder().UseModuleMiddleware(engine.MiddlewareOnly("fs", "os"))
 func DefaultRegistryModules() ModuleSpec {
 	return defaultRegistryModulesSpec{}
 }
@@ -169,6 +172,11 @@ func expandDefaultRegistryModuleNames(names []string) []string {
 
 // DefaultRegistryModule returns a ModuleSpec that registers one module from
 // modules.DefaultRegistry by its JavaScript require() name.
+//
+// Deprecated: Use UseModuleMiddleware with MiddlewareOnly instead.
+// For example:
+//
+//	engine.NewBuilder().UseModuleMiddleware(engine.MiddlewareOnly("fs"))
 func DefaultRegistryModule(name string) ModuleSpec {
 	name = strings.TrimSpace(name)
 	return namedDefaultRegistryModulesSpec{
@@ -178,8 +186,12 @@ func DefaultRegistryModule(name string) ModuleSpec {
 }
 
 // DefaultRegistryModulesNamed returns a ModuleSpec that registers only the
-// named modules from modules.DefaultRegistry. Use this for granular sandbox
-// composition instead of DefaultRegistryModules().
+// named modules from modules.DefaultRegistry.
+//
+// Deprecated: Use UseModuleMiddleware with MiddlewareOnly instead.
+// For example:
+//
+//	engine.NewBuilder().UseModuleMiddleware(engine.MiddlewareOnly("fs", "os"))
 func DefaultRegistryModulesNamed(names ...string) ModuleSpec {
 	trimmed := make([]string, 0, len(names))
 	for _, name := range names {
@@ -197,6 +209,11 @@ var dataOnlyDefaultRegistryModuleNames = []string{"crypto", "node:crypto", "even
 
 // DataOnlyDefaultRegistryModules returns the non-host-filesystem/non-process
 // primitives that are installed automatically for every engine runtime.
+//
+// Deprecated: Use UseModuleMiddleware with MiddlewareSafe instead.
+// For example:
+//
+//	engine.NewBuilder().UseModuleMiddleware(engine.MiddlewareSafe())
 func DataOnlyDefaultRegistryModules() ModuleSpec {
 	return namedDefaultRegistryModulesSpec{
 		id:    "data-only-default-registry-modules",

--- a/engine/module_specs.go
+++ b/engine/module_specs.go
@@ -139,11 +139,13 @@ func (s namedDefaultRegistryModulesSpec) Register(reg *require.Registry) error {
 }
 
 var defaultRegistryModuleAliases = map[string][]string{
-	"crypto": {"node:crypto"},
-	"events": {"node:events"},
-	"fs":     {"node:fs"},
-	"os":     {"node:os"},
-	"path":   {"node:path"},
+	"crypto":   {"node:crypto"},
+	"database": {"db"},
+	"db":       {"database"},
+	"events":   {"node:events"},
+	"fs":       {"node:fs"},
+	"os":       {"node:os"},
+	"path":     {"node:path"},
 }
 
 func expandDefaultRegistryModuleNames(names []string) []string {

--- a/engine/runtime.go
+++ b/engine/runtime.go
@@ -14,7 +14,7 @@ import (
 
 	// Blank imports ensure module init() functions run so they can register
 	// themselves in modules.DefaultRegistry. Registration is still explicit:
-	// callers must opt in via DefaultRegistryModules().
+	// callers must opt in via UseModuleMiddleware (e.g. MiddlewareSafe).
 	_ "github.com/go-go-golems/go-go-goja/modules/crypto"
 	_ "github.com/go-go-golems/go-go-goja/modules/database"
 	_ "github.com/go-go-golems/go-go-goja/modules/events"

--- a/engine/runtime.go
+++ b/engine/runtime.go
@@ -13,8 +13,9 @@ import (
 	"github.com/go-go-golems/go-go-goja/pkg/runtimeowner"
 
 	// Blank imports ensure module init() functions run so they can register
-	// themselves in modules.DefaultRegistry. Registration is still explicit:
-	// callers must opt in via UseModuleMiddleware (e.g. MiddlewareSafe).
+	// themselves in modules.DefaultRegistry. A plain NewBuilder().Build() exposes
+	// this default registry; callers can restrict it with UseModuleMiddleware
+	// (e.g. MiddlewareSafe or MiddlewareOnly).
 	_ "github.com/go-go-golems/go-go-goja/modules/crypto"
 	_ "github.com/go-go-golems/go-go-goja/modules/database"
 	_ "github.com/go-go-golems/go-go-goja/modules/events"

--- a/fuzz/testutil_test.go
+++ b/fuzz/testutil_test.go
@@ -15,7 +15,7 @@ import (
 
 func newFactory(t *testing.T) *engine.Factory {
 	t.Helper()
-	factory, err := engine.NewBuilder().WithModules(engine.DefaultRegistryModules()).Build()
+	factory, err := engine.NewBuilder().UseModuleMiddleware(engine.MiddlewareSafe()).Build()
 	if err != nil {
 		t.Fatalf("build factory: %v", err)
 	}

--- a/modules/crypto/crypto_test.go
+++ b/modules/crypto/crypto_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestCryptoModuleSmoke(t *testing.T) {
-	factory, err := gggengine.NewBuilder().WithModules(gggengine.DefaultRegistryModules()).Build()
+	factory, err := gggengine.NewBuilder().UseModuleMiddleware(gggengine.MiddlewareSafe()).Build()
 	if err != nil {
 		t.Fatalf("build factory: %v", err)
 	}

--- a/modules/database/database.go
+++ b/modules/database/database.go
@@ -90,7 +90,7 @@ func (m *DBModule) Name() string {
 
 func (m *DBModule) TypeScriptModule() *spec.Module {
 	return &spec.Module{
-		Name: "database",
+		Name: m.Name(),
 		Functions: []spec.Function{
 			{
 				Name: "configure",
@@ -308,4 +308,5 @@ func flattenArgs(args []any) []any {
 
 func init() {
 	modules.Register(New())
+	modules.Register(New(WithName("db")))
 }

--- a/modules/database/database_test.go
+++ b/modules/database/database_test.go
@@ -17,7 +17,7 @@ func TestDefaultDatabaseModuleConfigure(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "default.db")
 
 	factory, err := gggengine.NewBuilder().
-		WithModules(gggengine.DefaultRegistryModules()).
+		UseModuleMiddleware(gggengine.MiddlewareOnly("database")).
 		Build()
 	require.NoError(t, err)
 

--- a/modules/fs/fs_test.go
+++ b/modules/fs/fs_test.go
@@ -261,7 +261,7 @@ func TestFsAsyncErrorObjectSmoke(t *testing.T) {
 
 func newRuntime(t *testing.T) *gggengine.Runtime {
 	t.Helper()
-	factory, err := gggengine.NewBuilder().WithModules(gggengine.DefaultRegistryModules()).Build()
+	factory, err := gggengine.NewBuilder().UseModuleMiddleware(gggengine.MiddlewareOnly("fs")).Build()
 	if err != nil {
 		t.Fatalf("build factory: %v", err)
 	}

--- a/modules/os/os_test.go
+++ b/modules/os/os_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestOSModuleSmoke(t *testing.T) {
-	factory, err := gggengine.NewBuilder().WithModules(gggengine.DefaultRegistryModules()).Build()
+	factory, err := gggengine.NewBuilder().UseModuleMiddleware(gggengine.MiddlewareOnly("os")).Build()
 	if err != nil {
 		t.Fatalf("build factory: %v", err)
 	}

--- a/modules/path/path_test.go
+++ b/modules/path/path_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestPathModuleSmoke(t *testing.T) {
-	factory, err := gggengine.NewBuilder().WithModules(gggengine.DefaultRegistryModules()).Build()
+	factory, err := gggengine.NewBuilder().UseModuleMiddleware(gggengine.MiddlewareSafe()).Build()
 	if err != nil {
 		t.Fatalf("build factory: %v", err)
 	}

--- a/modules/time/time_test.go
+++ b/modules/time/time_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestTimeModuleSmoke(t *testing.T) {
-	factory, err := gggengine.NewBuilder().WithModules(gggengine.DefaultRegistryModules()).Build()
+	factory, err := gggengine.NewBuilder().UseModuleMiddleware(gggengine.MiddlewareSafe()).Build()
 	if err != nil {
 		t.Fatalf("build factory: %v", err)
 	}

--- a/modules/timer/timer_test.go
+++ b/modules/timer/timer_test.go
@@ -94,7 +94,7 @@ func newDefaultRuntime(t *testing.T) *gggengine.Runtime {
 	t.Helper()
 
 	factory, err := gggengine.NewBuilder().
-		WithModules(gggengine.DefaultRegistryModules()).
+		UseModuleMiddleware(gggengine.MiddlewareSafe()).
 		Build()
 	require.NoError(t, err)
 

--- a/modules/yaml/yaml_test.go
+++ b/modules/yaml/yaml_test.go
@@ -256,7 +256,7 @@ func newDefaultRuntime(t *testing.T) *gggengine.Runtime {
 	t.Helper()
 
 	factory, err := gggengine.NewBuilder().
-		WithModules(gggengine.DefaultRegistryModules()).
+		UseModuleMiddleware(gggengine.MiddlewareOnly("yaml")).
 		Build()
 	require.NoError(t, err)
 

--- a/perf/goja/bench_test.go
+++ b/perf/goja/bench_test.go
@@ -28,7 +28,7 @@ func newRuntime(tb testing.TB, opts ...require.Option) (*goja.Runtime, *require.
 	tb.Helper()
 	factory, err := engine.NewBuilder().
 		WithRequireOptions(opts...).
-		WithModules(engine.DefaultRegistryModules()).
+		UseModuleMiddleware(engine.MiddlewareSafe()).
 		Build()
 	if err != nil {
 		tb.Fatalf("build factory: %v", err)
@@ -75,7 +75,7 @@ func BenchmarkRuntimeSpawn(b *testing.B) {
 
 	b.Run("EngineFactory", func(b *testing.B) {
 		factory, err := engine.NewBuilder().
-			WithModules(engine.DefaultRegistryModules()).
+			UseModuleMiddleware(engine.MiddlewareSafe()).
 			Build()
 		if err != nil {
 			b.Fatalf("build factory: %v", err)

--- a/pkg/doc/04-repl-usage.md
+++ b/pkg/doc/04-repl-usage.md
@@ -83,6 +83,9 @@ go run ./cmd/goja-repl --safe-mode run ./script.js
 # Whitelist: load only specific modules
 go run ./cmd/goja-repl --enable-module fs,path run ./script.js
 
+# Whitelist in the TUI; db is an alias for the database module
+go run ./cmd/goja-repl tui --enable-module db
+
 # Blacklist: load all except specific modules
 go run ./cmd/goja-repl --disable-module fs,exec run ./script.js
 ```
@@ -98,7 +101,7 @@ These flags are persistent (available on all subcommands) and are applied when t
 **Module categories:**
 
 - **Safe (data-only):** `crypto`, `events`, `path`, `time`, `timer`
-- **Dangerous (host-access):** `fs`, `os`, `exec`, `database`, `yaml`
+- **Dangerous (host-access):** `fs`, `os`, `exec`, `database`/`db`, `yaml`
 - **Process exposure:** `process` (requires `WithProcess()`) 
 
 ### REPL Commands

--- a/pkg/doc/04-repl-usage.md
+++ b/pkg/doc/04-repl-usage.md
@@ -72,6 +72,35 @@ Root-level plugin flags still apply:
 go run ./cmd/goja-repl --plugin-dir ./plugins run ./scripts/with-plugins.js
 ```
 
+### Module Security Flags
+
+By default, `run` (and all other `goja-repl` commands) load **all** registered native modules. You can restrict the module sandbox using persistent flags:
+
+```bash
+# Safe mode: load only data-only modules (crypto, events, path, time, timer)
+go run ./cmd/goja-repl --safe-mode run ./script.js
+
+# Whitelist: load only specific modules
+go run ./cmd/goja-repl --enable-module fs,path run ./script.js
+
+# Blacklist: load all except specific modules
+go run ./cmd/goja-repl --disable-module fs,exec run ./script.js
+```
+
+| Flag | Effect | Example |
+|------|--------|---------|
+| `--safe-mode` | Only data-safe modules (no filesystem, process, or DB access) | `--safe-mode` |
+| `--enable-module` | Whitelist — only these modules are loaded | `--enable-module fs,path` |
+| `--disable-module` | Blacklist — all modules except these are loaded | `--disable-module exec,os` |
+
+These flags are persistent (available on all subcommands) and are applied when the engine runtime is built. They affect `run`, `tui`, `eval`, `create`, and all other commands that construct a runtime.
+
+**Module categories:**
+
+- **Safe (data-only):** `crypto`, `events`, `path`, `time`, `timer`
+- **Dangerous (host-access):** `fs`, `os`, `exec`, `database`, `yaml`
+- **Process exposure:** `process` (requires `WithProcess()`) 
+
 ### REPL Commands
 
 The REPL recognizes special commands prefixed with `:`:

--- a/pkg/doc/16-nodejs-primitives.md
+++ b/pkg/doc/16-nodejs-primitives.md
@@ -39,7 +39,7 @@ The factory always installs data-only primitives and safe globals:
 - `require("time")`
 - `require("timer")`
 
-Host-access modules are not enabled by default. Enable them one at a time with `engine.DefaultRegistryModule(name)` or in a selected group with `engine.DefaultRegistryModulesNamed(...)`:
+A plain `engine.NewBuilder().Build()` enables the full default registry, including host-access modules. For a tighter sandbox, enable modules one at a time with `engine.DefaultRegistryModule(name)`, select a named group with `engine.DefaultRegistryModulesNamed(...)`, or use `UseModuleMiddleware(engine.MiddlewareSafe())`:
 
 ```go
 factory, err := engine.NewBuilder().
@@ -50,7 +50,7 @@ factory, err := engine.NewBuilder().
     Build()
 ```
 
-You can still enable every module in `modules.DefaultRegistry` with `engine.DefaultRegistryModules()`, but that includes host-access modules such as `fs`, `os`, `exec`, and `database`. Use it only when the JavaScript code is trusted enough for that level of access.
+You can still explicitly enable every module in `modules.DefaultRegistry` with `engine.DefaultRegistryModules()`, but that includes host-access modules such as `fs`, `os`, `exec`, and `database`/`db`. Use the all-modules default only when the JavaScript code is trusted enough for that level of access.
 
 The `process` module and global are not installed by default. Enable them only when exposing host environment variables is acceptable:
 
@@ -132,7 +132,7 @@ fs.writeFileSync(file, Buffer.from("hello"));
 console.log(fs.readFileSync(file, "utf8"));
 ```
 
-For a tighter sandbox, do not use `DefaultRegistryModules()`. Instead, register only the modules your application wants through `DefaultRegistryModule`, `DefaultRegistryModulesNamed`, or explicit `engine.NativeModuleSpec` values.
+For a tighter sandbox, do not rely on the all-modules default or `DefaultRegistryModules()`. Instead, use `UseModuleMiddleware(engine.MiddlewareSafe())`, register only the modules your application wants through `DefaultRegistryModule`/`DefaultRegistryModulesNamed`, or provide explicit `engine.NativeModuleSpec` values.
 
 ## Available Primitives
 
@@ -144,10 +144,10 @@ This section lists the current built-in primitives, what each one is for, and ho
 | `URL`, `URLSearchParams` | global, `require("url")`, `require("node:url")` | URL parsing | Installed globally by default through goja_nodejs. |
 | `util` | `require("util")`, `require("node:util")` | Formatting helpers | Provided by goja_nodejs. |
 | `process` / `node:process` | opt-in `require("process")` or `require("node:process")` with `engine.ProcessModule()`; opt-in global with `engine.ProcessEnv()` | Environment variables | Both module and global are opt-in. |
-| `fs` / `node:fs` | opt-in `require("fs")` or `require("node:fs")` | Promise-based and sync file I/O | Host filesystem access; enabling `fs` also registers `node:fs`. |
+| `fs` / `node:fs` | default `require("fs")` or `require("node:fs")`; remove with safe/only middleware | Promise-based and sync file I/O | Host filesystem access; enabling `fs` also registers `node:fs`. |
 | `events` / `node:events` | default `require("events")` or `require("node:events")` | Go-native EventEmitter | Data-only; helper modules may adopt emitters explicitly. |
 | `path` / `node:path` | default `require("path")` or `require("node:path")` | Host-platform path helpers | Data-only; uses Go `filepath`; no `posix`/`win32` split yet. |
-| `os` / `node:os` | opt-in `require("os")` or `require("node:os")` | Host OS information | Host info access; enabling `os` also registers `node:os`. |
+| `os` / `node:os` | default `require("os")` or `require("node:os")`; remove with safe/only middleware | Host OS information | Host info access; enabling `os` also registers `node:os`. |
 | `crypto` / `node:crypto` | default `require("crypto")` or `require("node:crypto")` | UUIDs, random bytes, basic hashes | Data-only default primitive. |
 | `time` | default `require("time")` | Explicit timing helper | Data-only; pairs with global `performance.now()`. |
 | `performance` | global | Monotonic elapsed timing | Provides `performance.now()`. |
@@ -168,7 +168,7 @@ require("node:url");
 require("node:util");
 ```
 
-Host-access aliases remain opt-in. Calling `engine.DefaultRegistryModule("fs")` registers both `fs` and `node:fs`; calling `engine.DefaultRegistryModulesNamed("fs", "os")` registers `fs`, `node:fs`, `os`, and `node:os`. `engine.ProcessModule()` registers both `process` and `node:process`.
+Host-access aliases are part of the default registry unless you restrict it. Calling `engine.DefaultRegistryModule("fs")` registers both `fs` and `node:fs`; calling `engine.DefaultRegistryModulesNamed("fs", "os")` registers `fs`, `node:fs`, `os`, and `node:os`. `engine.ProcessModule()` registers both `process` and `node:process`.
 
 Custom go-go-goja modules do not receive `node:` aliases. For example, `time`, `timer`, `exec`, `database`, `fswatch`, and Watermill helpers are custom host/runtime features rather than Node built-ins.
 
@@ -399,13 +399,13 @@ The runtime uses monotonic elapsed time from Go's `time` package, so measurement
 
 These primitives expose useful host capabilities. That is powerful, but it means embedders need a clear sandbox policy.
 
-- `fs` and `os` expose host filesystem and OS details and must be enabled explicitly.
-- `events`, `path`, and `crypto` are enabled by default with bare and `node:` names; `time` and `timer` are custom data-only primitives and have no `node:` aliases.
+- `fs` and `os` expose host filesystem and OS details; they are present in the all-modules default and should be removed with `MiddlewareSafe`, `MiddlewareOnly`, or explicit module selection for untrusted code.
+- `events`, `path`, and `crypto` are data-only modules with bare and `node:` names; `time` and `timer` are custom data-only primitives and have no `node:` aliases.
 - `crypto.randomBytes()` uses host randomness.
 - `require("process").env` and `require("node:process").env` require explicit `engine.ProcessModule()` opt-in, and global `process` requires explicit `engine.ProcessEnv()` opt-in.
 - `exec` and `database` remain selectable modules and should be treated as more sensitive than the data-only primitives documented here.
 
-If your application runs untrusted JavaScript, do not blindly expose `DefaultRegistryModules()`. Compose a smaller registry with `DefaultRegistryModule(...)` or `DefaultRegistryModulesNamed(...)` before evaluating untrusted scripts.
+If your application runs untrusted JavaScript, do not blindly use the all-modules default or `DefaultRegistryModules()`. Compose a smaller registry with `UseModuleMiddleware(engine.MiddlewareSafe())`, `DefaultRegistryModule(...)`, or `DefaultRegistryModulesNamed(...)` before evaluating untrusted scripts.
 
 ## Implementation Map
 
@@ -429,7 +429,7 @@ Smoke tests live next to each module and execute real JavaScript through a real 
 
 | Problem | Cause | Solution |
 |---------|-------|----------|
-| `require("fs")` or `require("node:fs")` fails | `fs` is host filesystem access and is not enabled by default | Add `.WithModules(engine.DefaultRegistryModule("fs"))` or `.WithModules(engine.DefaultRegistryModulesNamed("fs", ...))`; this registers both names. |
+| `require("fs")` or `require("node:fs")` fails | The runtime was built with safe/only middleware or an explicit module set that excluded `fs` | Add `.UseModuleMiddleware(engine.MiddlewareOnly("fs", ...))`, `.WithModules(engine.DefaultRegistryModule("fs"))`, or `.WithModules(engine.DefaultRegistryModulesNamed("fs", ...))`; this registers both names. |
 | `process` is undefined | Global `process` is opt-in | Add `.WithRuntimeInitializers(engine.ProcessEnv())` if exposing global `process.env` is acceptable. |
 | `require("process")` or `require("node:process")` fails | The process module is opt-in because it exposes host environment variables | Add `.WithModules(engine.ProcessModule())` only if scripts should be able to import `process.env`. |
 | `fs.readFile(path)` returns a Buffer, not a string | Node-style default read behavior | Pass an encoding: `await fs.readFile(path, "utf8")`. |

--- a/pkg/jsverbs/jsverbs_test.go
+++ b/pkg/jsverbs/jsverbs_test.go
@@ -585,7 +585,7 @@ func TestInvokeInRuntimeReusesLiveRuntime(t *testing.T) {
 
 	builder := engine.NewBuilder().
 		WithRequireOptions(noderequire.WithLoader(registry.RequireLoader())).
-		WithModules(engine.DefaultRegistryModules())
+		UseModuleMiddleware(engine.MiddlewareOnly("fs", "events"))
 	if requireOpt != nil {
 		builder = builder.WithRequireOptions(requireOpt)
 	}
@@ -642,7 +642,7 @@ func TestFSWatchJsverbUsesInstalledHelper(t *testing.T) {
 
 	builder := engine.NewBuilder().
 		WithRequireOptions(noderequire.WithLoader(registry.RequireLoader())).
-		WithModules(engine.DefaultRegistryModules()).
+		UseModuleMiddleware(engine.MiddlewareOnly("fs", "events")).
 		WithRuntimeInitializers(
 			jsevents.Install(),
 			jsevents.FSWatchHelper(jsevents.FSWatchOptions{

--- a/pkg/jsverbs/model.go
+++ b/pkg/jsverbs/model.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/go-go-golems/go-go-goja/engine"
 )
 
 type ParameterKind string
@@ -81,6 +83,9 @@ type Registry struct {
 	verbsByKey         map[string]*VerbSpec
 	filesByModule      map[string]*FileSpec
 	options            ScanOptions
+	// ModuleMiddleware controls which native modules are available to jsverbs
+	// when the registry builds its own runtime. If nil, all modules are loaded.
+	ModuleMiddleware engine.ModuleMiddleware
 }
 
 type FileSpec struct {

--- a/pkg/jsverbs/runtime.go
+++ b/pkg/jsverbs/runtime.go
@@ -16,10 +16,12 @@ import (
 )
 
 func (r *Registry) invoke(ctx context.Context, verb *VerbSpec, parsedValues *values.Values) (interface{}, error) {
-	factory, err := engine.NewBuilder().
-		WithRequireOptions(require.WithLoader(r.sourceLoader)).
-		UseModuleMiddleware(engine.MiddlewareSafe()).
-		Build()
+	builder := engine.NewBuilder().
+		WithRequireOptions(require.WithLoader(r.sourceLoader))
+	if r.ModuleMiddleware != nil {
+		builder = builder.UseModuleMiddleware(r.ModuleMiddleware)
+	}
+	factory, err := builder.Build()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/jsverbs/runtime.go
+++ b/pkg/jsverbs/runtime.go
@@ -18,7 +18,7 @@ import (
 func (r *Registry) invoke(ctx context.Context, verb *VerbSpec, parsedValues *values.Values) (interface{}, error) {
 	factory, err := engine.NewBuilder().
 		WithRequireOptions(require.WithLoader(r.sourceLoader)).
-		WithModules(engine.DefaultRegistryModules()).
+		UseModuleMiddleware(engine.MiddlewareSafe()).
 		Build()
 	if err != nil {
 		return nil, err

--- a/pkg/repl/adapters/bobatea/replapi.go
+++ b/pkg/repl/adapters/bobatea/replapi.go
@@ -3,6 +3,7 @@ package bobatea
 import (
 	"context"
 	"strings"
+	"sync"
 
 	"github.com/dop251/goja"
 	bobarepl "github.com/go-go-golems/bobatea/pkg/repl"
@@ -25,6 +26,7 @@ type REPLAPIAdapter struct {
 	app       *replapi.App
 	sessionID string
 	assist    *js.Assistance
+	tsMu      sync.Mutex
 }
 
 // NewREPLAPIAdapter creates a Bobatea evaluator backed by one replapi session.
@@ -40,25 +42,27 @@ func NewREPLAPIAdapter(app *replapi.App, sessionID string) (*REPLAPIAdapter, err
 	if err != nil {
 		return nil, errors.Wrap(err, "replapi adapter: create TypeScript parser")
 	}
-	return &REPLAPIAdapter{
+	ret := &REPLAPIAdapter{
 		app:       app,
 		sessionID: sessionID,
-		assist: js.NewAssistance(js.AssistanceConfig{
-			TSParser: tsParser,
-			WithRuntime: func(ctx context.Context, fn func(*goja.Runtime, *docaccess.Hub) error) error {
-				return app.WithRuntime(ctx, sessionID, func(runtime *engine.Runtime) error {
-					return fn(runtime.VM, js.DocHubFromRuntime(runtime))
-				})
-			},
-			BindingHints: func(ctx context.Context) ([]jsparse.CompletionCandidate, error) {
-				bindings, err := app.Bindings(ctx, sessionID)
-				if err != nil {
-					return nil, nil
-				}
-				return bindingHintCandidates(bindings), nil
-			},
-		}),
-	}, nil
+	}
+	ret.assist = js.NewAssistance(js.AssistanceConfig{
+		TSParser: tsParser,
+		TSMu:     &ret.tsMu,
+		WithRuntime: func(ctx context.Context, fn func(*goja.Runtime, *docaccess.Hub) error) error {
+			return app.WithRuntime(ctx, sessionID, func(runtime *engine.Runtime) error {
+				return fn(runtime.VM, js.DocHubFromRuntime(runtime))
+			})
+		},
+		BindingHints: func(ctx context.Context) ([]jsparse.CompletionCandidate, error) {
+			bindings, err := app.Bindings(ctx, sessionID)
+			if err != nil {
+				return nil, nil
+			}
+			return bindingHintCandidates(bindings), nil
+		},
+	})
+	return ret, nil
 }
 
 // App returns the underlying replapi app for advanced integrations.

--- a/pkg/repl/adapters/bobatea/replapi_test.go
+++ b/pkg/repl/adapters/bobatea/replapi_test.go
@@ -228,7 +228,7 @@ func TestAppWithRuntimeAutoRestoresPersistentSession(t *testing.T) {
 func newAdapterTestFactory(t *testing.T) *engine.Factory {
 	t.Helper()
 
-	factory, err := engine.NewBuilder().WithModules(engine.DefaultRegistryModules()).Build()
+	factory, err := engine.NewBuilder().UseModuleMiddleware(engine.MiddlewareSafe()).Build()
 	if err != nil {
 		t.Fatalf("build factory: %v", err)
 	}

--- a/pkg/repl/adapters/bobatea/runtime_assistance.go
+++ b/pkg/repl/adapters/bobatea/runtime_assistance.go
@@ -19,6 +19,7 @@ type RuntimeAssistance struct {
 	runtime        *goja.Runtime
 	docHub         *docaccess.Hub
 	assist         *js.Assistance
+	tsMu           sync.Mutex
 	declaredMu     sync.RWMutex
 	declaredByName map[string]jsparse.CompletionCandidate
 }
@@ -46,6 +47,7 @@ func NewRuntimeAssistance(config RuntimeAssistanceConfig) (*RuntimeAssistance, e
 	}
 	ret.assist = js.NewAssistance(js.AssistanceConfig{
 		TSParser: tsParser,
+		TSMu:     &ret.tsMu,
 		WithRuntime: func(ctx context.Context, fn func(*goja.Runtime, *docaccess.Hub) error) error {
 			return fn(ret.runtime, ret.docHub)
 		},

--- a/pkg/repl/evaluators/javascript/evaluator.go
+++ b/pkg/repl/evaluators/javascript/evaluator.go
@@ -114,7 +114,7 @@ func New(config Config) (*Evaluator, error) {
 	} else if config.EnableModules {
 		// Create runtime with module support using explicit engine composition.
 		builder := ggjengine.NewBuilder().
-			WithModules(ggjengine.DefaultRegistryModules())
+			UseModuleMiddleware(ggjengine.MiddlewareSafe())
 		if len(config.PluginDirectories) > 0 {
 			builder = builder.WithRuntimeModuleRegistrars(host.NewRegistrar(host.Config{
 				Directories:  config.PluginDirectories,

--- a/pkg/replapi/app_test.go
+++ b/pkg/replapi/app_test.go
@@ -194,7 +194,7 @@ func TestAppDeletedSessionIsHiddenFromRestoreAndHistory(t *testing.T) {
 func newTestFactory(t *testing.T) *engine.Factory {
 	t.Helper()
 
-	factory, err := engine.NewBuilder().WithModules(engine.DefaultRegistryModules()).Build()
+	factory, err := engine.NewBuilder().UseModuleMiddleware(engine.MiddlewareSafe()).Build()
 	if err != nil {
 		t.Fatalf("build factory: %v", err)
 	}

--- a/pkg/replessay/handler_test.go
+++ b/pkg/replessay/handler_test.go
@@ -247,7 +247,7 @@ func TestHandlerRedirectsStaticEssayPrefix(t *testing.T) {
 func newTestHandler(t *testing.T) http.Handler {
 	t.Helper()
 
-	factory, err := engine.NewBuilder().WithModules(engine.DefaultRegistryModules()).Build()
+	factory, err := engine.NewBuilder().UseModuleMiddleware(engine.MiddlewareSafe()).Build()
 	if err != nil {
 		t.Fatalf("build factory: %v", err)
 	}

--- a/pkg/replhttp/handler_test.go
+++ b/pkg/replhttp/handler_test.go
@@ -79,7 +79,7 @@ func TestHandlerSessionLifecycleAndHistory(t *testing.T) {
 func newTestApp(t *testing.T) *replapi.App {
 	t.Helper()
 
-	factory, err := engine.NewBuilder().WithModules(engine.DefaultRegistryModules()).Build()
+	factory, err := engine.NewBuilder().UseModuleMiddleware(engine.MiddlewareSafe()).Build()
 	if err != nil {
 		t.Fatalf("build factory: %v", err)
 	}

--- a/pkg/replsession/service_persistence_test.go
+++ b/pkg/replsession/service_persistence_test.go
@@ -278,7 +278,7 @@ func TestServicePersistsBindingVersionsAndDocs(t *testing.T) {
 func newPersistenceTestFactory(t *testing.T) *engine.Factory {
 	t.Helper()
 
-	factory, err := engine.NewBuilder().WithModules(engine.DefaultRegistryModules()).Build()
+	factory, err := engine.NewBuilder().UseModuleMiddleware(engine.MiddlewareSafe()).Build()
 	if err != nil {
 		t.Fatalf("build factory: %v", err)
 	}

--- a/ttmp/2026/04/07/GOJA-041-EVALUATION-CONTROL--add-timeouts-interruption-and-eval-edge-case-tests/scripts/04-engine-runtimeowner-interrupt-sync-loop/main.go
+++ b/ttmp/2026/04/07/GOJA-041-EVALUATION-CONTROL--add-timeouts-interruption-and-eval-edge-case-tests/scripts/04-engine-runtimeowner-interrupt-sync-loop/main.go
@@ -13,7 +13,7 @@ import (
 func main() {
 	ctx := context.Background()
 
-	factory, err := engine.NewBuilder().WithModules(engine.DefaultRegistryModules()).Build()
+	factory, err := engine.NewBuilder().WithModules(engine.DefaultRegistryModules()).Build() //nolint:staticcheck
 	if err != nil {
 		panic(err)
 	}

--- a/ttmp/2026/04/20/GOJA-044-PR28-REPL-SERVICE-REVIEW--pr-28-review-repl-service-architecture-bug-report-and-regression-analysis/scripts/exp04_lowlevel.go
+++ b/ttmp/2026/04/20/GOJA-044-PR28-REPL-SERVICE-REVIEW--pr-28-review-repl-service-architecture-bug-report-and-regression-analysis/scripts/exp04_lowlevel.go
@@ -18,7 +18,7 @@ func main() {
 	report := &testReport{}
 
 	// --- Bootstrap ---
-	factory, err := engine.NewBuilder().WithModules(engine.DefaultRegistryModules()).Build()
+	factory, err := engine.NewBuilder().WithModules(engine.DefaultRegistryModules()).Build() //nolint:staticcheck
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "FATAL: build factory: %v\n", err)
 		os.Exit(1)
@@ -475,7 +475,7 @@ func main() {
 	// T17: Timeout on infinite loop (raw mode)
 	// ================================================================
 	report.run("T17: Timeout on infinite loop (raw mode)", func() error {
-		rawFactory, _ := engine.NewBuilder().WithModules(engine.DefaultRegistryModules()).Build()
+		rawFactory, _ := engine.NewBuilder().WithModules(engine.DefaultRegistryModules()).Build() //nolint:staticcheck
 		opts := replsession.RawSessionOptions()
 		opts.Policy.Eval.TimeoutMS = 50
 		svc := replsession.NewService(rawFactory, zerolog.Nop(),

--- a/ttmp/2026/04/20/GOJA-050--fuzzing-go-go-goja-replapi-analysis-design-and-implementation-guide/scripts/01-basic-replapi-fuzz/main.go
+++ b/ttmp/2026/04/20/GOJA-050--fuzzing-go-go-goja-replapi-analysis-design-and-implementation-guide/scripts/01-basic-replapi-fuzz/main.go
@@ -29,7 +29,7 @@ import (
 
 func main() {
 	ctx := context.Background()
-	factory, err := engine.NewBuilder().WithModules(engine.DefaultRegistryModules()).Build()
+	factory, err := engine.NewBuilder().WithModules(engine.DefaultRegistryModules()).Build() //nolint:staticcheck
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "build factory: %v\n", err)
 		os.Exit(1)

--- a/ttmp/2026/04/20/GOJA-050--fuzzing-go-go-goja-replapi-analysis-design-and-implementation-guide/scripts/02-native-go-fuzz/fuzz_test.go
+++ b/ttmp/2026/04/20/GOJA-050--fuzzing-go-go-goja-replapi-analysis-design-and-implementation-guide/scripts/02-native-go-fuzz/fuzz_test.go
@@ -24,7 +24,7 @@ import (
 // newTestFactory creates a factory with default modules for testing.
 func newTestFactory(t *testing.T) *engine.Factory {
 	t.Helper()
-	factory, err := engine.NewBuilder().WithModules(engine.DefaultRegistryModules()).Build()
+	factory, err := engine.NewBuilder().WithModules(engine.DefaultRegistryModules()).Build() //nolint:staticcheck
 	if err != nil {
 		t.Fatalf("build factory: %v", err)
 	}

--- a/ttmp/2026/04/20/GOJA-050--fuzzing-go-go-goja-replapi-analysis-design-and-implementation-guide/scripts/03-rewrite-pipeline-fuzz/fuzz_test.go
+++ b/ttmp/2026/04/20/GOJA-050--fuzzing-go-go-goja-replapi-analysis-design-and-implementation-guide/scripts/03-rewrite-pipeline-fuzz/fuzz_test.go
@@ -24,7 +24,7 @@ import (
 
 func newFactory(t *testing.T) *engine.Factory {
 	t.Helper()
-	factory, err := engine.NewBuilder().WithModules(engine.DefaultRegistryModules()).Build()
+	factory, err := engine.NewBuilder().WithModules(engine.DefaultRegistryModules()).Build() //nolint:staticcheck
 	if err != nil {
 		t.Fatalf("build factory: %v", err)
 	}

--- a/ttmp/2026/04/20/GOJA-050--fuzzing-go-go-goja-replapi-analysis-design-and-implementation-guide/scripts/04-persistence-fuzz/fuzz_test.go
+++ b/ttmp/2026/04/20/GOJA-050--fuzzing-go-go-goja-replapi-analysis-design-and-implementation-guide/scripts/04-persistence-fuzz/fuzz_test.go
@@ -27,7 +27,7 @@ import (
 
 func newFactory(t *testing.T) *engine.Factory {
 	t.Helper()
-	factory, err := engine.NewBuilder().WithModules(engine.DefaultRegistryModules()).Build()
+	factory, err := engine.NewBuilder().WithModules(engine.DefaultRegistryModules()).Build() //nolint:staticcheck
 	if err != nil {
 		t.Fatalf("build factory: %v", err)
 	}

--- a/ttmp/2026/04/28/GOJA-058--add-run-verb-support/README.md
+++ b/ttmp/2026/04/28/GOJA-058--add-run-verb-support/README.md
@@ -1,0 +1,21 @@
+# Add run verb support
+
+This is the document workspace for ticket GOJA-058.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr doc add --ticket GOJA-058 --doc-type design-doc --title "My Design"`
+- Import sources: `docmgr import file --ticket GOJA-058 --file /path/to/doc.md`
+- Update metadata: `docmgr meta update --ticket GOJA-058 --field Status --value review`

--- a/ttmp/2026/04/28/GOJA-058--add-run-verb-support/changelog.md
+++ b/ttmp/2026/04/28/GOJA-058--add-run-verb-support/changelog.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## 2026-04-28
+
+- Initial workspace created
+
+
+## 2026-04-28
+
+Ticket closed
+

--- a/ttmp/2026/04/28/GOJA-058--add-run-verb-support/index.md
+++ b/ttmp/2026/04/28/GOJA-058--add-run-verb-support/index.md
@@ -1,0 +1,57 @@
+---
+Title: Add run verb support
+Ticket: GOJA-058
+Status: complete
+Topics:
+    - backend
+    - cli
+    - go-go-golems
+DocType: index
+Intent: long-term
+Owners: []
+RelatedFiles: []
+ExternalSources: []
+Summary: ""
+LastUpdated: 2026-04-28T08:52:33.634863123-04:00
+WhatFor: ""
+WhenToUse: ""
+---
+
+
+# Add run verb support
+
+## Overview
+
+<!-- Provide a brief overview of the ticket, its goals, and current status -->
+
+## Key Links
+
+- **Related Files**: See frontmatter RelatedFiles field
+- **External Sources**: See frontmatter ExternalSources field
+
+## Status
+
+Current status: **active**
+
+## Topics
+
+- backend
+- cli
+- go-go-golems
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/2026/04/28/GOJA-058--add-run-verb-support/scripts/01-test-fs.js
+++ b/ttmp/2026/04/28/GOJA-058--add-run-verb-support/scripts/01-test-fs.js
@@ -1,0 +1,5 @@
+const fs = require("fs");
+const path = require("path");
+fs.writeFileSync("/tmp/goja-test.txt", "hello from goja");
+console.log("written:", fs.readFileSync("/tmp/goja-test.txt"));
+console.log("path.join:", path.join("a", "b"));

--- a/ttmp/2026/04/28/GOJA-058--add-run-verb-support/scripts/02-test-db.js
+++ b/ttmp/2026/04/28/GOJA-058--add-run-verb-support/scripts/02-test-db.js
@@ -1,0 +1,3 @@
+const db = require("database");
+console.log("db module type:", typeof db);
+console.log("OK");

--- a/ttmp/2026/04/28/GOJA-058--add-run-verb-support/scripts/03-test-exec.js
+++ b/ttmp/2026/04/28/GOJA-058--add-run-verb-support/scripts/03-test-exec.js
@@ -1,0 +1,3 @@
+const exec = require("exec");
+console.log("exec module type:", typeof exec);
+console.log("OK");

--- a/ttmp/2026/04/28/GOJA-058--add-run-verb-support/tasks.md
+++ b/ttmp/2026/04/28/GOJA-058--add-run-verb-support/tasks.md
@@ -1,0 +1,13 @@
+# Tasks
+
+## TODO
+
+- [x] Add tasks here
+
+- [x] Design run verb CLI interface (flags, args, and expected behavior)
+- [x] Implement run command registration and wiring in Cobra root
+- [x] Add run verb core execution logic
+- [x] Write unit tests for run verb execution paths
+- [x] Add integration/smoke tests for run command
+- [x] Update documentation and help text for run verb
+- [x] Validate run verb against existing command patterns and Glazed conventions

--- a/ttmp/2026/04/28/GOJA-059--add-granular-module-enablement-flags-to-goja-repl-commands/README.md
+++ b/ttmp/2026/04/28/GOJA-059--add-granular-module-enablement-flags-to-goja-repl-commands/README.md
@@ -1,0 +1,21 @@
+# Add granular module enablement flags to goja-repl commands
+
+This is the document workspace for ticket GOJA-059.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr doc add --ticket GOJA-059 --doc-type design-doc --title "My Design"`
+- Import sources: `docmgr import file --ticket GOJA-059 --file /path/to/doc.md`
+- Update metadata: `docmgr meta update --ticket GOJA-059 --field Status --value review`

--- a/ttmp/2026/04/28/GOJA-059--add-granular-module-enablement-flags-to-goja-repl-commands/changelog.md
+++ b/ttmp/2026/04/28/GOJA-059--add-granular-module-enablement-flags-to-goja-repl-commands/changelog.md
@@ -15,3 +15,18 @@ Step 1: Investigation complete. Confirmed all dangerous modules (fs, exec, datab
 - /home/manuel/workspaces/2026-04-28/add-run-verb/go-go-goja/cmd/goja-repl/root.go — Shared app construction
 - /home/manuel/workspaces/2026-04-28/add-run-verb/go-go-goja/engine/module_specs.go — Module spec APIs
 
+
+## 2026-04-28
+
+Step 1b: Uploaded ticket docs (design, diary, tasks, changelog) to reMarkable at /ai/2026/04/28/GOJA-059
+
+
+## 2026-04-28
+
+Step 2: Design refined to ModuleMiddleware pipeline pattern (f(next Handler) Handler). Design doc and diary updated. Old strategy-enum approach replaced with composable override+transform middlewares.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-04-28/add-run-verb/go-go-goja/ttmp/2026/04/28/GOJA-059--add-granular-module-enablement-flags-to-goja-repl-commands/design/01-module-enablement-design.md — Updated design doc with middleware pipeline pattern
+- /home/manuel/workspaces/2026-04-28/add-run-verb/go-go-goja/ttmp/2026/04/28/GOJA-059--add-granular-module-enablement-flags-to-goja-repl-commands/reference/01-diary.md — Updated diary with Step 2 design evolution
+

--- a/ttmp/2026/04/28/GOJA-059--add-granular-module-enablement-flags-to-goja-repl-commands/changelog.md
+++ b/ttmp/2026/04/28/GOJA-059--add-granular-module-enablement-flags-to-goja-repl-commands/changelog.md
@@ -30,3 +30,14 @@ Step 2: Design refined to ModuleMiddleware pipeline pattern (f(next Handler) Han
 - /home/manuel/workspaces/2026-04-28/add-run-verb/go-go-goja/ttmp/2026/04/28/GOJA-059--add-granular-module-enablement-flags-to-goja-repl-commands/design/01-module-enablement-design.md — Updated design doc with middleware pipeline pattern
 - /home/manuel/workspaces/2026-04-28/add-run-verb/go-go-goja/ttmp/2026/04/28/GOJA-059--add-granular-module-enablement-flags-to-goja-repl-commands/reference/01-diary.md — Updated diary with Step 2 design evolution
 
+
+## 2026-04-28
+
+Step 3: Implemented engine/module_middleware.go with ModuleSelector, ModuleMiddleware, built-in middlewares (Safe, Only, Exclude, Add, Custom), Pipeline helper, and comprehensive unit tests. Added UseModuleMiddleware to FactoryBuilder. Deprecated old API family. Migrated all callers. (commit 9148dd6)
+
+### Related Files
+
+- /home/manuel/workspaces/2026-04-28/add-run-verb/go-go-goja/engine/factory.go — UseModuleMiddleware integration in FactoryBuilder
+- /home/manuel/workspaces/2026-04-28/add-run-verb/go-go-goja/engine/module_middleware.go — Core middleware types and built-ins
+- /home/manuel/workspaces/2026-04-28/add-run-verb/go-go-goja/engine/module_specs.go — Deprecated old API family
+

--- a/ttmp/2026/04/28/GOJA-059--add-granular-module-enablement-flags-to-goja-repl-commands/changelog.md
+++ b/ttmp/2026/04/28/GOJA-059--add-granular-module-enablement-flags-to-goja-repl-commands/changelog.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## 2026-04-28
+
+- Initial workspace created
+
+
+## 2026-04-28
+
+Step 1: Investigation complete. Confirmed all dangerous modules (fs, exec, database, os, yaml) are already loaded by run/tui but there is no way to control this. Engine has all APIs needed. Design doc written.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-04-28/add-run-verb/go-go-goja/cmd/goja-repl/cmd_run.go — Run command
+- /home/manuel/workspaces/2026-04-28/add-run-verb/go-go-goja/cmd/goja-repl/root.go — Shared app construction
+- /home/manuel/workspaces/2026-04-28/add-run-verb/go-go-goja/engine/module_specs.go — Module spec APIs
+

--- a/ttmp/2026/04/28/GOJA-059--add-granular-module-enablement-flags-to-goja-repl-commands/changelog.md
+++ b/ttmp/2026/04/28/GOJA-059--add-granular-module-enablement-flags-to-goja-repl-commands/changelog.md
@@ -41,3 +41,8 @@ Step 3: Implemented engine/module_middleware.go with ModuleSelector, ModuleMiddl
 - /home/manuel/workspaces/2026-04-28/add-run-verb/go-go-goja/engine/module_middleware.go — Core middleware types and built-ins
 - /home/manuel/workspaces/2026-04-28/add-run-verb/go-go-goja/engine/module_specs.go — Deprecated old API family
 
+
+## 2026-04-28
+
+Ticket closed
+

--- a/ttmp/2026/04/28/GOJA-059--add-granular-module-enablement-flags-to-goja-repl-commands/design/01-module-enablement-design.md
+++ b/ttmp/2026/04/28/GOJA-059--add-granular-module-enablement-flags-to-goja-repl-commands/design/01-module-enablement-design.md
@@ -16,8 +16,8 @@ RelatedFiles:
     - /home/manuel/workspaces/2026-04-28/add-run-verb/go-go-goja/cmd/goja-repl/cmd_run.go:run command builder uses DefaultRegistryModules()
     - /home/manuel/workspaces/2026-04-28/add-run-verb/go-go-goja/pkg/repl/evaluators/javascript/evaluator.go:TUI evaluator Config and runtime builder
 ExternalSources: []
-Summary: "Design for adding granular module enablement flags (--enable-module, --disable-module, --safe-mode) to all goja-repl commands, with a common Glazed schema shared across run, tui, eval, create, and future jsverbs."
-LastUpdated: 2026-04-28T09:00:00-04:00
+Summary: "Design for adding granular module enablement via a ModuleMiddleware pipeline to all goja-repl commands, deprecating the baroque DefaultRegistryModules / DefaultRegistryModulesNamed / DataOnlyDefaultRegistryModules / DefaultRegistryModule API family in favor of a single UseModuleMiddleware builder method."
+LastUpdated: 2026-04-28T09:15:00-04:00
 WhatFor: "Reference design for implementing module security controls in goja-repl"
 WhenToUse: "When adding flags, updating builder logic, or wiring module filtering into commands"
 ---
@@ -26,12 +26,7 @@ WhenToUse: "When adding flags, updating builder logic, or wiring module filterin
 
 ## Goal
 
-Allow users to selectively enable or disable native Go modules when running JS through goja-repl. Today, `run` and `tui` unconditionally load **all** modules via `engine.DefaultRegistryModules()`. We want:
-
-- `--enable-module fs,exec` — load only specific modules (whitelist)
-- `--disable-module fs,exec` — load all except specific modules (blacklist)
-- `--safe-mode` — load only `DataOnlyDefaultRegistryModules()` (crypto, events, path, time, timer)
-- Default behavior stays as-is (all modules) for backward compatibility
+Allow users to selectively enable or disable native Go modules when running JS through goja-repl. Today, `run` and `tui` unconditionally load **all** modules via `engine.DefaultRegistryModules()`. We will replace this with a composable `ModuleMiddleware` pipeline that gives fine-grained control over the module sandbox.
 
 ## Current State
 
@@ -54,20 +49,177 @@ Allow users to selectively enable or disable native Go modules when running JS t
 
 All paths currently use the same unconditional `DefaultRegistryModules()` spec.
 
-### Engine APIs already available
+### The old API family (being deprecated)
 
 ```go
 engine.DefaultRegistryModules()                          // all modules
 engine.DataOnlyDefaultRegistryModules()                  // safe only
 engine.DefaultRegistryModulesNamed("fs", "os")          // named only
 engine.DefaultRegistryModule("fs")                       // single module
-engine.ProcessModule()                                   // process require()
-engine.ProcessEnv()                                      // global process
 ```
 
-## Proposed Design
+This is baroque: four functions for four selection strategies, none composable.
 
-### 1. Common Glazed schema for module enablement
+## Proposed Design: ModuleMiddleware Pipeline
+
+### Core types
+
+```go
+// ModuleSelector chooses which modules to register from the full set of available names.
+type ModuleSelector func(available []string) []string
+
+// ModuleMiddleware wraps a selector. The standard pattern is f(next) returns a new selector.
+// This gives explicit control flow: each middleware decides whether to call next,
+// short-circuit, modify before/after, etc.
+type ModuleMiddleware func(next ModuleSelector) ModuleSelector
+```
+
+### Base selector
+
+```go
+// SelectAll is the identity selector — includes all available modules.
+func SelectAll(available []string) []string { return available }
+```
+
+### Built-in middlewares
+
+**Override middlewares** (do NOT call next — replace the entire selection):
+
+```go
+// MiddlewareSafe returns only data-safe modules.
+func MiddlewareSafe() ModuleMiddleware {
+    return func(next ModuleSelector) ModuleSelector {
+        return func(available []string) []string {
+            return intersect(available, safeModuleNames)  // doesn't call next
+        }
+    }
+}
+
+// MiddlewareOnly returns only the named modules.
+func MiddlewareOnly(names ...string) ModuleMiddleware {
+    return func(next ModuleSelector) ModuleSelector {
+        return func(available []string) []string {
+            return intersect(available, names)  // doesn't call next
+        }
+    }
+}
+```
+
+**Transform middlewares** (call next first, then modify the result):
+
+```go
+// MiddlewareExclude calls next, then removes named modules.
+func MiddlewareExclude(names ...string) ModuleMiddleware {
+    return func(next ModuleSelector) ModuleSelector {
+        return func(available []string) []string {
+            selected := next(available)
+            return filterOut(selected, names)
+        }
+    }
+}
+
+// MiddlewareAdd calls next, then appends named modules.
+func MiddlewareAdd(names ...string) ModuleMiddleware {
+    return func(next ModuleSelector) ModuleSelector {
+        return func(available []string) []string {
+            selected := next(available)
+            return append(selected, intersect(available, names)...)
+        }
+    }
+}
+
+// MiddlewareCustom calls next, then applies an arbitrary transformation.
+func MiddlewareCustom(fn func(selected []string) []string) ModuleMiddleware {
+    return func(next ModuleSelector) ModuleSelector {
+        return func(available []string) []string {
+            return fn(next(available))
+        }
+    }
+}
+```
+
+### Pipeline helper
+
+```go
+// Pipeline composes middlewares left-to-right: the first middleware in the list
+// executes first, wrapping the subsequent ones.
+func Pipeline(mws ...ModuleMiddleware) ModuleMiddleware {
+    return func(next ModuleSelector) ModuleSelector {
+        handler := next
+        for i := len(mws) - 1; i >= 0; i-- {
+            handler = mws[i](handler)
+        }
+        return handler
+    }
+}
+```
+
+### Builder integration
+
+```go
+func (b *FactoryBuilder) UseModuleMiddleware(mw ...ModuleMiddleware) *FactoryBuilder {
+    b.assertMutable()
+    b.moduleMiddlewares = append(b.moduleMiddlewares, mw...)
+    return b
+}
+```
+
+In `Build()`:
+
+```go
+selector := SelectAll
+for i := len(b.moduleMiddlewares) - 1; i >= 0; i-- {
+    selector = b.moduleMiddlewares[i](selector)
+}
+selected := selector(allRegisteredNames)
+
+for _, name := range selected {
+    specs = append(specs, DefaultRegistryModule(name))
+}
+```
+
+### Usage examples
+
+```go
+// Safe mode (data-only modules)
+engine.NewBuilder().UseModuleMiddleware(MiddlewareSafe())
+
+// All except exec and os
+engine.NewBuilder().UseModuleMiddleware(MiddlewareExclude("exec", "os"))
+
+// Only fs and database
+engine.NewBuilder().UseModuleMiddleware(MiddlewareOnly("fs", "database"))
+
+// Safe + fs, no yaml (pipeline, order matters!)
+engine.NewBuilder().UseModuleMiddleware(Pipeline(
+    MiddlewareSafe(),
+    MiddlewareAdd("fs"),
+    MiddlewareExclude("yaml"),
+))
+
+// Custom transformation
+engine.NewBuilder().UseModuleMiddleware(MiddlewareCustom(func(selected []string) []string {
+    sort.Strings(selected)
+    return unique(selected)
+}))
+```
+
+## CLI flag mapping
+
+| Flag | Middleware equivalent |
+|------|----------------------|
+| `--safe-mode` | `MiddlewareSafe()` |
+| `--enable-module fs,db` | `MiddlewareOnly("fs", "database")` |
+| `--disable-module fs` | `MiddlewareExclude("fs")` |
+| (default) | none (SelectAll) |
+
+### Validation rules
+
+- `--enable-module` and `--disable-module` are mutually exclusive
+- `--safe-mode` is mutually exclusive with both `--enable-module` and `--disable-module`
+- Module names are validated against `modules.ListDefaultModules()` + known aliases
+
+## Common Glazed schema
 
 Add to `rootOptions` (shared by all commands via `commandSupport`):
 
@@ -78,9 +230,9 @@ type rootOptions struct {
     AllowPluginModules []string
     
     // NEW: module enablement
-    EnableModules      []string  // --enable-module  (whitelist)
-    DisableModules     []string  // --disable-module (blacklist)
-    SafeMode           bool      // --safe-mode
+    EnableModules      []string  // --enable-module  (whitelist → MiddlewareOnly)
+    DisableModules     []string  // --disable-module (blacklist → MiddlewareExclude)
+    SafeMode           bool      // --safe-mode      (→ MiddlewareSafe)
 }
 ```
 
@@ -99,62 +251,46 @@ fields.New("safe-mode", fields.TypeBool,
 )
 ```
 
-**Validation rules:**
-- `--enable-module` and `--disable-module` are mutually exclusive
-- `--safe-mode` is mutually exclusive with both `--enable-module` and `--disable-module`
-- Module names are validated against `modules.ListDefaultModules()` + known aliases
+## Propagation paths
 
-### 2. Module selection logic
+### Path A: CLI commands (run, tui, eval, create, etc.)
 
-```go
-func selectModules(enable, disable []string, safeMode bool) []engine.ModuleSpec {
-    if safeMode {
-        return []engine.ModuleSpec{engine.DataOnlyDefaultRegistryModules()}
-    }
-    if len(enable) > 0 {
-        return []engine.ModuleSpec{engine.DefaultRegistryModulesNamed(enable...)}
-    }
-    if len(disable) > 0 {
-        all := allModuleNames()
-        allowed := filterOut(all, disable)
-        return []engine.ModuleSpec{engine.DefaultRegistryModulesNamed(allowed...)}
-    }
-    return []engine.ModuleSpec{engine.DefaultRegistryModules()}
-}
-```
-
-### 3. Propagation paths
-
-**Path A: CLI commands (run, tui, eval, create, etc.)**
-
-All commands go through `commandSupport.newAppWithOptions()` which builds the engine. We change:
+All commands go through `commandSupport.newAppWithOptions()` which builds the engine.
 
 ```go
-// root.go
-func (s commandSupport) moduleSpecs() []engine.ModuleSpec {
-    return selectModules(s.opts.EnableModules, s.opts.DisableModules, s.opts.SafeMode)
+func (s commandSupport) moduleMiddleware() ModuleMiddleware {
+    if s.opts.SafeMode {
+        return MiddlewareSafe()
+    }
+    if len(s.opts.EnableModules) > 0 {
+        return MiddlewareOnly(s.opts.EnableModules...)
+    }
+    if len(s.opts.DisableModules) > 0 {
+        return MiddlewareExclude(s.opts.DisableModules...)
+    }
+    return nil  // SelectAll (default)
 }
 
 func (s commandSupport) newAppWithOptions(options appSupportOptions) (*replapi.App, *repldb.Store, error) {
-    // ...
-    builder := engine.NewBuilder().WithModules(s.moduleSpecs()...)
+    builder := engine.NewBuilder().
+        UseModuleMiddleware(s.moduleMiddleware())
     // ...
 }
 ```
 
-**Path B: run command (bypasses replapi.App)**
+### Path B: run command (bypasses replapi.App)
 
-`cmd_run.go` builds its own engine. Change:
+`cmd_run.go` builds its own engine:
 
 ```go
 func runScriptFile(ctx context.Context, opts runScriptOptions) error {
-    moduleSpecs := selectModules(opts.EnableModules, opts.DisableModules, opts.SafeMode)
-    builder := engine.NewBuilder().WithModules(moduleSpecs...)
+    builder := engine.NewBuilder().
+        UseModuleMiddleware(opts.moduleMiddleware())
     // ...
 }
 ```
 
-**Path C: TUI evaluator**
+### Path C: TUI evaluator
 
 The evaluator Config needs the same fields:
 
@@ -170,47 +306,61 @@ type Config struct {
 And in `New()`:
 
 ```go
-moduleSpecs := selectModules(config.EnableModules, config.DisableModules, config.SafeMode)
-builder := ggjengine.NewBuilder().WithModules(moduleSpecs...)
+mw := buildMiddlewareFromConfig(config)
+builder := ggjengine.NewBuilder().UseModuleMiddleware(mw)
 ```
 
-### 4. jsverbs integration (future)
+### Process stays orthogonal
 
-The `jsverbs` subsystem (`pkg/jsverbs`) currently invokes JS through a caller-provided runtime. It does not control module loading. However, the registry could accept module enablement settings:
+`ProcessModule` and `ProcessEnv` remain separate concerns:
 
 ```go
-type RegistryConfig struct {
-    EnableModules  []string
-    DisableModules []string
-    SafeMode       bool
-}
+engine.NewBuilder().
+    UseModuleMiddleware(Pipeline(MiddlewareSafe(), MiddlewareAdd("fs"))).
+    WithProcess()  // adds process module + global.process
 ```
 
-When `Registry.Commands()` builds command descriptions, it could inject the module flags into each verb's Glazed parameters, and the invoker would pass them to the runtime builder.
+## Deprecation plan
 
-**This is out of scope for GOJA-059** — noted as follow-up.
+The old API family is deprecated but retained as thin wrappers:
+
+| Old API | New equivalent |
+|---------|---------------|
+| `DefaultRegistryModules()` | `UseModuleMiddleware(nil)` (or omit) |
+| `DataOnlyDefaultRegistryModules()` | `UseModuleMiddleware(MiddlewareSafe())` |
+| `DefaultRegistryModulesNamed(names...)` | `UseModuleMiddleware(MiddlewareOnly(names...))` |
+| `DefaultRegistryModule(name)` | `UseModuleMiddleware(MiddlewareOnly(name))` |
+
+Mark old functions with `// Deprecated: Use UseModuleMiddleware instead.`
 
 ## Files to modify
 
 | File | Change |
 |------|--------|
-| `cmd/goja-repl/root.go` | Add module flags to rootOptions; add moduleSpecs() helper; wire into newAppWithOptions |
+| `engine/module_middleware.go` | NEW: ModuleSelector, ModuleMiddleware, built-ins, Pipeline |
+| `engine/factory.go` | Add `UseModuleMiddleware`, integrate into Build |
+| `engine/module_specs.go` | Deprecate old API family, add wrappers |
+| `cmd/goja-repl/root.go` | Add module flags to rootOptions; add `moduleMiddleware()` helper; wire into newAppWithOptions |
 | `cmd/goja-repl/cmd_run.go` | Add module fields to runScriptOptions; wire into runScriptFile |
 | `pkg/repl/evaluators/javascript/evaluator.go` | Add module fields to Config; wire into builder |
-| `engine/module_specs.go` | Add `AllModuleNames()` helper or expand existing APIs |
 | `cmd/goja-repl/root_test.go` | Add tests for module flag behavior |
 | `pkg/doc/04-repl-usage.md` | Document module security model |
 
 ## Test plan
 
-1. **Unit**: `selectModules()` with all combinations of enable/disable/safe/none
-2. **Integration**: `go run ./cmd/goja-repl run --safe-mode ./testdata/yaml.js` → expect `yaml` require to fail
-3. **Integration**: `go run ./cmd/goja-repl run --disable-module fs ./script-using-fs.js` → expect fs require to fail
-4. **Integration**: `go run ./cmd/goja-repl run --enable-module fs,path ./script.js` → only fs and path available
-5. **TUI smoke**: Start TUI with `--safe-mode`, verify `require("fs")` throws
+1. **Unit**: Middleware composition (Safe → Add → Exclude, pipeline order)
+2. **Unit**: Middleware edge cases (empty names, unknown names, deduplication)
+3. **Integration**: `go run ./cmd/goja-repl run --safe-mode ./testdata/yaml.js` → expect `yaml` require to fail
+4. **Integration**: `go run ./cmd/goja-repl run --disable-module fs ./script-using-fs.js` → expect fs require to fail
+5. **Integration**: `go run ./cmd/goja-repl run --enable-module fs,path ./script.js` → only fs and path available
+6. **TUI smoke**: Start TUI with `--safe-mode`, verify `require("fs")` throws
 
 ## Open questions
 
 1. Should `--safe-mode` also disable plugins? (Probably yes — plugins are arbitrary Go code)
-2. Should we add a `--no-modules` flag to disable everything except core JS? (Nice-to-have)
+2. Should we add a `--no-modules` flag to disable everything except core JS? (Nice-to-have; could be `MiddlewareOnly()` with no names)
 3. How does this interact with `--allow-plugin-module`? (Orthogonal — plugin filtering stays separate)
+
+## Key insight
+
+The middleware pattern decouples **selection strategy** from **implementation**. Users can compose strategies arbitrarily: whitelist after blacklist, add then remove, or write entirely custom logic. The engine no longer needs a growing family of `DefaultRegistry*` functions — one method, infinite combinations.

--- a/ttmp/2026/04/28/GOJA-059--add-granular-module-enablement-flags-to-goja-repl-commands/design/01-module-enablement-design.md
+++ b/ttmp/2026/04/28/GOJA-059--add-granular-module-enablement-flags-to-goja-repl-commands/design/01-module-enablement-design.md
@@ -1,0 +1,216 @@
+---
+Title: Module Enablement Design
+Ticket: GOJA-059
+Status: active
+Topics:
+    - backend
+    - cli
+    - security
+    - go-go-golems
+DocType: design
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - /home/manuel/workspaces/2026-04-28/add-run-verb/go-go-goja/engine/module_specs.go:Engine module spec APIs (DefaultRegistryModules, DataOnlyDefaultRegistryModules, DefaultRegistryModulesNamed)
+    - /home/manuel/workspaces/2026-04-28/add-run-verb/go-go-goja/cmd/goja-repl/root.go:rootOptions and commandSupport (shared app construction)
+    - /home/manuel/workspaces/2026-04-28/add-run-verb/go-go-goja/cmd/goja-repl/cmd_run.go:run command builder uses DefaultRegistryModules()
+    - /home/manuel/workspaces/2026-04-28/add-run-verb/go-go-goja/pkg/repl/evaluators/javascript/evaluator.go:TUI evaluator Config and runtime builder
+ExternalSources: []
+Summary: "Design for adding granular module enablement flags (--enable-module, --disable-module, --safe-mode) to all goja-repl commands, with a common Glazed schema shared across run, tui, eval, create, and future jsverbs."
+LastUpdated: 2026-04-28T09:00:00-04:00
+WhatFor: "Reference design for implementing module security controls in goja-repl"
+WhenToUse: "When adding flags, updating builder logic, or wiring module filtering into commands"
+---
+
+# Module Enablement Design (GOJA-059)
+
+## Goal
+
+Allow users to selectively enable or disable native Go modules when running JS through goja-repl. Today, `run` and `tui` unconditionally load **all** modules via `engine.DefaultRegistryModules()`. We want:
+
+- `--enable-module fs,exec` — load only specific modules (whitelist)
+- `--disable-module fs,exec` — load all except specific modules (blacklist)
+- `--safe-mode` — load only `DataOnlyDefaultRegistryModules()` (crypto, events, path, time, timer)
+- Default behavior stays as-is (all modules) for backward compatibility
+
+## Current State
+
+### Module categories
+
+| Category | Modules | Risk |
+|----------|---------|------|
+| Data-only (safe) | crypto, events, path, time, timer | Low — no host filesystem or process access |
+| Host-access (dangerous) | fs, os, exec, database, yaml | High — filesystem, subprocess, DB, env |
+| Process exposure | process, node:process | Medium — exposes `process.env` |
+
+### Where modules are loaded
+
+| Command | File | Builder call |
+|---------|------|-------------|
+| run | `cmd/goja-repl/cmd_run.go:94` | `engine.DefaultRegistryModules()` |
+| tui, eval, create, etc. | `cmd/goja-repl/root.go:123` | `engine.DefaultRegistryModules()` |
+| replapi.App (sessions) | `cmd/goja-repl/root.go:123` | `engine.DefaultRegistryModules()` |
+| TUI evaluator | `pkg/repl/evaluators/javascript/evaluator.go:117` | `engine.DefaultRegistryModules()` |
+
+All paths currently use the same unconditional `DefaultRegistryModules()` spec.
+
+### Engine APIs already available
+
+```go
+engine.DefaultRegistryModules()                          // all modules
+engine.DataOnlyDefaultRegistryModules()                  // safe only
+engine.DefaultRegistryModulesNamed("fs", "os")          // named only
+engine.DefaultRegistryModule("fs")                       // single module
+engine.ProcessModule()                                   // process require()
+engine.ProcessEnv()                                      // global process
+```
+
+## Proposed Design
+
+### 1. Common Glazed schema for module enablement
+
+Add to `rootOptions` (shared by all commands via `commandSupport`):
+
+```go
+type rootOptions struct {
+    DBPath             string
+    PluginDirs         []string
+    AllowPluginModules []string
+    
+    // NEW: module enablement
+    EnableModules      []string  // --enable-module  (whitelist)
+    DisableModules     []string  // --disable-module (blacklist)
+    SafeMode           bool      // --safe-mode
+}
+```
+
+Glazed field definitions:
+
+```go
+fields.New("enable-module", fields.TypeStringList,
+    fields.WithHelp("Enable only these native modules (comma-separated). Implies all others are disabled."),
+)
+fields.New("disable-module", fields.TypeStringList,
+    fields.WithHelp("Disable these native modules (comma-separated). All others remain enabled."),
+)
+fields.New("safe-mode", fields.TypeBool,
+    fields.WithHelp("Load only data-only modules (crypto, events, path, time, timer). Disables fs, os, exec, database, yaml, process."),
+    fields.WithDefault(false),
+)
+```
+
+**Validation rules:**
+- `--enable-module` and `--disable-module` are mutually exclusive
+- `--safe-mode` is mutually exclusive with both `--enable-module` and `--disable-module`
+- Module names are validated against `modules.ListDefaultModules()` + known aliases
+
+### 2. Module selection logic
+
+```go
+func selectModules(enable, disable []string, safeMode bool) []engine.ModuleSpec {
+    if safeMode {
+        return []engine.ModuleSpec{engine.DataOnlyDefaultRegistryModules()}
+    }
+    if len(enable) > 0 {
+        return []engine.ModuleSpec{engine.DefaultRegistryModulesNamed(enable...)}
+    }
+    if len(disable) > 0 {
+        all := allModuleNames()
+        allowed := filterOut(all, disable)
+        return []engine.ModuleSpec{engine.DefaultRegistryModulesNamed(allowed...)}
+    }
+    return []engine.ModuleSpec{engine.DefaultRegistryModules()}
+}
+```
+
+### 3. Propagation paths
+
+**Path A: CLI commands (run, tui, eval, create, etc.)**
+
+All commands go through `commandSupport.newAppWithOptions()` which builds the engine. We change:
+
+```go
+// root.go
+func (s commandSupport) moduleSpecs() []engine.ModuleSpec {
+    return selectModules(s.opts.EnableModules, s.opts.DisableModules, s.opts.SafeMode)
+}
+
+func (s commandSupport) newAppWithOptions(options appSupportOptions) (*replapi.App, *repldb.Store, error) {
+    // ...
+    builder := engine.NewBuilder().WithModules(s.moduleSpecs()...)
+    // ...
+}
+```
+
+**Path B: run command (bypasses replapi.App)**
+
+`cmd_run.go` builds its own engine. Change:
+
+```go
+func runScriptFile(ctx context.Context, opts runScriptOptions) error {
+    moduleSpecs := selectModules(opts.EnableModules, opts.DisableModules, opts.SafeMode)
+    builder := engine.NewBuilder().WithModules(moduleSpecs...)
+    // ...
+}
+```
+
+**Path C: TUI evaluator**
+
+The evaluator Config needs the same fields:
+
+```go
+type Config struct {
+    EnableModules      []string
+    DisableModules     []string
+    SafeMode           bool
+    // ... existing fields
+}
+```
+
+And in `New()`:
+
+```go
+moduleSpecs := selectModules(config.EnableModules, config.DisableModules, config.SafeMode)
+builder := ggjengine.NewBuilder().WithModules(moduleSpecs...)
+```
+
+### 4. jsverbs integration (future)
+
+The `jsverbs` subsystem (`pkg/jsverbs`) currently invokes JS through a caller-provided runtime. It does not control module loading. However, the registry could accept module enablement settings:
+
+```go
+type RegistryConfig struct {
+    EnableModules  []string
+    DisableModules []string
+    SafeMode       bool
+}
+```
+
+When `Registry.Commands()` builds command descriptions, it could inject the module flags into each verb's Glazed parameters, and the invoker would pass them to the runtime builder.
+
+**This is out of scope for GOJA-059** — noted as follow-up.
+
+## Files to modify
+
+| File | Change |
+|------|--------|
+| `cmd/goja-repl/root.go` | Add module flags to rootOptions; add moduleSpecs() helper; wire into newAppWithOptions |
+| `cmd/goja-repl/cmd_run.go` | Add module fields to runScriptOptions; wire into runScriptFile |
+| `pkg/repl/evaluators/javascript/evaluator.go` | Add module fields to Config; wire into builder |
+| `engine/module_specs.go` | Add `AllModuleNames()` helper or expand existing APIs |
+| `cmd/goja-repl/root_test.go` | Add tests for module flag behavior |
+| `pkg/doc/04-repl-usage.md` | Document module security model |
+
+## Test plan
+
+1. **Unit**: `selectModules()` with all combinations of enable/disable/safe/none
+2. **Integration**: `go run ./cmd/goja-repl run --safe-mode ./testdata/yaml.js` → expect `yaml` require to fail
+3. **Integration**: `go run ./cmd/goja-repl run --disable-module fs ./script-using-fs.js` → expect fs require to fail
+4. **Integration**: `go run ./cmd/goja-repl run --enable-module fs,path ./script.js` → only fs and path available
+5. **TUI smoke**: Start TUI with `--safe-mode`, verify `require("fs")` throws
+
+## Open questions
+
+1. Should `--safe-mode` also disable plugins? (Probably yes — plugins are arbitrary Go code)
+2. Should we add a `--no-modules` flag to disable everything except core JS? (Nice-to-have)
+3. How does this interact with `--allow-plugin-module`? (Orthogonal — plugin filtering stays separate)

--- a/ttmp/2026/04/28/GOJA-059--add-granular-module-enablement-flags-to-goja-repl-commands/index.md
+++ b/ttmp/2026/04/28/GOJA-059--add-granular-module-enablement-flags-to-goja-repl-commands/index.md
@@ -1,0 +1,58 @@
+---
+Title: Add granular module enablement flags to goja-repl commands
+Ticket: GOJA-059
+Status: active
+Topics:
+    - backend
+    - cli
+    - security
+    - go-go-golems
+DocType: index
+Intent: long-term
+Owners: []
+RelatedFiles: []
+ExternalSources: []
+Summary: ""
+LastUpdated: 2026-04-28T08:57:05.189938799-04:00
+WhatFor: ""
+WhenToUse: ""
+---
+
+# Add granular module enablement flags to goja-repl commands
+
+## Overview
+
+<!-- Provide a brief overview of the ticket, its goals, and current status -->
+
+## Key Links
+
+- **Related Files**: See frontmatter RelatedFiles field
+- **External Sources**: See frontmatter ExternalSources field
+
+## Status
+
+Current status: **active**
+
+## Topics
+
+- backend
+- cli
+- security
+- go-go-golems
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/2026/04/28/GOJA-059--add-granular-module-enablement-flags-to-goja-repl-commands/index.md
+++ b/ttmp/2026/04/28/GOJA-059--add-granular-module-enablement-flags-to-goja-repl-commands/index.md
@@ -1,7 +1,7 @@
 ---
 Title: Add granular module enablement flags to goja-repl commands
 Ticket: GOJA-059
-Status: active
+Status: complete
 Topics:
     - backend
     - cli
@@ -13,10 +13,11 @@ Owners: []
 RelatedFiles: []
 ExternalSources: []
 Summary: ""
-LastUpdated: 2026-04-28T08:57:05.189938799-04:00
+LastUpdated: 2026-04-28T17:07:15.955301657-04:00
 WhatFor: ""
 WhenToUse: ""
 ---
+
 
 # Add granular module enablement flags to goja-repl commands
 

--- a/ttmp/2026/04/28/GOJA-059--add-granular-module-enablement-flags-to-goja-repl-commands/reference/01-diary.md
+++ b/ttmp/2026/04/28/GOJA-059--add-granular-module-enablement-flags-to-goja-repl-commands/reference/01-diary.md
@@ -11,34 +11,22 @@ DocType: reference
 Intent: long-term
 Owners: []
 RelatedFiles:
-    - Path: cmd/goja-repl/cmd_run.go
-      Note: run command builder with DefaultRegistryModules
-    - Path: cmd/goja-repl/cmd_run.go:run command with DefaultRegistryModules
-    - Path: cmd/goja-repl/root.go
-      Note: rootOptions and commandSupport shared app construction
-    - Path: cmd/goja-repl/root.go:rootOptions and shared app construction
-    - Path: engine/module_specs.go
-      Note: Engine module spec APIs (DefaultRegistryModules
-    - Path: engine/module_specs.go:Engine module spec APIs
-    - Path: pkg/repl/evaluators/javascript/evaluator.go
-      Note: TUI evaluator Config and runtime builder
-    - Path: pkg/repl/evaluators/javascript/evaluator.go:TUI evaluator runtime builder
+    - /home/manuel/workspaces/2026-04-28/add-run-verb/go-go-goja/engine/module_specs.go:Engine module spec APIs
+    - /home/manuel/workspaces/2026-04-28/add-run-verb/go-go-goja/cmd/goja-repl/root.go:rootOptions and commandSupport shared app construction
+    - /home/manuel/workspaces/2026-04-28/add-run-verb/go-go-goja/cmd/goja-repl/cmd_run.go:run command with DefaultRegistryModules
+    - /home/manuel/workspaces/2026-04-28/add-run-verb/go-go-goja/pkg/repl/evaluators/javascript/evaluator.go:TUI evaluator runtime builder
 ExternalSources: []
-Summary: 'Implementation diary for GOJA-059: adding granular module enablement flags to goja-repl commands.'
-LastUpdated: 2026-04-28T09:00:00-04:00
-WhatFor: Chronological record of investigation, design, implementation, and validation
-WhenToUse: When resuming work, reviewing decisions, or understanding why something was built a certain way
+Summary: "Implementation diary for GOJA-059: adding granular module enablement via a ModuleMiddleware pipeline to goja-repl commands."
+LastUpdated: 2026-04-28T09:15:00-04:00
+WhatFor: "Chronological record of investigation, design, implementation, and validation"
+WhenToUse: "When resuming work, reviewing decisions, or understanding why something was built a certain way"
 ---
-
-
-
-
 
 # Diary — GOJA-059: Add granular module enablement flags to goja-repl commands
 
 ## Goal
 
-Allow users to selectively enable or disable native Go modules (fs, exec, database, os, yaml, process) when using goja-repl `run`, `tui`, and other commands. The current behavior loads **all** modules unconditionally, which is convenient but not always safe.
+Allow users to selectively enable or disable native Go modules (fs, exec, database, os, yaml, process) when using goja-repl `run`, `tui`, and other commands. The current behavior loads **all** modules unconditionally.
 
 ## Step 1: Investigation — Current module loading behavior
 
@@ -100,10 +88,11 @@ N/A — investigation only.
 
 ### What should be done in the future
 
-- Step 2: Design the common Glazed schema for module enablement flags
-- Step 3: Implement the schema in `rootOptions` and propagate through all three engine-building paths
-- Step 4: Add tests for module filtering
-- Step 5: Update documentation
+- Step 2: Design the module enablement API
+- Step 3: Implement the API in the engine
+- Step 4: Wire through CLI flags to all three engine-building paths
+- Step 5: Add tests for module filtering
+- Step 6: Update documentation
 
 ### Code review instructions
 
@@ -136,4 +125,104 @@ engine.NewBuilder().WithModules(engine.DataOnlyDefaultRegistryModules())
 
 // Named modules
 engine.NewBuilder().WithModules(engine.DefaultRegistryModulesNamed("fs", "path"))
+```
+
+## Step 2: Design — From Strategy Enums to Middleware Pipeline
+
+### Prompt Context
+
+**User prompt (verbatim):** "the whole set of engine APIs is a bit baroque and could be unified, right? The engine.DefaultRegistryModules estc..."
+
+**Assistant interpretation:** The user wants a cleaner, unified API for module selection instead of the current grab-bag of four functions.
+
+**Inferred user intent:** Replace `DefaultRegistryModules()`, `DataOnlyDefaultRegistryModules()`, `DefaultRegistryModulesNamed()`, and `DefaultRegistryModule()` with a single, composable mechanism.
+
+### What I did
+
+- Proposed a `ModuleSelection` struct with a `SelectionStrategy` enum (All/Safe/Only/Except)
+- User pushed back: "can we chain multiple selections? Could ProcessModule and ProcessEnv just be two modules too?"
+- Proposed a `ModuleFilter` pipeline (pure functions over `[]string`)
+- User pushed for the `f(next Handler) Handler` pattern for explicit control flow
+- Landed on `ModuleMiddleware func(next ModuleSelector) ModuleSelector`
+- Updated the design doc with the full middleware pipeline approach
+
+### What worked
+
+- The `f(next) Handler` pattern maps cleanly to module selection:
+  - **Override middlewares** (Safe, Only) don't call next → replace entire selection
+  - **Transform middlewares** (Exclude, Add, Custom) call next → modify result
+- `Pipeline()` helper composes middlewares left-to-right
+- Old API can be deprecated as thin wrappers
+- CLI flags map 1:1 to middlewares:
+  - `--safe-mode` → `MiddlewareSafe()`
+  - `--enable-module fs,db` → `MiddlewareOnly("fs", "database")`
+  - `--disable-module fs` → `MiddlewareExclude("fs")`
+
+### What didn't work
+
+- Initial `ModuleSelection` enum approach was rejected as not composable enough
+- `ModuleFilter` pipeline was close but lacked explicit control flow
+- The `f(next Handler) Handler` pattern was the right abstraction
+
+### What I learned
+
+- The middleware pattern gives users **full control flow**: short-circuit, pre/post transform, arbitrary composition
+- Order matters: `Pipeline(Safe, Add("fs"))` is different from `Pipeline(Add("fs"), Safe)`
+- `ProcessModule` and `ProcessEnv` **cannot** be folded into module middleware because:
+  - `ProcessModule` is a `ModuleSpec` (factory-time registration)
+  - `ProcessEnv` is a `RuntimeInitializer` (per-runtime global variable)
+  - They stay orthogonal via `WithProcess()` builder method
+
+### What was tricky to build
+
+N/A — design discussion, no code yet.
+
+### What warrants a second pair of eyes
+
+- The `Pipeline` composition order: first middleware executes first, wrapping subsequent ones. This is standard HTTP middleware behavior but could be surprising.
+- Deprecation strategy: old functions will be thin wrappers calling `UseModuleMiddleware`. Need to ensure no behavioral changes.
+
+### What should be done in the future
+
+- Step 3: Implement `engine/module_middleware.go` with core types and built-ins
+- Step 4: Add `UseModuleMiddleware` to `FactoryBuilder`
+- Step 5: Deprecate old API family in `module_specs.go`
+- Step 6: Wire CLI flags through all three engine-building paths
+- Step 7: Write tests
+
+### Code review instructions
+
+N/A — design only.
+
+### Technical details
+
+**Core types:**
+```go
+type ModuleSelector func(available []string) []string
+type ModuleMiddleware func(next ModuleSelector) ModuleSelector
+```
+
+**Built-in middlewares:**
+```go
+func MiddlewareSafe() ModuleMiddleware       // override: data-only
+func MiddlewareOnly(names...) ModuleMiddleware // override: whitelist
+func MiddlewareExclude(names...) ModuleMiddleware // transform: blacklist
+func MiddlewareAdd(names...) ModuleMiddleware     // transform: append
+func MiddlewareCustom(fn) ModuleMiddleware        // transform: arbitrary
+```
+
+**Usage:**
+```go
+// Safe + fs, no yaml
+engine.NewBuilder().UseModuleMiddleware(Pipeline(
+    MiddlewareSafe(),
+    MiddlewareAdd("fs"),
+    MiddlewareExclude("yaml"),
+))
+
+// All except exec
+engine.NewBuilder().UseModuleMiddleware(MiddlewareExclude("exec"))
+
+// Only fs and db
+engine.NewBuilder().UseModuleMiddleware(MiddlewareOnly("fs", "database"))
 ```

--- a/ttmp/2026/04/28/GOJA-059--add-granular-module-enablement-flags-to-goja-repl-commands/reference/01-diary.md
+++ b/ttmp/2026/04/28/GOJA-059--add-granular-module-enablement-flags-to-goja-repl-commands/reference/01-diary.md
@@ -1,0 +1,139 @@
+---
+Title: Diary
+Ticket: GOJA-059
+Status: active
+Topics:
+    - backend
+    - cli
+    - security
+    - go-go-golems
+DocType: reference
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: cmd/goja-repl/cmd_run.go
+      Note: run command builder with DefaultRegistryModules
+    - Path: cmd/goja-repl/cmd_run.go:run command with DefaultRegistryModules
+    - Path: cmd/goja-repl/root.go
+      Note: rootOptions and commandSupport shared app construction
+    - Path: cmd/goja-repl/root.go:rootOptions and shared app construction
+    - Path: engine/module_specs.go
+      Note: Engine module spec APIs (DefaultRegistryModules
+    - Path: engine/module_specs.go:Engine module spec APIs
+    - Path: pkg/repl/evaluators/javascript/evaluator.go
+      Note: TUI evaluator Config and runtime builder
+    - Path: pkg/repl/evaluators/javascript/evaluator.go:TUI evaluator runtime builder
+ExternalSources: []
+Summary: 'Implementation diary for GOJA-059: adding granular module enablement flags to goja-repl commands.'
+LastUpdated: 2026-04-28T09:00:00-04:00
+WhatFor: Chronological record of investigation, design, implementation, and validation
+WhenToUse: When resuming work, reviewing decisions, or understanding why something was built a certain way
+---
+
+
+
+
+
+# Diary — GOJA-059: Add granular module enablement flags to goja-repl commands
+
+## Goal
+
+Allow users to selectively enable or disable native Go modules (fs, exec, database, os, yaml, process) when using goja-repl `run`, `tui`, and other commands. The current behavior loads **all** modules unconditionally, which is convenient but not always safe.
+
+## Step 1: Investigation — Current module loading behavior
+
+The user asked for the ability to load "dangerous" modules into the repl tui and run command. I first investigated whether these modules are already available.
+
+### Prompt Context
+
+**User prompt (verbatim):** "Ok, I want to be able to load some of the 'dangerous' modules into the repl tui and the run command, for example db/fs/exec, etc... How do I do that? I basically want to be able to open a sqlite db and write to disk from the repl or from a script to test things. Create a new docmgr ticket about loading modules for the run/tui methods (and other goja-repl verbs, tbh. Maybe we can make a common glazed schema for that and handle it as a base part of the framework, for jsverbs too for example)"
+
+**Assistant interpretation:** The user wants CLI flags to control which native Go modules are loaded when running JS through goja-repl. They want this as a reusable pattern across all commands.
+
+**Inferred user intent:** Make module loading granular and controllable from the CLI, not just all-or-nothing. This improves security and gives users explicit control over the sandbox boundary.
+
+### What I did
+
+- Read `engine/module_specs.go` to understand module registration APIs:
+  - `DefaultRegistryModules()` — loads ALL modules (safe + dangerous)
+  - `DataOnlyDefaultRegistryModules()` — loads only safe modules (crypto, events, path, time, timer)
+  - `DefaultRegistryModulesNamed(names...)` — loads only named modules
+  - `DefaultRegistryModule(name)` — loads a single module
+- Read `cmd/goja-repl/cmd_run.go` — confirms `run` uses `DefaultRegistryModules()`
+- Read `cmd/goja-repl/root.go` — confirms `newAppWithOptions` (used by tui, eval, create, etc.) also uses `DefaultRegistryModules()`
+- Read `pkg/repl/evaluators/javascript/evaluator.go` — confirms TUI evaluator also uses `DefaultRegistryModules()`
+- Created test scripts in `/tmp/` and ran them with `go run ./cmd/goja-repl run ...`:
+  - `test-fs.js` — `require("fs")` ✅ works (writes/reads `/tmp/goja-test.txt`)
+  - `test-db.js` — `require("database")` ✅ works
+  - `test-exec.js` — `require("exec")` ✅ works
+- Checked `goja-repl tui --help` — no module-related flags exist
+
+### What worked
+
+- The dangerous modules (fs, db, exec, os, yaml) are **already loaded** by both `run` and `tui` today.
+- The engine already has all the APIs needed for granular loading.
+- Test scripts confirmed modules are functional.
+
+### What didn't work
+
+- There is **no way to selectively disable** modules. It's all-or-nothing.
+- There is **no way to run in safe mode** (data-only modules) from the CLI.
+- The `--safe-mode` concept exists in the engine (`DataOnlyDefaultRegistryModules`) but is not exposed to users.
+
+### What I learned
+
+- The engine is already well-designed for sandboxing — `DataOnlyDefaultRegistryModules()` exists, `DefaultRegistryModulesNamed()` exists.
+- The gap is purely in **CLI flag plumbing** and **propagation to all code paths** that build engines.
+- There are **three independent code paths** that build engines:
+  1. `commandSupport.newAppWithOptions()` — for replapi-backed commands (tui, eval, create, etc.)
+  2. `runScriptFile()` — for the `run` command (standalone, no replapi)
+  3. `javascript.New()` — for the TUI evaluator (standalone, no replapi)
+- All three currently hardcode `DefaultRegistryModules()`.
+
+### What was tricky to build
+
+N/A — this was investigation only.
+
+### What warrants a second pair of eyes
+
+N/A — investigation only.
+
+### What should be done in the future
+
+- Step 2: Design the common Glazed schema for module enablement flags
+- Step 3: Implement the schema in `rootOptions` and propagate through all three engine-building paths
+- Step 4: Add tests for module filtering
+- Step 5: Update documentation
+
+### Code review instructions
+
+N/A — no code changes yet.
+
+### Technical details
+
+**Available modules:**
+```
+crypto, node:crypto    → safe (data-only)
+events, node:events    → safe (data-only)
+path, node:path        → safe (data-only)
+time                   → safe (data-only)
+timer                  → safe (data-only)
+fs, node:fs            → dangerous (filesystem)
+os, node:os            → dangerous (system info)
+exec                   → dangerous (subprocess)
+database               → dangerous (SQLite)
+yaml                   → dangerous (file I/O via fs helpers)
+process, node:process  → dangerous (env vars)
+```
+
+**Engine builder patterns:**
+```go
+// Current (all modules)
+engine.NewBuilder().WithModules(engine.DefaultRegistryModules())
+
+// Safe mode (data only)
+engine.NewBuilder().WithModules(engine.DataOnlyDefaultRegistryModules())
+
+// Named modules
+engine.NewBuilder().WithModules(engine.DefaultRegistryModulesNamed("fs", "path"))
+```

--- a/ttmp/2026/04/28/GOJA-059--add-granular-module-enablement-flags-to-goja-repl-commands/reference/01-diary.md
+++ b/ttmp/2026/04/28/GOJA-059--add-granular-module-enablement-flags-to-goja-repl-commands/reference/01-diary.md
@@ -226,3 +226,147 @@ engine.NewBuilder().UseModuleMiddleware(MiddlewareExclude("exec"))
 // Only fs and db
 engine.NewBuilder().UseModuleMiddleware(MiddlewareOnly("fs", "database"))
 ```
+
+## Step 3: Implementation — ModuleMiddleware pipeline
+
+### Prompt Context
+
+**User prompt (verbatim):** "Add tasks. Implement in ./go-go-goja"
+
+**Assistant interpretation:** The user wants me to add implementation tasks to the ticket and start building the middleware system in the go-go-goja codebase.
+
+**Inferred user intent:** Move from design to implementation: create the core middleware types, integrate with the builder, deprecate old APIs, and migrate all callers.
+
+**Commit (code):** `9148dd6` — "fix(tests): update module-specific tests to use MiddlewareOnly instead of MiddlewareSafe"
+
+### What I did
+
+- Created `engine/module_middleware.go` with core types and built-ins:
+  - `ModuleSelector` — function type for selecting modules from available names
+  - `ModuleMiddleware` — `func(next ModuleSelector) ModuleSelector` pattern
+  - `MiddlewareSafe()` — override, returns data-only modules
+  - `MiddlewareOnly(names...)` — override, returns only named modules (with alias expansion)
+  - `MiddlewareExclude(names...)` — transform, removes named modules after calling next
+  - `MiddlewareAdd(names...)` — transform, appends named modules after calling next
+  - `MiddlewareCustom(fn)` — transform, applies arbitrary function after calling next
+  - `Pipeline(mws...)` — composes middlewares left-to-right
+  - Helper functions: `intersect`, `filterOut`, `appendUnique`, `sortedUnique`, `allRegisteredModuleNames`
+- Added `UseModuleMiddleware` method to `FactoryBuilder` in `engine/factory.go`
+- Integrated middleware evaluation into `Build()`: applies pipeline to all registered module names, converts selected names to `DefaultRegistryModule(name)` specs
+- Deprecated old API family in `engine/module_specs.go` with `// Deprecated:` comments and migration examples
+- Migrated all callers across the codebase:
+  - `cmd/goja-repl/root.go` → `UseModuleMiddleware(MiddlewareSafe())`
+  - `cmd/goja-repl/cmd_run.go` → `UseModuleMiddleware(MiddlewareSafe())`
+  - `pkg/repl/evaluators/javascript/evaluator.go` → `UseModuleMiddleware(MiddlewareSafe())`
+  - `pkg/jsverbs/runtime.go` → `UseModuleMiddleware(MiddlewareSafe())`
+  - `cmd/bun-demo/main.go` → `UseModuleMiddleware(MiddlewareSafe())`
+  - All test files updated to use `MiddlewareOnly("module-name")` for module-specific tests
+  - `ttmp/` investigation scripts updated with `//nolint:staticcheck` comments
+- Created comprehensive unit tests in `engine/module_middleware_test.go`:
+  - `TestMiddlewareSafe` — verifies only data-only modules returned
+  - `TestMiddlewareSafeIgnoresNext` — confirms override behavior
+  - `TestMiddlewareOnly` — whitelist with aliases
+  - `TestMiddlewareOnlyIgnoresUnknown` — unknown names filtered out
+  - `TestMiddlewareExclude` — blacklist behavior
+  - `TestMiddlewareAdd` — append after next
+  - `TestMiddlewareAddSkipsUnavailable` — only adds if in available set
+  - `TestMiddlewareCustom` — arbitrary transformation
+  - `TestPipelineOrder` — Safe short-circuits subsequent middlewares
+  - `TestPipelineAddThenSafe` — Add runs before Safe, then appends
+  - `TestMiddlewareOnlyForSafePlusExtra` — explicit whitelist for safe+extra
+  - Helper tests: `TestIntersect`, `TestFilterOut`, `TestAppendUnique`, `TestSortedUnique`, `TestAllRegisteredModuleNames`
+
+### Why
+
+- The old API family (`DefaultRegistryModules`, `DataOnlyDefaultRegistryModules`, `DefaultRegistryModulesNamed`, `DefaultRegistryModule`) was baroque and non-composable
+- The middleware pattern provides a single, unified mechanism with explicit control flow
+- Each middleware is a pure function, making it easy to test and reason about
+- Users can write custom middlewares for domain-specific sandbox policies
+
+### What worked
+
+- All engine tests pass (including new middleware tests)
+- All codebase tests pass after migration
+- Linter passes with 0 issues
+- The old API still works (backward compatibility via deprecated wrappers)
+- `Pipeline` composition correctly implements left-to-right execution
+- Override middlewares (Safe, Only) properly short-circuit when placed early in the pipeline
+
+### What didn't work
+
+- Blanket sed replacement `DefaultRegistryModules() → MiddlewareSafe()` broke module-specific tests (database, fs, os, yaml) because those modules are NOT in the safe set
+- Fixed by using `MiddlewareOnly("module-name")` for module-specific tests
+- The `TestPipelineOrder` test initially expected Safe+Add to produce safe+fs, but Safe short-circuits and the result is just safe modules. Fixed test expectation to match actual behavior.
+- The `TestPipelineAddThenSafe` test initially expected Add+Safe to strip fs, but Add calls Safe (override → safe only), then appends fs. Result is safe+fs. Fixed test expectation.
+
+### What I learned
+
+- The middleware pipeline order is crucial and must be documented clearly:
+  - `Pipeline(Safe, Add(fs))` → Safe short-circuits, result = safe only
+  - `Pipeline(Add(fs), Safe)` → Add calls Safe (safe only), then appends fs → safe + fs
+  - For "safe + specific extras", use `MiddlewareOnly` with explicit list
+- The `f(next Handler) Handler` pattern gives precise control but requires users to understand short-circuit vs. transform semantics
+- Deprecating widely-used functions requires updating ALL call sites before the deprecation warnings become noise
+
+### What was tricky to build
+
+- **Pipeline composition order**: The standard `for i := len(mws)-1; i >= 0; i--` wrapping pattern means the last middleware in the list is the innermost (closest to the base selector). When executed, the first middleware in the list runs first. This is standard HTTP middleware behavior but can be surprising for module selection.
+- **Linter suppression for ttmp/ scripts**: Adding `//nolint:staticcheck` to lines inside method chains without breaking syntax was error-prone. Eventually used a perl one-liner that appends the comment at end-of-line.
+- **Test migration**: The blanket `DefaultRegistryModules → MiddlewareSafe` sed broke tests because it changed semantics. Module-specific tests need `MiddlewareOnly("module")`, not `MiddlewareSafe()`.
+
+### What warrants a second pair of eyes
+
+- The `Build()` integration in `factory.go`: middleware-derived specs are appended to `modules_` alongside any explicit `WithModules` specs. If both are used, there could be duplicate module registrations (require registry handles this by overwriting, but it's worth noting).
+- The deprecation comments: they include code examples that might need updating as the API evolves.
+
+### What should be done in the future
+
+- Step 4: Add `--enable-module`, `--disable-module`, `--safe-mode` CLI flags to `rootOptions`
+- Step 5: Wire flags through `commandSupport.newAppWithOptions`, `runScriptFile`, and `javascript.New`
+- Step 6: Write integration tests for CLI flag behavior
+- Step 7: Update documentation (pkg/doc/04-repl-usage.md, README.md)
+
+### Code review instructions
+
+Start with `engine/module_middleware.go`:
+1. Review `ModuleSelector` and `ModuleMiddleware` type definitions
+2. Review each built-in middleware: Safe, Only, Exclude, Add, Custom
+3. Review `Pipeline` composition logic
+4. Check `engine/factory.go` lines ~120-140 for `UseModuleMiddleware` integration
+5. Check `engine/module_specs.go` deprecation comments
+6. Run tests: `go test ./engine/... -v`
+
+### Technical details
+
+**New API:**
+```go
+// Safe mode (data-only modules)
+engine.NewBuilder().UseModuleMiddleware(engine.MiddlewareSafe())
+
+// Whitelist
+engine.NewBuilder().UseModuleMiddleware(engine.MiddlewareOnly("fs", "database"))
+
+// Blacklist
+engine.NewBuilder().UseModuleMiddleware(engine.MiddlewareExclude("exec", "os"))
+
+// Pipeline (order matters!)
+engine.NewBuilder().UseModuleMiddleware(engine.Pipeline(
+    engine.MiddlewareSafe(),
+    engine.MiddlewareAdd("fs"),
+))
+```
+
+**Files changed:**
+- `engine/module_middleware.go` — NEW
+- `engine/module_middleware_test.go` — NEW
+- `engine/factory.go` — added `UseModuleMiddleware` + `Build()` integration
+- `engine/module_specs.go` — deprecated old APIs
+- `engine/runtime.go` — updated comment
+- `engine/granular_modules_test.go` — nolint for deprecated API tests
+- `cmd/goja-repl/root.go` — migrated to middleware
+- `cmd/goja-repl/cmd_run.go` — migrated to middleware
+- `pkg/repl/evaluators/javascript/evaluator.go` — migrated to middleware
+- `pkg/jsverbs/runtime.go` — migrated to middleware
+- `cmd/bun-demo/main.go` — migrated to middleware
+- 16 test files — migrated to `MiddlewareOnly` for module-specific tests
+- 7 ttmp/ scripts — added nolint comments

--- a/ttmp/2026/04/28/GOJA-059--add-granular-module-enablement-flags-to-goja-repl-commands/scripts/01-test-fs.js
+++ b/ttmp/2026/04/28/GOJA-059--add-granular-module-enablement-flags-to-goja-repl-commands/scripts/01-test-fs.js
@@ -1,0 +1,5 @@
+const fs = require("fs");
+const path = require("path");
+fs.writeFileSync("/tmp/goja-test.txt", "hello from goja");
+console.log("written:", fs.readFileSync("/tmp/goja-test.txt"));
+console.log("path.join:", path.join("a", "b"));

--- a/ttmp/2026/04/28/GOJA-059--add-granular-module-enablement-flags-to-goja-repl-commands/scripts/02-test-db.js
+++ b/ttmp/2026/04/28/GOJA-059--add-granular-module-enablement-flags-to-goja-repl-commands/scripts/02-test-db.js
@@ -1,0 +1,3 @@
+const db = require("database");
+console.log("db module type:", typeof db);
+console.log("OK");

--- a/ttmp/2026/04/28/GOJA-059--add-granular-module-enablement-flags-to-goja-repl-commands/scripts/03-test-exec.js
+++ b/ttmp/2026/04/28/GOJA-059--add-granular-module-enablement-flags-to-goja-repl-commands/scripts/03-test-exec.js
@@ -1,0 +1,3 @@
+const exec = require("exec");
+console.log("exec module type:", typeof exec);
+console.log("OK");

--- a/ttmp/2026/04/28/GOJA-059--add-granular-module-enablement-flags-to-goja-repl-commands/tasks.md
+++ b/ttmp/2026/04/28/GOJA-059--add-granular-module-enablement-flags-to-goja-repl-commands/tasks.md
@@ -3,14 +3,22 @@
 ## TODO
 
 - [x] Add tasks here
-
-- [ ] Investigate current module loading behavior across all goja-repl commands (run, tui, eval, create, etc.)
-- [ ] Design common Glazed schema/flags for module enablement (--enable-module, --disable-module, --safe-mode, etc.)
+- [x] Investigate current module loading behavior across all goja-repl commands (run, tui, eval, create, etc.)
+- [x] Design common Glazed schema/flags for module enablement (--enable-module, --disable-module, --safe-mode, etc.)
 - [ ] Add module enablement flags to rootOptions and propagate to all commands
-- [ ] Implement module filtering logic in engine builder based on flag values
+- [x] Implement module filtering logic in engine builder based on flag values
 - [ ] Add module enablement to TUI/evaluator Config and wire through command flags
 - [ ] Add module enablement to run command and runScriptOptions
-- [ ] Write tests for module enablement filtering (enable specific, disable specific, safe mode)
+- [x] Write tests for module enablement filtering (enable specific, disable specific, safe mode)
 - [ ] Write tests for CLI flag parsing and integration
 - [ ] Update documentation (pkg/doc, README, help) with module security model
 - [ ] Consider jsverbs integration: extend registry/invoker to respect module enablement
+- [x] Implement engine/module_middleware.go: ModuleSelector, ModuleMiddleware, built-in middlewares (Safe, Only, Exclude, Add, Custom), Pipeline helper, intersect/filterOut utilities
+- [x] Add UseModuleMiddleware to FactoryBuilder and integrate into Build()
+- [x] Deprecate old API family in engine/module_specs.go (DefaultRegistryModules, DataOnlyDefaultRegistryModules, DefaultRegistryModulesNamed, DefaultRegistryModule) as thin wrappers
+- [ ] Wire module middleware through commandSupport.newAppWithOptions (replapi-backed commands)
+- [ ] Wire module middleware through runScriptFile (run command)
+- [ ] Wire module middleware through javascript.New (TUI evaluator)
+- [ ] Write integration tests for CLI flags (--safe-mode, --enable-module, --disable-module)
+- [ ] Update pkg/doc/04-repl-usage.md and README.md with module security model
+- [ ] Final review: ensure no behavioral regression, old APIs still work, all tests pass

--- a/ttmp/2026/04/28/GOJA-059--add-granular-module-enablement-flags-to-goja-repl-commands/tasks.md
+++ b/ttmp/2026/04/28/GOJA-059--add-granular-module-enablement-flags-to-goja-repl-commands/tasks.md
@@ -1,0 +1,16 @@
+# Tasks
+
+## TODO
+
+- [x] Add tasks here
+
+- [ ] Investigate current module loading behavior across all goja-repl commands (run, tui, eval, create, etc.)
+- [ ] Design common Glazed schema/flags for module enablement (--enable-module, --disable-module, --safe-mode, etc.)
+- [ ] Add module enablement flags to rootOptions and propagate to all commands
+- [ ] Implement module filtering logic in engine builder based on flag values
+- [ ] Add module enablement to TUI/evaluator Config and wire through command flags
+- [ ] Add module enablement to run command and runScriptOptions
+- [ ] Write tests for module enablement filtering (enable specific, disable specific, safe mode)
+- [ ] Write tests for CLI flag parsing and integration
+- [ ] Update documentation (pkg/doc, README, help) with module security model
+- [ ] Consider jsverbs integration: extend registry/invoker to respect module enablement

--- a/ttmp/2026/04/28/GOJA-059--add-granular-module-enablement-flags-to-goja-repl-commands/tasks.md
+++ b/ttmp/2026/04/28/GOJA-059--add-granular-module-enablement-flags-to-goja-repl-commands/tasks.md
@@ -5,20 +5,20 @@
 - [x] Add tasks here
 - [x] Investigate current module loading behavior across all goja-repl commands (run, tui, eval, create, etc.)
 - [x] Design common Glazed schema/flags for module enablement (--enable-module, --disable-module, --safe-mode, etc.)
-- [ ] Add module enablement flags to rootOptions and propagate to all commands
+- [x] Add module enablement flags to rootOptions and propagate to all commands
 - [x] Implement module filtering logic in engine builder based on flag values
-- [ ] Add module enablement to TUI/evaluator Config and wire through command flags
-- [ ] Add module enablement to run command and runScriptOptions
+- [x] Add module enablement to TUI/evaluator Config and wire through command flags
+- [x] Add module enablement to run command and runScriptOptions
 - [x] Write tests for module enablement filtering (enable specific, disable specific, safe mode)
-- [ ] Write tests for CLI flag parsing and integration
-- [ ] Update documentation (pkg/doc, README, help) with module security model
-- [ ] Consider jsverbs integration: extend registry/invoker to respect module enablement
+- [x] Write tests for CLI flag parsing and integration
+- [x] Update documentation (pkg/doc, README, help) with module security model
+- [x] Consider jsverbs integration: extend registry/invoker to respect module enablement
 - [x] Implement engine/module_middleware.go: ModuleSelector, ModuleMiddleware, built-in middlewares (Safe, Only, Exclude, Add, Custom), Pipeline helper, intersect/filterOut utilities
 - [x] Add UseModuleMiddleware to FactoryBuilder and integrate into Build()
 - [x] Deprecate old API family in engine/module_specs.go (DefaultRegistryModules, DataOnlyDefaultRegistryModules, DefaultRegistryModulesNamed, DefaultRegistryModule) as thin wrappers
-- [ ] Wire module middleware through commandSupport.newAppWithOptions (replapi-backed commands)
-- [ ] Wire module middleware through runScriptFile (run command)
-- [ ] Wire module middleware through javascript.New (TUI evaluator)
-- [ ] Write integration tests for CLI flags (--safe-mode, --enable-module, --disable-module)
-- [ ] Update pkg/doc/04-repl-usage.md and README.md with module security model
-- [ ] Final review: ensure no behavioral regression, old APIs still work, all tests pass
+- [x] Wire module middleware through commandSupport.newAppWithOptions (replapi-backed commands)
+- [x] Wire module middleware through runScriptFile (run command)
+- [x] Wire module middleware through javascript.New (TUI evaluator)
+- [x] Write integration tests for CLI flags (--safe-mode, --enable-module, --disable-module)
+- [x] Update pkg/doc/04-repl-usage.md and README.md with module security model
+- [x] Final review: ensure no behavioral regression, old APIs still work, all tests pass

--- a/ttmp/2026/04/28/GOJA-060--fix-tsparser-thread-safety-crash-in-tui-tree-sitter-assertion-failure/README.md
+++ b/ttmp/2026/04/28/GOJA-060--fix-tsparser-thread-safety-crash-in-tui-tree-sitter-assertion-failure/README.md
@@ -1,0 +1,21 @@
+# Fix TSParser thread-safety crash in TUI (tree-sitter assertion failure)
+
+This is the document workspace for ticket GOJA-060.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr doc add --ticket GOJA-060 --doc-type design-doc --title "My Design"`
+- Import sources: `docmgr import file --ticket GOJA-060 --file /path/to/doc.md`
+- Update metadata: `docmgr meta update --ticket GOJA-060 --field Status --value review`

--- a/ttmp/2026/04/28/GOJA-060--fix-tsparser-thread-safety-crash-in-tui-tree-sitter-assertion-failure/changelog.md
+++ b/ttmp/2026/04/28/GOJA-060--fix-tsparser-thread-safety-crash-in-tui-tree-sitter-assertion-failure/changelog.md
@@ -4,3 +4,8 @@
 
 - Initial workspace created
 
+
+## 2026-04-28
+
+Ticket closed
+

--- a/ttmp/2026/04/28/GOJA-060--fix-tsparser-thread-safety-crash-in-tui-tree-sitter-assertion-failure/changelog.md
+++ b/ttmp/2026/04/28/GOJA-060--fix-tsparser-thread-safety-crash-in-tui-tree-sitter-assertion-failure/changelog.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 2026-04-28
+
+- Initial workspace created
+

--- a/ttmp/2026/04/28/GOJA-060--fix-tsparser-thread-safety-crash-in-tui-tree-sitter-assertion-failure/index.md
+++ b/ttmp/2026/04/28/GOJA-060--fix-tsparser-thread-safety-crash-in-tui-tree-sitter-assertion-failure/index.md
@@ -1,7 +1,7 @@
 ---
 Title: Fix TSParser thread-safety crash in TUI (tree-sitter assertion failure)
 Ticket: GOJA-060
-Status: active
+Status: complete
 Topics:
     - backend
     - bug
@@ -13,10 +13,11 @@ Owners: []
 RelatedFiles: []
 ExternalSources: []
 Summary: ""
-LastUpdated: 2026-04-28T22:19:34.72992934-04:00
+LastUpdated: 2026-04-28T22:22:18.139566807-04:00
 WhatFor: ""
 WhenToUse: ""
 ---
+
 
 # Fix TSParser thread-safety crash in TUI (tree-sitter assertion failure)
 

--- a/ttmp/2026/04/28/GOJA-060--fix-tsparser-thread-safety-crash-in-tui-tree-sitter-assertion-failure/index.md
+++ b/ttmp/2026/04/28/GOJA-060--fix-tsparser-thread-safety-crash-in-tui-tree-sitter-assertion-failure/index.md
@@ -1,0 +1,58 @@
+---
+Title: Fix TSParser thread-safety crash in TUI (tree-sitter assertion failure)
+Ticket: GOJA-060
+Status: active
+Topics:
+    - backend
+    - bug
+    - tui
+    - go-go-golems
+DocType: index
+Intent: long-term
+Owners: []
+RelatedFiles: []
+ExternalSources: []
+Summary: ""
+LastUpdated: 2026-04-28T22:19:34.72992934-04:00
+WhatFor: ""
+WhenToUse: ""
+---
+
+# Fix TSParser thread-safety crash in TUI (tree-sitter assertion failure)
+
+## Overview
+
+<!-- Provide a brief overview of the ticket, its goals, and current status -->
+
+## Key Links
+
+- **Related Files**: See frontmatter RelatedFiles field
+- **External Sources**: See frontmatter ExternalSources field
+
+## Status
+
+Current status: **active**
+
+## Topics
+
+- backend
+- bug
+- tui
+- go-go-golems
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/2026/04/28/GOJA-060--fix-tsparser-thread-safety-crash-in-tui-tree-sitter-assertion-failure/tasks.md
+++ b/ttmp/2026/04/28/GOJA-060--fix-tsparser-thread-safety-crash-in-tui-tree-sitter-assertion-failure/tasks.md
@@ -1,0 +1,6 @@
+# Tasks
+
+## TODO
+
+- [ ] Add tasks here
+

--- a/ttmp/2026/04/28/GOJA-060--fix-tsparser-thread-safety-crash-in-tui-tree-sitter-assertion-failure/tasks.md
+++ b/ttmp/2026/04/28/GOJA-060--fix-tsparser-thread-safety-crash-in-tui-tree-sitter-assertion-failure/tasks.md
@@ -2,5 +2,9 @@
 
 ## TODO
 
-- [ ] Add tasks here
+- [x] Add tasks here
 
+- [x] Investigate /tmp/goja.log crash signature and identify root cause
+- [x] Add sync.Mutex to REPLAPIAdapter and pass as TSMu in AssistanceConfig
+- [x] Add sync.Mutex to RuntimeAssistance and pass as TSMu in AssistanceConfig
+- [x] Verify fix builds and all tests pass

--- a/ttmp/2026/04/28/GOJA-061--add-db-alias-for-database-module-enablement-in-tui/README.md
+++ b/ttmp/2026/04/28/GOJA-061--add-db-alias-for-database-module-enablement-in-tui/README.md
@@ -1,0 +1,21 @@
+# Add db alias for database module enablement in TUI
+
+This is the document workspace for ticket GOJA-061.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr doc add --ticket GOJA-061 --doc-type design-doc --title "My Design"`
+- Import sources: `docmgr import file --ticket GOJA-061 --file /path/to/doc.md`
+- Update metadata: `docmgr meta update --ticket GOJA-061 --field Status --value review`

--- a/ttmp/2026/04/28/GOJA-061--add-db-alias-for-database-module-enablement-in-tui/changelog.md
+++ b/ttmp/2026/04/28/GOJA-061--add-db-alias-for-database-module-enablement-in-tui/changelog.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## 2026-04-28
+
+- Initial workspace created
+
+
+## 2026-04-28
+
+Ticket closed
+

--- a/ttmp/2026/04/28/GOJA-061--add-db-alias-for-database-module-enablement-in-tui/index.md
+++ b/ttmp/2026/04/28/GOJA-061--add-db-alias-for-database-module-enablement-in-tui/index.md
@@ -1,0 +1,59 @@
+---
+Title: Add db alias for database module enablement in TUI
+Ticket: GOJA-061
+Status: complete
+Topics:
+    - bug
+    - tui
+    - modules
+    - go-go-goja
+DocType: index
+Intent: long-term
+Owners: []
+RelatedFiles: []
+ExternalSources: []
+Summary: ""
+LastUpdated: 2026-04-28T22:41:17.01029629-04:00
+WhatFor: ""
+WhenToUse: ""
+---
+
+
+# Add db alias for database module enablement in TUI
+
+## Overview
+
+<!-- Provide a brief overview of the ticket, its goals, and current status -->
+
+## Key Links
+
+- **Related Files**: See frontmatter RelatedFiles field
+- **External Sources**: See frontmatter ExternalSources field
+
+## Status
+
+Current status: **active**
+
+## Topics
+
+- bug
+- tui
+- modules
+- go-go-goja
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/2026/04/28/GOJA-061--add-db-alias-for-database-module-enablement-in-tui/reference/01-diary.md
+++ b/ttmp/2026/04/28/GOJA-061--add-db-alias-for-database-module-enablement-in-tui/reference/01-diary.md
@@ -1,0 +1,56 @@
+---
+title: GOJA-061 Diary — db alias for database module enablement
+---
+
+# Diary
+
+## Reproduction
+
+Ran the user command in tmux:
+
+```bash
+go run ./cmd/goja-repl tui --alt-screen=false --enable-module db
+```
+
+Then evaluated:
+
+```js
+const db = require("db"); typeof db
+```
+
+The TUI returned:
+
+```text
+promise rejected: GoError: Invalid modulepromise rejected: GoError: Invalid module
+```
+
+This reproduced the bug. The middleware treated `db` as an exact module name, but the default database module was only registered as `database`, so `--enable-module db` selected no usable database module and `require("db")` failed.
+
+## Fix
+
+- Registered `modules/database` twice: canonical `database` and short alias `db`.
+- Added middleware alias expansion in both directions: `database -> db` and `db -> database`.
+- Made the database TypeScript declaration use `m.Name()` so the alias declaration name is correct if inspected.
+- Added regression tests for `MiddlewareOnly("db")` and `runScriptFile(... EnableModules: []string{"db"})` with `require("db")`.
+
+## Verification
+
+After the fix, reran tmux:
+
+```bash
+go run ./cmd/goja-repl tui --alt-screen=false --enable-module db
+```
+
+Evaluated:
+
+```js
+const db = require("db"); typeof db.query
+```
+
+The TUI returned:
+
+```text
+"function"
+```
+
+Also verified `typeof require("database").query` returned `"function"` in the same TUI session.

--- a/ttmp/2026/04/28/GOJA-061--add-db-alias-for-database-module-enablement-in-tui/tasks.md
+++ b/ttmp/2026/04/28/GOJA-061--add-db-alias-for-database-module-enablement-in-tui/tasks.md
@@ -1,0 +1,10 @@
+# Tasks
+
+## TODO
+
+- [x] Add tasks here
+
+- [x] Reproduce tui --enable-module db failure in tmux
+- [x] Register db as an alias for database and expand enable-module aliases both ways
+- [x] Add regression tests for --enable-module db
+- [x] Verify TUI in tmux can require db

--- a/ttmp/2026/04/28/GOJA-062--restore-default-all-modules-behavior-when-no-module-middleware-is-configured/README.md
+++ b/ttmp/2026/04/28/GOJA-062--restore-default-all-modules-behavior-when-no-module-middleware-is-configured/README.md
@@ -1,0 +1,21 @@
+# Restore default all-modules behavior when no module middleware is configured
+
+This is the document workspace for ticket GOJA-062.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr doc add --ticket GOJA-062 --doc-type design-doc --title "My Design"`
+- Import sources: `docmgr import file --ticket GOJA-062 --file /path/to/doc.md`
+- Update metadata: `docmgr meta update --ticket GOJA-062 --field Status --value review`

--- a/ttmp/2026/04/28/GOJA-062--restore-default-all-modules-behavior-when-no-module-middleware-is-configured/changelog.md
+++ b/ttmp/2026/04/28/GOJA-062--restore-default-all-modules-behavior-when-no-module-middleware-is-configured/changelog.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## 2026-04-28
+
+- Initial workspace created
+
+
+## 2026-04-28
+
+Ticket closed
+

--- a/ttmp/2026/04/28/GOJA-062--restore-default-all-modules-behavior-when-no-module-middleware-is-configured/index.md
+++ b/ttmp/2026/04/28/GOJA-062--restore-default-all-modules-behavior-when-no-module-middleware-is-configured/index.md
@@ -1,0 +1,59 @@
+---
+Title: Restore default all-modules behavior when no module middleware is configured
+Ticket: GOJA-062
+Status: complete
+Topics:
+    - bug
+    - engine
+    - modules
+    - go-go-goja
+DocType: index
+Intent: long-term
+Owners: []
+RelatedFiles: []
+ExternalSources: []
+Summary: ""
+LastUpdated: 2026-04-28T23:37:12.312268062-04:00
+WhatFor: ""
+WhenToUse: ""
+---
+
+
+# Restore default all-modules behavior when no module middleware is configured
+
+## Overview
+
+<!-- Provide a brief overview of the ticket, its goals, and current status -->
+
+## Key Links
+
+- **Related Files**: See frontmatter RelatedFiles field
+- **External Sources**: See frontmatter ExternalSources field
+
+## Status
+
+Current status: **active**
+
+## Topics
+
+- bug
+- engine
+- modules
+- go-go-goja
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/2026/04/28/GOJA-062--restore-default-all-modules-behavior-when-no-module-middleware-is-configured/reference/01-diary.md
+++ b/ttmp/2026/04/28/GOJA-062--restore-default-all-modules-behavior-when-no-module-middleware-is-configured/reference/01-diary.md
@@ -1,0 +1,42 @@
+---
+title: GOJA-062 Diary — restore default all-modules behavior
+---
+
+# Diary
+
+## Issue
+
+Review feedback pointed out that `FactoryBuilder.Build()` only evaluated the module middleware pipeline under:
+
+```go
+if len(b.moduleMiddlewares) > 0 { ... }
+```
+
+That meant a plain `engine.NewBuilder().Build()` appended no default-registry module specs. Because `Factory.NewRuntime()` still has the historical data-only baseline, these runtimes ended up with only safe/data modules. This broke the intended compatibility contract: no middleware/flags should expose all default modules, while `--safe-mode`/`MiddlewareSafe()` should be the restriction.
+
+## Fix
+
+Changed the build condition to evaluate the default-registry selector when either:
+
+- module middlewares are present, or
+- the caller supplied no explicit `WithModules(...)` specs.
+
+This preserves three cases:
+
+1. Plain `NewBuilder().Build()` => all default-registry modules.
+2. `NewBuilder().UseModuleMiddleware(MiddlewareSafe()).Build()` => safe/data-only modules.
+3. `NewBuilder().WithModules(DefaultRegistryModule("fs")).Build()` => explicit module composition remains explicit.
+
+## Validation
+
+Updated tests in `engine/granular_modules_test.go` to assert plain default builder exposes host modules (`fs`, `os`, `exec`, `database`, `db`) and safe middleware removes them.
+
+Commands run:
+
+```bash
+go test ./engine ./cmd/goja-repl -count=1
+golangci-lint run
+go test ./...
+```
+
+All passed.

--- a/ttmp/2026/04/28/GOJA-062--restore-default-all-modules-behavior-when-no-module-middleware-is-configured/tasks.md
+++ b/ttmp/2026/04/28/GOJA-062--restore-default-all-modules-behavior-when-no-module-middleware-is-configured/tasks.md
@@ -1,0 +1,10 @@
+# Tasks
+
+## TODO
+
+- [x] Add tasks here
+
+- [x] Fix FactoryBuilder.Build to append default-registry modules for plain NewBuilder
+- [x] Add/update tests distinguishing default all-modules from safe middleware
+- [x] Update Node.js primitives docs to match default all-modules behavior
+- [x] Run full test suite and linter


### PR DESCRIPTION
This change introduces a new, flexible system for controlling which native
modules are loaded into the Goja runtime, enhancing security and
configurability. It replaces the previous all-or-nothing approach with a
middleware-based system.

**Go API Changes**
- A new `UseModuleMiddleware` option on the `engine.Builder` allows fine-
  grained control over module loading.
- Pre-built middleware provides common security policies:
  - `MiddlewareSafe()`: Enables only data-safe modules.
  - `MiddlewareOnly("fs", "path")`: Whitelists specific modules.
  - `MiddlewareExclude("exec")`: Blacklists specific modules.
- The `WithModules(...)` method is now deprecated. The default behavior is
  to load all registered modules if no middleware is applied.

**CLI (`goja-repl`) Changes**
- New persistent flags allow module control from the command line:
  - `--safe-mode`: Restricts to safe modules.
  - `--enable-module <list>`: Whitelists modules.
  - `--disable-module <list>`: Blacklists modules.