### PR TITLE
Add express HTTP module and ui.dsl for server-side rendering

### DIFF
--- a/cmd/gen-dts/main.go
+++ b/cmd/gen-dts/main.go
@@ -195,6 +195,7 @@ func writeOrCheck(path string, content string, check bool) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return fmt.Errorf("create output directory: %w", err)
 	}
+	// #nosec G703 -- gen-dts intentionally writes to the caller-selected output path.
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		return fmt.Errorf("write %s: %w", path, err)
 	}

--- a/cmd/goja-perf/phase1_run_command.go
+++ b/cmd/goja-perf/phase1_run_command.go
@@ -103,6 +103,7 @@ func (c *phase1RunCommand) Run(ctx context.Context, vals *values.Values) error {
 
 func runPhase1Task(ctx context.Context, settings phase1CommandSettings, task phase1Task) phase1TaskResult {
 	started := time.Now()
+	// #nosec G204 -- goja-perf executes benchmark task commands from the explicit benchmark task list.
 	cmd := exec.CommandContext(ctx, task.Command, task.Args...)
 	cmd.Dir = settings.RepoRoot
 	output, err := cmd.CombinedOutput()

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/go-go-golems/go-go-goja
 
 go 1.26.1
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	dagger.io/dagger v0.20.3

--- a/modules/common.go
+++ b/modules/common.go
@@ -3,7 +3,6 @@ package modules
 import (
 	"github.com/dop251/goja"
 	"github.com/dop251/goja_nodejs/require"
-	"github.com/rs/zerolog/log"
 )
 
 // NativeModule is the interface every sub-module must satisfy.
@@ -86,7 +85,6 @@ func (r *Registry) ListModules() []NativeModule {
 // Enable registers all modules from this registry with a goja_nodejs/require.Registry.
 func (r *Registry) Enable(gojaRegistry *require.Registry) {
 	for _, m := range r.modules {
-		log.Trace().Str("module", m.Name()).Msg("modules: registering native module")
 		gojaRegistry.RegisterNativeModule(m.Name(), m.Loader)
 	}
 }

--- a/modules/exec/exec.go
+++ b/modules/exec/exec.go
@@ -43,6 +43,7 @@ func (mod m) Loader(vm *goja.Runtime, moduleObj *goja.Object) {
 
 	// run(cmd, args[]) -> string
 	modules.SetExport(exports, mod.Name(), "run", func(cmd string, args []string) (string, error) {
+		// #nosec G204 -- this module exists specifically to run caller-selected commands in trusted runtimes.
 		out, err := exec.Command(cmd, args...).CombinedOutput()
 		return string(out), err
 	})

--- a/modules/express/express.go
+++ b/modules/express/express.go
@@ -1,0 +1,79 @@
+package express
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/dop251/goja"
+	"github.com/dop251/goja_nodejs/require"
+	"github.com/go-go-golems/go-go-goja/engine"
+	"github.com/go-go-golems/go-go-goja/pkg/gojahttp"
+)
+
+type Option func(*Registrar)
+
+type Registrar struct {
+	host *gojahttp.Host
+	name string
+}
+
+func NewRegistrar(host *gojahttp.Host, opts ...Option) *Registrar {
+	r := &Registrar{host: host, name: "express"}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(r)
+		}
+	}
+	return r
+}
+
+func WithName(name string) Option {
+	return func(r *Registrar) {
+		if r != nil && name != "" {
+			r.name = name
+		}
+	}
+}
+
+func (r *Registrar) ID() string { return "express-http" }
+
+func (r *Registrar) RegisterRuntimeModules(ctx *engine.RuntimeModuleContext, reg *require.Registry) error {
+	if r.host == nil {
+		return fmt.Errorf("express registrar requires host")
+	}
+	r.host.SetRuntime(ctx.Owner)
+	name := r.name
+	if name == "" {
+		name = "express"
+	}
+	reg.RegisterNativeModule(name, r.loader)
+	return nil
+}
+
+func (r *Registrar) loader(vm *goja.Runtime, moduleObj *goja.Object) {
+	exports := moduleObj.Get("exports").(*goja.Object)
+	_ = exports.Set("app", func() goja.Value { return r.appObject(vm) })
+}
+
+func (r *Registrar) appObject(vm *goja.Runtime) goja.Value {
+	obj := vm.NewObject()
+	for _, method := range []string{"get", "post", "put", "patch", "delete", "all"} {
+		method := method
+		_ = obj.Set(method, func(pattern string, handler goja.Value) error {
+			fn, ok := goja.AssertFunction(handler)
+			if !ok {
+				return fmt.Errorf("app.%s(%q) requires a function handler", method, pattern)
+			}
+			r.host.Register(strings.ToUpper(method), pattern, fn)
+			return nil
+		})
+	}
+	_ = obj.Set("static", func(prefix, dir string) error {
+		if prefix == "" || dir == "" {
+			return fmt.Errorf("app.static requires prefix and directory")
+		}
+		r.host.RegisterStatic(prefix, dir)
+		return nil
+	})
+	return obj
+}

--- a/modules/express/express_integration_test.go
+++ b/modules/express/express_integration_test.go
@@ -85,6 +85,84 @@ func TestExpressPostJSONEcho(t *testing.T) {
 	}
 }
 
+func TestExpressRouteAwaitsReturnedPromise(t *testing.T) {
+	host := gojahttp.NewHost(gojahttp.HostOptions{Dev: true, Renderer: uidsl.RenderAny})
+	factory, err := engine.NewBuilder().UseModuleMiddleware(engine.MiddlewareOnly("timer")).WithRuntimeModuleRegistrars(NewRegistrar(host), uidsl.NewRegistrar()).Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rt, err := factory.NewRuntime(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = rt.Close(context.Background()) }()
+	host.SetRuntime(rt.Owner)
+	_, err = rt.Owner.Call(context.Background(), "load-test", func(_ context.Context, vm *goja.Runtime) (any, error) {
+		_, err := vm.RunString(`
+			const express = require("express");
+			const ui = require("ui.dsl");
+			const timer = require("timer");
+			const app = express.app();
+			app.get("/async-return", async (req, res) => {
+			  await timer.sleep(5);
+			  return ui.h1("async " + req.query.name);
+			});
+		`)
+		return nil, err
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	buf := httptest.NewRecorder()
+	host.ServeHTTP(buf, httptest.NewRequest(http.MethodGet, "/async-return?name=route", nil))
+	if buf.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", buf.Code, buf.Body.String())
+	}
+	if !strings.Contains(buf.Body.String(), "<h1>async route</h1>") {
+		t.Fatalf("body=%s", buf.Body.String())
+	}
+	if strings.Contains(buf.Body.String(), "Promise") {
+		t.Fatalf("promise was rendered instead of awaited: %s", buf.Body.String())
+	}
+}
+
+func TestExpressRouteAwaitsPromiseThatSendsResponse(t *testing.T) {
+	host := gojahttp.NewHost(gojahttp.HostOptions{Dev: true, Renderer: uidsl.RenderAny})
+	factory, err := engine.NewBuilder().UseModuleMiddleware(engine.MiddlewareOnly("timer")).WithRuntimeModuleRegistrars(NewRegistrar(host), uidsl.NewRegistrar()).Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rt, err := factory.NewRuntime(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = rt.Close(context.Background()) }()
+	host.SetRuntime(rt.Owner)
+	_, err = rt.Owner.Call(context.Background(), "load-test", func(_ context.Context, vm *goja.Runtime) (any, error) {
+		_, err := vm.RunString(`
+			const express = require("express");
+			const timer = require("timer");
+			const app = express.app();
+			app.get("/async-send", async (req, res) => {
+			  await timer.sleep(5);
+			  res.json({ ok: true, name: req.query.name });
+			});
+		`)
+		return nil, err
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr := httptest.NewRecorder()
+	host.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/async-send?name=response", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), `"ok":true`) || !strings.Contains(rr.Body.String(), `"name":"response"`) {
+		t.Fatalf("body=%s", rr.Body.String())
+	}
+}
+
 func TestHeadFallsBackToGetWithoutBody(t *testing.T) {
 	host := gojahttp.NewHost(gojahttp.HostOptions{Dev: true, Renderer: uidsl.RenderAny})
 	factory, err := engine.NewBuilder().WithRuntimeModuleRegistrars(NewRegistrar(host), uidsl.NewRegistrar()).Build()

--- a/modules/express/express_integration_test.go
+++ b/modules/express/express_integration_test.go
@@ -1,0 +1,122 @@
+package express
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/dop251/goja"
+	"github.com/go-go-golems/go-go-goja/engine"
+	"github.com/go-go-golems/go-go-goja/modules/uidsl"
+	"github.com/go-go-golems/go-go-goja/pkg/gojahttp"
+)
+
+func TestExpressRouteReturnsHTMLNode(t *testing.T) {
+	host := gojahttp.NewHost(gojahttp.HostOptions{Dev: true, Renderer: uidsl.RenderAny})
+	factory, err := engine.NewBuilder().WithRuntimeModuleRegistrars(NewRegistrar(host), uidsl.NewRegistrar()).Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rt, err := factory.NewRuntime(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = rt.Close(context.Background()) }()
+	host.SetRuntime(rt.Owner)
+	_, err = rt.Owner.Call(context.Background(), "load-test", func(_ context.Context, vm *goja.Runtime) (any, error) {
+		_, err := vm.RunString(`
+			const express = require("express");
+			const ui = require("ui.dsl");
+			const app = express.app();
+			app.get("/hello/:name", (req, res) => ui.h1("Hello " + req.params.name));
+		`)
+		return nil, err
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr := httptest.NewRecorder()
+	host.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/hello/Goja", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	if ct := rr.Header().Get("Content-Type"); !strings.Contains(ct, "text/html") {
+		t.Fatalf("content-type=%s", ct)
+	}
+	if !strings.Contains(rr.Body.String(), "<h1>Hello Goja</h1>") {
+		t.Fatalf("body=%s", rr.Body.String())
+	}
+}
+
+func TestExpressPostJSONEcho(t *testing.T) {
+	host := gojahttp.NewHost(gojahttp.HostOptions{Dev: true, Renderer: uidsl.RenderAny})
+	factory, err := engine.NewBuilder().WithRuntimeModuleRegistrars(NewRegistrar(host), uidsl.NewRegistrar()).Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rt, err := factory.NewRuntime(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = rt.Close(context.Background()) }()
+	host.SetRuntime(rt.Owner)
+	_, err = rt.Owner.Call(context.Background(), "load-test", func(_ context.Context, vm *goja.Runtime) (any, error) {
+		_, err := vm.RunString(`
+			const express = require("express");
+			const app = express.app();
+			app.post("/echo", (req, res) => res.status(201).json({ title: req.body.title }));
+		`)
+		return nil, err
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/echo", strings.NewReader(`{"title":"Card"}`))
+	req.Header.Set("Content-Type", "application/json")
+	host.ServeHTTP(rr, req)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), `"title":"Card"`) {
+		t.Fatalf("body=%s", rr.Body.String())
+	}
+}
+
+func TestHeadFallsBackToGetWithoutBody(t *testing.T) {
+	host := gojahttp.NewHost(gojahttp.HostOptions{Dev: true, Renderer: uidsl.RenderAny})
+	factory, err := engine.NewBuilder().WithRuntimeModuleRegistrars(NewRegistrar(host), uidsl.NewRegistrar()).Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rt, err := factory.NewRuntime(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = rt.Close(context.Background()) }()
+	host.SetRuntime(rt.Owner)
+	_, err = rt.Owner.Call(context.Background(), "load-test", func(_ context.Context, vm *goja.Runtime) (any, error) {
+		_, err := vm.RunString(`
+			const express = require("express");
+			const app = express.app();
+			app.get("/hello", (req, res) => res.type("text/plain").send("hello body"));
+		`)
+		return nil, err
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rr := httptest.NewRecorder()
+	host.ServeHTTP(rr, httptest.NewRequest(http.MethodHead, "/hello", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rr.Code, rr.Body.String())
+	}
+	if rr.Body.Len() != 0 {
+		t.Fatalf("expected empty HEAD body, got %q", rr.Body.String())
+	}
+	if ct := rr.Header().Get("Content-Type"); !strings.Contains(ct, "text/plain") {
+		t.Fatalf("content-type=%s", ct)
+	}
+}

--- a/modules/express/typescript.go
+++ b/modules/express/typescript.go
@@ -1,0 +1,59 @@
+package express
+
+import (
+	"github.com/go-go-golems/go-go-goja/modules"
+	"github.com/go-go-golems/go-go-goja/pkg/tsgen/spec"
+)
+
+var _ modules.TypeScriptDeclarer = (*Registrar)(nil)
+
+func (r *Registrar) TypeScriptModule() *spec.Module {
+	name := "express"
+	if r != nil && r.name != "" {
+		name = r.name
+	}
+	return &spec.Module{
+		Name:        name,
+		Description: "Express-style HTTP route registration for go-go-goja hosts.",
+		Functions: []spec.Function{
+			{Name: "app", Returns: spec.Named("App")},
+		},
+		RawDTS: []string{
+			"export interface App {",
+			"  get(pattern: string, handler: Handler): void;",
+			"  post(pattern: string, handler: Handler): void;",
+			"  put(pattern: string, handler: Handler): void;",
+			"  patch(pattern: string, handler: Handler): void;",
+			"  delete(pattern: string, handler: Handler): void;",
+			"  all(pattern: string, handler: Handler): void;",
+			"  static(prefix: string, directory: string): void;",
+			"}",
+			"export type Handler = (req: Request, res: Response) => unknown;",
+			"export interface Request {",
+			"  method: string;",
+			"  url: string;",
+			"  path: string;",
+			"  query: Record<string, string | string[]>;",
+			"  params: Record<string, string>;",
+			"  headers: Record<string, string>;",
+			"  cookies: Record<string, string>;",
+			"  session: Session | null;",
+			"  ip: string;",
+			"  body: unknown;",
+			"  rawBody: string;",
+			"}",
+			"export interface Session { id: string; isNew: boolean; cookieName: string; }",
+			"export interface Response {",
+			"  status(code: number): Response;",
+			"  set(name: string, value: string): Response;",
+			"  type(value: string): Response;",
+			"  json(value: unknown): void;",
+			"  send(value?: unknown): void;",
+			"  html(value: unknown): void;",
+			"  redirect(url: string): void;",
+			"  redirect(status: number, url: string): void;",
+			"  end(): void;",
+			"}",
+		},
+	}
+}

--- a/modules/uidsl/components.go
+++ b/modules/uidsl/components.go
@@ -1,0 +1,499 @@
+package uidsl
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"github.com/dop251/goja"
+)
+
+var allowedBadgeTones = map[string]bool{
+	"default": true,
+	"info":    true,
+	"success": true,
+	"warning": true,
+	"danger":  true,
+	"muted":   true,
+}
+
+type codeBlockOptions struct {
+	Title       string
+	LineNumbers bool
+	Wrap        bool
+	Copy        bool
+	MaxHeight   string
+	Class       string
+}
+
+func codeBlockNode(language string, source any, opts map[string]any) Node {
+	lang := cssToken(language)
+	if lang == "empty" {
+		lang = "text"
+	}
+	options := parseCodeBlockOptions(opts)
+	classes := []any{"ui-codeblock", "ui-codeblock--" + lang}
+	if options.Wrap {
+		classes = append(classes, "ui-codeblock--wrap")
+	} else {
+		classes = append(classes, "ui-codeblock--nowrap")
+	}
+	if options.LineNumbers {
+		classes = append(classes, "ui-codeblock--line-numbers")
+	}
+	if options.Class != "" {
+		classes = append(classes, options.Class)
+	}
+	preAttrs := map[string]any{}
+	if options.MaxHeight != "" {
+		preAttrs["style"] = map[string]any{"max-height": options.MaxHeight, "overflow": "auto"}
+	}
+	sourceText := stringifySource(source)
+	code := &Element{Tag: "code", Attrs: map[string]any{"class": "language-" + lang}, Children: highlightCode(lang, sourceText)}
+	if options.Title == "" && !options.Copy {
+		preAttrs["class"] = classes
+		return &Element{Tag: "pre", Attrs: preAttrs, Children: []Node{code}}
+	}
+	captionChildren := []Node{}
+	if options.Title != "" {
+		captionChildren = append(captionChildren, &Element{Tag: "span", Attrs: map[string]any{"class": "ui-codeblock__title"}, Children: []Node{&Text{Value: options.Title}}})
+	}
+	if options.Copy {
+		captionChildren = append(captionChildren, &Element{Tag: "button", Attrs: map[string]any{"class": "ui-codeblock__copy", "type": "button"}, Children: []Node{&Text{Value: "Copy"}}})
+	}
+	preAttrs["class"] = "ui-codeblock__pre"
+	return &Element{Tag: "figure", Attrs: map[string]any{"class": classes}, Children: []Node{
+		&Element{Tag: "figcaption", Attrs: map[string]any{"class": "ui-codeblock__caption"}, Children: captionChildren},
+		&Element{Tag: "pre", Attrs: preAttrs, Children: []Node{code}},
+	}}
+}
+
+func parseCodeBlockOptions(opts map[string]any) codeBlockOptions {
+	return codeBlockOptions{
+		Title:       stringFromAny(opts["title"]),
+		LineNumbers: boolFromAny(opts["lineNumbers"]),
+		Wrap:        optionBool(opts, "wrap", true),
+		Copy:        boolFromAny(opts["copy"]),
+		MaxHeight:   stringFromAny(opts["maxHeight"]),
+		Class:       stringFromAny(opts["class"]),
+	}
+}
+
+func badgeNode(value any, opts map[string]any) Node {
+	text := stringifySource(value)
+	tone := cssToken(stringFromAny(opts["tone"]))
+	if !allowedBadgeTones[tone] {
+		tone = "default"
+	}
+	classes := []any{"ui-badge", "ui-badge--" + tone, "ui-badge--value-" + cssToken(text)}
+	if className := stringFromAny(opts["class"]); className != "" {
+		classes = append(classes, className)
+	}
+	attrs := map[string]any{"class": classes}
+	if title := stringFromAny(opts["title"]); title != "" {
+		attrs["title"] = title
+	}
+	return &Element{Tag: "span", Attrs: attrs, Children: []Node{&Text{Value: text}}}
+}
+
+type tabSpec struct {
+	ID       string
+	Label    string
+	Content  Node
+	Disabled bool
+}
+
+func tabsNode(id string, value goja.Value, opts map[string]any) (Node, error) {
+	baseID := domToken(id, "tabs")
+	tabs, err := parseTabs(value)
+	if err != nil {
+		return nil, err
+	}
+	if len(tabs) == 0 {
+		return &Element{Tag: "div", Attrs: map[string]any{"class": []any{"ui-tabs", stringFromAny(opts["class"])}, "id": baseID}}, nil
+	}
+	assignTabIDs(tabs)
+	selected := selectedTabIndex(tabs, opts["selected"])
+	classes := []any{"ui-tabs"}
+	if className := stringFromAny(opts["class"]); className != "" {
+		classes = append(classes, className)
+	}
+	children := []Node{tabsStyleNode(baseID, tabs)}
+	children = append(children, tabInputNodes(baseID, tabs, selected)...)
+	children = append(children, &Element{Tag: "div", Attrs: map[string]any{"class": "ui-tabs__tablist", "role": "tablist"}, Children: tabLabelNodes(baseID, tabs)})
+	panels := make([]Node, 0, len(tabs))
+	for i, tab := range tabs {
+		panelClasses := []any{"ui-tabs__panel"}
+		if i == selected {
+			panelClasses = append(panelClasses, "ui-tabs__panel--active")
+		}
+		panels = append(panels, &Element{Tag: "section", Attrs: map[string]any{"class": panelClasses, "data-tab": tab.ID}, Children: []Node{tab.Content}})
+	}
+	children = append(children, &Element{Tag: "div", Attrs: map[string]any{"class": "ui-tabs__panels"}, Children: panels})
+	return &Element{Tag: "div", Attrs: map[string]any{"class": classes, "id": baseID}, Children: children}, nil
+}
+
+func parseTabs(value goja.Value) ([]tabSpec, error) {
+	if value == nil || goja.IsUndefined(value) || goja.IsNull(value) {
+		return nil, nil
+	}
+	exported := value.Export()
+	items, ok := exported.([]any)
+	if !ok {
+		return nil, fmt.Errorf("ui.tabs expects an array of tab specs, got %T", exported)
+	}
+	tabs := make([]tabSpec, 0, len(items))
+	for i, item := range items {
+		m, ok := item.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("ui.tabs tab %d must be an object, got %T", i, item)
+		}
+		content, err := NormalizeExport(m["content"])
+		if err != nil {
+			return nil, err
+		}
+		label := stringFromAny(m["label"])
+		if label == "" {
+			label = fmt.Sprintf("Tab %d", i+1)
+		}
+		tabs = append(tabs, tabSpec{ID: stringFromAny(m["id"]), Label: label, Content: content, Disabled: boolFromAny(m["disabled"])})
+	}
+	return tabs, nil
+}
+
+func assignTabIDs(tabs []tabSpec) {
+	seen := map[string]int{}
+	for i := range tabs {
+		base := domToken(tabs[i].ID, "")
+		if base == "" {
+			base = domToken(tabs[i].Label, fmt.Sprintf("tab-%d", i+1))
+		}
+		seen[base]++
+		if seen[base] > 1 {
+			tabs[i].ID = fmt.Sprintf("%s-%d", base, seen[base])
+		} else {
+			tabs[i].ID = base
+		}
+	}
+}
+
+func selectedTabIndex(tabs []tabSpec, selected any) int {
+	fallback := -1
+	for i, tab := range tabs {
+		if !tab.Disabled && fallback == -1 {
+			fallback = i
+		}
+	}
+	if fallback == -1 {
+		return 0
+	}
+	if idx, ok := intLike(selected); ok && idx >= 0 && idx < len(tabs) && !tabs[idx].Disabled {
+		return idx
+	}
+	selectedID := domToken(stringFromAny(selected), "")
+	if selectedID != "" {
+		for i, tab := range tabs {
+			if tab.ID == selectedID && !tab.Disabled {
+				return i
+			}
+		}
+	}
+	return fallback
+}
+
+func tabInputNodes(baseID string, tabs []tabSpec, selected int) []Node {
+	children := make([]Node, 0, len(tabs))
+	for i, tab := range tabs {
+		inputID := baseID + "-" + tab.ID
+		inputAttrs := map[string]any{"class": "ui-tabs__radio", "type": "radio", "name": baseID, "id": inputID}
+		if i == selected && !tab.Disabled {
+			inputAttrs["checked"] = true
+		}
+		if tab.Disabled {
+			inputAttrs["disabled"] = true
+		}
+		children = append(children, &Element{Tag: "input", Attrs: inputAttrs})
+	}
+	return children
+}
+
+func tabLabelNodes(baseID string, tabs []tabSpec) []Node {
+	children := make([]Node, 0, len(tabs))
+	for _, tab := range tabs {
+		inputID := baseID + "-" + tab.ID
+		labelClasses := []any{"ui-tabs__tab"}
+		if tab.Disabled {
+			labelClasses = append(labelClasses, "ui-tabs__tab--disabled")
+		}
+		children = append(children, &Element{Tag: "label", Attrs: map[string]any{"class": labelClasses, "for": inputID}, Children: []Node{&Text{Value: tab.Label}}})
+	}
+	return children
+}
+
+func tabsStyleNode(baseID string, tabs []tabSpec) Node {
+	var b strings.Builder
+	fmt.Fprintf(&b, "#%s>.ui-tabs__radio{position:absolute;left:-9999px;}\n", baseID)
+	fmt.Fprintf(&b, "#%s>.ui-tabs__panels>.ui-tabs__panel{display:none;}\n", baseID)
+	for _, tab := range tabs {
+		inputID := baseID + "-" + tab.ID
+		fmt.Fprintf(&b, "#%s:checked~.ui-tabs__panels>[data-tab=\"%s\"]{display:block;}\n", inputID, tab.ID)
+		fmt.Fprintf(&b, "#%s:checked~.ui-tabs__tablist>label[for=\"%s\"]{background:#fff;font-weight:900;}\n", inputID, inputID)
+	}
+	return &Element{Tag: "style", Attrs: map[string]any{"class": "ui-tabs__style"}, Children: []Node{&RawHTML{Value: b.String()}}}
+}
+
+func jsonBlockSource(value goja.Value) string {
+	if value == nil || goja.IsUndefined(value) || goja.IsNull(value) {
+		return "null"
+	}
+	exported := value.Export()
+	if s, ok := exported.(string); ok {
+		var parsed any
+		if err := json.Unmarshal([]byte(s), &parsed); err == nil {
+			if b, err := json.MarshalIndent(parsed, "", "  "); err == nil {
+				return string(b)
+			}
+		}
+		return s
+	}
+	if b, err := json.MarshalIndent(exported, "", "  "); err == nil {
+		return string(b)
+	}
+	return stringifySource(exported)
+}
+
+func highlightCode(language string, source string) []Node {
+	switch language {
+	case "sql":
+		return highlightSQLLike(source, sqlKeywords(), true)
+	case "javascript", "js":
+		return highlightSQLLike(source, jsKeywords(), false)
+	case "json":
+		return highlightJSON(source)
+	default:
+		return []Node{&Text{Value: source}}
+	}
+}
+
+func highlightSQLLike(source string, keywords map[string]bool, sql bool) []Node {
+	nodes := []Node{}
+	for i := 0; i < len(source); {
+		if sql && i+1 < len(source) && source[i] == '-' && source[i+1] == '-' {
+			j := i + 2
+			for j < len(source) && source[j] != '\n' {
+				j++
+			}
+			nodes = append(nodes, tokenNode("comment", source[i:j]))
+			i = j
+			continue
+		}
+		if !sql && i+1 < len(source) && source[i] == '/' && source[i+1] == '/' {
+			j := i + 2
+			for j < len(source) && source[j] != '\n' {
+				j++
+			}
+			nodes = append(nodes, tokenNode("comment", source[i:j]))
+			i = j
+			continue
+		}
+		if i+1 < len(source) && source[i] == '/' && source[i+1] == '*' {
+			j := i + 2
+			for j+1 < len(source) && (source[j] != '*' || source[j+1] != '/') {
+				j++
+			}
+			if j+1 < len(source) {
+				j += 2
+			}
+			nodes = append(nodes, tokenNode("comment", source[i:j]))
+			i = j
+			continue
+		}
+		if source[i] == '\'' || source[i] == '"' || (!sql && source[i] == '`') {
+			j := scanString(source, i)
+			nodes = append(nodes, tokenNode("string", source[i:j]))
+			i = j
+			continue
+		}
+		if isDigit(source[i]) {
+			j := i + 1
+			for j < len(source) && (isDigit(source[j]) || source[j] == '.') {
+				j++
+			}
+			nodes = append(nodes, tokenNode("number", source[i:j]))
+			i = j
+			continue
+		}
+		if isIdentStart(source[i]) {
+			j := i + 1
+			for j < len(source) && isIdentPart(source[j]) {
+				j++
+			}
+			word := source[i:j]
+			lower := strings.ToLower(word)
+			if keywords[lower] {
+				nodes = append(nodes, tokenNode("keyword", word))
+			} else if !sql && (lower == "true" || lower == "false" || lower == "null" || lower == "undefined") {
+				nodes = append(nodes, tokenNode("literal", word))
+			} else {
+				nodes = append(nodes, &Text{Value: word})
+			}
+			i = j
+			continue
+		}
+		nodes = append(nodes, &Text{Value: source[i : i+1]})
+		i++
+	}
+	return coalesceText(nodes)
+}
+
+func highlightJSON(source string) []Node {
+	nodes := []Node{}
+	for i := 0; i < len(source); {
+		if source[i] == '"' {
+			j := scanString(source, i)
+			kind := "string"
+			k := j
+			for k < len(source) && unicode.IsSpace(rune(source[k])) {
+				k++
+			}
+			if k < len(source) && source[k] == ':' {
+				kind = "key"
+			}
+			nodes = append(nodes, tokenNode(kind, source[i:j]))
+			i = j
+			continue
+		}
+		if isDigit(source[i]) || source[i] == '-' {
+			j := i + 1
+			for j < len(source) && (isDigit(source[j]) || strings.ContainsRune(".eE+-", rune(source[j]))) {
+				j++
+			}
+			nodes = append(nodes, tokenNode("number", source[i:j]))
+			i = j
+			continue
+		}
+		matched := false
+		for _, literal := range []string{"true", "false", "null"} {
+			if strings.HasPrefix(source[i:], literal) {
+				nodes = append(nodes, tokenNode("literal", literal))
+				i += len(literal)
+				matched = true
+				break
+			}
+		}
+		if matched {
+			continue
+		}
+		nodes = append(nodes, &Text{Value: source[i : i+1]})
+		i++
+	}
+	return coalesceText(nodes)
+}
+
+func tokenNode(kind string, text string) Node {
+	return &Element{Tag: "span", Attrs: map[string]any{"class": []any{"ui-codeblock__token", "ui-codeblock__token--" + kind}}, Children: []Node{&Text{Value: text}}}
+}
+
+func scanString(source string, i int) int {
+	quote := source[i]
+	j := i + 1
+	for j < len(source) {
+		if source[j] == '\\' {
+			j += 2
+			continue
+		}
+		if source[j] == quote {
+			return j + 1
+		}
+		j++
+	}
+	return j
+}
+
+func coalesceText(nodes []Node) []Node {
+	out := []Node{}
+	for _, n := range nodes {
+		if text, ok := n.(*Text); ok {
+			if len(out) > 0 {
+				if prev, ok := out[len(out)-1].(*Text); ok {
+					prev.Value += text.Value
+					continue
+				}
+			}
+		}
+		out = append(out, n)
+	}
+	return out
+}
+
+func sqlKeywords() map[string]bool {
+	return keywordSet("select from where join left right inner outer on as create table view index trigger insert update delete values into primary key references not null integer text real blob autoincrement case when then else end exists and or order by group having limit offset union all distinct count sum min max coalesce")
+}
+
+func jsKeywords() map[string]bool {
+	return keywordSet("const let var function return if else for while do switch case break continue try catch finally throw new class extends import export require async await in of typeof instanceof")
+}
+
+func keywordSet(words string) map[string]bool {
+	ret := map[string]bool{}
+	for _, word := range strings.Fields(words) {
+		ret[word] = true
+	}
+	return ret
+}
+
+func isDigit(b byte) bool { return b >= '0' && b <= '9' }
+func isIdentStart(b byte) bool {
+	return (b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z') || b == '_'
+}
+func isIdentPart(b byte) bool { return isIdentStart(b) || isDigit(b) || b == '$' }
+
+func stringifySource(value any) string {
+	if value == nil {
+		return ""
+	}
+	return fmt.Sprint(value)
+}
+
+func firstOptions(options []map[string]any) map[string]any {
+	if len(options) == 0 || options[0] == nil {
+		return map[string]any{}
+	}
+	return options[0]
+}
+
+func optionBool(opts map[string]any, key string, fallback bool) bool {
+	if _, ok := opts[key]; !ok {
+		return fallback
+	}
+	return boolFromAny(opts[key])
+}
+
+func domToken(value string, fallback string) string {
+	token := cssToken(value)
+	if token == "empty" {
+		return fallback
+	}
+	if token[0] >= '0' && token[0] <= '9' {
+		return "x-" + token
+	}
+	return token
+}
+
+func intLike(value any) (int, bool) {
+	switch v := value.(type) {
+	case int:
+		return v, true
+	case int64:
+		return int(v), true
+	case float64:
+		return int(v), true
+	case string:
+		n, err := strconv.Atoi(v)
+		return n, err == nil
+	default:
+		return 0, false
+	}
+}

--- a/modules/uidsl/components_test.go
+++ b/modules/uidsl/components_test.go
@@ -1,0 +1,133 @@
+package uidsl
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dop251/goja"
+)
+
+func testUI(t *testing.T) *goja.Runtime {
+	t.Helper()
+	vm := goja.New()
+	obj := vm.NewObject()
+	exports := vm.NewObject()
+	_ = obj.Set("exports", exports)
+	Loader(vm, obj)
+	_ = vm.Set("ui", exports)
+	return vm
+}
+
+func renderJS(t *testing.T, script string) string {
+	t.Helper()
+	vm := testUI(t)
+	value, err := vm.RunString(script)
+	if err != nil {
+		t.Fatal(err)
+	}
+	html, err := RenderAny(vm, value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return html
+}
+
+func TestCodeBlockEscapesSimplePre(t *testing.T) {
+	html := renderJS(t, `ui.codeBlock("sql!!", "SELECT '<x>'")`)
+	for _, want := range []string{
+		`<pre class="ui-codeblock ui-codeblock--sql ui-codeblock--wrap">`,
+		`<span class="ui-codeblock__token ui-codeblock__token--keyword">SELECT</span>`,
+		`<span class="ui-codeblock__token ui-codeblock__token--string">&#39;&lt;x&gt;&#39;</span>`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("missing %q in %s", want, html)
+		}
+	}
+}
+
+func TestCodeBlockFigureOptions(t *testing.T) {
+	html := renderJS(t, `ui.codeBlock("", "line1\nline2", { title: "T <x>", lineNumbers: true, wrap: false, copy: true, maxHeight: "120px", class: "extra" })`)
+	for _, want := range []string{
+		`<figure class="ui-codeblock ui-codeblock--text ui-codeblock--nowrap ui-codeblock--line-numbers extra">`,
+		`<figcaption class="ui-codeblock__caption">`,
+		`<span class="ui-codeblock__title">T &lt;x&gt;</span>`,
+		`<button class="ui-codeblock__copy" type="button">Copy</button>`,
+		`<pre class="ui-codeblock__pre" style="max-height:120px;overflow:auto">`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("missing %q in %s", want, html)
+		}
+	}
+}
+
+func TestCodeBlockAliasesAndJSON(t *testing.T) {
+	html := renderJS(t, `ui.fragment(
+		ui.sql("SELECT 1"),
+		ui.js("const x = 1"),
+		ui.jsonBlock({ b: 2, a: "<x>" }),
+		ui.jsonBlock('{"z":1}')
+	)`)
+	for _, want := range []string{
+		`ui-codeblock--sql`,
+		`language-javascript`,
+		`<span class="ui-codeblock__token ui-codeblock__token--key">&#34;a&#34;</span>`,
+		`<span class="ui-codeblock__token ui-codeblock__token--string">&#34;\u003cx\u003e&#34;</span>`,
+		`<span class="ui-codeblock__token ui-codeblock__token--number">1</span>`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("missing %q in %s", want, html)
+		}
+	}
+}
+
+func TestBadgeRendersToneAndEscapes(t *testing.T) {
+	html := renderJS(t, `ui.badge("yes <ok>", { tone: "success", title: "A <B>", class: "extra" })`)
+	for _, want := range []string{
+		`<span class="ui-badge ui-badge--success ui-badge--value-yes-ok extra" title="A &lt;B&gt;">yes &lt;ok&gt;</span>`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("missing %q in %s", want, html)
+		}
+	}
+}
+
+func TestBadgeUnknownToneDefaults(t *testing.T) {
+	html := renderJS(t, `ui.badge("view", { tone: "weird" })`)
+	if !strings.Contains(html, `ui-badge--default`) {
+		t.Fatalf("expected default tone in %s", html)
+	}
+}
+
+func TestTabsRenderSelectedDuplicateDisabledAndEscaped(t *testing.T) {
+	html := renderJS(t, `ui.tabs("Record Tabs!", [
+		{ id: "summary", label: "Summary <x>", content: "safe <content>" },
+		{ id: "json", label: "JSON", content: ui.jsonBlock({ a: 1 }) },
+		{ id: "json", label: "Duplicate", content: "second" },
+		{ id: "disabled", label: "Disabled", content: "no", disabled: true }
+	], { selected: "json", class: "extra" })`)
+	for _, want := range []string{
+		`<div class="ui-tabs extra" id="record-tabs">`,
+		`#record-tabs-json:checked~.ui-tabs__panels>[data-tab="json"]{display:block;}`,
+		`<input class="ui-tabs__radio" id="record-tabs-summary" name="record-tabs" type="radio">`,
+		`<label class="ui-tabs__tab" for="record-tabs-summary">Summary &lt;x&gt;</label>`,
+		`<input checked class="ui-tabs__radio" id="record-tabs-json" name="record-tabs" type="radio">`,
+		`data-tab="json-2"`,
+		`disabled`,
+		`ui-tabs__tab--disabled`,
+		`safe &lt;content&gt;`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("missing %q in %s", want, html)
+		}
+	}
+}
+
+func TestTabsInvalidSelectionFallsBack(t *testing.T) {
+	html := renderJS(t, `ui.tabs("tabs", [
+		{ id: "off", label: "Off", content: "off", disabled: true },
+		{ id: "on", label: "On", content: "on" }
+	], { selected: "missing" })`)
+	if !strings.Contains(html, `<input checked class="ui-tabs__radio" id="tabs-on" name="tabs" type="radio">`) {
+		t.Fatalf("expected first non-disabled tab selected in %s", html)
+	}
+}

--- a/modules/uidsl/module.go
+++ b/modules/uidsl/module.go
@@ -1,0 +1,139 @@
+package uidsl
+
+import (
+	"fmt"
+
+	"github.com/dop251/goja"
+	"github.com/dop251/goja_nodejs/require"
+	"github.com/go-go-golems/go-go-goja/engine"
+)
+
+type Registrar struct{}
+
+func NewRegistrar() *Registrar  { return &Registrar{} }
+func (r *Registrar) ID() string { return "ui-dsl" }
+func (r *Registrar) RegisterRuntimeModules(ctx *engine.RuntimeModuleContext, reg *require.Registry) error {
+	reg.RegisterNativeModule("ui.dsl", Loader)
+	reg.RegisterNativeModule("ui", Loader)
+	return nil
+}
+
+var tags = []string{"html", "head", "body", "title", "meta", "link", "script", "style", "main", "img", "br", "hr", "time", "svg", "path", "rect", "line", "polyline", "circle", "div", "span", "h1", "h2", "h3", "h4", "p", "a", "form", "input", "button", "select", "option", "ul", "ol", "li", "table", "thead", "tbody", "tr", "th", "td", "section", "article", "header", "footer", "nav", "label", "textarea", "strong", "em", "small", "pre", "code"}
+var headTags = map[string]bool{"meta": true, "link": true, "style": true, "title": true}
+
+func Loader(vm *goja.Runtime, moduleObj *goja.Object) {
+	exports := moduleObj.Get("exports").(*goja.Object)
+	for _, tag := range tags {
+		tag := tag
+		_ = exports.Set(tag, func(call goja.FunctionCall) goja.Value { return vm.ToValue(elementFromCall(tag, call)) })
+	}
+	_ = exports.Set("fragment", func(call goja.FunctionCall) goja.Value {
+		return vm.ToValue(&Fragment{Children: nodesFromArgs(call.Arguments)})
+	})
+	_ = exports.Set("text", func(v any) *Text { return &Text{Value: fmt.Sprint(v)} })
+	_ = exports.Set("raw", func(s string) *RawHTML { return &RawHTML{Value: s} })
+	_ = exports.Set("render", func(v goja.Value) (string, error) { return RenderAny(vm, v) })
+	_ = exports.Set("page", func(call goja.FunctionCall) goja.Value { return vm.ToValue(pageFromCall(call)) })
+	_ = exports.Set("codeBlock", func(language string, source goja.Value, options ...map[string]any) goja.Value {
+		return vm.ToValue(codeBlockNode(language, source.Export(), firstOptions(options)))
+	})
+	_ = exports.Set("sql", func(source goja.Value, options ...map[string]any) goja.Value {
+		return vm.ToValue(codeBlockNode("sql", source.Export(), firstOptions(options)))
+	})
+	_ = exports.Set("js", func(source goja.Value, options ...map[string]any) goja.Value {
+		return vm.ToValue(codeBlockNode("javascript", source.Export(), firstOptions(options)))
+	})
+	_ = exports.Set("jsonBlock", func(value goja.Value, options ...map[string]any) goja.Value {
+		return vm.ToValue(codeBlockNode("json", jsonBlockSource(value), firstOptions(options)))
+	})
+	_ = exports.Set("badge", func(value goja.Value, options ...map[string]any) goja.Value {
+		return vm.ToValue(badgeNode(value.Export(), firstOptions(options)))
+	})
+	_ = exports.Set("tabs", func(id string, tabs goja.Value, options ...map[string]any) (goja.Value, error) {
+		n, err := tabsNode(id, tabs, firstOptions(options))
+		if err != nil {
+			return nil, err
+		}
+		return vm.ToValue(n), nil
+	})
+	tableValue := vm.ToValue(func(id string) goja.Value { return tableBuilderObject(vm, newTableBuilder(id)) })
+	if tableObj, ok := tableValue.(*goja.Object); ok {
+		_ = tableObj.Set("fromRows", func(id string, rows goja.Value) (goja.Value, error) {
+			builder, err := tableFromRows(id, rows)
+			if err != nil {
+				return nil, err
+			}
+			return tableBuilderObject(vm, builder), nil
+		})
+	}
+	_ = exports.Set("table", tableValue)
+}
+
+func elementFromCall(tag string, call goja.FunctionCall) *Element {
+	attrs := map[string]any{}
+	args := call.Arguments
+	if len(args) > 0 && isAttrs(args[0]) {
+		if m, ok := args[0].Export().(map[string]any); ok {
+			attrs = m
+		}
+		args = args[1:]
+	}
+	return &Element{Tag: tag, Attrs: attrs, Children: nodesFromArgs(args)}
+}
+
+func pageFromCall(call goja.FunctionCall) *Document {
+	title := ""
+	args := call.Arguments
+	if len(args) > 0 && isAttrs(args[0]) {
+		if m, ok := args[0].Export().(map[string]any); ok {
+			if t, ok := m["title"]; ok {
+				title = fmt.Sprint(t)
+			}
+		}
+		args = args[1:]
+	}
+	children := nodesFromArgs(args)
+	doc := &Document{Title: title}
+	for _, child := range children {
+		if e, ok := child.(*Element); ok && headTags[e.Tag] {
+			doc.Head = append(doc.Head, child)
+		} else {
+			doc.Body = append(doc.Body, child)
+		}
+	}
+	return doc
+}
+
+func nodesFromArgs(args []goja.Value) []Node {
+	var out []Node
+	for _, arg := range args {
+		if arg == nil || goja.IsUndefined(arg) || goja.IsNull(arg) {
+			continue
+		}
+		n, err := NormalizeExport(arg.Export())
+		if err != nil {
+			out = append(out, &Text{Value: err.Error()})
+			continue
+		}
+		if f, ok := n.(*Fragment); ok {
+			out = append(out, f.Children...)
+		} else {
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
+func isAttrs(v goja.Value) bool {
+	if v == nil || goja.IsUndefined(v) || goja.IsNull(v) {
+		return false
+	}
+	switch v.Export().(type) {
+	case Node, string, []any, []Node, int, int64, float64, bool:
+		return false
+	case map[string]any:
+		return true
+	default:
+		return false
+	}
+}

--- a/modules/uidsl/node.go
+++ b/modules/uidsl/node.go
@@ -1,0 +1,32 @@
+package uidsl
+
+// Node is a normalized HTML node produced by ui.dsl.
+type Node interface{ isNode() }
+
+type Document struct {
+	Title string
+	Head  []Node
+	Body  []Node
+}
+
+func (*Document) isNode() {}
+
+type Element struct {
+	Tag      string
+	Attrs    map[string]any
+	Children []Node
+}
+
+func (*Element) isNode() {}
+
+type Text struct{ Value string }
+
+func (*Text) isNode() {}
+
+type RawHTML struct{ Value string }
+
+func (*RawHTML) isNode() {}
+
+type Fragment struct{ Children []Node }
+
+func (*Fragment) isNode() {}

--- a/modules/uidsl/render.go
+++ b/modules/uidsl/render.go
@@ -1,0 +1,215 @@
+package uidsl
+
+import (
+	"bytes"
+	"fmt"
+	"html"
+	"sort"
+	"strings"
+
+	"github.com/dop251/goja"
+)
+
+func RenderAny(vm *goja.Runtime, v goja.Value) (string, error) {
+	n, err := Normalize(vm, v)
+	if err != nil {
+		return "", err
+	}
+	var b bytes.Buffer
+	if err := renderNode(&b, n); err != nil {
+		return "", err
+	}
+	return b.String(), nil
+}
+
+func Normalize(vm *goja.Runtime, v goja.Value) (Node, error) {
+	if v == nil || goja.IsUndefined(v) || goja.IsNull(v) {
+		return &Fragment{}, nil
+	}
+	return NormalizeExport(v.Export())
+}
+
+func NormalizeExport(x any) (Node, error) {
+	switch v := x.(type) {
+	case nil:
+		return &Fragment{}, nil
+	case Node:
+		return v, nil
+	case string:
+		return &Text{Value: v}, nil
+	case int, int64, float64, bool:
+		return &Text{Value: fmt.Sprint(v)}, nil
+	case []Node:
+		return &Fragment{Children: v}, nil
+	case []any:
+		children, err := normalizeChildren(v)
+		if err != nil {
+			return nil, err
+		}
+		return &Fragment{Children: children}, nil
+	default:
+		return &Text{Value: fmt.Sprint(v)}, nil
+	}
+}
+
+func normalizeChildren(values []any) ([]Node, error) {
+	var out []Node
+	for _, v := range values {
+		if v == nil {
+			continue
+		}
+		n, err := NormalizeExport(v)
+		if err != nil {
+			return nil, err
+		}
+		if f, ok := n.(*Fragment); ok {
+			out = append(out, f.Children...)
+		} else {
+			out = append(out, n)
+		}
+	}
+	return out, nil
+}
+
+func renderNode(b *bytes.Buffer, n Node) error {
+	switch v := n.(type) {
+	case *Document:
+		b.WriteString("<!doctype html><html><head><meta charset=\"utf-8\"><meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">")
+		if v.Title != "" {
+			b.WriteString("<title>")
+			b.WriteString(html.EscapeString(v.Title))
+			b.WriteString("</title>")
+		}
+		for _, c := range v.Head {
+			if err := renderNode(b, c); err != nil {
+				return err
+			}
+		}
+		b.WriteString("</head><body>")
+		for _, c := range v.Body {
+			if err := renderNode(b, c); err != nil {
+				return err
+			}
+		}
+		b.WriteString("</body></html>")
+	case *Element:
+		b.WriteByte('<')
+		b.WriteString(v.Tag)
+		renderAttrs(b, v.Attrs)
+		if voidTags[v.Tag] {
+			b.WriteByte('>')
+			return nil
+		}
+		b.WriteByte('>')
+		for _, c := range v.Children {
+			if err := renderNode(b, c); err != nil {
+				return err
+			}
+		}
+		b.WriteString("</")
+		b.WriteString(v.Tag)
+		b.WriteByte('>')
+	case *Text:
+		b.WriteString(html.EscapeString(v.Value))
+	case *RawHTML:
+		b.WriteString(v.Value)
+	case *Fragment:
+		for _, c := range v.Children {
+			if err := renderNode(b, c); err != nil {
+				return err
+			}
+		}
+	default:
+		return fmt.Errorf("unknown node type %T", n)
+	}
+	return nil
+}
+
+func renderAttrs(b *bytes.Buffer, attrs map[string]any) {
+	if len(attrs) == 0 {
+		return
+	}
+	keys := make([]string, 0, len(attrs))
+	for k := range attrs {
+		if k != "" {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		v := attrs[k]
+		if v == nil {
+			continue
+		}
+		if bv, ok := v.(bool); ok {
+			if bv {
+				b.WriteByte(' ')
+				b.WriteString(k)
+			}
+			continue
+		}
+		value := attrValue(k, v)
+		if value == "" {
+			continue
+		}
+		b.WriteByte(' ')
+		b.WriteString(k)
+		b.WriteString("=\"")
+		b.WriteString(html.EscapeString(value))
+		b.WriteByte('"')
+	}
+}
+
+func attrValue(k string, v any) string {
+	if k == "class" {
+		switch x := v.(type) {
+		case []any:
+			parts := []string{}
+			for _, p := range x {
+				if p != nil && fmt.Sprint(p) != "" && fmt.Sprint(p) != "false" {
+					parts = append(parts, fmt.Sprint(p))
+				}
+			}
+			return strings.Join(parts, " ")
+		case map[string]any:
+			parts := []string{}
+			for name, enabled := range x {
+				if truthy(enabled) {
+					parts = append(parts, name)
+				}
+			}
+			sort.Strings(parts)
+			return strings.Join(parts, " ")
+		}
+	}
+	if k == "style" {
+		if m, ok := v.(map[string]any); ok {
+			keys := make([]string, 0, len(m))
+			for kk := range m {
+				keys = append(keys, kk)
+			}
+			sort.Strings(keys)
+			parts := []string{}
+			for _, kk := range keys {
+				parts = append(parts, kk+":"+fmt.Sprint(m[kk]))
+			}
+			return strings.Join(parts, ";")
+		}
+	}
+	return fmt.Sprint(v)
+}
+
+func truthy(v any) bool {
+	switch x := v.(type) {
+	case bool:
+		return x
+	case nil:
+		return false
+	case string:
+		return x != "" && x != "false"
+	default:
+		return true
+	}
+}
+
+var voidTags = map[string]bool{"area": true, "base": true, "br": true, "col": true, "embed": true, "hr": true, "img": true, "input": true, "link": true, "meta": true, "source": true, "track": true, "wbr": true}

--- a/modules/uidsl/render.go
+++ b/modules/uidsl/render.go
@@ -149,7 +149,7 @@ func renderAttrs(b *bytes.Buffer, attrs map[string]any) {
 			continue
 		}
 		value := attrValue(k, v)
-		if value == "" {
+		if value == "" && k != "value" {
 			continue
 		}
 		b.WriteByte(' ')

--- a/modules/uidsl/render_attrs_test.go
+++ b/modules/uidsl/render_attrs_test.go
@@ -1,0 +1,43 @@
+package uidsl
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dop251/goja"
+)
+
+func TestRenderOptionPreservesEmptyValue(t *testing.T) {
+	vm := goja.New()
+	moduleObj := vm.NewObject()
+	exports := vm.NewObject()
+	if err := moduleObj.Set("exports", exports); err != nil {
+		t.Fatal(err)
+	}
+	Loader(vm, moduleObj)
+	optionFn, ok := goja.AssertFunction(exports.Get("option"))
+	if !ok {
+		t.Fatalf("option export is not callable")
+	}
+	attrs := vm.NewObject()
+	if err := attrs.Set("value", ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := attrs.Set("selected", true); err != nil {
+		t.Fatal(err)
+	}
+	node, err := optionFn(goja.Undefined(), attrs, vm.ToValue("All columns"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	rendered, err := RenderAny(vm, node)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(rendered, `value=""`) {
+		t.Fatalf("expected empty value attribute in %q", rendered)
+	}
+	if !strings.Contains(rendered, `selected`) {
+		t.Fatalf("expected selected attribute in %q", rendered)
+	}
+}

--- a/modules/uidsl/render_test.go
+++ b/modules/uidsl/render_test.go
@@ -1,0 +1,42 @@
+package uidsl
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dop251/goja"
+)
+
+func TestRenderEscapesTextAndAttributes(t *testing.T) {
+	vm := goja.New()
+	node := vm.ToValue(&Element{Tag: "div", Attrs: map[string]any{"class": "a&b", "hidden": true}, Children: []Node{&Text{Value: "<hello>"}}})
+	got, err := RenderAny(vm, node)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != `<div class="a&amp;b" hidden>&lt;hello&gt;</div>` {
+		t.Fatalf("unexpected render: %s", got)
+	}
+}
+
+func TestUIDSLModulePage(t *testing.T) {
+	vm := goja.New()
+	mod := vm.NewObject()
+	exports := vm.NewObject()
+	_ = mod.Set("exports", exports)
+	Loader(vm, mod)
+	_ = vm.Set("ui", exports)
+	v, err := vm.RunString(`ui.page({title:"Demo"}, ui.link({rel:"stylesheet", href:"/x.css"}), ui.main(ui.h1("Hi")))`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := RenderAny(vm, v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"<!doctype html>", "<title>Demo</title>", `<link href="/x.css" rel="stylesheet">`, "<main><h1>Hi</h1></main>"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("render missing %q in %s", want, got)
+		}
+	}
+}

--- a/modules/uidsl/table.go
+++ b/modules/uidsl/table.go
@@ -1,0 +1,771 @@
+package uidsl
+
+import (
+	"fmt"
+	"net/url"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/dop251/goja"
+)
+
+type TableBuilder struct {
+	ID        string
+	Rows      []map[string]any
+	features  TableFeatures
+	dataFn    goja.Callable
+	columnsFn goja.Callable
+}
+
+type TableFeatures struct {
+	Pagination   bool
+	Sorting      bool
+	ColumnPicker bool
+	Filters      bool
+	PageSize     int
+}
+
+type ColumnSpec struct {
+	Name       string
+	Label      string
+	Kind       string
+	Sortable   bool
+	Filterable bool
+	Align      string
+	LinkHref   string
+	LinkFn     goja.Callable
+}
+
+type RenderContext struct {
+	Query  map[string]any    `json:"query"`
+	Page   map[string]any    `json:"page"`
+	Order  map[string]any    `json:"order"`
+	State  map[string]any    `json:"state"`
+	Filter map[string]any    `json:"filter"`
+	Params map[string]string `json:"params"`
+}
+
+func newTableBuilder(id string) *TableBuilder {
+	return &TableBuilder{ID: id, Rows: []map[string]any{}}
+}
+
+func tableFromRows(id string, value goja.Value) (*TableBuilder, error) {
+	rows, err := rowsFromValue(value)
+	if err != nil {
+		return nil, err
+	}
+	return &TableBuilder{ID: id, Rows: rows}, nil
+}
+
+func tableBuilderObject(vm *goja.Runtime, builder *TableBuilder) goja.Value {
+	obj := vm.NewObject()
+	_ = obj.Set("features", func(callback goja.Value) goja.Value {
+		if fn, ok := goja.AssertFunction(callback); ok {
+			_, _ = fn(goja.Undefined(), featureBuilderObject(vm, &builder.features))
+		}
+		return obj
+	})
+	_ = obj.Set("data", func(callback goja.Value) goja.Value {
+		if fn, ok := goja.AssertFunction(callback); ok {
+			builder.dataFn = fn
+		}
+		return obj
+	})
+	_ = obj.Set("columns", func(callback goja.Value) goja.Value {
+		if fn, ok := goja.AssertFunction(callback); ok {
+			builder.columnsFn = fn
+		}
+		return obj
+	})
+	_ = obj.Set("render", func(input map[string]any) (Node, error) {
+		return builder.render(vm, input)
+	})
+	return obj
+}
+
+func (t *TableBuilder) render(vm *goja.Runtime, input map[string]any) (Node, error) {
+	ctx := t.context(input)
+	rows := append([]map[string]any(nil), t.Rows...)
+	total := len(rows)
+	if t.dataFn != nil {
+		value, err := t.dataFn(goja.Undefined(), vm.ToValue(ctx))
+		if err != nil {
+			return nil, err
+		}
+		dataRows, dataTotal, err := dataResultFromValue(value)
+		if err != nil {
+			return nil, err
+		}
+		rows = dataRows
+		total = dataTotal
+	}
+	columns, err := t.resolveColumns(vm, ctx, rows)
+	if err != nil {
+		return nil, err
+	}
+	if t.dataFn == nil {
+		rows = filterRows(rows, columns, ctx.Filter)
+		rows = sortRows(rows, columns, ctx.Order)
+		total = len(rows)
+		if t.features.Pagination {
+			rows = paginateRows(rows, ctx)
+		}
+	}
+	return t.node(vm, ctx, rows, total, columns), nil
+}
+
+func (t *TableBuilder) context(input map[string]any) RenderContext {
+	query := mapFromAny(input["query"])
+	params := stringMapFromAny(input["params"])
+	pageSize := intFromAny(query["limit"], t.features.PageSize)
+	if pageSize <= 0 {
+		pageSize = 25
+	}
+	if pageSize > 500 {
+		pageSize = 500
+	}
+	pageIndex := intFromAny(query["page"], 1)
+	if pageIndex < 1 {
+		pageIndex = 1
+	}
+	sortKey := stringFromAny(query["sort"])
+	dir := strings.ToLower(stringFromAny(query["dir"]))
+	if dir != "desc" {
+		dir = "asc"
+	}
+	return RenderContext{
+		Query:  query,
+		Params: params,
+		State:  map[string]any{},
+		Filter: filterMapFromQuery(query),
+		Page: map[string]any{
+			"index":  pageIndex,
+			"size":   pageSize,
+			"limit":  pageSize,
+			"offset": (pageIndex - 1) * pageSize,
+		},
+		Order: map[string]any{"key": sortKey, "dir": dir},
+	}
+}
+
+func (t *TableBuilder) resolveColumns(vm *goja.Runtime, ctx RenderContext, rows []map[string]any) ([]ColumnSpec, error) {
+	if t.columnsFn == nil {
+		cols := tableColumns(rows)
+		ret := make([]ColumnSpec, 0, len(cols))
+		for _, col := range cols {
+			ret = append(ret, ColumnSpec{Name: col, Label: col, Kind: "text", Filterable: true})
+		}
+		return ret, nil
+	}
+	cols := []ColumnSpec{}
+	cb := columnBuilderObject(vm, &cols)
+	value, err := t.columnsFn(goja.Undefined(), cb, vm.ToValue(ctx))
+	if err != nil {
+		return nil, err
+	}
+	if exported := value.Export(); exported != nil {
+		if parsed := columnsFromExport(exported); len(parsed) > 0 {
+			return parsed, nil
+		}
+	}
+	return cols, nil
+}
+
+func (t *TableBuilder) node(vm *goja.Runtime, ctx RenderContext, rows []map[string]any, total int, columns []ColumnSpec) Node {
+	headCells := make([]Node, 0, len(columns))
+	for _, column := range columns {
+		label := column.Label
+		if label == "" {
+			label = column.Name
+		}
+		var child Node = &Text{Value: label}
+		if t.features.Sorting && column.Sortable {
+			dir := "asc"
+			if stringFromAny(ctx.Order["key"]) == column.Name && stringFromAny(ctx.Order["dir"]) == "asc" {
+				dir = "desc"
+			}
+			child = &Element{Tag: "a", Attrs: map[string]any{"href": queryHref(ctx.Query, map[string]any{"sort": column.Name, "dir": dir, "page": 1})}, Children: []Node{&Text{Value: label}}}
+		}
+		headCells = append(headCells, &Element{Tag: "th", Attrs: map[string]any{"data-column": column.Name}, Children: []Node{child}})
+	}
+	bodyRows := make([]Node, 0, len(rows))
+	for _, row := range rows {
+		cells := make([]Node, 0, len(columns))
+		for _, column := range columns {
+			attrs := map[string]any{"data-column": column.Name}
+			if column.Align != "" {
+				attrs["class"] = "align-" + column.Align
+			}
+			cells = append(cells, &Element{Tag: "td", Attrs: attrs, Children: []Node{cellNode(vm, row, row[column.Name], column)}})
+		}
+		bodyRows = append(bodyRows, &Element{Tag: "tr", Children: cells})
+	}
+	if len(bodyRows) == 0 {
+		bodyRows = append(bodyRows, &Element{Tag: "tr", Attrs: map[string]any{"class": "ui-table-empty-row"}, Children: []Node{
+			&Element{Tag: "td", Attrs: map[string]any{"class": "ui-table-empty", "colspan": len(columns)}, Children: []Node{&Text{Value: "No rows match the current filters."}}},
+		}})
+	}
+	attrs := map[string]any{"class": tableClass(t.features)}
+	if t.ID != "" {
+		attrs["id"] = t.ID
+	}
+	table := &Element{Tag: "table", Attrs: attrs, Children: []Node{
+		&Element{Tag: "thead", Children: []Node{&Element{Tag: "tr", Children: headCells}}},
+		&Element{Tag: "tbody", Children: bodyRows},
+	}}
+	children := []Node{}
+	if t.features.Filters {
+		children = append(children, filtersNode(ctx, columns))
+	}
+	children = append(children, table)
+	if t.features.Pagination {
+		children = append(children, paginationNode(ctx, total))
+	}
+	if len(children) == 1 {
+		return children[0]
+	}
+	return &Fragment{Children: children}
+}
+
+func featureBuilderObject(vm *goja.Runtime, features *TableFeatures) goja.Value {
+	obj := vm.NewObject()
+	_ = obj.Set("pagination", func(options ...map[string]any) goja.Value {
+		features.Pagination = true
+		if len(options) > 0 {
+			features.PageSize = intFromAny(options[0]["size"], features.PageSize)
+		}
+		return obj
+	})
+	_ = obj.Set("sorting", func(_ ...any) goja.Value { features.Sorting = true; return obj })
+	_ = obj.Set("filters", func(_ ...any) goja.Value { features.Filters = true; return obj })
+	_ = obj.Set("columnPicker", func(_ ...any) goja.Value { features.ColumnPicker = true; return obj })
+	return obj
+}
+
+func columnBuilderObject(vm *goja.Runtime, columns *[]ColumnSpec) goja.Value {
+	obj := vm.NewObject()
+	add := func(kind string, name string) goja.Value {
+		col := ColumnSpec{Name: name, Label: name, Kind: kind}
+		*columns = append(*columns, col)
+		return columnObject(vm, &(*columns)[len(*columns)-1], columns)
+	}
+	for _, kind := range []string{"text", "badge", "money", "date", "tags"} {
+		kind := kind
+		_ = obj.Set(kind, func(name string, _ ...map[string]any) goja.Value { return add(kind, name) })
+	}
+	return obj
+}
+
+func columnObject(vm *goja.Runtime, col *ColumnSpec, columns *[]ColumnSpec) goja.Value {
+	obj := vm.NewObject()
+	_ = obj.Set("label", func(label string) goja.Value { col.Label = label; return obj })
+	_ = obj.Set("sortable", func(_ ...any) goja.Value { col.Sortable = true; return obj })
+	_ = obj.Set("filterable", func(_ ...any) goja.Value { col.Filterable = true; return obj })
+	_ = obj.Set("align", func(align string) goja.Value { col.Align = align; return obj })
+	_ = obj.Set("mono", func(_ ...any) goja.Value { return obj })
+	_ = obj.Set("truncate", func(_ ...any) goja.Value { return obj })
+	_ = obj.Set("link", func(target goja.Value) goja.Value {
+		if fn, ok := goja.AssertFunction(target); ok {
+			col.LinkFn = fn
+		} else if !goja.IsUndefined(target) && !goja.IsNull(target) {
+			col.LinkHref = fmt.Sprint(target.Export())
+		}
+		return obj
+	})
+	for _, kind := range []string{"text", "badge", "money", "date", "tags"} {
+		kind := kind
+		_ = obj.Set(kind, func(name string, _ ...map[string]any) goja.Value {
+			next := ColumnSpec{Name: name, Label: name, Kind: kind}
+			*columns = append(*columns, next)
+			return columnObject(vm, &(*columns)[len(*columns)-1], columns)
+		})
+	}
+	return obj
+}
+
+func rowsFromValue(value goja.Value) ([]map[string]any, error) {
+	if value == nil || goja.IsUndefined(value) || goja.IsNull(value) {
+		return []map[string]any{}, nil
+	}
+	exported := value.Export()
+	rows, ok := rowsFromExport(exported)
+	if !ok {
+		return nil, fmt.Errorf("ui.table.fromRows expects an array, got %T", exported)
+	}
+	return rows, nil
+}
+
+func rowsFromExport(exported any) ([]map[string]any, bool) {
+	if exported == nil {
+		return []map[string]any{}, true
+	}
+	if slice, ok := exported.([]any); ok {
+		return rowsFromSlice(slice), true
+	}
+	rv := reflect.ValueOf(exported)
+	if !rv.IsValid() || (rv.Kind() != reflect.Slice && rv.Kind() != reflect.Array) {
+		return nil, false
+	}
+	rows := make([]map[string]any, 0, rv.Len())
+	for i := 0; i < rv.Len(); i++ {
+		rows = append(rows, rowFromAny(rv.Index(i).Interface()))
+	}
+	return rows, true
+}
+
+func rowsFromSlice(slice []any) []map[string]any {
+	rows := make([]map[string]any, 0, len(slice))
+	for _, item := range slice {
+		rows = append(rows, rowFromAny(item))
+	}
+	return rows
+}
+
+func rowFromAny(item any) map[string]any {
+	if row, ok := item.(map[string]any); ok {
+		return row
+	}
+	rv := reflect.ValueOf(item)
+	if rv.IsValid() && rv.Kind() == reflect.Map && rv.Type().Key().Kind() == reflect.String {
+		row := map[string]any{}
+		iter := rv.MapRange()
+		for iter.Next() {
+			row[iter.Key().String()] = iter.Value().Interface()
+		}
+		return row
+	}
+	return map[string]any{"value": item}
+}
+
+func dataResultFromValue(value goja.Value) ([]map[string]any, int, error) {
+	exported := value.Export()
+	if rows, ok := rowsFromExport(exported); ok {
+		return rows, len(rows), nil
+	}
+	m, ok := exported.(map[string]any)
+	if !ok {
+		return nil, 0, fmt.Errorf("table data callback must return rows array or {rows,total}, got %T", exported)
+	}
+	rows, _ := rowsFromExport(m["rows"])
+	total := intFromAny(m["total"], len(rows))
+	return rows, total, nil
+}
+
+func tableColumns(rows []map[string]any) []string {
+	seen := map[string]struct{}{}
+	columns := []string{}
+	for _, row := range rows {
+		keys := make([]string, 0, len(row))
+		for key := range row {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			columns = append(columns, key)
+		}
+	}
+	return columns
+}
+
+func columnsFromExport(exported any) []ColumnSpec {
+	items, ok := exported.([]any)
+	if !ok {
+		return nil
+	}
+	ret := []ColumnSpec{}
+	for _, item := range items {
+		if m, ok := item.(map[string]any); ok {
+			name := stringFromAny(m["name"])
+			if name == "" {
+				continue
+			}
+			ret = append(ret, ColumnSpec{Name: name, Label: stringFromAny(m["label"]), Kind: stringFromAny(m["kind"]), Sortable: boolFromAny(m["sortable"]), Filterable: boolFromAny(m["filterable"]), Align: stringFromAny(m["align"])})
+		}
+	}
+	return ret
+}
+
+func tableClass(features TableFeatures) []any {
+	classes := []any{"ui-table"}
+	if features.Pagination {
+		classes = append(classes, "ui-table--pagination")
+	}
+	if features.Sorting {
+		classes = append(classes, "ui-table--sorting")
+	}
+	if features.ColumnPicker {
+		classes = append(classes, "ui-table--column-picker")
+	}
+	if features.Filters {
+		classes = append(classes, "ui-table--filters")
+	}
+	return classes
+}
+
+func paginationNode(ctx RenderContext, total int) Node {
+	page := intFromAny(ctx.Page["index"], 1)
+	limit := intFromAny(ctx.Page["limit"], 25)
+	pages := 1
+	if limit > 0 && total > 0 {
+		pages = (total + limit - 1) / limit
+	}
+	children := []Node{&Text{Value: fmt.Sprintf("Page %d of %d (%d rows)", page, pages, total)}}
+	if page > 1 {
+		children = append(children, &Text{Value: " "}, &Element{Tag: "a", Attrs: map[string]any{"href": queryHref(ctx.Query, map[string]any{"page": page - 1})}, Children: []Node{&Text{Value: "Previous"}}})
+	}
+	if page < pages {
+		children = append(children, &Text{Value: " "}, &Element{Tag: "a", Attrs: map[string]any{"href": queryHref(ctx.Query, map[string]any{"page": page + 1})}, Children: []Node{&Text{Value: "Next"}}})
+	}
+	return &Element{Tag: "nav", Attrs: map[string]any{"class": "ui-table-pagination"}, Children: children}
+}
+
+func cellNode(vm *goja.Runtime, row map[string]any, value any, col ColumnSpec) Node {
+	text := formatCell(value, col)
+	var child Node
+	switch col.Kind {
+	case "badge":
+		child = &Element{Tag: "span", Attrs: map[string]any{"class": []any{"ui-badge", "ui-badge--" + cssToken(text)}}, Children: []Node{&Text{Value: text}}}
+	case "tags":
+		parts := splitTags(value)
+		children := make([]Node, 0, len(parts))
+		for i, part := range parts {
+			if i > 0 {
+				children = append(children, &Text{Value: " "})
+			}
+			children = append(children, &Element{Tag: "span", Attrs: map[string]any{"class": []any{"ui-tag", "ui-tag--" + cssToken(part)}}, Children: []Node{&Text{Value: part}}})
+		}
+		child = &Fragment{Children: children}
+	default:
+		child = &Text{Value: text}
+	}
+	if href := linkHref(vm, row, value, col); href != "" {
+		return &Element{Tag: "a", Attrs: map[string]any{"href": href}, Children: []Node{child}}
+	}
+	return child
+}
+
+func linkHref(vm *goja.Runtime, row map[string]any, value any, col ColumnSpec) string {
+	if col.LinkFn != nil {
+		ret, err := col.LinkFn(goja.Undefined(), vm.ToValue(row), vm.ToValue(value))
+		if err != nil || goja.IsUndefined(ret) || goja.IsNull(ret) {
+			return ""
+		}
+		return fmt.Sprint(ret.Export())
+	}
+	if col.LinkHref == "" {
+		return ""
+	}
+	href := col.LinkHref
+	for key, value := range row {
+		href = strings.ReplaceAll(href, "{"+key+"}", url.QueryEscape(fmt.Sprint(value)))
+	}
+	return href
+}
+
+func formatCell(value any, col ColumnSpec) string {
+	if value == nil {
+		return ""
+	}
+	if col.Kind == "money" {
+		cents := intFromAny(value, 0)
+		return fmt.Sprintf("$%d.%02d", cents/100, absInt(cents%100))
+	}
+	return fmt.Sprint(value)
+}
+
+func filtersNode(ctx RenderContext, columns []ColumnSpec) Node {
+	children := []Node{}
+	for _, key := range []string{"sort", "dir"} {
+		if value := stringFromAny(ctx.Query[key]); value != "" {
+			children = append(children, &Element{Tag: "input", Attrs: map[string]any{"type": "hidden", "name": key, "value": value}})
+		}
+	}
+	children = append(children,
+		&Element{Tag: "label", Children: []Node{&Text{Value: "Search "}, &Element{Tag: "input", Attrs: map[string]any{"type": "search", "name": "q", "value": stringFromAny(ctx.Filter["q"]), "placeholder": "all columns"}}}},
+	)
+	for _, column := range columns {
+		if !column.Filterable {
+			continue
+		}
+		label := column.Label
+		if label == "" {
+			label = column.Name
+		}
+		name := "filter." + column.Name
+		children = append(children, &Element{Tag: "label", Children: []Node{&Text{Value: label + " "}, &Element{Tag: "input", Attrs: map[string]any{"type": "search", "name": name, "value": stringFromAny(ctx.Filter[column.Name])}}}})
+	}
+	children = append(children,
+		&Element{Tag: "button", Attrs: map[string]any{"type": "submit"}, Children: []Node{&Text{Value: "Filter"}}},
+		&Text{Value: " "},
+		&Element{Tag: "a", Attrs: map[string]any{"href": "?"}, Children: []Node{&Text{Value: "Clear"}}},
+	)
+	return &Element{Tag: "form", Attrs: map[string]any{"class": "ui-table-filters", "method": "get"}, Children: children}
+}
+
+func filterRows(rows []map[string]any, columns []ColumnSpec, filter map[string]any) []map[string]any {
+	if len(filter) == 0 {
+		return rows
+	}
+	q := strings.ToLower(strings.TrimSpace(stringFromAny(filter["q"])))
+	out := make([]map[string]any, 0, len(rows))
+	for _, row := range rows {
+		if q != "" {
+			matched := false
+			for _, column := range columns {
+				if strings.Contains(strings.ToLower(fmt.Sprint(row[column.Name])), q) {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				continue
+			}
+		}
+		ok := true
+		for _, column := range columns {
+			want := strings.ToLower(strings.TrimSpace(stringFromAny(filter[column.Name])))
+			if want == "" {
+				continue
+			}
+			if !strings.Contains(strings.ToLower(fmt.Sprint(row[column.Name])), want) {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			out = append(out, row)
+		}
+	}
+	return out
+}
+
+func sortRows(rows []map[string]any, columns []ColumnSpec, order map[string]any) []map[string]any {
+	key := stringFromAny(order["key"])
+	if key == "" {
+		return rows
+	}
+	allowed := false
+	for _, column := range columns {
+		if column.Name == key && column.Sortable {
+			allowed = true
+			break
+		}
+	}
+	if !allowed {
+		return rows
+	}
+	desc := stringFromAny(order["dir"]) == "desc"
+	out := append([]map[string]any(nil), rows...)
+	sort.SliceStable(out, func(i, j int) bool {
+		cmp := compareAny(out[i][key], out[j][key])
+		if desc {
+			return cmp > 0
+		}
+		return cmp < 0
+	})
+	return out
+}
+
+func paginateRows(rows []map[string]any, ctx RenderContext) []map[string]any {
+	limit := intFromAny(ctx.Page["limit"], 25)
+	offset := intFromAny(ctx.Page["offset"], 0)
+	if limit <= 0 || offset >= len(rows) {
+		if offset >= len(rows) {
+			return []map[string]any{}
+		}
+		return rows
+	}
+	end := offset + limit
+	if end > len(rows) {
+		end = len(rows)
+	}
+	return rows[offset:end]
+}
+
+func compareAny(a, b any) int {
+	af, aok := numeric(a)
+	bf, bok := numeric(b)
+	if aok && bok {
+		switch {
+		case af < bf:
+			return -1
+		case af > bf:
+			return 1
+		default:
+			return 0
+		}
+	}
+	as := strings.ToLower(fmt.Sprint(a))
+	bs := strings.ToLower(fmt.Sprint(b))
+	return strings.Compare(as, bs)
+}
+
+func numeric(v any) (float64, bool) {
+	switch x := v.(type) {
+	case int:
+		return float64(x), true
+	case int64:
+		return float64(x), true
+	case float64:
+		return x, true
+	case string:
+		f, err := strconv.ParseFloat(x, 64)
+		return f, err == nil
+	default:
+		return 0, false
+	}
+}
+
+func queryHref(query map[string]any, updates map[string]any) string {
+	values := url.Values{}
+	for key, value := range query {
+		if value == nil {
+			continue
+		}
+		values.Set(key, fmt.Sprint(value))
+	}
+	for key, value := range updates {
+		values.Set(key, fmt.Sprint(value))
+	}
+	encoded := values.Encode()
+	if encoded == "" {
+		return "?"
+	}
+	return "?" + encoded
+}
+
+func filterMapFromQuery(query map[string]any) map[string]any {
+	ret := map[string]any{}
+	if q := strings.TrimSpace(stringFromAny(query["q"])); q != "" {
+		ret["q"] = q
+	}
+	for key, value := range query {
+		if value == nil || strings.TrimSpace(stringFromAny(value)) == "" {
+			continue
+		}
+		if strings.HasPrefix(key, "filter.") {
+			ret[strings.TrimPrefix(key, "filter.")] = value
+		}
+		if strings.HasPrefix(key, "filter_") {
+			ret[strings.TrimPrefix(key, "filter_")] = value
+		}
+	}
+	return ret
+}
+
+func splitTags(value any) []string {
+	if value == nil {
+		return []string{}
+	}
+	switch v := value.(type) {
+	case []any:
+		parts := make([]string, 0, len(v))
+		for _, item := range v {
+			if s := strings.TrimSpace(fmt.Sprint(item)); s != "" {
+				parts = append(parts, s)
+			}
+		}
+		return parts
+	case []string:
+		return v
+	default:
+		text := fmt.Sprint(value)
+		fields := strings.FieldsFunc(text, func(r rune) bool { return r == ',' || r == ';' })
+		parts := []string{}
+		for _, field := range fields {
+			if s := strings.TrimSpace(field); s != "" {
+				parts = append(parts, s)
+			}
+		}
+		return parts
+	}
+}
+
+func cssToken(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	var b strings.Builder
+	lastDash := false
+	for _, r := range value {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+			lastDash = false
+			continue
+		}
+		if !lastDash {
+			b.WriteByte('-')
+			lastDash = true
+		}
+	}
+	ret := strings.Trim(b.String(), "-")
+	if ret == "" {
+		return "empty"
+	}
+	return ret
+}
+
+func absInt(v int) int {
+	if v < 0 {
+		return -v
+	}
+	return v
+}
+
+func mapFromAny(value any) map[string]any {
+	ret := map[string]any{}
+	if m, ok := value.(map[string]any); ok {
+		for k, v := range m {
+			ret[k] = v
+		}
+	}
+	return ret
+}
+
+func stringMapFromAny(value any) map[string]string {
+	ret := map[string]string{}
+	if m, ok := value.(map[string]any); ok {
+		for k, v := range m {
+			ret[k] = fmt.Sprint(v)
+		}
+	}
+	return ret
+}
+
+func intFromAny(value any, fallback int) int {
+	switch v := value.(type) {
+	case int:
+		return v
+	case int64:
+		return int(v)
+	case float64:
+		return int(v)
+	case string:
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return fallback
+}
+
+func stringFromAny(value any) string {
+	if value == nil {
+		return ""
+	}
+	return fmt.Sprint(value)
+}
+
+func boolFromAny(value any) bool {
+	switch v := value.(type) {
+	case bool:
+		return v
+	case string:
+		return v == "true"
+	default:
+		return false
+	}
+}

--- a/modules/uidsl/table_filters_test.go
+++ b/modules/uidsl/table_filters_test.go
@@ -1,0 +1,80 @@
+package uidsl
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dop251/goja"
+)
+
+func TestTableFromRowsFiltersSortsAndPaginates(t *testing.T) {
+	vm := goja.New()
+	obj := vm.NewObject()
+	exports := vm.NewObject()
+	_ = obj.Set("exports", exports)
+	Loader(vm, obj)
+	_ = vm.Set("ui", exports)
+	value, err := vm.RunString(`
+		ui.table.fromRows("customers", [
+		  { id: 3, name: "Carla Canvas", segment: "prospect", total_cents: 0 },
+		  { id: 1, name: "Alice Example", segment: "vip", total_cents: 17998 },
+		  { id: 2, name: "Bob Browser", segment: "active", total_cents: 2500 }
+		])
+		.columns(c => c
+		  .text("id").label("ID").sortable()
+		  .text("name").label("Customer").sortable().filterable()
+		  .badge("segment").label("Segment").filterable()
+		  .money("total_cents").label("Total").align("right")
+		)
+		.features(f => f.filters().pagination({ size: 1 }).sorting())
+		.render({ query: { q: "example", sort: "id", dir: "desc", page: "1" } })
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	html, err := RenderAny(vm, value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		`<form class="ui-table-filters" method="get">`,
+		`name="q" placeholder="all columns" type="search" value="example"`,
+		`<td data-column="name">Alice Example</td>`,
+		`<span class="ui-badge ui-badge--vip">vip</span>`,
+		`<td class="align-right" data-column="total_cents">$179.98</td>`,
+		`Page 1 of 1 (1 rows)`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("missing %q in %s", want, html)
+		}
+	}
+	for _, notWant := range []string{"Bob Browser", "Carla Canvas"} {
+		if strings.Contains(html, notWant) {
+			t.Fatalf("unexpected %q in %s", notWant, html)
+		}
+	}
+}
+
+func TestTableFilterEmptyState(t *testing.T) {
+	vm := goja.New()
+	obj := vm.NewObject()
+	exports := vm.NewObject()
+	_ = obj.Set("exports", exports)
+	Loader(vm, obj)
+	_ = vm.Set("ui", exports)
+	value, err := vm.RunString(`
+		ui.table.fromRows("customers", [{ name: "Alice" }])
+		  .features(f => f.filters())
+		  .render({ query: { q: "zzz" } })
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	html, err := RenderAny(vm, value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(html, `No rows match the current filters.`) {
+		t.Fatalf("missing empty state in %s", html)
+	}
+}

--- a/modules/uidsl/table_links_test.go
+++ b/modules/uidsl/table_links_test.go
@@ -1,0 +1,58 @@
+package uidsl
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dop251/goja"
+)
+
+func TestTableColumnLinks(t *testing.T) {
+	vm := goja.New()
+	obj := vm.NewObject()
+	exports := vm.NewObject()
+	_ = obj.Set("exports", exports)
+	Loader(vm, obj)
+	_ = vm.Set("ui", exports)
+	value, err := vm.RunString(`
+		ui.table.fromRows("customers", [{ id: 7, name: "Alice & Co" }])
+		  .columns(c => c.text("name").label("Customer").link(row => "/customers/" + row.id))
+		  .render({ query: {} })
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	html, err := RenderAny(vm, value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `<td data-column="name"><a href="/customers/7">Alice &amp; Co</a></td>`
+	if !strings.Contains(html, want) {
+		t.Fatalf("missing %q in %s", want, html)
+	}
+}
+
+func TestTableColumnTemplateLinks(t *testing.T) {
+	vm := goja.New()
+	obj := vm.NewObject()
+	exports := vm.NewObject()
+	_ = obj.Set("exports", exports)
+	Loader(vm, obj)
+	_ = vm.Set("ui", exports)
+	value, err := vm.RunString(`
+		ui.table.fromRows("tables", [{ name: "order items" }])
+		  .columns(c => c.text("name").link("/tables/{name}"))
+		  .render({ query: {} })
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	html, err := RenderAny(vm, value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `<a href="/tables/order+items">order items</a>`
+	if !strings.Contains(html, want) {
+		t.Fatalf("missing %q in %s", want, html)
+	}
+}

--- a/modules/uidsl/table_rich_test.go
+++ b/modules/uidsl/table_rich_test.go
@@ -1,0 +1,52 @@
+package uidsl
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dop251/goja"
+)
+
+func TestRichTableDataColumnsSortingAndPagination(t *testing.T) {
+	vm := goja.New()
+	obj := vm.NewObject()
+	exports := vm.NewObject()
+	_ = obj.Set("exports", exports)
+	Loader(vm, obj)
+	_ = vm.Set("ui", exports)
+	value, err := vm.RunString(`
+		ui.table("orders")
+		  .data(ctx => ({
+		    rows: [
+		      { id: "A-1", status: "paid", total: 1200 },
+		      { id: "A-2", status: "pending", total: 900 }
+		    ],
+		    total: 30
+		  }))
+		  .columns(c => c
+		    .text("id").label("Order").sortable()
+		    .badge("status").label("Status")
+		    .money("total").label("Total").align("right")
+		  )
+		  .features(f => f.pagination({ size: 10 }).sorting())
+		  .render({ query: { page: "2", sort: "id", dir: "asc" } })
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	html, err := RenderAny(vm, value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		`<a href="?dir=desc&amp;page=1&amp;sort=id">Order</a>`,
+		`<td class="align-right" data-column="total">$12.00</td>`,
+		`<nav class="ui-table-pagination">Page 2 of 3 (30 rows)`,
+		`<a href="?dir=asc&amp;page=1&amp;sort=id">Previous</a>`,
+		`<a href="?dir=asc&amp;page=3&amp;sort=id">Next</a>`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("missing %q in %s", want, html)
+		}
+	}
+}

--- a/modules/uidsl/table_test.go
+++ b/modules/uidsl/table_test.go
@@ -1,0 +1,61 @@
+package uidsl
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dop251/goja"
+)
+
+func TestTableFromRowsRendersEscapedHTMLTable(t *testing.T) {
+	vm := goja.New()
+	obj := vm.NewObject()
+	exports := vm.NewObject()
+	_ = obj.Set("exports", exports)
+	Loader(vm, obj)
+	_ = vm.Set("ui", exports)
+	value, err := vm.RunString(`
+		ui.table.fromRows("people", [
+		  { name: "Alice", note: "<admin>" },
+		  { name: "Bob", note: "ok" }
+		]).features(f => f.pagination().sorting().columnPicker()).render({ query: {} })
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	html, err := RenderAny(vm, value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		`<table class="ui-table ui-table--pagination ui-table--sorting ui-table--column-picker" id="people">`,
+		`<th data-column="name">name</th>`,
+		`<th data-column="note">note</th>`,
+		`<td data-column="name">Alice</td>`,
+		`<td data-column="note">&lt;admin&gt;</td>`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("rendered table missing %q in %s", want, html)
+		}
+	}
+}
+
+func TestTableFunctionBuilderRendersEmptyTable(t *testing.T) {
+	vm := goja.New()
+	obj := vm.NewObject()
+	exports := vm.NewObject()
+	_ = obj.Set("exports", exports)
+	Loader(vm, obj)
+	_ = vm.Set("ui", exports)
+	value, err := vm.RunString(`ui.table("empty").render({})`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	html, err := RenderAny(vm, value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(html, `<table class="ui-table" id="empty">`) {
+		t.Fatalf("rendered empty table = %s", html)
+	}
+}

--- a/modules/uidsl/typescript.go
+++ b/modules/uidsl/typescript.go
@@ -1,0 +1,42 @@
+package uidsl
+
+import (
+	"github.com/go-go-golems/go-go-goja/modules"
+	"github.com/go-go-golems/go-go-goja/pkg/tsgen/spec"
+)
+
+var _ modules.TypeScriptDeclarer = (*Registrar)(nil)
+
+func (r *Registrar) TypeScriptModule() *spec.Module {
+	return &spec.Module{
+		Name:        "ui.dsl",
+		Description: "Server-rendered HTML node DSL for go-go-goja runtimes.",
+		Functions: []spec.Function{
+			{Name: "page", Params: []spec.Param{{Name: "children", Type: spec.Unknown(), Variadic: true}}, Returns: spec.Named("Node")},
+			{Name: "fragment", Params: []spec.Param{{Name: "children", Type: spec.Unknown(), Variadic: true}}, Returns: spec.Named("Node")},
+			{Name: "text", Params: []spec.Param{{Name: "value", Type: spec.Unknown()}}, Returns: spec.Named("Node")},
+			{Name: "raw", Params: []spec.Param{{Name: "html", Type: spec.String()}}, Returns: spec.Named("Node")},
+			{Name: "render", Params: []spec.Param{{Name: "value", Type: spec.Unknown()}}, Returns: spec.String()},
+			{Name: "codeBlock", Params: []spec.Param{{Name: "language", Type: spec.String()}, {Name: "source", Type: spec.Unknown()}, {Name: "options", Type: spec.Unknown(), Optional: true}}, Returns: spec.Named("Node")},
+			{Name: "sql", Params: []spec.Param{{Name: "source", Type: spec.Unknown()}, {Name: "options", Type: spec.Unknown(), Optional: true}}, Returns: spec.Named("Node")},
+			{Name: "js", Params: []spec.Param{{Name: "source", Type: spec.Unknown()}, {Name: "options", Type: spec.Unknown(), Optional: true}}, Returns: spec.Named("Node")},
+			{Name: "jsonBlock", Params: []spec.Param{{Name: "value", Type: spec.Unknown()}, {Name: "options", Type: spec.Unknown(), Optional: true}}, Returns: spec.Named("Node")},
+			{Name: "badge", Params: []spec.Param{{Name: "value", Type: spec.Unknown()}, {Name: "options", Type: spec.Unknown(), Optional: true}}, Returns: spec.Named("Node")},
+			{Name: "tabs", Params: []spec.Param{{Name: "id", Type: spec.String()}, {Name: "tabs", Type: spec.Unknown()}, {Name: "options", Type: spec.Unknown(), Optional: true}}, Returns: spec.Named("Node")},
+		},
+		RawDTS: []string{
+			"export type Node = unknown;",
+			"export type Attrs = Record<string, unknown>;",
+			"export type Child = Node | string | number | boolean | null | undefined;",
+			"export type Tag = (attrsOrChild?: Attrs | Child, ...children: Child[]) => Node;",
+			"export const table: ((id: string) => unknown) & { fromRows(id: string, rows: unknown[]): unknown };",
+			"export const html: Tag; export const head: Tag; export const body: Tag; export const title: Tag;",
+			"export const meta: Tag; export const link: Tag; export const script: Tag; export const style: Tag;",
+			"export const main: Tag; export const div: Tag; export const span: Tag; export const h1: Tag; export const h2: Tag; export const h3: Tag; export const h4: Tag;",
+			"export const p: Tag; export const a: Tag; export const form: Tag; export const input: Tag; export const button: Tag; export const select: Tag; export const option: Tag;",
+			"export const ul: Tag; export const ol: Tag; export const li: Tag; export const thead: Tag; export const tbody: Tag; export const tr: Tag; export const th: Tag; export const td: Tag;",
+			"export const section: Tag; export const article: Tag; export const header: Tag; export const footer: Tag; export const nav: Tag; export const label: Tag; export const textarea: Tag;",
+			"export const strong: Tag; export const em: Tag; export const small: Tag; export const pre: Tag; export const code: Tag; export const img: Tag; export const br: Tag; export const hr: Tag;",
+		},
+	}
+}

--- a/pkg/doc/18-express-module.md
+++ b/pkg/doc/18-express-module.md
@@ -1,0 +1,112 @@
+---
+Title: Express-style HTTP Module
+Slug: express-module
+Short: Host Goja HTTP routes with an Express-style JavaScript API
+Topics:
+- http
+- modules
+- goja
+- javascript
+Commands:
+- goja-repl
+IsTopLevel: true
+IsTemplate: false
+ShowPerDefault: true
+SectionType: GeneralTopic
+---
+
+The `express` module exposes a small Express-style route registration API for Goja-hosted applications. It is intentionally **Express-style**, not full Express-compatible: it supports route handlers and static mounts, but not middleware stacks, routers, `next()`, template engines, or npm Express plugins.
+
+## Go setup
+
+`express` is runtime-scoped because it needs a configured `gojahttp.Host` and runtime owner. Install it with `modules/express.NewRegistrar(host)` rather than through the default native module registry.
+
+```go
+host := gojahttp.NewHost(gojahttp.HostOptions{
+    Dev:      true,
+    Renderer: uidsl.RenderAny,
+})
+
+factory, err := engine.NewBuilder().
+    WithRuntimeModuleRegistrars(
+        express.NewRegistrar(host),
+        uidsl.NewRegistrar(),
+    ).
+    Build()
+```
+
+`pkg/gojahttp` owns the reusable HTTP host, route matching, request/response DTOs, body parsing, sessions, static mounts, and dispatch into the Goja runtime. The host is renderer-neutral; `HostOptions.Renderer` decides how `res.html(value)` renders non-string values.
+
+## JavaScript usage
+
+```javascript
+const express = require("express");
+const ui = require("ui.dsl");
+
+const app = express.app();
+
+app.get("/hello/:name", (req, res) => {
+  return ui.page(
+    { title: "Hello" },
+    ui.h1("Hello " + req.params.name)
+  );
+});
+
+app.post("/api/echo", (req, res) => {
+  res.status(201).json({ body: req.body });
+});
+```
+
+Handlers may call `res.*` explicitly. If a handler returns a string, the host sends it as text/HTML depending on content. If a handler returns any other non-null value, the host calls `res.html(value)` and uses the configured renderer.
+
+## App API
+
+```javascript
+app.get(pattern, handler)
+app.post(pattern, handler)
+app.put(pattern, handler)
+app.patch(pattern, handler)
+app.delete(pattern, handler)
+app.all(pattern, handler)
+app.static(prefix, directory)
+```
+
+Route patterns support exact paths, `:params`, and `*` wildcards.
+
+## Request object
+
+Handlers receive a plain JavaScript request object:
+
+```ts
+type Request = {
+  method: string;
+  url: string;
+  path: string;
+  query: Record<string, string | string[]>;
+  params: Record<string, string>;
+  headers: Record<string, string>;
+  cookies: Record<string, string>;
+  session: { id: string; isNew: boolean; cookieName: string } | null;
+  ip: string;
+  body: unknown;
+  rawBody: string;
+};
+```
+
+JSON and form bodies are parsed automatically. Other request bodies are exposed as strings.
+
+## Response object
+
+```javascript
+res.status(code)
+res.set(name, value)
+res.type(contentType)
+res.json(value)
+res.send(value)
+res.html(value)
+res.redirect(url)
+res.redirect(status, url)
+res.end()
+```
+
+`res.html(value)` requires a renderer in `gojahttp.HostOptions`. With `modules/uidsl.RenderAny`, route handlers can return or send `ui.dsl` nodes directly.

--- a/pkg/doc/19-uidsl-module.md
+++ b/pkg/doc/19-uidsl-module.md
@@ -1,0 +1,97 @@
+---
+Title: ui.dsl Module
+Slug: uidsl-module
+Short: Render safe server-side HTML nodes from Goja JavaScript
+Topics:
+- ui-dsl
+- modules
+- html
+- javascript
+Commands:
+- goja-repl
+IsTopLevel: true
+IsTemplate: false
+ShowPerDefault: true
+SectionType: GeneralTopic
+---
+
+The `ui.dsl` module provides a server-side HTML node DSL for Goja runtimes. It exports safe tag builders, document rendering, and internal-tool components such as tables, code blocks, badges, and tabs.
+
+The module is available through both aliases when registered with `uidsl.NewRegistrar()`:
+
+```javascript
+const ui = require("ui.dsl");
+// or
+const ui = require("ui");
+```
+
+## Go setup
+
+```go
+factory, err := engine.NewBuilder().
+    WithRuntimeModuleRegistrars(uidsl.NewRegistrar()).
+    Build()
+```
+
+For HTTP applications, pair it with `pkg/gojahttp` and `modules/express`:
+
+```go
+host := gojahttp.NewHost(gojahttp.HostOptions{
+    Renderer: uidsl.RenderAny,
+})
+```
+
+## Core API
+
+```javascript
+ui.page({ title: "Title" }, ...children)
+ui.fragment(...children)
+ui.text(value)
+ui.raw(html)
+ui.render(value)
+```
+
+The module exports common HTML tag helpers such as `div`, `span`, `h1`, `p`, `a`, `form`, `input`, `table`, `tr`, `td`, `script`, `style`, and SVG helpers. Tag helpers accept an optional first attribute object followed by children:
+
+```javascript
+ui.div({ class: "card" },
+  ui.h2("Result"),
+  ui.p("Safe text")
+)
+```
+
+## Safety model
+
+Normal text and attribute values are escaped. `ui.raw(html)` intentionally bypasses escaping and should only be used with trusted HTML or CSS.
+
+```javascript
+ui.p("<script>")      // renders escaped text
+ui.raw("<strong>ok</strong>") // renders raw HTML
+```
+
+## Tables
+
+```javascript
+ui.table.fromRows("users", [
+  { id: 1, name: "Ada", active: true },
+  { id: 2, name: "Grace", active: false },
+])
+```
+
+The richer table builder supports columns, filters, sorting, pagination, money/date/tags/badge cell kinds, links, and empty states. These components are designed for server-rendered internal tools and database browsers.
+
+## Inspection components
+
+```javascript
+ui.codeBlock("sql", "select * from users")
+ui.sql("select * from users")
+ui.js("console.log('hello')")
+ui.jsonBlock({ ok: true })
+ui.badge("active", { tone: "success" })
+ui.tabs("details", [
+  { id: "summary", label: "Summary", content: ui.p("Overview") },
+  { id: "raw", label: "Raw", content: ui.jsonBlock({ ok: true }) },
+])
+```
+
+These helpers render static HTML/CSS and do not require client-side JavaScript for their basic behavior.

--- a/pkg/gojahttp/body.go
+++ b/pkg/gojahttp/body.go
@@ -1,0 +1,46 @@
+package gojahttp
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+)
+
+func parseBody(r *http.Request) (any, string, error) {
+	if r.Body == nil {
+		return nil, "", nil
+	}
+	data, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, "", err
+	}
+	raw := string(data)
+	ct := strings.ToLower(r.Header.Get("Content-Type"))
+	if len(data) == 0 {
+		return nil, raw, nil
+	}
+	if strings.Contains(ct, "application/json") {
+		var v any
+		if err := json.Unmarshal(data, &v); err != nil {
+			return nil, raw, err
+		}
+		return v, raw, nil
+	}
+	if strings.Contains(ct, "application/x-www-form-urlencoded") || strings.Contains(ct, "multipart/form-data") {
+		r.Body = io.NopCloser(strings.NewReader(raw))
+		if err := r.ParseForm(); err != nil {
+			return nil, raw, err
+		}
+		m := map[string]any{}
+		for k, vals := range r.PostForm {
+			if len(vals) == 1 {
+				m[k] = vals[0]
+			} else {
+				m[k] = vals
+			}
+		}
+		return m, raw, nil
+	}
+	return raw, raw, nil
+}

--- a/pkg/gojahttp/body.go
+++ b/pkg/gojahttp/body.go
@@ -2,20 +2,28 @@ package gojahttp
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
 )
 
-const multipartFormMemoryLimit = 32 << 20
+const (
+	maxRequestBodyBytes      = 64 << 20
+	multipartFormMemoryLimit = 32 << 20
+)
 
 func parseBody(r *http.Request) (any, string, error) {
 	if r.Body == nil {
 		return nil, "", nil
 	}
-	data, err := io.ReadAll(r.Body)
+	limited := &io.LimitedReader{R: r.Body, N: maxRequestBodyBytes + 1}
+	data, err := io.ReadAll(limited)
 	if err != nil {
 		return nil, "", err
+	}
+	if int64(len(data)) > maxRequestBodyBytes {
+		return nil, "", fmt.Errorf("request body exceeds %d bytes", maxRequestBodyBytes)
 	}
 	raw := string(data)
 	ct := strings.ToLower(r.Header.Get("Content-Type"))
@@ -38,7 +46,8 @@ func parseBody(r *http.Request) (any, string, error) {
 	}
 	if strings.Contains(ct, "multipart/form-data") {
 		r.Body = io.NopCloser(strings.NewReader(raw))
-		if err := r.ParseMultipartForm(multipartFormMemoryLimit); err != nil {
+		// Request body is capped above and ParseMultipartForm uses a bounded in-memory budget.
+		if err := r.ParseMultipartForm(multipartFormMemoryLimit); err != nil { // #nosec G120
 			return nil, raw, err
 		}
 		return postFormMap(r), raw, nil

--- a/pkg/gojahttp/body.go
+++ b/pkg/gojahttp/body.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 )
 
+const multipartFormMemoryLimit = 32 << 20
+
 func parseBody(r *http.Request) (any, string, error) {
 	if r.Body == nil {
 		return nil, "", nil
@@ -27,20 +29,31 @@ func parseBody(r *http.Request) (any, string, error) {
 		}
 		return v, raw, nil
 	}
-	if strings.Contains(ct, "application/x-www-form-urlencoded") || strings.Contains(ct, "multipart/form-data") {
+	if strings.Contains(ct, "application/x-www-form-urlencoded") {
 		r.Body = io.NopCloser(strings.NewReader(raw))
 		if err := r.ParseForm(); err != nil {
 			return nil, raw, err
 		}
-		m := map[string]any{}
-		for k, vals := range r.PostForm {
-			if len(vals) == 1 {
-				m[k] = vals[0]
-			} else {
-				m[k] = vals
-			}
+		return postFormMap(r), raw, nil
+	}
+	if strings.Contains(ct, "multipart/form-data") {
+		r.Body = io.NopCloser(strings.NewReader(raw))
+		if err := r.ParseMultipartForm(multipartFormMemoryLimit); err != nil {
+			return nil, raw, err
 		}
-		return m, raw, nil
+		return postFormMap(r), raw, nil
 	}
 	return raw, raw, nil
+}
+
+func postFormMap(r *http.Request) map[string]any {
+	m := map[string]any{}
+	for k, vals := range r.PostForm {
+		if len(vals) == 1 {
+			m[k] = vals[0]
+		} else {
+			m[k] = vals
+		}
+	}
+	return m
 }

--- a/pkg/gojahttp/body_test.go
+++ b/pkg/gojahttp/body_test.go
@@ -1,0 +1,50 @@
+package gojahttp
+
+import (
+	"bytes"
+	"mime/multipart"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestParseBodyMultipartFormFields(t *testing.T) {
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	if err := writer.WriteField("title", "Trail notes"); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.WriteField("tag", "Planning"); err != nil {
+		t.Fatal(err)
+	}
+	file, err := writer.CreateFormFile("attachment", "note.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := file.Write([]byte("hello")); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest("POST", "/upload", strings.NewReader(body.String()))
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	parsed, raw, err := parseBody(req)
+	if err != nil {
+		t.Fatalf("parseBody() error = %v", err)
+	}
+	if raw == "" {
+		t.Fatalf("expected raw multipart body")
+	}
+	fields, ok := parsed.(map[string]any)
+	if !ok {
+		t.Fatalf("parsed body type = %T, want map[string]any", parsed)
+	}
+	if fields["title"] != "Trail notes" || fields["tag"] != "Planning" {
+		t.Fatalf("parsed fields = %#v", fields)
+	}
+	if req.MultipartForm == nil || len(req.MultipartForm.File["attachment"]) != 1 {
+		t.Fatalf("expected multipart file metadata, got %#v", req.MultipartForm)
+	}
+}

--- a/pkg/gojahttp/host.go
+++ b/pkg/gojahttp/host.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/dop251/goja"
 	"github.com/go-go-golems/go-go-goja/pkg/runtimeowner"
@@ -76,22 +77,21 @@ func (h *Host) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	res := NewResponse(w, h.renderer)
-	_, err = h.owner.Call(r.Context(), "http-handler", func(ctx context.Context, vm *goja.Runtime) (any, error) {
+	ret, err := h.owner.Call(r.Context(), "http-handler", func(ctx context.Context, vm *goja.Runtime) (any, error) {
 		result, err := route.Handler(goja.Undefined(), vm.ToValue(req.Map()), res.JSObject(vm))
 		if err != nil {
 			return nil, err
 		}
-		if !res.Sent() && !goja.IsUndefined(result) && !goja.IsNull(result) {
-			if _, ok := result.Export().(string); ok {
-				return nil, res.Send(vm, result)
-			}
-			return nil, res.HTML(vm, result)
+		if promise, ok := result.Export().(*goja.Promise); ok {
+			return promise, nil
 		}
-		if !res.Sent() {
-			return nil, res.End()
-		}
-		return nil, nil
+		return nil, h.finishHandlerResult(vm, res, result)
 	})
+	if err == nil {
+		if promise, ok := ret.(*goja.Promise); ok {
+			err = h.awaitAndFinishPromise(r.Context(), res, promise)
+		}
+	}
 	if err != nil && !res.Sent() {
 		if h.dev {
 			http.Error(w, fmt.Sprintf("JavaScript handler error: %v", err), http.StatusInternalServerError)
@@ -99,6 +99,61 @@ func (h *Host) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "internal server error", http.StatusInternalServerError)
 		}
 	}
+}
+
+func (h *Host) finishHandlerResult(vm *goja.Runtime, res *Response, result goja.Value) error {
+	if !res.Sent() && !goja.IsUndefined(result) && !goja.IsNull(result) {
+		if _, ok := result.Export().(string); ok {
+			return res.Send(vm, result)
+		}
+		return res.HTML(vm, result)
+	}
+	if !res.Sent() {
+		return res.End()
+	}
+	return nil
+}
+
+func (h *Host) awaitAndFinishPromise(ctx context.Context, res *Response, promise *goja.Promise) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		ret, err := h.owner.Call(ctx, "http-handler.promise-state", func(_ context.Context, vm *goja.Runtime) (any, error) {
+			snapshot := promiseSnapshot{State: promise.State(), Result: promise.Result()}
+			if snapshot.State == goja.PromiseStateFulfilled {
+				return snapshot, h.finishHandlerResult(vm, res, snapshot.Result)
+			}
+			return snapshot, nil
+		})
+		if err != nil {
+			return err
+		}
+		snapshot := ret.(promiseSnapshot)
+		switch snapshot.State {
+		case goja.PromiseStatePending:
+			time.Sleep(5 * time.Millisecond)
+		case goja.PromiseStateRejected:
+			return fmt.Errorf("promise rejected: %s", valueString(snapshot.Result))
+		case goja.PromiseStateFulfilled:
+			return nil
+		}
+	}
+}
+
+type promiseSnapshot struct {
+	State  goja.PromiseState
+	Result goja.Value
+}
+
+func valueString(value goja.Value) string {
+	if value == nil || goja.IsUndefined(value) || goja.IsNull(value) {
+		return "undefined"
+	}
+	return value.String()
 }
 
 type headResponseWriter struct {

--- a/pkg/gojahttp/host.go
+++ b/pkg/gojahttp/host.go
@@ -1,0 +1,110 @@
+package gojahttp
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/dop251/goja"
+	"github.com/go-go-golems/go-go-goja/pkg/runtimeowner"
+)
+
+type HostOptions struct {
+	Dev      bool
+	Renderer Renderer
+	Sessions SessionOptions
+}
+
+type StaticMount struct {
+	Prefix  string
+	Handler http.Handler
+}
+
+type Host struct {
+	registry *Registry
+	dev      bool
+	renderer Renderer
+	owner    runtimeowner.Runner
+	sessions *SessionManager
+	static   []StaticMount
+}
+
+func NewHost(opts HostOptions) *Host {
+	return &Host{registry: NewRegistry(), dev: opts.Dev, renderer: opts.Renderer, sessions: NewSessionManager(opts.Sessions)}
+}
+
+func (h *Host) SetRuntime(owner runtimeowner.Runner) { h.owner = owner }
+func (h *Host) Register(method, pattern string, handler goja.Callable) {
+	h.registry.Add(method, pattern, handler)
+}
+func (h *Host) RegisterStatic(prefix, dir string) {
+	prefix = cleanPath(prefix)
+	h.static = append(h.static, StaticMount{Prefix: prefix, Handler: http.StripPrefix(prefix, http.FileServer(http.Dir(dir)))})
+}
+
+func (h *Host) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	for _, mount := range h.static {
+		if r.URL.Path == mount.Prefix || strings.HasPrefix(r.URL.Path, mount.Prefix+"/") {
+			mount.Handler.ServeHTTP(w, r)
+			return
+		}
+	}
+	if h.owner == nil {
+		http.Error(w, "runtime not initialized", http.StatusInternalServerError)
+		return
+	}
+	route, params, ok := h.registry.Match(r.Method, r.URL.Path)
+	if !ok && r.Method == http.MethodHead {
+		route, params, ok = h.registry.Match(http.MethodGet, r.URL.Path)
+		if ok {
+			w = headResponseWriter{ResponseWriter: w}
+		}
+	}
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	session, err := h.sessions.Session(w, r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	req, err := NewRequestDTO(r, params, session)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	res := NewResponse(w, h.renderer)
+	_, err = h.owner.Call(r.Context(), "http-handler", func(ctx context.Context, vm *goja.Runtime) (any, error) {
+		result, err := route.Handler(goja.Undefined(), vm.ToValue(req.Map()), res.JSObject(vm))
+		if err != nil {
+			return nil, err
+		}
+		if !res.Sent() && !goja.IsUndefined(result) && !goja.IsNull(result) {
+			if _, ok := result.Export().(string); ok {
+				return nil, res.Send(vm, result)
+			}
+			return nil, res.HTML(vm, result)
+		}
+		if !res.Sent() {
+			return nil, res.End()
+		}
+		return nil, nil
+	})
+	if err != nil && !res.Sent() {
+		if h.dev {
+			http.Error(w, fmt.Sprintf("JavaScript handler error: %v", err), http.StatusInternalServerError)
+		} else {
+			http.Error(w, "internal server error", http.StatusInternalServerError)
+		}
+	}
+}
+
+type headResponseWriter struct {
+	http.ResponseWriter
+}
+
+func (w headResponseWriter) Write(b []byte) (int, error) {
+	return len(b), nil
+}

--- a/pkg/gojahttp/request_response.go
+++ b/pkg/gojahttp/request_response.go
@@ -1,0 +1,214 @@
+package gojahttp
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/dop251/goja"
+)
+
+type Renderer func(*goja.Runtime, goja.Value) (string, error)
+
+type RequestDTO struct {
+	Method  string
+	URL     string
+	Path    string
+	Query   map[string]any
+	Params  map[string]string
+	Headers map[string]string
+	Cookies map[string]string
+	Session *SessionDTO
+	IP      string
+	Body    any
+	RawBody string
+}
+
+func (r *RequestDTO) Map() map[string]any {
+	return map[string]any{
+		"method":  r.Method,
+		"url":     r.URL,
+		"path":    r.Path,
+		"query":   r.Query,
+		"params":  r.Params,
+		"headers": r.Headers,
+		"cookies": r.Cookies,
+		"session": r.Session.Map(),
+		"ip":      r.IP,
+		"body":    r.Body,
+		"rawBody": r.RawBody,
+	}
+}
+
+func NewRequestDTO(r *http.Request, params map[string]string, session *SessionDTO) (*RequestDTO, error) {
+	body, raw, err := parseBody(r)
+	if err != nil {
+		return nil, err
+	}
+	query := map[string]any{}
+	for k, vals := range r.URL.Query() {
+		if len(vals) == 1 {
+			query[k] = vals[0]
+		} else {
+			query[k] = vals
+		}
+	}
+	headers := map[string]string{}
+	for k, vals := range r.Header {
+		headers[k] = strings.Join(vals, ", ")
+	}
+	cookies := map[string]string{}
+	for _, c := range r.Cookies() {
+		cookies[c.Name] = c.Value
+	}
+	ip, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		ip = r.RemoteAddr
+	}
+	return &RequestDTO{Method: r.Method, URL: r.URL.String(), Path: r.URL.Path, Query: query, Params: params, Headers: headers, Cookies: cookies, Session: session, IP: ip, Body: body, RawBody: raw}, nil
+}
+
+type Response struct {
+	mu       sync.Mutex
+	w        http.ResponseWriter
+	renderer Renderer
+	status   int
+	headers  map[string]string
+	sent     bool
+}
+
+func NewResponse(w http.ResponseWriter, renderer Renderer) *Response {
+	return &Response{w: w, renderer: renderer, status: http.StatusOK, headers: map[string]string{}}
+}
+
+func (r *Response) Sent() bool { r.mu.Lock(); defer r.mu.Unlock(); return r.sent }
+
+func (r *Response) JSObject(vm *goja.Runtime) *goja.Object {
+	obj := vm.NewObject()
+	_ = obj.Set("status", func(code int) *goja.Object { r.setStatus(code); return obj })
+	_ = obj.Set("set", func(name, value string) *goja.Object { r.setHeader(name, value); return obj })
+	_ = obj.Set("type", func(value string) *goja.Object { r.setHeader("Content-Type", value); return obj })
+	_ = obj.Set("json", func(v goja.Value) error { return r.JSON(vm, v) })
+	_ = obj.Set("send", func(v goja.Value) error { return r.Send(vm, v) })
+	_ = obj.Set("html", func(v goja.Value) error { return r.HTML(vm, v) })
+	_ = obj.Set("redirect", func(call goja.FunctionCall) goja.Value {
+		if err := r.Redirect(call); err != nil {
+			panic(vm.NewGoError(err))
+		}
+		return goja.Undefined()
+	})
+	_ = obj.Set("end", func() error { return r.End() })
+	return obj
+}
+
+func (r *Response) setStatus(code int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if !r.sent {
+		r.status = code
+	}
+}
+func (r *Response) setHeader(k, v string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if !r.sent {
+		r.headers[k] = v
+	}
+}
+
+func (r *Response) applyLocked() {
+	for k, v := range r.headers {
+		r.w.Header().Set(k, v)
+	}
+	r.w.WriteHeader(r.status)
+	r.sent = true
+}
+
+func (r *Response) Send(vm *goja.Runtime, v goja.Value) error {
+	if goja.IsUndefined(v) || goja.IsNull(v) {
+		return r.End()
+	}
+	if s, ok := v.Export().(string); ok {
+		return r.writeString(s)
+	}
+	return r.JSON(vm, v)
+}
+
+func (r *Response) HTML(vm *goja.Runtime, v goja.Value) error {
+	if r.renderer == nil {
+		return fmt.Errorf("no HTML renderer configured")
+	}
+	html, err := r.renderer(vm, v)
+	if err != nil {
+		return err
+	}
+	r.setHeader("Content-Type", "text/html; charset=utf-8")
+	return r.writeString(html)
+}
+
+func (r *Response) JSON(vm *goja.Runtime, v goja.Value) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.sent {
+		return nil
+	}
+	r.w.Header().Set("Content-Type", "application/json")
+	r.applyLocked()
+	return json.NewEncoder(r.w).Encode(v.Export())
+}
+
+func (r *Response) writeString(s string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.sent {
+		return nil
+	}
+	if r.headers["Content-Type"] == "" {
+		trim := strings.TrimSpace(s)
+		if strings.HasPrefix(trim, "<") {
+			r.w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		} else {
+			r.w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		}
+	}
+	r.applyLocked()
+	_, err := r.w.Write([]byte(s))
+	return err
+}
+
+func (r *Response) Redirect(call goja.FunctionCall) error {
+	status := http.StatusFound
+	url := ""
+	if len(call.Arguments) == 1 {
+		url = call.Argument(0).String()
+	}
+	if len(call.Arguments) >= 2 {
+		status = int(call.Argument(0).ToInteger())
+		url = call.Argument(1).String()
+	}
+	if url == "" {
+		return fmt.Errorf("redirect URL is required")
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.sent {
+		return nil
+	}
+	r.w.Header().Set("Location", url)
+	r.status = status
+	r.applyLocked()
+	return nil
+}
+
+func (r *Response) End() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.sent {
+		return nil
+	}
+	r.applyLocked()
+	return nil
+}

--- a/pkg/gojahttp/route_registry.go
+++ b/pkg/gojahttp/route_registry.go
@@ -1,0 +1,94 @@
+package gojahttp
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/dop251/goja"
+)
+
+type Route struct {
+	Method  string
+	Pattern string
+	Handler goja.Callable
+}
+
+type Registry struct {
+	mu     sync.RWMutex
+	routes []Route
+}
+
+func NewRegistry() *Registry { return &Registry{} }
+
+func (r *Registry) Add(method, pattern string, handler goja.Callable) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.routes = append(r.routes, Route{Method: strings.ToUpper(method), Pattern: cleanPath(pattern), Handler: handler})
+}
+
+func (r *Registry) Match(method, path string) (Route, map[string]string, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	method = strings.ToUpper(method)
+	path = cleanPath(path)
+	for _, route := range r.routes {
+		if route.Method != method && route.Method != "ALL" {
+			continue
+		}
+		params, ok := matchPattern(route.Pattern, path)
+		if ok {
+			return route, params, true
+		}
+	}
+	return Route{}, nil, false
+}
+
+func cleanPath(p string) string {
+	if p == "" {
+		return "/"
+	}
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	if len(p) > 1 {
+		p = strings.TrimRight(p, "/")
+	}
+	if p == "" {
+		return "/"
+	}
+	return p
+}
+
+func splitPath(p string) []string {
+	p = strings.Trim(cleanPath(p), "/")
+	if p == "" {
+		return nil
+	}
+	return strings.Split(p, "/")
+}
+
+func matchPattern(pattern, path string) (map[string]string, bool) {
+	pp := splitPath(pattern)
+	sp := splitPath(path)
+	params := map[string]string{}
+	for i := 0; i < len(pp); i++ {
+		if pp[i] == "*" {
+			return params, true
+		}
+		if i >= len(sp) {
+			return nil, false
+		}
+		if strings.HasPrefix(pp[i], ":") {
+			name := strings.TrimPrefix(pp[i], ":")
+			if name == "" {
+				return nil, false
+			}
+			params[name] = sp[i]
+			continue
+		}
+		if pp[i] != sp[i] {
+			return nil, false
+		}
+	}
+	return params, len(pp) == len(sp)
+}

--- a/pkg/gojahttp/route_registry_test.go
+++ b/pkg/gojahttp/route_registry_test.go
@@ -1,0 +1,26 @@
+package gojahttp
+
+import "testing"
+
+func TestRegistryMatchesParamsInOrder(t *testing.T) {
+	r := NewRegistry()
+	r.Add("GET", "/cards/:id/move", nil)
+	_, params, ok := r.Match("GET", "/cards/42/move")
+	if !ok {
+		t.Fatal("expected route match")
+	}
+	if params["id"] != "42" {
+		t.Fatalf("expected id param, got %#v", params)
+	}
+}
+
+func TestRegistryMethodAndWildcard(t *testing.T) {
+	r := NewRegistry()
+	r.Add("ALL", "/health", nil)
+	if _, _, ok := r.Match("POST", "/health"); !ok {
+		t.Fatal("expected ALL match")
+	}
+	if _, _, ok := r.Match("GET", "/missing"); ok {
+		t.Fatal("unexpected missing match")
+	}
+}

--- a/pkg/gojahttp/session.go
+++ b/pkg/gojahttp/session.go
@@ -71,7 +71,8 @@ func (m *SessionManager) Session(w http.ResponseWriter, r *http.Request) (*Sessi
 	if err != nil {
 		return nil, err
 	}
-	http.SetCookie(w, &http.Cookie{
+	// Secure is configurable so localhost HTTP development can receive the cookie; HttpOnly and SameSite are always set.
+	http.SetCookie(w, &http.Cookie{ // #nosec G124
 		Name:     m.opts.CookieName,
 		Value:    id,
 		Path:     m.opts.Path,

--- a/pkg/gojahttp/session.go
+++ b/pkg/gojahttp/session.go
@@ -1,0 +1,96 @@
+package gojahttp
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"regexp"
+	"time"
+)
+
+const defaultSessionCookieName = "go_go_goja_session"
+
+var sessionIDPattern = regexp.MustCompile(`^[A-Za-z0-9_-]{22,128}$`)
+
+// SessionOptions configures the lightweight cookie-backed session identity used
+// by go-go-goja. The session stores only an opaque ID in a cookie; application
+// state remains in the application's database.
+type SessionOptions struct {
+	Disabled   bool
+	CookieName string
+	Path       string
+	MaxAge     time.Duration
+	Secure     bool
+	SameSite   http.SameSite
+}
+
+type SessionDTO struct {
+	ID         string
+	IsNew      bool
+	CookieName string
+}
+
+func (s *SessionDTO) Map() map[string]any {
+	if s == nil {
+		return nil
+	}
+	return map[string]any{
+		"id":         s.ID,
+		"isNew":      s.IsNew,
+		"cookieName": s.CookieName,
+	}
+}
+
+type SessionManager struct{ opts SessionOptions }
+
+func NewSessionManager(opts SessionOptions) *SessionManager {
+	if opts.CookieName == "" {
+		opts.CookieName = defaultSessionCookieName
+	}
+	if opts.Path == "" {
+		opts.Path = "/"
+	}
+	if opts.MaxAge == 0 {
+		opts.MaxAge = 365 * 24 * time.Hour
+	}
+	if opts.SameSite == 0 {
+		opts.SameSite = http.SameSiteLaxMode
+	}
+	return &SessionManager{opts: opts}
+}
+
+func (m *SessionManager) Session(w http.ResponseWriter, r *http.Request) (*SessionDTO, error) {
+	if m == nil || m.opts.Disabled {
+		return nil, nil
+	}
+	if cookie, err := r.Cookie(m.opts.CookieName); err == nil && validSessionID(cookie.Value) {
+		return &SessionDTO{ID: cookie.Value, CookieName: m.opts.CookieName}, nil
+	}
+	id, err := newSessionID()
+	if err != nil {
+		return nil, err
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     m.opts.CookieName,
+		Value:    id,
+		Path:     m.opts.Path,
+		MaxAge:   int(m.opts.MaxAge.Seconds()),
+		HttpOnly: true,
+		Secure:   m.opts.Secure,
+		SameSite: m.opts.SameSite,
+	})
+	return &SessionDTO{ID: id, IsNew: true, CookieName: m.opts.CookieName}, nil
+}
+
+func newSessionID() (string, error) {
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("generate session id: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}
+
+func validSessionID(id string) bool {
+	return sessionIDPattern.MatchString(id)
+}

--- a/pkg/gojahttp/session_integration_test.go
+++ b/pkg/gojahttp/session_integration_test.go
@@ -1,0 +1,79 @@
+package gojahttp_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/dop251/goja"
+	"github.com/go-go-golems/go-go-goja/engine"
+	"github.com/go-go-golems/go-go-goja/modules/express"
+	"github.com/go-go-golems/go-go-goja/modules/uidsl"
+	"github.com/go-go-golems/go-go-goja/pkg/gojahttp"
+)
+
+var sessionIDPattern = regexp.MustCompile(`^[A-Za-z0-9_-]{22,128}$`)
+
+func TestSessionCookieIssuedAndReused(t *testing.T) {
+	const cookieName = "test_session"
+	host := gojahttp.NewHost(gojahttp.HostOptions{
+		Dev:      true,
+		Renderer: uidsl.RenderAny,
+		Sessions: gojahttp.SessionOptions{CookieName: cookieName},
+	})
+	factory, err := engine.NewBuilder().WithRuntimeModuleRegistrars(express.NewRegistrar(host), uidsl.NewRegistrar()).Build()
+	if err != nil {
+		t.Fatalf("build factory: %v", err)
+	}
+	rt, err := factory.NewRuntime(context.Background())
+	if err != nil {
+		t.Fatalf("new runtime: %v", err)
+	}
+	defer func() { _ = rt.Close(context.Background()) }()
+	host.SetRuntime(rt.Owner)
+
+	_, err = rt.Owner.Call(context.Background(), "load-test", func(_ context.Context, vm *goja.Runtime) (any, error) {
+		_, err := vm.RunString(`
+			const express = require("express");
+			const app = express.app();
+			app.get("/session", (req, res) => res.json({ id: req.session.id, isNew: req.session.isNew }));
+		`)
+		return nil, err
+	})
+	if err != nil {
+		t.Fatalf("load script: %v", err)
+	}
+
+	first := httptest.NewRecorder()
+	host.ServeHTTP(first, httptest.NewRequest(http.MethodGet, "/session", nil))
+	if first.Code != http.StatusOK {
+		t.Fatalf("first status=%d body=%s", first.Code, first.Body.String())
+	}
+	cookies := first.Result().Cookies()
+	if len(cookies) != 1 || cookies[0].Name != cookieName {
+		t.Fatalf("expected %s cookie, got %#v", cookieName, cookies)
+	}
+	if !sessionIDPattern.MatchString(cookies[0].Value) {
+		t.Fatalf("invalid session id %q", cookies[0].Value)
+	}
+	if !strings.Contains(first.Body.String(), `"isNew":true`) || !strings.Contains(first.Body.String(), cookies[0].Value) {
+		t.Fatalf("first response missing new session: %s", first.Body.String())
+	}
+
+	secondReq := httptest.NewRequest(http.MethodGet, "/session", nil)
+	secondReq.AddCookie(cookies[0])
+	second := httptest.NewRecorder()
+	host.ServeHTTP(second, secondReq)
+	if second.Code != http.StatusOK {
+		t.Fatalf("second status=%d body=%s", second.Code, second.Body.String())
+	}
+	if strings.Contains(second.Header().Get("Set-Cookie"), cookieName) {
+		t.Fatalf("did not expect replacement session cookie: %s", second.Header().Get("Set-Cookie"))
+	}
+	if !strings.Contains(second.Body.String(), `"isNew":false`) || !strings.Contains(second.Body.String(), cookies[0].Value) {
+		t.Fatalf("second response missing reused session: %s", second.Body.String())
+	}
+}

--- a/pkg/hashiplugin/contract/internal/cmd/generate/main.go
+++ b/pkg/hashiplugin/contract/internal/cmd/generate/main.go
@@ -63,6 +63,7 @@ func run() error {
 }
 
 func installTool(toolDir, pkg string) error {
+	// #nosec G204 -- generator installs fixed Go tool package arguments controlled by this program.
 	cmd := exec.Command("go", "install", pkg)
 	cmd.Dir = "."
 	cmd.Stdout = os.Stdout

--- a/pkg/jsverbrepos/bootstrap.go
+++ b/pkg/jsverbrepos/bootstrap.go
@@ -1,0 +1,310 @@
+package jsverbrepos
+
+import (
+	"context"
+	"embed"
+	"encoding/csv"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	EnvVar             = "GOJA_VERB_REPOSITORIES"
+	RepositoryFlag     = "repository"
+	VerbRepositoryFlag = "verb-repository"
+
+	LocalConfigFileName         = ".goja-verbs.yml"
+	LocalOverrideConfigFileName = ".goja-verbs.override.yml"
+)
+
+//go:embed builtin/*.js
+var builtinScripts embed.FS
+
+type Bootstrap struct {
+	Repositories []Repository
+}
+
+type Repository struct {
+	Name       string
+	Source     string
+	SourceRef  string
+	RootDir    string
+	EmbeddedFS fs.FS
+	Embedded   bool
+	EmbeddedAt string
+}
+
+type appConfig struct {
+	Verbs verbsConfig `yaml:"verbs"`
+}
+
+type verbsConfig struct {
+	Repositories []repositorySpec `yaml:"repositories"`
+}
+
+type repositorySpec struct {
+	Name    string `yaml:"name,omitempty"`
+	Path    string `yaml:"path"`
+	Enabled *bool  `yaml:"enabled,omitempty"`
+}
+
+func Discover(ctx context.Context, args []string) (Bootstrap, []string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return Bootstrap{}, nil, fmt.Errorf("resolve cwd: %w", err)
+	}
+	return DiscoverFrom(ctx, cwd, args)
+}
+
+func DiscoverFrom(ctx context.Context, cwd string, args []string) (Bootstrap, []string, error) {
+	cliRepos, remainingArgs, err := RepositoriesFromArgs(args, cwd)
+	if err != nil {
+		return Bootstrap{}, nil, err
+	}
+	bootstrap, err := discoverFromSources(ctx, cwd, cliRepos)
+	if err != nil {
+		return Bootstrap{}, nil, err
+	}
+	return bootstrap, remainingArgs, nil
+}
+
+func discoverFromSources(ctx context.Context, cwd string, cliRepos []Repository) (Bootstrap, error) {
+	_ = ctx
+	repositories := []Repository{BuiltinRepository()}
+	seen := map[string]struct{}{RepositoryIdentity(repositories[0]): {}}
+
+	configRepos, err := LoadConfigRepositories(cwd)
+	if err != nil {
+		return Bootstrap{}, err
+	}
+	for _, repo := range configRepos {
+		appendRepository(&repositories, seen, repo)
+	}
+
+	envRepos, err := RepositoriesFromEnv(cwd)
+	if err != nil {
+		return Bootstrap{}, err
+	}
+	for _, repo := range envRepos {
+		appendRepository(&repositories, seen, repo)
+	}
+	for _, repo := range cliRepos {
+		appendRepository(&repositories, seen, repo)
+	}
+
+	return Bootstrap{Repositories: repositories}, nil
+}
+
+func BuiltinRepository() Repository {
+	return Repository{
+		Name:       "builtin",
+		Source:     "embedded",
+		SourceRef:  "builtin scripts",
+		EmbeddedFS: builtinScripts,
+		Embedded:   true,
+		EmbeddedAt: "builtin",
+	}
+}
+
+func appendRepository(repositories *[]Repository, seen map[string]struct{}, repo Repository) {
+	identity := RepositoryIdentity(repo)
+	if _, ok := seen[identity]; ok {
+		return
+	}
+	seen[identity] = struct{}{}
+	*repositories = append(*repositories, repo)
+}
+
+func RepositoryIdentity(repo Repository) string {
+	if repo.Embedded {
+		return "embedded:" + repo.Name + ":" + repo.EmbeddedAt
+	}
+	return "path:" + filepath.Clean(repo.RootDir)
+}
+
+func LoadConfigRepositories(cwd string) ([]Repository, error) {
+	paths := configPaths(cwd)
+	ret := []Repository{}
+	for _, path := range paths {
+		repos, err := loadRepositoriesFromConfigFile(path)
+		if err != nil {
+			return nil, err
+		}
+		ret = append(ret, repos...)
+	}
+	return ret, nil
+}
+
+func configPaths(cwd string) []string {
+	candidates := []string{}
+	if root := findGitRoot(cwd); root != "" {
+		candidates = append(candidates,
+			filepath.Join(root, LocalConfigFileName),
+			filepath.Join(root, LocalOverrideConfigFileName),
+		)
+	}
+	candidates = append(candidates,
+		filepath.Join(cwd, LocalConfigFileName),
+		filepath.Join(cwd, LocalOverrideConfigFileName),
+	)
+
+	seen := map[string]struct{}{}
+	ret := []string{}
+	for _, path := range candidates {
+		path = filepath.Clean(path)
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+		if info, err := os.Stat(path); err == nil && !info.IsDir() {
+			ret = append(ret, path)
+		}
+	}
+	return ret
+}
+
+func findGitRoot(cwd string) string {
+	dir := filepath.Clean(cwd)
+	for {
+		if info, err := os.Stat(filepath.Join(dir, ".git")); err == nil && info.IsDir() {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}
+
+func loadRepositoriesFromConfigFile(path string) ([]Repository, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read app config %s: %w", path, err)
+	}
+	cfg := &appConfig{}
+	if err := yaml.Unmarshal(data, cfg); err != nil {
+		return nil, fmt.Errorf("parse app config %s: %w", path, err)
+	}
+	baseDir := filepath.Dir(path)
+	ret := []Repository{}
+	for _, spec := range cfg.Verbs.Repositories {
+		if spec.Enabled != nil && !*spec.Enabled {
+			continue
+		}
+		normalized, err := NormalizeFilesystemRepositoryPath(spec.Path, baseDir)
+		if err != nil {
+			return nil, fmt.Errorf("config repository %q in %s: %w", spec.Path, path, err)
+		}
+		name := strings.TrimSpace(spec.Name)
+		if name == "" {
+			name = filepath.Base(normalized)
+		}
+		ret = append(ret, Repository{Name: name, Source: "config", SourceRef: path, RootDir: normalized})
+	}
+	return ret, nil
+}
+
+func RepositoriesFromEnv(cwd string) ([]Repository, error) {
+	value := strings.TrimSpace(os.Getenv(EnvVar))
+	if value == "" {
+		return nil, nil
+	}
+	return repositoriesFromPathList(filepath.SplitList(value), cwd, "env", EnvVar)
+}
+
+func RepositoriesFromArgs(args []string, cwd string) ([]Repository, []string, error) {
+	paths := []string{}
+	remainingStart := 0
+	for remainingStart < len(args) {
+		arg := args[remainingStart]
+		switch {
+		case arg == "--":
+			remainingStart++
+			goto done
+		case arg == "--"+RepositoryFlag || arg == "--"+VerbRepositoryFlag:
+			if remainingStart+1 >= len(args) {
+				return nil, nil, fmt.Errorf("%s requires a value", arg)
+			}
+			paths = appendCSVPaths(paths, args[remainingStart+1])
+			remainingStart += 2
+		case strings.HasPrefix(arg, "--"+RepositoryFlag+"="):
+			paths = appendCSVPaths(paths, strings.TrimPrefix(arg, "--"+RepositoryFlag+"="))
+			remainingStart++
+		case strings.HasPrefix(arg, "--"+VerbRepositoryFlag+"="):
+			paths = appendCSVPaths(paths, strings.TrimPrefix(arg, "--"+VerbRepositoryFlag+"="))
+			remainingStart++
+		default:
+			goto done
+		}
+	}
+
+done:
+	repos, err := repositoriesFromPathList(paths, cwd, "cli", "--"+RepositoryFlag)
+	if err != nil {
+		return nil, nil, err
+	}
+	return repos, append([]string{}, args[remainingStart:]...), nil
+}
+
+func appendCSVPaths(paths []string, value string) []string {
+	reader := csv.NewReader(strings.NewReader(value))
+	fields, err := reader.Read()
+	if err != nil || len(fields) == 0 {
+		return append(paths, value)
+	}
+	return append(paths, fields...)
+}
+
+func repositoriesFromPathList(paths []string, cwd string, source string, sourceRef string) ([]Repository, error) {
+	ret := []Repository{}
+	for _, raw := range paths {
+		normalized, err := NormalizeFilesystemRepositoryPath(raw, cwd)
+		if err != nil {
+			return nil, fmt.Errorf("%s repository %q: %w", source, raw, err)
+		}
+		ret = append(ret, Repository{Name: filepath.Base(normalized), Source: source, SourceRef: sourceRef, RootDir: normalized})
+	}
+	return ret, nil
+}
+
+func NormalizeFilesystemRepositoryPath(path string, baseDir string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", fmt.Errorf("repository path is empty")
+	}
+	if path == "~" || strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home directory: %w", err)
+		}
+		path = filepath.Join(home, strings.TrimPrefix(path, "~/"))
+	}
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(baseDir, path)
+	}
+	path = filepath.Clean(path)
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", err
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("%s is not a directory", path)
+	}
+	return path, nil
+}
+
+func RepositoryNames(repos []Repository) []string {
+	names := make([]string, 0, len(repos))
+	for _, repo := range repos {
+		names = append(names, repo.Name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/pkg/jsverbrepos/bootstrap_test.go
+++ b/pkg/jsverbrepos/bootstrap_test.go
@@ -1,0 +1,138 @@
+package jsverbrepos
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRepositoriesFromArgsParsesLeadingRepositoryFlags(t *testing.T) {
+	dir := t.TempDir()
+	repoA := mkdir(t, dir, "repo-a")
+	repoB := mkdir(t, dir, "repo-b")
+
+	repos, remaining, err := RepositoriesFromArgs([]string{
+		"--repository", repoA,
+		"--verb-repository=" + repoB,
+		"examples", "builtin", "hello", "--name", "Manuel",
+	}, dir)
+	if err != nil {
+		t.Fatalf("RepositoriesFromArgs() error = %v", err)
+	}
+	if len(repos) != 2 {
+		t.Fatalf("expected 2 repos, got %d", len(repos))
+	}
+	if repos[0].RootDir != repoA || repos[1].RootDir != repoB {
+		t.Fatalf("unexpected repo roots: %#v", repos)
+	}
+	wantRemaining := []string{"examples", "builtin", "hello", "--name", "Manuel"}
+	if !equalStrings(remaining, wantRemaining) {
+		t.Fatalf("remaining = %#v, want %#v", remaining, wantRemaining)
+	}
+}
+
+func TestRepositoriesFromArgsStopsAtFirstNonRepositoryArg(t *testing.T) {
+	dir := t.TempDir()
+	repoA := mkdir(t, dir, "repo-a")
+
+	repos, remaining, err := RepositoriesFromArgs([]string{
+		"--repository", repoA,
+		"examples", "--repository", repoA,
+	}, dir)
+	if err != nil {
+		t.Fatalf("RepositoriesFromArgs() error = %v", err)
+	}
+	if len(repos) != 1 {
+		t.Fatalf("expected 1 repo, got %d", len(repos))
+	}
+	wantRemaining := []string{"examples", "--repository", repoA}
+	if !equalStrings(remaining, wantRemaining) {
+		t.Fatalf("remaining = %#v, want %#v", remaining, wantRemaining)
+	}
+}
+
+func TestDiscoverFromIncludesBuiltinConfigEnvAndCLIWithDedupe(t *testing.T) {
+	t.Setenv(EnvVar, "")
+	dir := t.TempDir()
+	repoConfig := mkdir(t, dir, "config-repo")
+	repoEnv := mkdir(t, dir, "env-repo")
+	repoCLI := mkdir(t, dir, "cli-repo")
+	writeFile(t, filepath.Join(dir, LocalConfigFileName), "verbs:\n  repositories:\n    - name: configured\n      path: ./config-repo\n    - name: disabled\n      path: ./config-repo\n      enabled: false\n")
+	t.Setenv(EnvVar, repoEnv+string(os.PathListSeparator)+repoConfig)
+
+	bootstrap, remaining, err := DiscoverFrom(context.Background(), dir, []string{"--repository", repoCLI, "list"})
+	if err != nil {
+		t.Fatalf("DiscoverFrom() error = %v", err)
+	}
+	if !equalStrings(remaining, []string{"list"}) {
+		t.Fatalf("remaining = %#v", remaining)
+	}
+	if len(bootstrap.Repositories) != 4 {
+		t.Fatalf("expected builtin + config + env + cli after dedupe, got %d: %#v", len(bootstrap.Repositories), bootstrap.Repositories)
+	}
+	if bootstrap.Repositories[0].Name != "builtin" || !bootstrap.Repositories[0].Embedded {
+		t.Fatalf("first repository should be embedded builtin: %#v", bootstrap.Repositories[0])
+	}
+	if bootstrap.Repositories[1].Name != "configured" || bootstrap.Repositories[1].RootDir != repoConfig {
+		t.Fatalf("second repository should be config repo: %#v", bootstrap.Repositories[1])
+	}
+	if bootstrap.Repositories[2].RootDir != repoEnv {
+		t.Fatalf("third repository should be env repo: %#v", bootstrap.Repositories[2])
+	}
+	if bootstrap.Repositories[3].RootDir != repoCLI {
+		t.Fatalf("fourth repository should be cli repo: %#v", bootstrap.Repositories[3])
+	}
+}
+
+func TestNormalizeFilesystemRepositoryPathExpandsRelativeAndHome(t *testing.T) {
+	dir := t.TempDir()
+	repo := mkdir(t, dir, "repo")
+
+	normalized, err := NormalizeFilesystemRepositoryPath("./repo", dir)
+	if err != nil {
+		t.Fatalf("NormalizeFilesystemRepositoryPath(relative) error = %v", err)
+	}
+	if normalized != repo {
+		t.Fatalf("relative normalized = %q, want %q", normalized, repo)
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	homeRepo := mkdir(t, home, "home-repo")
+	normalized, err = NormalizeFilesystemRepositoryPath("~/home-repo", dir)
+	if err != nil {
+		t.Fatalf("NormalizeFilesystemRepositoryPath(home) error = %v", err)
+	}
+	if normalized != homeRepo {
+		t.Fatalf("home normalized = %q, want %q", normalized, homeRepo)
+	}
+}
+
+func mkdir(t *testing.T, base string, name string) string {
+	t.Helper()
+	path := filepath.Join(base, name)
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", path, err)
+	}
+	return path
+}
+
+func writeFile(t *testing.T, path string, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/jsverbrepos/builtin/db.js
+++ b/pkg/jsverbrepos/builtin/db.js
@@ -1,0 +1,20 @@
+__package__({
+  name: "builtin",
+  parents: ["examples"],
+  short: "Built-in goja smoke-test verbs",
+});
+
+function tables() {
+  const db = require("db");
+  return db.query(`
+    SELECT name
+    FROM sqlite_schema
+    WHERE type = 'table'
+      AND name NOT LIKE 'sqlite_%'
+    ORDER BY name
+  `);
+}
+
+__verb__("tables", {
+  short: "List user tables from the configured SQLite database",
+});

--- a/pkg/jsverbrepos/builtin/hello.js
+++ b/pkg/jsverbrepos/builtin/hello.js
@@ -1,0 +1,16 @@
+__package__({
+  name: "builtin",
+  parents: ["examples"],
+  short: "Built-in goja smoke-test verbs",
+});
+
+function hello(name) {
+  return { greeting: "hello " + (name || "world") };
+}
+
+__verb__("hello", {
+  short: "Return a greeting from the built-in verb repository",
+  fields: {
+    name: { type: "string", default: "world", help: "Name to greet" },
+  },
+});

--- a/pkg/jsverbrepos/builtin/ui.js
+++ b/pkg/jsverbrepos/builtin/ui.js
@@ -1,0 +1,18 @@
+__package__({
+  name: "builtin",
+  parents: ["examples"],
+  short: "Built-in goja smoke-test verbs",
+});
+
+function renderSampleTable() {
+  const ui = require("ui.dsl");
+  return ui.render(ui.table.fromRows("sample", [
+    { name: "Alice", role: "admin" },
+    { name: "Bob", role: "viewer" },
+  ]).features(f => f.pagination().sorting()).render({}));
+}
+
+__verb__("renderSampleTable", {
+  short: "Render a sample HTML table with ui.dsl",
+  outputMode: "text",
+});

--- a/pkg/jsverbrepos/builtin/yaml.js
+++ b/pkg/jsverbrepos/builtin/yaml.js
@@ -1,0 +1,18 @@
+__package__({
+  name: "builtin",
+  parents: ["examples"],
+  short: "Built-in goja smoke-test verbs",
+});
+
+function yamlKeys(text) {
+  const yaml = require("yaml");
+  const value = yaml.parse(text || "{}");
+  return Object.keys(value || {}).map(key => ({ key }));
+}
+
+__verb__("yamlKeys", {
+  short: "Parse YAML text and emit top-level keys",
+  fields: {
+    text: { type: "string", required: true, help: "YAML text to parse" },
+  },
+});

--- a/pkg/jsverbscli/command.go
+++ b/pkg/jsverbscli/command.go
@@ -1,0 +1,195 @@
+package jsverbscli
+
+import (
+	"fmt"
+	"sort"
+
+	glazedcli "github.com/go-go-golems/glazed/pkg/cli"
+	"github.com/go-go-golems/glazed/pkg/cmds"
+	"github.com/go-go-golems/go-go-goja/pkg/jsverbs"
+	"github.com/spf13/cobra"
+
+	"github.com/go-go-golems/go-go-goja/pkg/jsverbrepos"
+)
+
+type ScannedRepository struct {
+	Repository jsverbrepos.Repository
+	Registry   *jsverbs.Registry
+}
+
+type DiscoveredVerb struct {
+	Repository ScannedRepository
+	Verb       *jsverbs.VerbSpec
+}
+
+type InvokerFactory func(repo ScannedRepository, verb *jsverbs.VerbSpec) jsverbs.VerbInvoker
+
+func NewLazyCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:                "verbs",
+		Short:              "Run repository-scanned JavaScript verbs",
+		DisableFlagParsing: true,
+		Args:               cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			bootstrap, remainingArgs, err := jsverbrepos.Discover(cmd.Context(), args)
+			if err != nil {
+				return err
+			}
+			resolved, err := NewCommand(bootstrap)
+			if err != nil {
+				return err
+			}
+			adoptHelpAndOutput(cmd, resolved)
+			resolved.SetArgs(remainingArgs)
+			return resolved.ExecuteContext(cmd.Context())
+		},
+	}
+}
+
+func NewCommand(bootstrap jsverbrepos.Bootstrap) (*cobra.Command, error) {
+	settings := &RuntimeSettings{ReadOnly: true}
+	return newCommandWithInvokerFactory(bootstrap, runtimeInvokerFactory(settings), settings)
+}
+
+func newCommandWithInvokerFactory(bootstrap jsverbrepos.Bootstrap, invokers InvokerFactory, settings *RuntimeSettings) (*cobra.Command, error) {
+	root := &cobra.Command{
+		Use:   "verbs",
+		Short: "Run repository-scanned JavaScript verbs",
+	}
+	if settings != nil {
+		root.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+			if flag := cmd.Flag("db"); flag != nil {
+				settings.DBPath = flag.Value.String()
+			}
+			if flag := cmd.Flag("readonly"); flag != nil {
+				settings.ReadOnly = flag.Value.String() != "false"
+			}
+			if flag := cmd.Flag("allow-writes"); flag != nil {
+				settings.AllowWrites = flag.Value.String() == "true"
+			}
+			return nil
+		}
+		root.PersistentFlags().StringVar(&settings.DBPath, "db", "", "SQLite database path exposed as require(\"database\") and require(\"db\")")
+		root.PersistentFlags().BoolVar(&settings.ReadOnly, "readonly", true, "Open the JavaScript database API in read-only mode")
+		root.PersistentFlags().BoolVar(&settings.AllowWrites, "allow-writes", false, "Allow db.exec writes when --readonly=false")
+	}
+
+	repositories, err := ScanRepositories(bootstrap)
+	if err != nil {
+		return nil, err
+	}
+	discovered, err := CollectDiscoveredVerbs(repositories)
+	if err != nil {
+		return nil, err
+	}
+	listCmd, err := newListCommand(discovered)
+	if err != nil {
+		return nil, err
+	}
+	root.AddCommand(listCmd)
+	commands, err := buildCommands(discovered, invokers)
+	if err != nil {
+		return nil, err
+	}
+	if err := glazedcli.AddCommandsToRootCommand(root, commands, nil, glazedcli.WithParserConfig(glazedcli.CobraParserConfig{
+		MiddlewaresFunc: glazedcli.CobraCommandDefaultMiddlewares,
+	})); err != nil {
+		return nil, err
+	}
+	return root, nil
+}
+
+func ScanRepositories(bootstrap jsverbrepos.Bootstrap) ([]ScannedRepository, error) {
+	opts := jsverbs.DefaultScanOptions()
+	opts.IncludePublicFunctions = false
+
+	ret := make([]ScannedRepository, 0, len(bootstrap.Repositories))
+	for _, repo := range bootstrap.Repositories {
+		var (
+			registry *jsverbs.Registry
+			err      error
+		)
+		if repo.Embedded {
+			registry, err = jsverbs.ScanFS(repo.EmbeddedFS, repo.EmbeddedAt, opts)
+		} else {
+			registry, err = jsverbs.ScanDir(repo.RootDir, opts)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("scan repository %s: %w", repo.Name, err)
+		}
+		ret = append(ret, ScannedRepository{Repository: repo, Registry: registry})
+	}
+	return ret, nil
+}
+
+func CollectDiscoveredVerbs(repositories []ScannedRepository) ([]DiscoveredVerb, error) {
+	seen := map[string]DiscoveredVerb{}
+	ret := []DiscoveredVerb{}
+	for _, repo := range repositories {
+		if repo.Registry == nil {
+			continue
+		}
+		for _, verb := range repo.Registry.Verbs() {
+			key := verb.FullPath()
+			candidate := DiscoveredVerb{Repository: repo, Verb: verb}
+			if prev, ok := seen[key]; ok {
+				return nil, fmt.Errorf("duplicate jsverb path %q from %s and %s", key, discoveredVerbSource(prev), discoveredVerbSource(candidate))
+			}
+			seen[key] = candidate
+			ret = append(ret, candidate)
+		}
+	}
+	sort.Slice(ret, func(i, j int) bool {
+		return ret[i].Verb.FullPath() < ret[j].Verb.FullPath()
+	})
+	return ret, nil
+}
+
+func buildCommands(discovered []DiscoveredVerb, invokers InvokerFactory) ([]cmds.Command, error) {
+	commands := make([]cmds.Command, 0, len(discovered))
+	for _, discoveredVerb := range discovered {
+		repo := discoveredVerb.Repository
+		verb := discoveredVerb.Verb
+		cmd, err := repo.Registry.CommandForVerbWithInvoker(verb, invokers(repo, verb))
+		if err != nil {
+			return nil, err
+		}
+		commands = append(commands, cmd)
+	}
+	return commands, nil
+}
+
+func discoveredVerbSource(verb DiscoveredVerb) string {
+	if verb.Verb == nil || verb.Verb.File == nil {
+		return verb.Repository.Repository.Name
+	}
+	if verb.Verb.File.AbsPath != "" {
+		return fmt.Sprintf("%s (%s)", verb.Repository.Repository.Name, verb.Verb.File.AbsPath)
+	}
+	return fmt.Sprintf("%s (%s)", verb.Repository.Repository.Name, verb.Verb.File.RelPath)
+}
+
+func describeRepository(repo ScannedRepository) string {
+	if repo.Repository.Embedded {
+		return fmt.Sprintf("%s:%s", repo.Repository.Name, repo.Repository.EmbeddedAt)
+	}
+	return repo.Repository.RootDir
+}
+
+func adoptHelpAndOutput(source *cobra.Command, target *cobra.Command) {
+	if source == nil || target == nil {
+		return
+	}
+	target.SetOut(source.OutOrStdout())
+	target.SetErr(source.ErrOrStderr())
+	root := source.Root()
+	if root == nil {
+		return
+	}
+	target.SetHelpFunc(root.HelpFunc())
+	if usageFunc := root.UsageFunc(); usageFunc != nil {
+		target.SetUsageFunc(usageFunc)
+	}
+	target.SetHelpTemplate(root.HelpTemplate())
+	target.SetUsageTemplate(root.UsageTemplate())
+}

--- a/pkg/jsverbscli/command_test.go
+++ b/pkg/jsverbscli/command_test.go
@@ -1,0 +1,117 @@
+package jsverbscli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-go-golems/go-go-goja/pkg/jsverbrepos"
+)
+
+func TestScanRepositoriesDiscoversBuiltinVerb(t *testing.T) {
+	repos, err := ScanRepositories(jsverbrepos.Bootstrap{Repositories: []jsverbrepos.Repository{jsverbrepos.BuiltinRepository()}})
+	if err != nil {
+		t.Fatalf("ScanRepositories() error = %v", err)
+	}
+	discovered, err := CollectDiscoveredVerbs(repos)
+	if err != nil {
+		t.Fatalf("CollectDiscoveredVerbs() error = %v", err)
+	}
+	if len(discovered) != 4 {
+		t.Fatalf("expected four built-in verbs, got %d", len(discovered))
+	}
+	paths := []string{}
+	for _, item := range discovered {
+		paths = append(paths, item.Verb.FullPath())
+	}
+	if !contains(paths, "examples builtin hello") || !contains(paths, "examples builtin yaml-keys") || !contains(paths, "examples builtin tables") || !contains(paths, "examples builtin render-sample-table") {
+		t.Fatalf("builtin verb paths = %#v", paths)
+	}
+}
+
+func TestCollectDiscoveredVerbsRejectsDuplicatePaths(t *testing.T) {
+	dir := t.TempDir()
+	repoA := writeRepo(t, dir, "a")
+	repoB := writeRepo(t, dir, "b")
+	repos, err := ScanRepositories(jsverbrepos.Bootstrap{Repositories: []jsverbrepos.Repository{
+		{Name: "a", Source: "test", RootDir: repoA},
+		{Name: "b", Source: "test", RootDir: repoB},
+	}})
+	if err != nil {
+		t.Fatalf("ScanRepositories() error = %v", err)
+	}
+	_, err = CollectDiscoveredVerbs(repos)
+	if err == nil {
+		t.Fatalf("expected duplicate error")
+	}
+	if !strings.Contains(err.Error(), "duplicate jsverb path") {
+		t.Fatalf("unexpected duplicate error: %v", err)
+	}
+}
+
+func TestLazyCommandListsBuiltinVerb(t *testing.T) {
+	cmd := NewLazyCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"list", "--output", "json"})
+	stdout := captureStdout(t, func() {
+		if err := cmd.ExecuteContext(context.Background()); err != nil {
+			t.Fatalf("ExecuteContext() error = %v\noutput:\n%s", err, out.String())
+		}
+	})
+	if !strings.Contains(stdout, `"path": "examples builtin hello"`) {
+		t.Fatalf("list JSON output did not contain builtin verb: %q", stdout)
+	}
+	if !strings.Contains(stdout, `"repository": "builtin"`) {
+		t.Fatalf("list JSON output did not contain repository: %q", stdout)
+	}
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = old }()
+	fn()
+	if err := w.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatalf("read stdout: %v", err)
+	}
+	return buf.String()
+}
+
+func contains(values []string, needle string) bool {
+	for _, value := range values {
+		if value == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func writeRepo(t *testing.T, base string, name string) string {
+	t.Helper()
+	dir := filepath.Join(base, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	content := `__package__({ name: "dupe", parents: ["examples"] });
+function hello() { return { ok: true }; }
+__verb__("hello", { short: "duplicate" });
+`
+	if err := os.WriteFile(filepath.Join(dir, "dupe.js"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write dupe.js: %v", err)
+	}
+	return dir
+}

--- a/pkg/jsverbscli/list.go
+++ b/pkg/jsverbscli/list.go
@@ -1,0 +1,70 @@
+package jsverbscli
+
+import (
+	"context"
+
+	glazedcli "github.com/go-go-golems/glazed/pkg/cli"
+	"github.com/go-go-golems/glazed/pkg/cmds"
+	"github.com/go-go-golems/glazed/pkg/cmds/schema"
+	"github.com/go-go-golems/glazed/pkg/cmds/values"
+	"github.com/go-go-golems/glazed/pkg/middlewares"
+	"github.com/go-go-golems/glazed/pkg/settings"
+	"github.com/go-go-golems/glazed/pkg/types"
+	"github.com/spf13/cobra"
+)
+
+type listCommand struct {
+	*cmds.CommandDescription
+	discovered []DiscoveredVerb
+}
+
+func newListCommand(discovered []DiscoveredVerb) (*cobra.Command, error) {
+	glazedSection, err := settings.NewGlazedSchema()
+	if err != nil {
+		return nil, err
+	}
+	commandSettingsSection, err := glazedcli.NewCommandSettingsSection()
+	if err != nil {
+		return nil, err
+	}
+	cmd := &listCommand{
+		CommandDescription: cmds.NewCommandDescription(
+			"list",
+			cmds.WithShort("List discovered JavaScript verbs"),
+			cmds.WithLong(`List discovered JavaScript verbs as structured rows.
+
+Each row includes the mounted verb path, repository provenance, source file,
+function name, output mode, repository source, and repository root/embedded
+location. Use Glazed output flags such as --output json, --output yaml,
+--fields, and --sort-by to process the list in scripts.`),
+			cmds.WithSections(glazedSection, commandSettingsSection),
+		),
+		discovered: discovered,
+	}
+	return glazedcli.BuildCobraCommandFromCommand(cmd, glazedcli.WithParserConfig(glazedcli.CobraParserConfig{
+		ShortHelpSections: []string{schema.DefaultSlug, settings.GlazedSlug},
+		MiddlewaresFunc:   glazedcli.CobraCommandDefaultMiddlewares,
+	}))
+}
+
+func (c *listCommand) RunIntoGlazeProcessor(ctx context.Context, _ *values.Values, gp middlewares.Processor) error {
+	for _, item := range c.discovered {
+		verb := item.Verb
+		if verb == nil || verb.File == nil {
+			continue
+		}
+		row := types.NewRow(
+			types.MRP("path", verb.FullPath()),
+			types.MRP("repository", item.Repository.Repository.Name),
+			types.MRP("file", verb.File.RelPath),
+			types.MRP("function", verb.FunctionName),
+			types.MRP("output_mode", verb.OutputMode),
+			types.MRP("source", item.Repository.Repository.Source),
+			types.MRP("location", describeRepository(item.Repository)),
+		)
+		if err := gp.AddRow(ctx, row); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/jsverbscli/runtime.go
+++ b/pkg/jsverbscli/runtime.go
@@ -1,0 +1,119 @@
+package jsverbscli
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+
+	noderequire "github.com/dop251/goja_nodejs/require"
+	"github.com/go-go-golems/glazed/pkg/cmds/values"
+	"github.com/go-go-golems/go-go-goja/engine"
+	databasemod "github.com/go-go-golems/go-go-goja/modules/database"
+	"github.com/go-go-golems/go-go-goja/modules/uidsl"
+	"github.com/go-go-golems/go-go-goja/pkg/jsverbs"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+type RuntimeSettings struct {
+	DBPath      string
+	ReadOnly    bool
+	AllowWrites bool
+}
+
+func runtimeInvokerFactory(settings *RuntimeSettings) InvokerFactory {
+	return func(repo ScannedRepository, _ *jsverbs.VerbSpec) jsverbs.VerbInvoker {
+		return func(ctx context.Context, registry *jsverbs.Registry, verb *jsverbs.VerbSpec, parsedValues *values.Values) (interface{}, error) {
+			factory, cleanup, err := newRuntimeFactory(repo, settings)
+			if err != nil {
+				return nil, err
+			}
+			defer cleanup()
+
+			rt, err := factory.NewRuntime(ctx)
+			if err != nil {
+				return nil, err
+			}
+			defer func() { _ = rt.Close(context.Background()) }()
+
+			return registry.InvokeInRuntime(ctx, rt, verb, parsedValues)
+		}
+	}
+}
+
+func newRuntimeFactory(repo ScannedRepository, settings *RuntimeSettings) (*engine.Factory, func(), error) {
+	if repo.Registry == nil {
+		return nil, nil, fmt.Errorf("repository %s has no jsverbs registry", describeRepository(repo))
+	}
+	if settings == nil {
+		settings = &RuntimeSettings{ReadOnly: true}
+	}
+
+	cleanup := func() {}
+	moduleSpecs := []engine.ModuleSpec{}
+	if settings.DBPath != "" {
+		db, err := sql.Open("sqlite3", settings.DBPath)
+		if err != nil {
+			return nil, nil, fmt.Errorf("open sqlite database %s: %w", settings.DBPath, err)
+		}
+		if err := db.Ping(); err != nil {
+			_ = db.Close()
+			return nil, nil, fmt.Errorf("ping sqlite database %s: %w", settings.DBPath, err)
+		}
+		guarded := &guardedDB{db: db, allowWrites: settings.AllowWrites && !settings.ReadOnly}
+		databaseModule := databasemod.New(
+			databasemod.WithPreconfiguredDB(guarded),
+			databasemod.WithConfigureEnabled(false),
+		)
+		dbAliasModule := databasemod.New(
+			databasemod.WithName("db"),
+			databasemod.WithPreconfiguredDB(guarded),
+			databasemod.WithConfigureEnabled(false),
+		)
+		moduleSpecs = append(moduleSpecs,
+			engine.NativeModuleSpec{ModuleID: "database:configured", ModuleName: databaseModule.Name(), Loader: databaseModule.Loader},
+			engine.NativeModuleSpec{ModuleID: "database:db-alias", ModuleName: dbAliasModule.Name(), Loader: dbAliasModule.Loader},
+		)
+		cleanup = func() { _ = db.Close() }
+	}
+
+	builder := engine.NewBuilder(runtimeOptions(repo)...).
+		WithRequireOptions(noderequire.WithLoader(repo.Registry.RequireLoader())).
+		UseModuleMiddleware(engine.MiddlewareOnly("fs", "path", "time", "timer", "yaml")).
+		WithModules(moduleSpecs...).
+		WithRuntimeModuleRegistrars(uidsl.NewRegistrar())
+	factory, err := builder.Build()
+	if err != nil {
+		cleanup()
+		return nil, nil, err
+	}
+	return factory, cleanup, nil
+}
+
+func runtimeOptions(repo ScannedRepository) []engine.Option {
+	if repo.Repository.Embedded {
+		return nil
+	}
+	folders := []string{repo.Repository.RootDir, filepath.Join(repo.Repository.RootDir, "node_modules")}
+	parent := filepath.Dir(repo.Repository.RootDir)
+	if parent != repo.Repository.RootDir {
+		folders = append(folders, parent, filepath.Join(parent, "node_modules"))
+	}
+	return []engine.Option{engine.WithRequireOptions(noderequire.WithGlobalFolders(folders...))}
+}
+
+type guardedDB struct {
+	db          *sql.DB
+	allowWrites bool
+}
+
+func (g *guardedDB) Query(query string, args ...any) (*sql.Rows, error) {
+	return g.db.Query(query, args...)
+}
+
+func (g *guardedDB) Exec(query string, args ...any) (sql.Result, error) {
+	if !g.allowWrites {
+		return nil, fmt.Errorf("database writes are disabled; rerun with --readonly=false --allow-writes")
+	}
+	return g.db.Exec(query, args...)
+}

--- a/pkg/replessay/handler.go
+++ b/pkg/replessay/handler.go
@@ -390,6 +390,7 @@ func resolveEssayUIDistFS() fs.FS {
 }
 
 func dirFSIfExists(path string) fs.FS {
+	// #nosec G703 -- path is an explicit operator-provided UI dist directory or repo-local fallback.
 	info, err := os.Stat(path)
 	if err != nil || !info.IsDir() {
 		return nil

--- a/pkg/replsession/evaluate.go
+++ b/pkg/replsession/evaluate.go
@@ -362,6 +362,9 @@ func (s *Service) evaluateRaw(ctx context.Context, state *sessionState, cell *Ce
 	state.consoleSink = nil
 	start := time.Now()
 	outcome, execErr := state.executeRaw(ctx, rewrite.TransformedSource, policy)
+	if policy.Eval.SupportTopLevelAwait && isTopLevelAwaitExpression(cell.Source) {
+		outcome.Awaited = true
+	}
 	duration := time.Since(start)
 	consoleEvents := append([]ConsoleEvent{}, state.consoleSink...)
 	state.consoleSink = nil
@@ -447,10 +450,15 @@ func (s *Service) evaluateRaw(ctx context.Context, state *sessionState, cell *Ce
 
 func wrapTopLevelAwaitExpression(source string) (string, bool) {
 	trimmed := strings.TrimSpace(source)
-	if strings.HasPrefix(trimmed, "await ") || strings.HasPrefix(trimmed, "await(") {
+	if isTopLevelAwaitExpression(trimmed) {
 		return "(async () => { return " + trimmed + "; })()", true
 	}
 	return source, false
+}
+
+func isTopLevelAwaitExpression(source string) bool {
+	trimmed := strings.TrimSpace(source)
+	return strings.HasPrefix(trimmed, "await ") || strings.HasPrefix(trimmed, "await(")
 }
 
 // buildAwaitIIFEWithCapture constructs an async IIFE that wraps a top-level

--- a/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/README.md
+++ b/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/README.md
@@ -1,0 +1,21 @@
+# Upstream Express and ui.dsl modules into go-go-goja
+
+This is the document workspace for ticket GO-GO-GOJA-EXPRESS-UIDSL-MODULES.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr doc add --ticket GO-GO-GOJA-EXPRESS-UIDSL-MODULES --doc-type design-doc --title "My Design"`
+- Import sources: `docmgr import file --ticket GO-GO-GOJA-EXPRESS-UIDSL-MODULES --file /path/to/doc.md`
+- Update metadata: `docmgr meta update --ticket GO-GO-GOJA-EXPRESS-UIDSL-MODULES --field Status --value review`

--- a/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/changelog.md
+++ b/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/changelog.md
@@ -87,3 +87,14 @@ T14: added goja-site verbs by wiring jsverbscli.NewLazyCommand into goja-site an
 - /home/manuel/workspaces/2026-05-08/extract-express-goja/2026-05-03--goja-hosting-site/cmd/goja-site/main.go — goja-site verbs command integration
 - /home/manuel/workspaces/2026-05-08/extract-express-goja/go-go-goja/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/log/01-implementation-diary.md — T14 implementation diary
 
+
+## 2026-05-08
+
+T15: generalized goja-site script loading to repeatable script directories, updated multi-site config to scripts lists, and added script discovery tests (goja-hosting-site commit 67eff77dfa48f5fe4d521fef9cfd5aae99414051).
+
+### Related Files
+
+- /home/manuel/workspaces/2026-05-08/extract-express-goja/2026-05-03--goja-hosting-site/cmd/goja-site/serve.go — Repeatable --scripts flag
+- /home/manuel/workspaces/2026-05-08/extract-express-goja/2026-05-03--goja-hosting-site/pkg/app/scripts.go — Multi-directory script discovery
+- /home/manuel/workspaces/2026-05-08/extract-express-goja/go-go-goja/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/log/01-implementation-diary.md — T15 implementation diary
+

--- a/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/changelog.md
+++ b/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/changelog.md
@@ -110,3 +110,15 @@ T16: added goja-site database policy selection with guarded and simple modes, si
 - /home/manuel/workspaces/2026-05-08/extract-express-goja/2026-05-03--goja-hosting-site/pkg/app/database.go — Policy-specific database module construction and simple write gate
 - /home/manuel/workspaces/2026-05-08/extract-express-goja/go-go-goja/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/log/01-implementation-diary.md — T16 implementation diary
 
+
+## 2026-05-08
+
+T17: migrated db-browser generic browser, YAML dashboard, Playwright smoke app, and editable verb examples into goja-hosting-site; updated paths/commands, enabled yaml in the web runtime, and validated serve/verbs examples (goja-hosting-site commit 46b34df74a2bdef9223643f0b395d2394243bc5f).
+
+### Related Files
+
+- /home/manuel/workspaces/2026-05-08/extract-express-goja/2026-05-03--goja-hosting-site/examples/db-browser — Moved db-browser web examples under goja-site
+- /home/manuel/workspaces/2026-05-08/extract-express-goja/2026-05-03--goja-hosting-site/examples/verbs — User-visible local jsverbs examples
+- /home/manuel/workspaces/2026-05-08/extract-express-goja/2026-05-03--goja-hosting-site/pkg/app/server.go — Enabled yaml module for route scripts
+- /home/manuel/workspaces/2026-05-08/extract-express-goja/go-go-goja/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/log/01-implementation-diary.md — T17 implementation diary
+

--- a/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/changelog.md
+++ b/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/changelog.md
@@ -57,3 +57,13 @@ Committed baseline extraction and downstream migrations: go-go-goja 229fd920786a
 
 - /home/manuel/workspaces/2026-05-08/extract-express-goja/go-go-goja/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/log/01-implementation-diary.md — Baseline commit hashes and setup diary
 
+
+## 2026-05-08
+
+T12: extracted db-browser verb repository discovery into go-go-goja/pkg/jsverbrepos with neutral GOJA_VERB_REPOSITORIES and .goja-verbs.yml names (commit d4aec1568fa1278d2a612780f2c68de27c46a7db).
+
+### Related Files
+
+- /home/manuel/workspaces/2026-05-08/extract-express-goja/go-go-goja/pkg/jsverbrepos — Reusable jsverbs repository discovery package
+- /home/manuel/workspaces/2026-05-08/extract-express-goja/go-go-goja/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/log/01-implementation-diary.md — T12 implementation diary
+

--- a/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/changelog.md
+++ b/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/changelog.md
@@ -14,3 +14,37 @@ Created initial design guide and task plan for upstreaming Express-style HTTP ho
 - /home/manuel/code/wesen/2026-05-07--db-browser/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/design-doc/01-go-go-goja-express-and-ui-dsl-module-upstreaming-design-guide.md — Initial upstreaming analysis and design guide
 - /home/manuel/code/wesen/2026-05-07--db-browser/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/tasks.md — Implementation task sequence
 
+
+## 2026-05-08
+
+Upstreamed db-browser/goja-hosting-site HTTP hosting and ui.dsl into go-go-goja, migrated both downstream apps to the new packages, deleted local copied packages, added docs/type descriptors, and validated go-go-goja plus downstream tests.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-05-08/extract-express-goja/2026-05-03--goja-hosting-site/pkg/app/server.go — goja-hosting-site now consumes upstream gojahttp/express/uidsl
+- /home/manuel/workspaces/2026-05-08/extract-express-goja/2026-05-07--db-browser/internal/app/server.go — db-browser now consumes upstream gojahttp/express/uidsl
+- /home/manuel/workspaces/2026-05-08/extract-express-goja/go-go-goja/modules/express — Runtime-scoped express module registrar
+- /home/manuel/workspaces/2026-05-08/extract-express-goja/go-go-goja/modules/uidsl — Rich UI DSL module moved from db-browser
+- /home/manuel/workspaces/2026-05-08/extract-express-goja/go-go-goja/pkg/gojahttp — Reusable renderer-neutral HTTP host copied from db-browser internal/web
+
+
+## 2026-05-08
+
+Ran targeted golangci-lint for pkg/gojahttp, modules/express, and modules/uidsl; fixed errcheck/staticcheck/unused findings in the moved code.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-05-08/extract-express-goja/go-go-goja/modules/express — Cleaned lint findings in Express integration tests
+- /home/manuel/workspaces/2026-05-08/extract-express-goja/go-go-goja/modules/uidsl — Cleaned lint findings in moved UI DSL tests/components
+- /home/manuel/workspaces/2026-05-08/extract-express-goja/go-go-goja/pkg/gojahttp — Cleaned lint findings in gojahttp integration tests
+
+
+## 2026-05-08
+
+Added shell merge design and detailed task plan using Option A (retire db-browser) and Option C (support both dbguard and simple DB policies).
+
+### Related Files
+
+- /home/manuel/workspaces/2026-05-08/extract-express-goja/go-go-goja/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/design-doc/02-merge-db-browser-and-goja-hosting-site-web-shells.md — Shell merge design
+- /home/manuel/workspaces/2026-05-08/extract-express-goja/go-go-goja/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/tasks.md — Detailed task plan
+

--- a/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/changelog.md
+++ b/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/changelog.md
@@ -122,3 +122,15 @@ T17: migrated db-browser generic browser, YAML dashboard, Playwright smoke app, 
 - /home/manuel/workspaces/2026-05-08/extract-express-goja/2026-05-03--goja-hosting-site/pkg/app/server.go — Enabled yaml module for route scripts
 - /home/manuel/workspaces/2026-05-08/extract-express-goja/go-go-goja/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/log/01-implementation-diary.md — T17 implementation diary
 
+
+## 2026-05-08
+
+T18: retired db-browser in place by replacing README with migration guidance, removing duplicated runtime/examples/old validation scripts, adding a marker package, tidying goja-site standalone deps, and running final validation (db-browser commit 1b9e06350efcc0fd6e967311966859f689b61766; goja-site commit 48f5420d094b23c4cdf208a39fd7f94859ce7b52).
+
+### Related Files
+
+- /home/manuel/workspaces/2026-05-08/extract-express-goja/2026-05-03--goja-hosting-site/go.mod — Standalone tidy after migration
+- /home/manuel/workspaces/2026-05-08/extract-express-goja/2026-05-07--db-browser/README.md — Retirement notice and migration commands
+- /home/manuel/workspaces/2026-05-08/extract-express-goja/2026-05-07--db-browser/retired.go — Marker package for retired module
+- /home/manuel/workspaces/2026-05-08/extract-express-goja/go-go-goja/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/log/01-implementation-diary.md — T18 implementation diary
+

--- a/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/changelog.md
+++ b/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/changelog.md
@@ -67,3 +67,13 @@ T12: extracted db-browser verb repository discovery into go-go-goja/pkg/jsverbre
 - /home/manuel/workspaces/2026-05-08/extract-express-goja/go-go-goja/pkg/jsverbrepos — Reusable jsverbs repository discovery package
 - /home/manuel/workspaces/2026-05-08/extract-express-goja/go-go-goja/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/log/01-implementation-diary.md — T12 implementation diary
 
+
+## 2026-05-08
+
+T13: extracted db-browser jsverbs CLI/runtime shell into go-go-goja/pkg/jsverbscli, wired it to pkg/jsverbrepos, and replaced deprecated module registration (commit d84a38f177a6e5e9cf375b14d1d7fb1f90fc4ae9).
+
+### Related Files
+
+- /home/manuel/workspaces/2026-05-08/extract-express-goja/go-go-goja/pkg/jsverbscli — Reusable jsverbs CLI and runtime invocation package
+- /home/manuel/workspaces/2026-05-08/extract-express-goja/go-go-goja/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/log/01-implementation-diary.md — T13 implementation diary
+

--- a/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/changelog.md
+++ b/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/changelog.md
@@ -77,3 +77,13 @@ T13: extracted db-browser jsverbs CLI/runtime shell into go-go-goja/pkg/jsverbsc
 - /home/manuel/workspaces/2026-05-08/extract-express-goja/go-go-goja/pkg/jsverbscli — Reusable jsverbs CLI and runtime invocation package
 - /home/manuel/workspaces/2026-05-08/extract-express-goja/go-go-goja/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/log/01-implementation-diary.md — T13 implementation diary
 
+
+## 2026-05-08
+
+T14: added goja-site verbs by wiring jsverbscli.NewLazyCommand into goja-site and validating built-in hello/yaml/renderSampleTable/tables verbs (goja-hosting-site commit d62fa16c71d2f6567bca53915888910247667d3a).
+
+### Related Files
+
+- /home/manuel/workspaces/2026-05-08/extract-express-goja/2026-05-03--goja-hosting-site/cmd/goja-site/main.go — goja-site verbs command integration
+- /home/manuel/workspaces/2026-05-08/extract-express-goja/go-go-goja/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/log/01-implementation-diary.md — T14 implementation diary
+

--- a/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/changelog.md
+++ b/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/changelog.md
@@ -48,3 +48,12 @@ Added shell merge design and detailed task plan using Option A (retire db-browse
 - /home/manuel/workspaces/2026-05-08/extract-express-goja/go-go-goja/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/design-doc/02-merge-db-browser-and-goja-hosting-site-web-shells.md — Shell merge design
 - /home/manuel/workspaces/2026-05-08/extract-express-goja/go-go-goja/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/tasks.md — Detailed task plan
 
+
+## 2026-05-08
+
+Committed baseline extraction and downstream migrations: go-go-goja 229fd920786ae83dc96bac1732bf80eda4c68307, goja-hosting-site dda6fa41cee1048b7e54087f535eed99432c1cbc, db-browser 4e3009f8ee68e119d31aa08f451644ace896fbee.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-05-08/extract-express-goja/go-go-goja/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/log/01-implementation-diary.md — Baseline commit hashes and setup diary
+

--- a/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/changelog.md
+++ b/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/changelog.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## 2026-05-08
+
+- Initial workspace created
+
+
+## 2026-05-08
+
+Created initial design guide and task plan for upstreaming Express-style HTTP hosting and ui.dsl into go-go-goja.
+
+### Related Files
+
+- /home/manuel/code/wesen/2026-05-07--db-browser/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/design-doc/01-go-go-goja-express-and-ui-dsl-module-upstreaming-design-guide.md — Initial upstreaming analysis and design guide
+- /home/manuel/code/wesen/2026-05-07--db-browser/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/tasks.md — Implementation task sequence
+

--- a/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/changelog.md
+++ b/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/changelog.md
@@ -98,3 +98,15 @@ T15: generalized goja-site script loading to repeatable script directories, upda
 - /home/manuel/workspaces/2026-05-08/extract-express-goja/2026-05-03--goja-hosting-site/pkg/app/scripts.go — Multi-directory script discovery
 - /home/manuel/workspaces/2026-05-08/extract-express-goja/go-go-goja/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/log/01-implementation-diary.md — T15 implementation diary
 
+
+## 2026-05-08
+
+T16: added goja-site database policy selection with guarded and simple modes, simple read/write gate, serve flags, multi-site policy config, tests, lint, and standalone module tidy (goja-hosting-site commit 5142843b00c96415f0138e881c9edeadbd650ba9).
+
+### Related Files
+
+- /home/manuel/workspaces/2026-05-08/extract-express-goja/2026-05-03--goja-hosting-site/cmd/goja-site/serve.go — Database policy CLI flags
+- /home/manuel/workspaces/2026-05-08/extract-express-goja/2026-05-03--goja-hosting-site/pkg/app/config.go — DBPolicy config normalization
+- /home/manuel/workspaces/2026-05-08/extract-express-goja/2026-05-03--goja-hosting-site/pkg/app/database.go — Policy-specific database module construction and simple write gate
+- /home/manuel/workspaces/2026-05-08/extract-express-goja/go-go-goja/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/log/01-implementation-diary.md — T16 implementation diary
+

--- a/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/changelog.md
+++ b/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/changelog.md
@@ -134,3 +134,15 @@ T18: retired db-browser in place by replacing README with migration guidance, re
 - /home/manuel/workspaces/2026-05-08/extract-express-goja/2026-05-07--db-browser/retired.go — Marker package for retired module
 - /home/manuel/workspaces/2026-05-08/extract-express-goja/go-go-goja/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/log/01-implementation-diary.md — T18 implementation diary
 
+
+## 2026-05-08
+
+Post-T18: fixed ui.dsl empty value attribute rendering for Kanban's All columns option and added a repeatable Kanban Playwright smoke script (go-go-goja commit bcf26bc4f84e55decb4c634d7eec1573edab4bf4; goja-site commit c53ebdcb013203be568e344293ba4afb1c97cf59).
+
+### Related Files
+
+- /home/manuel/workspaces/2026-05-08/extract-express-goja/2026-05-03--goja-hosting-site/scripts/playwright-kanban-smoke.sh — Repeatable Kanban Playwright E2E smoke
+- /home/manuel/workspaces/2026-05-08/extract-express-goja/go-go-goja/modules/uidsl/render.go — Preserve empty value attributes
+- /home/manuel/workspaces/2026-05-08/extract-express-goja/go-go-goja/modules/uidsl/render_attrs_test.go — Regression test for empty option value
+- /home/manuel/workspaces/2026-05-08/extract-express-goja/go-go-goja/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/log/01-implementation-diary.md — Post-T18 Playwright diary
+

--- a/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/design-doc/01-go-go-goja-express-and-ui-dsl-module-upstreaming-design-guide.md
+++ b/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/design-doc/01-go-go-goja-express-and-ui-dsl-module-upstreaming-design-guide.md
@@ -1,0 +1,910 @@
+---
+Title: go-go-goja Express and ui.dsl module upstreaming design guide
+Ticket: GO-GO-GOJA-EXPRESS-UIDSL-MODULES
+Status: active
+Topics:
+  - goja
+  - ui-dsl
+  - web-ui
+  - documentation
+DocType: design-doc
+Intent: long-term
+Owners: []
+RelatedFiles:
+  - path: /home/manuel/code/wesen/2026-05-07--db-browser/internal/web
+    note: Current db-browser copy/adaptation of the Express-style HTTP host.
+  - path: /home/manuel/code/wesen/2026-05-07--db-browser/internal/uidsl
+    note: Current db-browser ui.dsl implementation, including rich tables and inspection components.
+  - path: /home/manuel/code/wesen/2026-05-03--goja-hosting-site/pkg/web
+    note: Original Express-style HTTP host copied into db-browser.
+  - path: /home/manuel/code/wesen/2026-05-03--goja-hosting-site/pkg/uidsl
+    note: Original low-level ui.dsl renderer copied into db-browser.
+  - path: /home/manuel/code/wesen/corporate-headquarters/go-go-goja/modules/common.go
+    note: NativeModule registry interface and default module registration pattern.
+  - path: /home/manuel/code/wesen/corporate-headquarters/go-go-goja/engine/runtime_modules.go
+    note: RuntimeModuleRegistrar interface needed for runtime-scoped modules such as express.
+  - path: /home/manuel/code/wesen/corporate-headquarters/go-go-goja/modules/database/database.go
+    note: Existing module option/declaration pattern to follow for configurable modules.
+ExternalSources: []
+Summary: "Initial design for upstreaming db-browser/goja-hosting-site Express-style web hosting and ui.dsl into go-go-goja as reusable packages."
+LastUpdated: 2026-05-08T18:35:00-04:00
+WhatFor: "Use this before implementing go-go-goja packages for Express-style HTTP hosting and server-rendered ui.dsl."
+WhenToUse: "Read when moving code from db-browser/goja-hosting-site into corporate-headquarters/go-go-goja or when updating downstream repos to use the upstream packages."
+---
+
+# go-go-goja Express and ui.dsl module upstreaming design guide
+
+## Executive Summary
+
+`db-browser` currently carries local copies of two generally useful Goja-hosting packages:
+
+1. `internal/web`: an Express-style HTTP host that lets JavaScript register route handlers with `app.get(...)`, `app.post(...)`, and response helpers such as `res.html(...)` and `res.json(...)`.
+2. `internal/uidsl`: a server-rendered HTML node DSL exposed as `require("ui.dsl")` / `require("ui")`, including tag helpers, document rendering, rich tables, code blocks, badges, and tabs.
+
+Both originated from `../2026-05-03--goja-hosting-site`, then `db-browser` adapted and extended them. `internal/web` remains very close to the original package. `internal/uidsl` is now a superset: it includes the original low-level renderer plus rich inspection components built during the db-browser work.
+
+The best upstream shape in `go-go-goja` is to split responsibilities into three packages:
+
+```text
+go-go-goja/
+├── pkg/gojahttp/
+│   ├── host.go
+│   ├── request_response.go
+│   ├── route_registry.go
+│   ├── session.go
+│   ├── body.go
+│   └── *_test.go
+├── modules/express/
+│   ├── express.go
+│   ├── express_test.go
+│   └── typescript.go
+└── modules/uidsl/
+    ├── node.go
+    ├── render.go
+    ├── module.go
+    ├── table.go
+    ├── components.go
+    └── *_test.go
+```
+
+`pkg/gojahttp` should contain the reusable HTTP host. `modules/express` should be a small runtime-scoped adapter that exposes that host as `require("express")`. `modules/uidsl` should contain the reusable UI DSL and renderer.
+
+The most important design decision is that `express` must **not** be a default globally registered `modules.NativeModule`. It requires a configured `Host`, renderer, session manager, and runtime owner. It should be installed through `engine.RuntimeModuleRegistrar`, the same mechanism that can receive runtime-scoped context from the engine.
+
+## Problem Statement
+
+The current implementation is duplicated across three repositories:
+
+```text
+/home/manuel/code/wesen/2026-05-03--goja-hosting-site/pkg/web
+/home/manuel/code/wesen/2026-05-03--goja-hosting-site/pkg/uidsl
+/home/manuel/code/wesen/2026-05-07--db-browser/internal/web
+/home/manuel/code/wesen/2026-05-07--db-browser/internal/uidsl
+/home/manuel/code/wesen/corporate-headquarters/go-go-goja
+```
+
+`db-browser` copied `pkg/web` and `pkg/uidsl` as requested, then adapted imports and extended `ui.dsl`. That was a good implementation shortcut, but it creates drift:
+
+- future fixes to `express` routing/session/body parsing need to be applied in multiple repos;
+- future `ui.dsl` components would likely be useful beyond db-browser;
+- consumers of `go-go-goja` cannot currently build server-rendered JavaScript apps without copying these packages again;
+- TypeScript declarations and module documentation cannot live in one canonical place;
+- the current package names are local (`internal/web`, `pkg/web`) rather than a reusable `go-go-goja` module boundary.
+
+The upstreaming project should make the Express-style host and `ui.dsl` first-class reusable parts of `go-go-goja` while preserving db-browser's current JavaScript API.
+
+## Current State Analysis
+
+### `internal/web` versus `goja-hosting-site/pkg/web`
+
+A recursive diff shows that db-browser's `internal/web` is nearly identical to the original `goja-hosting-site/pkg/web`. The main differences are tests:
+
+- imports changed from `github.com/go-go-golems/goja-site/pkg/uidsl` to `github.com/go-go-golems/db-browser/internal/uidsl`;
+- copied tests removed calls to `engine.NewBuilder().UseModuleMiddleware(engine.MiddlewareOnly("time"))` because the db-browser dependency version initially did not expose the same API shape.
+
+The production package files are effectively reusable as the starting point for `pkg/gojahttp` and `modules/express`.
+
+Current files:
+
+```text
+internal/web/body.go
+internal/web/express_module.go
+internal/web/host.go
+internal/web/request_response.go
+internal/web/route_registry.go
+internal/web/session.go
+```
+
+### `internal/uidsl` versus `goja-hosting-site/pkg/uidsl`
+
+`goja-hosting-site/pkg/uidsl` contains the base renderer:
+
+```text
+module.go
+node.go
+render.go
+render_test.go
+```
+
+`db-browser/internal/uidsl` now contains the base renderer plus:
+
+```text
+components.go
+components_test.go
+table.go
+table_test.go
+table_rich_test.go
+table_filters_test.go
+table_links_test.go
+```
+
+The db-browser version is therefore the canonical candidate for upstreaming. It includes:
+
+- safe text and attribute escaping;
+- `ui.page`, tag helpers, `ui.text`, `ui.raw`, and `ui.render`;
+- `ui.table.fromRows(...)` and `ui.table(id).data(...)`;
+- table columns, filters, sorting, pagination, money/date/tags/badge kinds, links, empty states;
+- `ui.codeBlock`, `ui.sql`, `ui.js`, `ui.jsonBlock`;
+- `ui.badge`;
+- `ui.tabs` with CSS-only radio switching and per-instance CSS.
+
+### `go-go-goja` module architecture
+
+`go-go-goja` already has two relevant extension mechanisms.
+
+The first is `modules.NativeModule`:
+
+```go
+type NativeModule interface {
+    Name() string
+    Doc() string
+    Loader(*goja.Runtime, *goja.Object)
+}
+```
+
+This is correct for modules such as `yaml`, `path`, `time`, and `database` when no per-runtime host object is needed.
+
+The second is `engine.RuntimeModuleRegistrar`:
+
+```go
+type RuntimeModuleRegistrar interface {
+    ID() string
+    RegisterRuntimeModules(ctx *RuntimeModuleContext, reg *require.Registry) error
+}
+```
+
+This is the correct fit for `express`, because `express` needs access to:
+
+- the configured `Host`;
+- the current runtime owner (`ctx.Owner`);
+- optionally future runtime-scoped values such as sessions, event bridges, or per-runtime app IDs.
+
+## Goals
+
+1. Provide a reusable Express-style HTTP host in `go-go-goja`.
+2. Provide a reusable `ui.dsl` module in `go-go-goja`.
+3. Preserve the current JavaScript API used by db-browser examples:
+
+   ```js
+   const express = require("express");
+   const ui = require("ui.dsl");
+   const app = express.app();
+   ```
+
+4. Keep `express` runtime-scoped rather than default-global.
+5. Keep the HTTP host renderer-neutral; it should accept a renderer function rather than import `ui.dsl` directly.
+6. Add TypeScript declarations for both modules.
+7. Add runtime integration tests proving `require("express")` and `require("ui.dsl")` work in `go-go-goja` runtimes.
+8. Migrate `goja-hosting-site` and `db-browser` to use the upstream packages and delete local copies.
+
+## Non-goals
+
+- Do not implement full Express compatibility.
+- Do not implement Express middleware/`next` semantics in the first upstreaming pass.
+- Do not make `express` available in every default runtime.
+- Do not couple `express` to SQLite or db-browser.
+- Do not implement server-interactive UI events in this ticket.
+- Do not require client-side JavaScript for `ui.dsl` components in the first pass.
+
+## Proposed Package Layout
+
+### `pkg/gojahttp`
+
+Move host infrastructure here:
+
+```text
+pkg/gojahttp/body.go
+pkg/gojahttp/host.go
+pkg/gojahttp/request_response.go
+pkg/gojahttp/route_registry.go
+pkg/gojahttp/session.go
+```
+
+Suggested public API:
+
+```go
+package gojahttp
+
+type Renderer func(*goja.Runtime, goja.Value) (string, error)
+
+type HostOptions struct {
+    Dev      bool
+    Renderer Renderer
+    Sessions SessionOptions
+}
+
+type Host struct { ... }
+
+func NewHost(opts HostOptions) *Host
+func (h *Host) SetRuntime(owner runtimeowner.Runner)
+func (h *Host) Register(method, pattern string, handler goja.Callable)
+func (h *Host) RegisterStatic(prefix, dir string)
+func (h *Host) ServeHTTP(w http.ResponseWriter, r *http.Request)
+```
+
+This package should not import `modules/uidsl`. It accepts a renderer so different applications can provide different HTML rendering strategies.
+
+### `modules/express`
+
+Move the current `express_module.go` into a module adapter package:
+
+```text
+modules/express/express.go
+modules/express/express_test.go
+modules/express/typescript.go
+```
+
+Suggested API:
+
+```go
+package expressmod
+
+type Option func(*Registrar)
+
+type Registrar struct {
+    host *gojahttp.Host
+    name string
+}
+
+func NewRegistrar(host *gojahttp.Host, opts ...Option) *Registrar
+func WithName(name string) Option
+
+func (r *Registrar) ID() string
+func (r *Registrar) RegisterRuntimeModules(ctx *engine.RuntimeModuleContext, reg *require.Registry) error
+```
+
+`RegisterRuntimeModules` should set the host runtime owner and register the native module:
+
+```go
+func (r *Registrar) RegisterRuntimeModules(ctx *engine.RuntimeModuleContext, reg *require.Registry) error {
+    if r.host == nil {
+        return fmt.Errorf("express registrar requires host")
+    }
+    r.host.SetRuntime(ctx.Owner)
+    reg.RegisterNativeModule(r.name, r.loader)
+    return nil
+}
+```
+
+The loader should export:
+
+```js
+express.app(): App
+```
+
+`App` should support:
+
+```js
+app.get(pattern, handler)
+app.post(pattern, handler)
+app.put(pattern, handler)
+app.patch(pattern, handler)
+app.delete(pattern, handler)
+app.all(pattern, handler)
+app.static(prefix, dir)
+```
+
+### `modules/uidsl`
+
+Move db-browser's richer UI DSL into:
+
+```text
+modules/uidsl/node.go
+modules/uidsl/render.go
+modules/uidsl/module.go
+modules/uidsl/table.go
+modules/uidsl/components.go
+```
+
+Suggested public API:
+
+```go
+package uidsl
+
+func RenderAny(vm *goja.Runtime, v goja.Value) (string, error)
+func Loader(vm *goja.Runtime, moduleObj *goja.Object)
+func NewRegistrar() *Registrar
+```
+
+`NewRegistrar()` should register both `ui.dsl` and `ui`:
+
+```go
+reg.RegisterNativeModule("ui.dsl", Loader)
+reg.RegisterNativeModule("ui", Loader)
+```
+
+A future optional `modules.NativeModule` wrapper can be added later if we want `ui.dsl` to participate in the default module registry. Start with the explicit registrar because it preserves the current db-browser pattern and avoids surprising default availability.
+
+## JavaScript API Contract
+
+### Express-style host
+
+The first stable API should be:
+
+```js
+const express = require("express");
+const app = express.app();
+
+app.get("/", (req, res) => {
+  res.html("<h1>Hello</h1>");
+});
+
+app.post("/api/echo", (req, res) => {
+  res.json({ body: req.body });
+});
+```
+
+Request object:
+
+```ts
+type Request = {
+  method: string;
+  url: string;
+  path: string;
+  query: Record<string, string | string[]>;
+  params: Record<string, string>;
+  headers: Record<string, string>;
+  cookies: Record<string, string>;
+  session: Session | null;
+  ip: string;
+  body: unknown;
+  rawBody: string;
+};
+```
+
+Response object:
+
+```ts
+type Response = {
+  status(code: number): Response;
+  set(name: string, value: string): Response;
+  type(value: string): Response;
+  json(value: unknown): void;
+  send(value?: unknown): void;
+  html(value: unknown): void;
+  redirect(url: string): void;
+  redirect(status: number, url: string): void;
+  end(): void;
+};
+```
+
+### UI DSL
+
+The first stable API should include:
+
+```js
+const ui = require("ui.dsl");
+
+ui.page({ title }, ...children)
+ui.fragment(...children)
+ui.text(value)
+ui.raw(html)
+ui.render(value)
+
+ui.div(attrs?, ...children)
+ui.span(attrs?, ...children)
+ui.a(attrs, ...children)
+ui.form(attrs?, ...children)
+ui.input(attrs)
+// plus the current tag list
+```
+
+Inspection components:
+
+```js
+ui.table.fromRows(id, rows)
+ui.table(id).data(fn)
+ui.codeBlock(language, source, options?)
+ui.sql(source, options?)
+ui.js(source, options?)
+ui.jsonBlock(value, options?)
+ui.badge(value, options?)
+ui.tabs(id, tabs, options?)
+```
+
+The safety contract should be explicit in docs:
+
+- normal text and attribute values are escaped;
+- `ui.raw` bypasses escaping and is only for trusted HTML/CSS;
+- code blocks and JSON blocks must escape source text by default;
+- tab IDs, badge values, and language classes are normalized into CSS/DOM-safe tokens.
+
+## Recommended Consumer Usage
+
+A consumer should configure the host explicitly:
+
+```go
+host := gojahttp.NewHost(gojahttp.HostOptions{
+    Dev:      true,
+    Renderer: uidsl.RenderAny,
+})
+
+factory, err := engine.NewBuilder().
+    UseModuleMiddleware(engine.MiddlewareOnly("fs", "path", "yaml", "time", "timer")).
+    WithRuntimeModuleRegistrars(
+        expressmod.NewRegistrar(host),
+        uidsl.NewRegistrar(),
+    ).
+    Build()
+```
+
+Then load app code:
+
+```go
+rt, err := factory.NewRuntime(ctx)
+if err != nil {
+    return err
+}
+
+_, err = rt.Owner.Call(ctx, "load-script", func(_ context.Context, vm *goja.Runtime) (any, error) {
+    _, err := vm.RunScript("app.js", source)
+    return nil, err
+})
+```
+
+Then serve:
+
+```go
+return http.ListenAndServe(":8080", host)
+```
+
+App JavaScript:
+
+```js
+const express = require("express");
+const ui = require("ui.dsl");
+
+const app = express.app();
+
+app.get("/", (req, res) => {
+  res.html(ui.page(
+    { title: "Hello" },
+    ui.h1("Hello from Goja"),
+    ui.p("Path: " + req.path)
+  ));
+});
+```
+
+## TypeScript Declaration Plan
+
+`modules/express` should implement a TypeScript declaration provider if the current `go-go-goja` declaration generator can represent the module shape. If the generator cannot describe nested interfaces well enough, store a hand-authored declaration document next to the module and wire it into the docs first.
+
+Initial `express` declaration:
+
+```ts
+declare module "express" {
+  export function app(): App;
+
+  export interface App {
+    get(pattern: string, handler: Handler): void;
+    post(pattern: string, handler: Handler): void;
+    put(pattern: string, handler: Handler): void;
+    patch(pattern: string, handler: Handler): void;
+    delete(pattern: string, handler: Handler): void;
+    all(pattern: string, handler: Handler): void;
+    static(prefix: string, dir: string): void;
+  }
+
+  export type Handler = (req: Request, res: Response) => unknown;
+
+  export interface Request {
+    method: string;
+    url: string;
+    path: string;
+    query: Record<string, string | string[]>;
+    params: Record<string, string>;
+    headers: Record<string, string>;
+    cookies: Record<string, string>;
+    session: Session | null;
+    ip: string;
+    body: unknown;
+    rawBody: string;
+  }
+
+  export interface Session {
+    id: string;
+    isNew: boolean;
+    cookieName: string;
+  }
+
+  export interface Response {
+    status(code: number): Response;
+    set(name: string, value: string): Response;
+    type(value: string): Response;
+    json(value: unknown): void;
+    send(value?: unknown): void;
+    html(value: unknown): void;
+    redirect(url: string): void;
+    redirect(status: number, url: string): void;
+    end(): void;
+  }
+}
+```
+
+Initial `ui.dsl` declaration should cover common tag helpers and rich components. It can start conservative with `unknown`/`Node` where the generator cannot express fluent builders.
+
+## Implementation Plan
+
+### T01 — Create upstream package skeletons
+
+In `/home/manuel/code/wesen/corporate-headquarters/go-go-goja`:
+
+```text
+pkg/gojahttp
+modules/express
+modules/uidsl
+```
+
+Copy from db-browser first because db-browser is the current adapted/superset version.
+
+### T02 — Move HTTP host into `pkg/gojahttp`
+
+Copy and rename package from `web` to `gojahttp`:
+
+```text
+internal/web/body.go              -> pkg/gojahttp/body.go
+internal/web/host.go              -> pkg/gojahttp/host.go
+internal/web/request_response.go  -> pkg/gojahttp/request_response.go
+internal/web/route_registry.go    -> pkg/gojahttp/route_registry.go
+internal/web/session.go           -> pkg/gojahttp/session.go
+```
+
+Cleanups:
+
+- rename default cookie from `goja_site_session` to a neutral `goja_http_session` or `go_go_goja_session`;
+- update comments that mention `goja-site`;
+- keep `HostOptions.Renderer` as an injected function;
+- keep session configuration unchanged except naming.
+
+### T03 — Add `modules/express`
+
+Move/adapt `express_module.go` into `modules/express`.
+
+Do not call `modules.Register(...)` in `init()` for the first version.
+
+Expose:
+
+```go
+func NewRegistrar(host *gojahttp.Host, opts ...Option) *Registrar
+func WithName(name string) Option
+```
+
+Default module name should be `express`.
+
+### T04 — Move `ui.dsl` into `modules/uidsl`
+
+Copy db-browser's `internal/uidsl` into `modules/uidsl`.
+
+Keep package name `uidsl`.
+
+Expose:
+
+```go
+func RenderAny(vm *goja.Runtime, v goja.Value) (string, error)
+func NewRegistrar() *Registrar
+func Loader(vm *goja.Runtime, moduleObj *goja.Object)
+```
+
+Register aliases `ui.dsl` and `ui` through the registrar.
+
+### T05 — Add tests in go-go-goja
+
+Move/adapt tests:
+
+```text
+pkg/gojahttp/route_registry_test.go
+pkg/gojahttp/session_test.go
+modules/express/express_test.go
+modules/uidsl/render_test.go
+modules/uidsl/table_test.go
+modules/uidsl/table_rich_test.go
+modules/uidsl/table_filters_test.go
+modules/uidsl/table_links_test.go
+modules/uidsl/components_test.go
+```
+
+Add an integration test that builds an engine runtime with both registrars and serves a route via `httptest`.
+
+### T06 — Add docs and declarations
+
+Add docs under `go-go-goja/pkg/doc`, for example:
+
+```text
+pkg/doc/18-express-module.md
+pkg/doc/19-uidsl-module.md
+```
+
+Document:
+
+- host setup from Go;
+- JavaScript route API;
+- request/response shapes;
+- renderer injection;
+- `ui.dsl` escaping model;
+- table/component APIs;
+- limitations compared with Express.
+
+Add TypeScript declarations or declaration descriptors where practical.
+
+### T07 — Validate upstream package
+
+Run in `go-go-goja`:
+
+```bash
+go test ./pkg/gojahttp ./modules/express ./modules/uidsl -count=1
+go test ./... -count=1
+GOWORK=off go test ./... -count=1
+```
+
+If lint is configured and quick enough:
+
+```bash
+GOWORK=off make lint
+```
+
+### T08 — Update goja-hosting-site
+
+Replace local imports with upstream:
+
+```go
+github.com/go-go-golems/go-go-goja/pkg/gojahttp
+github.com/go-go-golems/go-go-goja/modules/express
+github.com/go-go-golems/go-go-goja/modules/uidsl
+```
+
+Delete or deprecate local `pkg/web` and `pkg/uidsl` after tests pass.
+
+### T09 — Update db-browser
+
+Replace local imports:
+
+```go
+github.com/go-go-golems/db-browser/internal/web
+github.com/go-go-golems/db-browser/internal/uidsl
+```
+
+with upstream imports:
+
+```go
+gojahttp "github.com/go-go-golems/go-go-goja/pkg/gojahttp"
+expressmod "github.com/go-go-golems/go-go-goja/modules/express"
+uidsl "github.com/go-go-golems/go-go-goja/modules/uidsl"
+```
+
+Then delete local copies if no db-browser-specific behavior remains.
+
+## Test Plan
+
+### `pkg/gojahttp`
+
+Tests should cover:
+
+- exact route matching;
+- `:param` extraction;
+- wildcard routes;
+- method matching and `all` behavior;
+- HEAD fallback to GET without body;
+- JSON body parsing;
+- form body parsing;
+- cookie/session issue and reuse;
+- static mount serving;
+- dev error response versus production error response.
+
+### `modules/express`
+
+Tests should cover:
+
+- `require("express")` loads when registrar is installed;
+- `express.app()` returns an app object;
+- route registration calls `Host.Register`;
+- handler receives `req` and `res`;
+- `res.html(ui.h1("ok"))` renders through injected renderer;
+- `res.json(...)` returns JSON;
+- invalid handler value throws/returns a useful error.
+
+### `modules/uidsl`
+
+Tests should cover the current db-browser behavior:
+
+- text and attribute escaping;
+- `ui.page` document layout;
+- `ui.raw` bypass behavior;
+- tag helper argument parsing;
+- `ui.table.fromRows`;
+- dynamic `ui.table(id).data(ctx => ...)`;
+- filters, sorting, pagination;
+- cell links;
+- code block escaping and token classes;
+- JSON block safe formatting;
+- badge tone/value classes;
+- tabs selected fallback, duplicate IDs, disabled tabs, and generated CSS.
+
+### Downstream validation
+
+After upstreaming, run in db-browser:
+
+```bash
+go test ./...
+ttmp/2026/05/07/DB-BROWSER-JSVERBS-DESIGN--goja-jsverbs-database-browser-web-app-design/scripts/011-final-validation.sh
+ttmp/2026/05/07/DB-BROWSER-UIDSL-COMPONENTS--ui-dsl-component-spec-for-code-blocks-badges-and-tabs/scripts/001-uidsl-components-smoke.sh
+```
+
+## Design Decisions
+
+### Decision: `express` is runtime-scoped
+
+`express` requires a host and runtime owner, so it belongs behind `engine.RuntimeModuleRegistrar`. It should not be default-registered through `modules.Register` in the first version.
+
+### Decision: the HTTP host is renderer-neutral
+
+`pkg/gojahttp` accepts a renderer callback. It should not import `modules/uidsl`. This lets consumers render with `ui.dsl`, plain strings, or other renderers.
+
+### Decision: `ui.dsl` moves as the rich db-browser version
+
+The richer db-browser implementation is the useful reusable surface. Upstreaming only the older low-level renderer would immediately require another downstream extension package.
+
+### Decision: preserve current JavaScript names
+
+Keep:
+
+```js
+require("express")
+require("ui.dsl")
+require("ui")
+```
+
+Changing names would break existing examples and produce no meaningful architectural gain.
+
+### Decision: call it Express-style, not Express-compatible
+
+The module implements a compact route API inspired by Express. It does not implement middleware stacks, `next`, routers, template engines, or npm package compatibility.
+
+## Alternatives Considered
+
+### Alternative A: keep packages copied in each app
+
+Rejected because duplicated host and UI fixes will drift across repos.
+
+### Alternative B: put all code under `modules/express`
+
+Rejected because the HTTP host is reusable Go infrastructure, while the JavaScript module adapter is only one way to expose it.
+
+### Alternative C: make `express` a default `NativeModule`
+
+Rejected because default modules cannot carry a configured host and runtime owner. A default `require("express")` without a host would fail at request registration time.
+
+### Alternative D: make `express` depend directly on `ui.dsl`
+
+Rejected because the host should be renderer-neutral. `res.html(...)` should call a configured renderer.
+
+### Alternative E: upstream only low-level `ui.dsl`
+
+Rejected for now because db-browser already proved rich tables and inspection components are generally useful for Goja-hosted internal tools.
+
+## Migration Notes for db-browser
+
+`internal/app/server.go` should change from:
+
+```go
+host := web.NewHost(web.HostOptions{Dev: cfg.Dev, Renderer: uidsl.RenderAny})
+...
+WithRuntimeModuleRegistrars(web.NewExpressRegistrar(host), uidsl.NewRegistrar())
+```
+
+to:
+
+```go
+host := gojahttp.NewHost(gojahttp.HostOptions{Dev: cfg.Dev, Renderer: uidsl.RenderAny})
+...
+WithRuntimeModuleRegistrars(expressmod.NewRegistrar(host), uidsl.NewRegistrar())
+```
+
+After migration, delete:
+
+```text
+internal/web
+internal/uidsl
+```
+
+unless db-browser keeps a small local extension layer. The preferred result is no local copy.
+
+## Open Questions
+
+1. Should `ui.dsl` also be default-registered as a `modules.NativeModule`, or only runtime-registered at first?
+2. What should the neutral session cookie name be: `goja_http_session`, `go_go_goja_session`, or configurable-only with no public default mention?
+3. Should `modules/express` offer `WithName(...)` for aliases such as `web`, or only `express`?
+4. Should TypeScript declarations be generated through `modules.TypeScriptDeclarer`, hand-authored, or both?
+5. Should rich `ui.table` move upstream before scoped table query state, or should scoped state be implemented first in db-browser and then moved?
+6. Should the upstream `ui.dsl` include retro theme helpers, or should theme assets remain downstream until static asset support is clearer?
+
+## Risks
+
+### Runtime-scoped module confusion
+
+Consumers may expect `require("express")` to work with `DefaultRegistryModules()`. Documentation must show that `express` is installed with `expressmod.NewRegistrar(host)`.
+
+### API stabilization too early
+
+Moving rich `ui.dsl` upstream makes table/component APIs more durable. This is acceptable, but docs should mark some features as current behavior rather than final API if they remain experimental.
+
+### Package naming bikeshed
+
+`pkg/gojahttp` is explicit and avoids collision with `net/http`, but names are easy to debate. Avoid blocking implementation on naming after a reasonable choice is made.
+
+### Downstream module version timing
+
+db-browser depends on a tagged `go-go-goja` version. After upstreaming, either tag a new release or use a temporary replace directive during migration.
+
+## Recommended First Pull Request
+
+The first upstream PR should be intentionally small:
+
+1. Add `pkg/gojahttp` from db-browser `internal/web`, excluding `express_module.go`.
+2. Rename package and comments.
+3. Add/move tests for route registry, sessions, request/response, and host basics.
+4. Do not add `modules/express` yet.
+5. Run `go test ./pkg/gojahttp -count=1` and `go test ./... -count=1`.
+
+The second PR can add `modules/express`. The third can add `modules/uidsl`.
+
+## References
+
+Primary source packages:
+
+```text
+/home/manuel/code/wesen/2026-05-07--db-browser/internal/web
+/home/manuel/code/wesen/2026-05-07--db-browser/internal/uidsl
+/home/manuel/code/wesen/2026-05-03--goja-hosting-site/pkg/web
+/home/manuel/code/wesen/2026-05-03--goja-hosting-site/pkg/uidsl
+```
+
+Upstream target:
+
+```text
+/home/manuel/code/wesen/corporate-headquarters/go-go-goja
+```
+
+Relevant go-go-goja files:
+
+```text
+modules/common.go
+modules/exports.go
+modules/typing.go
+modules/database/database.go
+modules/yaml/yaml.go
+engine/runtime_modules.go
+engine/module_specs.go
+pkg/doc/02-creating-modules.md
+```
+
+Downstream db-browser files to update after upstreaming:
+
+```text
+cmd/db-browser/main.go
+internal/app/server.go
+internal/verbcli/runtime.go
+internal/doc/topics/js-api-reference.md
+examples/generic-browser/scripts/app.js
+examples/playwright-smoke/scripts/app.js
+examples/yaml-dashboard/scripts/app.js
+```

--- a/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/design-doc/02-merge-db-browser-and-goja-hosting-site-web-shells.md
+++ b/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/design-doc/02-merge-db-browser-and-goja-hosting-site-web-shells.md
@@ -1,0 +1,487 @@
+---
+Title: Merge db-browser and goja-hosting-site web shells
+Ticket: GO-GO-GOJA-EXPRESS-UIDSL-MODULES
+Status: active
+Topics:
+  - goja
+  - ui-dsl
+  - web-ui
+  - documentation
+DocType: design-doc
+Intent: long-term
+Owners: []
+RelatedFiles:
+  - path: /home/manuel/workspaces/2026-05-08/extract-express-goja/2026-05-03--goja-hosting-site/pkg/app/server.go
+    note: Current goja-site single-site runtime/server shell to become the canonical web shell.
+  - path: /home/manuel/workspaces/2026-05-08/extract-express-goja/2026-05-03--goja-hosting-site/pkg/app/multi.go
+    note: Current goja-site multi-site server support to keep in the unified shell.
+  - path: /home/manuel/workspaces/2026-05-08/extract-express-goja/2026-05-07--db-browser/internal/app/server.go
+    note: Current db-browser runtime/server shell to retire after its unique behavior is migrated.
+  - path: /home/manuel/workspaces/2026-05-08/extract-express-goja/2026-05-07--db-browser/internal/verbcli
+    note: db-browser jsverbs CLI layer to move into the canonical shell or upstream reusable package.
+  - path: /home/manuel/workspaces/2026-05-08/extract-express-goja/2026-05-07--db-browser/internal/verbrepos
+    note: db-browser verb repository discovery and built-in verbs to migrate.
+  - path: /home/manuel/workspaces/2026-05-08/extract-express-goja/go-go-goja/pkg/jsverbs
+    note: Existing reusable jsverbs scanner/registry/invocation core.
+ExternalSources: []
+Summary: "Design for making goja-hosting-site the canonical web/jsverbs shell, migrating db-browser's unique jsverbs and SQLite-browser assets into it, and retiring db-browser."
+LastUpdated: 2026-05-08T22:40:00-04:00
+WhatFor: "Use this before merging db-browser and goja-hosting-site after express/ui.dsl/gojahttp were upstreamed."
+WhenToUse: "Read when implementing goja-site verbs, multi-script support, unified database policy, db-browser example migration, and db-browser retirement."
+---
+
+# Merge db-browser and goja-hosting-site web shells
+
+## Executive Summary
+
+After upstreaming the shared HTTP host, Express-style module, and `ui.dsl` module into `go-go-goja`, `db-browser` and `goja-hosting-site` are no longer meaningfully separate runtime stacks. Both now create a Goja runtime, configure SQLite access, register `express` and `ui.dsl`, load trusted JavaScript, and serve HTTP routes registered by those scripts.
+
+The remaining difference is product shape:
+
+- `goja-hosting-site` is the richer web shell: single-site serving, multi-site Host dispatch, `kanban.dsl`, `dbguard`, deployment config, and site examples.
+- `db-browser` is the SQLite/jsverbs shell: database-browser examples, `verbs` CLI, repository discovery, built-in jsverbs, and a simple read/write-gated DB wrapper.
+
+The chosen direction is **Option A — delete/retire `db-browser` as an independent shell** after moving its unique behavior into `goja-hosting-site` or reusable `go-go-goja` packages. For database policy, choose **Option C — support both `dbguard` and a normal/simple read-write guard**, so goja-site can serve the current site examples and the db-browser-style generic SQLite tools without forcing one policy onto all apps.
+
+The final target is:
+
+```text
+go-go-goja/
+  pkg/gojahttp
+  modules/express
+  modules/uidsl
+  modules/database
+  pkg/jsverbs
+  pkg/jsverbscli        # optional reusable extraction target
+  pkg/jsverbrepos       # optional reusable extraction target
+
+goja-hosting-site/
+  cmd/goja-site
+    serve
+    serve-multi
+    verbs              # migrated db-browser CLI
+    inspect            # optional db-browser inspect equivalent
+  pkg/app              # canonical web shell
+  pkg/dbguard
+  pkg/kanbanddsl
+  examples/db-browser  # migrated db-browser examples
+  examples/verbs       # migrated built-in verb examples
+  sites/*
+
+db-browser/
+  retired/deleted, or temporarily left as a tiny compatibility wrapper only if needed
+```
+
+## Problem Statement
+
+Before the upstream extraction, `db-browser` and `goja-hosting-site` each carried local copies of the HTTP host and UI DSL. That duplication justified separate shells because each repo owned critical runtime pieces. That is no longer true.
+
+Current duplication now lives at the shell level:
+
+- both shells open SQLite databases;
+- both construct Goja runtimes;
+- both register upstream `express` and `ui.dsl`;
+- both load JavaScript route files from a scripts directory;
+- both expose database modules to JavaScript;
+- both have examples that are just trusted JavaScript plus a database.
+
+Keeping both as full applications would create renewed drift in CLI flags, database policy, runtime options, docs, and examples. The better result is one canonical web/jsverbs shell and one reusable upstream runtime library.
+
+## Chosen Options
+
+### Option A — delete/retire `db-browser`
+
+`db-browser` should not remain a separate full shell once its unique jsverbs and database-browser examples are migrated. The name can remain temporarily only as a compatibility wrapper if users/scripts need it, but the implementation should live in `goja-hosting-site` and/or `go-go-goja`.
+
+Rationale:
+
+- avoids two commands that both mean "serve trusted Goja web scripts with SQLite";
+- avoids two database policy implementations drifting apart;
+- makes goja-site examples the canonical place for small web apps;
+- lets `goja-site verbs` cover the current db-browser CLI workflow;
+- reduces maintenance surface after the shared runtime pieces moved upstream.
+
+### Option C — support both `dbguard` and normal/simple DB policy
+
+The unified shell should support two database modes:
+
+1. **normal/simple DB policy** for db-browser-style tools:
+   - preconfigured `database` and `db` modules;
+   - read-only by default;
+   - writes allowed only when `--readonly=false --allow-writes=true`;
+   - easy to understand and suitable for generic SQLite inspection.
+
+2. **`dbguard` policy** for goja-hosting-site apps:
+   - metered/guarded DB wrapper;
+   - `db.guard` module available to JavaScript;
+   - existing site/kanban behavior preserved.
+
+The shell should make this explicit, probably through a flag such as:
+
+```bash
+goja-site serve --db-policy simple
+goja-site serve --db-policy guarded
+```
+
+Default can remain `guarded` for existing goja-site compatibility, while db-browser examples can document `--db-policy simple --readonly`.
+
+## Proposed User-Facing CLI
+
+### Serve one site
+
+```bash
+goja-site serve \
+  --addr :8080 \
+  --db app.db \
+  --scripts sites/pizza/scripts \
+  --scripts shared/scripts \
+  --db-policy guarded \
+  --dev
+```
+
+`--scripts` should become repeatable. Loading order is deterministic:
+
+1. script directories in CLI/config order;
+2. files sorted lexicographically within each directory.
+
+Keep `--scripts-dir` as an alias only if needed for a short migration window. If not needed, do not add it.
+
+### Serve multiple sites
+
+```bash
+goja-site serve-multi --config deploy/sites.yaml
+```
+
+Multi-site should keep working, and the site config should eventually gain the same fields:
+
+```yaml
+sites:
+  - host: pizza.localhost
+    db: sites/pizza/app.db
+    scripts:
+      - sites/pizza/scripts
+      - shared/scripts
+    dbPolicy: guarded
+```
+
+### Run jsverbs
+
+```bash
+goja-site verbs list
+
+goja-site verbs \
+  --repository examples/verbs \
+  --db app.db \
+  examples tables
+```
+
+The `verbs` command should expose:
+
+- `fs`, `path`, `time`, `timer`, `yaml`;
+- `ui.dsl` / `ui`;
+- `database` / `db` when `--db` is set;
+- simple read/write policy by default;
+- optionally `db.guard` and `kanban.dsl` if the shell config requests them.
+
+## Proposed Package Layout
+
+### Preferred clean layout
+
+Move reusable jsverbs CLI/repository plumbing to `go-go-goja`:
+
+```text
+go-go-goja/pkg/jsverbscli
+  command.go
+  list.go
+  runtime.go
+
+go-go-goja/pkg/jsverbrepos
+  bootstrap.go
+  builtin/*.js
+```
+
+Then wire those packages into `goja-hosting-site/cmd/goja-site`.
+
+### Fast local layout
+
+If the migration should avoid upstreaming more packages initially, move db-browser internals into goja-site:
+
+```text
+goja-hosting-site/pkg/verbcli
+  command.go
+  list.go
+  runtime.go
+
+goja-hosting-site/pkg/verbrepos
+  bootstrap.go
+  builtin/*.js
+```
+
+This is quicker but less reusable. Since `go-go-goja/pkg/jsverbs` already exists, the preferred layout is to upstream the CLI/repository plumbing as a reusable sibling.
+
+## Runtime Architecture
+
+The unified `pkg/app` should factor runtime construction into smaller pieces:
+
+```text
+pkg/app/config.go       public Config, DBPolicy, ScriptSource
+pkg/app/database.go     open DB, choose guarded/simple policy, produce module specs/registrars
+pkg/app/runtime.go      build engine.Factory with common modules and runtime registrars
+pkg/app/scripts.go      deterministic multi-directory script discovery/loading
+pkg/app/server.go       single-site HTTP server
+pkg/app/multi.go        host-dispatched multi-site server
+```
+
+The key invariant is that web serving and jsverbs invocation share one module vocabulary but not necessarily one runtime lifetime:
+
+- web server: one runtime per site, route scripts loaded for side effects;
+- jsverbs: one runtime per invocation, verb repository loader installed, selected verb invoked.
+
+## Script Loading Model
+
+Current goja-site loads all `.js` files from one directory. The unified shell should support multiple roots:
+
+```go
+type Config struct {
+    Addr       string
+    DBPath     string
+    ScriptDirs []string
+    Dev        bool
+    DBPolicy   DBPolicy
+    ReadOnly   bool
+    AllowWrites bool
+}
+```
+
+For compatibility inside Go code, `ScriptsDir` can remain temporarily only if existing callers still need it. Prefer moving call sites to `ScriptDirs` and deleting `ScriptsDir` if this is a breaking internal cleanup.
+
+Rules:
+
+- missing script directory is an error;
+- non-directory path is an error;
+- only `.js` files are loaded;
+- files are sorted within each directory;
+- duplicate absolute file paths are loaded once;
+- errors include the file path that failed.
+
+## Database Policy Model
+
+Introduce:
+
+```go
+type DBPolicy string
+
+const (
+    DBPolicySimple  DBPolicy = "simple"
+    DBPolicyGuarded DBPolicy = "guarded"
+)
+```
+
+Simple policy:
+
+- use a lightweight wrapper similar to db-browser's `guardedDB`;
+- expose `database` and `db`;
+- reject writes unless both `AllowWrites` and `!ReadOnly` are true.
+
+Guarded policy:
+
+- keep current `dbguard.New`, `dbguard.NewMeteredDB`, and `dbguard.NewRegistrar`;
+- expose `database`, `db`, and `db.guard`;
+- preserve current goja-site behavior.
+
+Open question for implementation: whether `guarded` should also honor `ReadOnly`/`AllowWrites` directly or whether `dbguard` remains the policy authority. The design preference is for all policies to honor CLI flags, but do not hack this in if `dbguard` requires a proper API change.
+
+## jsverbs Migration Details
+
+The db-browser jsverbs layer contains three separable pieces:
+
+1. repository discovery and config:
+   - CLI `--repository` / `--verb-repository`;
+   - env var currently `DB_BROWSER_VERB_REPOSITORIES`;
+   - config files currently `.db-browser.yml` and `.db-browser.override.yml`;
+   - built-in repository embedding.
+
+2. command generation:
+   - scan repos with `jsverbs.ScanDir` / `jsverbs.ScanFS`;
+   - collect verbs;
+   - generate Glazed/Cobra commands;
+   - add list command.
+
+3. runtime invocation:
+   - create one Goja runtime per verb invocation;
+   - install repo require loader;
+   - install default modules and `ui.dsl`;
+   - optionally install `database` and `db`.
+
+Neutral names should replace db-browser-specific names:
+
+```text
+GOJA_VERB_REPOSITORIES
+.goja-verbs.yml
+.goja-verbs.override.yml
+```
+
+Because the chosen retirement path does not require backwards compatibility unless explicitly requested, do not add compatibility aliases by default. If existing scripts need them, add aliases deliberately and document them.
+
+## Example Migration
+
+Move:
+
+```text
+2026-05-07--db-browser/examples/generic-browser
+2026-05-07--db-browser/examples/yaml-dashboard
+2026-05-07--db-browser/examples/playwright-smoke
+2026-05-07--db-browser/examples/builtin-verbs
+```
+
+To:
+
+```text
+2026-05-03--goja-hosting-site/examples/db-browser/generic-browser
+2026-05-03--goja-hosting-site/examples/db-browser/yaml-dashboard
+2026-05-03--goja-hosting-site/examples/db-browser/playwright-smoke
+2026-05-03--goja-hosting-site/examples/verbs/builtin
+```
+
+Update docs and smoke scripts to run with `goja-site`.
+
+## Retirement Plan for db-browser
+
+The selected option is deletion/retirement. Practical steps:
+
+1. finish migrating code/examples/docs;
+2. validate goja-site covers serve and verbs workflows;
+3. leave a short retirement note in db-browser if the repo remains during transition;
+4. remove db-browser-specific runtime packages;
+5. archive/delete db-browser repo when no scripts depend on it.
+
+If a compatibility wrapper is requested later, keep it tiny and make it delegate to the canonical implementation. Do not keep a second runtime stack.
+
+## Implementation Plan
+
+### Phase 0 — Baseline and docs
+
+- Commit the completed express/ui.dsl/gojahttp upstream extraction and downstream migration baseline.
+- Add this design document.
+- Add detailed ticket tasks.
+- Keep a diary after every implementation step.
+
+### Phase 1 — Reusable jsverbs CLI/repository packages
+
+- Move db-browser `internal/verbrepos` to `go-go-goja/pkg/jsverbrepos` or goja-site `pkg/verbrepos`.
+- Move db-browser `internal/verbcli` to `go-go-goja/pkg/jsverbscli` or goja-site `pkg/verbcli`.
+- Rename package imports and db-browser-specific identifiers.
+- Change env/config names to neutral goja names.
+- Preserve built-in smoke verbs under the new package.
+- Add focused tests for repository discovery and command construction.
+
+### Phase 2 — Add `goja-site verbs`
+
+- Wire the migrated jsverbs command into `cmd/goja-site/main.go`.
+- Ensure verb runtime has `ui.dsl`, `yaml`, common modules, and optional `database`/`db`.
+- Validate built-in verbs:
+  - hello;
+  - yaml keys;
+  - table list with a temp SQLite DB;
+  - render sample table.
+
+### Phase 3 — Unify web server config
+
+- Add `ScriptDirs []string` to app config.
+- Update `serve` CLI to accept repeatable `--scripts`.
+- Refactor script discovery/loading into `pkg/app/scripts.go`.
+- Keep deterministic load order and good error messages.
+- Update single-site tests.
+
+### Phase 4 — Add database policy selection
+
+- Add `DBPolicy` to app config.
+- Implement simple read/write-gated policy.
+- Keep guarded policy with `dbguard` and `db.guard` registrar.
+- Add CLI flags: `--db-policy`, `--readonly`, `--allow-writes`.
+- Validate both policies.
+
+### Phase 5 — Migrate db-browser examples and scripts
+
+- Move db-browser examples into goja-site examples.
+- Update paths and docs.
+- Update smoke scripts to call `goja-site`.
+- Validate generic browser and yaml dashboard examples.
+
+### Phase 6 — Retire db-browser
+
+- Remove or archive db-browser runtime code.
+- If the repo remains, replace implementation docs with a retirement note pointing to goja-site.
+- Remove redundant validation scripts after they are represented in goja-site.
+
+## Detailed Task List
+
+The ticket task list should include the implementation tasks below as T10 onward. The tasks are intentionally small enough to commit after each phase or subphase.
+
+## Validation Plan
+
+Run after each major phase:
+
+```bash
+cd go-go-goja && go test ./pkg/jsverbs ./pkg/jsverbscli ./pkg/jsverbrepos -count=1
+cd go-go-goja && go test ./... -count=1
+cd 2026-05-03--goja-hosting-site && go test ./... -count=1
+```
+
+Run after adding `goja-site verbs`:
+
+```bash
+go run ./cmd/goja-site verbs list
+go run ./cmd/goja-site verbs examples hello --name Manuel
+```
+
+Run after example migration:
+
+```bash
+go run ./cmd/goja-site serve --db /tmp/test.sqlite --scripts examples/db-browser/generic-browser/scripts --db-policy simple --readonly --addr :18080
+```
+
+Use tmux for long-running server smoke tests.
+
+## Risks and Review Notes
+
+### Risk: mixing route scripts and verb scripts
+
+Do not auto-load verb repositories as web route scripts. Keep `--scripts` and `--repository` separate unless an explicit require-loader integration is designed.
+
+### Risk: unclear write policy
+
+The unified shell must make database write behavior obvious. `--readonly` should be the safe default for generic SQLite browser use.
+
+### Risk: config-name churn
+
+Renaming `.db-browser.yml` to `.goja-verbs.yml` is a breaking cleanup. This is acceptable under Option A unless compatibility is explicitly required.
+
+### Risk: package placement churn
+
+Moving `verbcli`/`verbrepos` directly into goja-site is fastest, but moving to go-go-goja is cleaner. Prefer upstream if the implementation is not blocked by dependency cycles.
+
+## Alternatives Considered
+
+### Keep both shells
+
+Rejected. The shared runtime has moved upstream, so separate shells would mostly duplicate CLI and app bootstrapping.
+
+### Make db-browser the canonical shell
+
+Rejected. goja-hosting-site already has multi-site support, deployment config, site examples, and `kanban.dsl`; it is the broader shell.
+
+### Keep only `dbguard`
+
+Rejected. db-browser-style generic SQLite inspection benefits from a simple, transparent read/write guard and should not require dbguard semantics.
+
+### Keep only simple DB policy
+
+Rejected. goja-hosting-site already uses `dbguard`, and existing site behavior should remain available.
+
+## Open Questions
+
+1. Should reusable `jsverbscli` and `jsverbrepos` live in go-go-goja immediately, or start in goja-site and upstream later?
+2. Should `kanban.dsl` be available in CLI jsverbs runtimes by default?
+3. Should multi-site config support verb repositories per site, or should `verbs` remain a process-level CLI concern?
+4. Should `db-browser` be deleted in this workspace or left with a retirement README until external scripts are updated?

--- a/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/index.md
+++ b/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/index.md
@@ -1,0 +1,58 @@
+---
+Title: Upstream Express and ui.dsl modules into go-go-goja
+Ticket: GO-GO-GOJA-EXPRESS-UIDSL-MODULES
+Status: active
+Topics:
+    - goja
+    - ui-dsl
+    - web-ui
+    - documentation
+DocType: index
+Intent: long-term
+Owners: []
+RelatedFiles: []
+ExternalSources: []
+Summary: ""
+LastUpdated: 2026-05-08T14:29:03.028112443-04:00
+WhatFor: ""
+WhenToUse: ""
+---
+
+# Upstream Express and ui.dsl modules into go-go-goja
+
+## Overview
+
+<!-- Provide a brief overview of the ticket, its goals, and current status -->
+
+## Key Links
+
+- **Related Files**: See frontmatter RelatedFiles field
+- **External Sources**: See frontmatter ExternalSources field
+
+## Status
+
+Current status: **active**
+
+## Topics
+
+- goja
+- ui-dsl
+- web-ui
+- documentation
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/index.md
+++ b/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/index.md
@@ -11,10 +11,6 @@ DocType: index
 Intent: long-term
 Owners: []
 RelatedFiles:
-    - Path: ../../../../../../2026-05-03--goja-hosting-site/cmd/goja-site/main.go
-      Note: goja-site verbs command registration
-    - Path: ../../../../../../2026-05-03--goja-hosting-site/pkg/app/scripts.go
-      Note: Canonical multi-directory script loading helper
     - Path: modules/express
       Note: Runtime-scoped Express-style Goja module
     - Path: modules/uidsl
@@ -37,6 +33,7 @@ LastUpdated: 2026-05-08T14:29:03.028112443-04:00
 WhatFor: ""
 WhenToUse: ""
 ---
+
 
 
 

--- a/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/index.md
+++ b/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/index.md
@@ -17,6 +17,8 @@ RelatedFiles:
       Note: Reusable rich UI DSL module
     - Path: pkg/gojahttp
       Note: Upstream renderer-neutral HTTP host
+    - Path: pkg/jsverbrepos
+      Note: Reusable jsverbs repository discovery extracted from db-browser
     - Path: ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/design-doc/02-merge-db-browser-and-goja-hosting-site-web-shells.md
       Note: Design for retiring db-browser into the goja-site shell
     - Path: ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/log/01-implementation-diary.md
@@ -29,6 +31,7 @@ LastUpdated: 2026-05-08T14:29:03.028112443-04:00
 WhatFor: ""
 WhenToUse: ""
 ---
+
 
 
 

--- a/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/index.md
+++ b/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/index.md
@@ -13,6 +13,8 @@ Owners: []
 RelatedFiles:
     - Path: ../../../../../../2026-05-03--goja-hosting-site/cmd/goja-site/main.go
       Note: goja-site verbs command registration
+    - Path: ../../../../../../2026-05-03--goja-hosting-site/pkg/app/scripts.go
+      Note: Canonical multi-directory script loading helper
     - Path: modules/express
       Note: Runtime-scoped Express-style Goja module
     - Path: modules/uidsl
@@ -35,6 +37,7 @@ LastUpdated: 2026-05-08T14:29:03.028112443-04:00
 WhatFor: ""
 WhenToUse: ""
 ---
+
 
 
 

--- a/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/index.md
+++ b/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/index.md
@@ -19,6 +19,8 @@ RelatedFiles:
       Note: Upstream renderer-neutral HTTP host
     - Path: pkg/jsverbrepos
       Note: Reusable jsverbs repository discovery extracted from db-browser
+    - Path: pkg/jsverbscli
+      Note: Reusable jsverbs CLI shell extracted from db-browser
     - Path: ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/design-doc/02-merge-db-browser-and-goja-hosting-site-web-shells.md
       Note: Design for retiring db-browser into the goja-site shell
     - Path: ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/log/01-implementation-diary.md
@@ -31,6 +33,7 @@ LastUpdated: 2026-05-08T14:29:03.028112443-04:00
 WhatFor: ""
 WhenToUse: ""
 ---
+
 
 
 

--- a/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/index.md
+++ b/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/index.md
@@ -11,6 +11,8 @@ DocType: index
 Intent: long-term
 Owners: []
 RelatedFiles:
+    - Path: ../../../../../../2026-05-03--goja-hosting-site/cmd/goja-site/main.go
+      Note: goja-site verbs command registration
     - Path: modules/express
       Note: Runtime-scoped Express-style Goja module
     - Path: modules/uidsl
@@ -33,6 +35,7 @@ LastUpdated: 2026-05-08T14:29:03.028112443-04:00
 WhatFor: ""
 WhenToUse: ""
 ---
+
 
 
 

--- a/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/index.md
+++ b/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/index.md
@@ -10,13 +10,28 @@ Topics:
 DocType: index
 Intent: long-term
 Owners: []
-RelatedFiles: []
+RelatedFiles:
+    - Path: modules/express
+      Note: Runtime-scoped Express-style Goja module
+    - Path: modules/uidsl
+      Note: Reusable rich UI DSL module
+    - Path: pkg/gojahttp
+      Note: Upstream renderer-neutral HTTP host
+    - Path: ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/design-doc/02-merge-db-browser-and-goja-hosting-site-web-shells.md
+      Note: Design for retiring db-browser into the goja-site shell
+    - Path: ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/log/01-implementation-diary.md
+      Note: Running diary for extraction and shell merge work
+    - Path: ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/tasks.md
+      Note: Detailed task plan including shell merge phases
 ExternalSources: []
 Summary: ""
 LastUpdated: 2026-05-08T14:29:03.028112443-04:00
 WhatFor: ""
 WhenToUse: ""
 ---
+
+
+
 
 # Upstream Express and ui.dsl modules into go-go-goja
 

--- a/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/log/01-implementation-diary.md
+++ b/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/log/01-implementation-diary.md
@@ -20,6 +20,98 @@ WhenToUse: "Read before continuing Express/ui.dsl upstreaming or downstream clea
 
 # Implementation Diary
 
+## 2026-05-08 - Migrate db-browser examples to goja-site
+
+Moved the db-browser example apps into goja-hosting-site so the canonical shell now carries the generic SQLite browser, YAML dashboard, Playwright smoke app, and editable verb examples. The migrated web examples all document and validate the new `goja-site serve --db-policy simple --readonly` flow.
+
+This step also uncovered one missing piece in the goja-site server module vocabulary: the YAML dashboard needed `require("yaml")`, so the web server now enables the upstream YAML module just like the jsverbs runtime does.
+
+### Prompt Context
+
+**User prompt (verbatim):** "continue"
+
+**Assistant interpretation:** Continue with the next open ticket phase after T16, which is T17/example migration.
+
+**Inferred user intent:** Keep moving through the shell-merge task list, validating and committing at useful phase boundaries.
+
+**Commit (code):** 46b34df74a2bdef9223643f0b395d2394243bc5f — "Migrate db-browser examples to goja-site"
+
+### What I did
+
+- Copied db-browser examples into goja-hosting-site:
+  - `examples/db-browser/generic-browser`
+  - `examples/db-browser/yaml-dashboard`
+  - `examples/db-browser/playwright-smoke`
+- Updated example READMEs to use `go run ./cmd/goja-site serve`, repeatable `--scripts`, and `--db-policy simple --readonly`.
+- Updated the YAML dashboard script to load `examples/db-browser/yaml-dashboard/dashboard.yaml` from its new path.
+- Added `examples/db-browser/README.md` explaining the migrated read-only SQLite app workflow.
+- Added user-visible local verb examples under `examples/verbs/builtin` and adapted their package path to `examples local-builtin ...` to avoid colliding with the embedded built-in verbs.
+- Added `examples/verbs/README.md` with `goja-site verbs --repository ...` examples.
+- Enabled the `yaml` module in goja-site's web server runtime middleware.
+- Added `pkg/app/modules_test.go` to verify web route scripts can `require("yaml")`.
+- Validated generic-browser, yaml-dashboard, and playwright-smoke through live `goja-site serve` + `curl` smoke tests.
+- Validated local verb examples with `goja-site verbs --repository examples/verbs/builtin`.
+
+### Why
+
+- db-browser cannot be retired until its useful examples live under the canonical shell.
+- The YAML dashboard is a concrete test that goja-site's web runtime module vocabulary matches the migrated apps' expectations.
+- Local verb examples give users editable examples without depending on the embedded Go package location.
+
+### What worked
+
+- The generic browser and Playwright smoke examples ran under simple read-only policy without code changes beyond README paths.
+- The local verb examples worked after renaming their package to `local-builtin`.
+- Full goja-hosting-site tests, standalone `GOWORK=off` tests, and focused lint passed.
+
+### What didn't work
+
+- The first YAML dashboard live smoke failed while loading the script:
+  - `Error: execute script .../examples/db-browser/yaml-dashboard/scripts/app.js: GoError: Invalid module at github.com/dop251/goja_nodejs/require.(*RequireModule).require-fm (native)`
+- Root cause: goja-site web serving enabled `fs`, `path`, `time`, and `timer`, but not `yaml`.
+- Fix: added `yaml` to `engine.MiddlewareOnly(...)` in `pkg/app/server.go` and added a unit test for route-level `require("yaml")`.
+
+### What I learned
+
+- The jsverbs runtime already exposed YAML, but the web runtime did not; migrating examples helped align those vocabularies.
+- Embedded built-in verbs are always loaded, so user-visible copies must use a different package path to avoid duplicate verb paths.
+
+### What was tricky to build
+
+- The examples were mostly portable, but path-sensitive assets such as `dashboard.yaml` needed explicit updates.
+- Local verb examples could not simply be byte-for-byte copies of embedded built-ins because `goja-site verbs` always scans the embedded repository before CLI repositories.
+- Live smoke tests need careful cleanup of background `go run ./cmd/goja-site serve` processes when a later example fails.
+
+### What warrants a second pair of eyes
+
+- Whether the local verb examples should be named `local-builtin` or something more tutorial-oriented.
+- Whether enabling `yaml` in all goja-site web runtimes is acceptable from a module-surface perspective.
+- Whether committing the small seeded `examples/db-browser/playwright-smoke/data/app.db` binary is preferred over adding a seed script.
+
+### What should be done in the future
+
+- Start the db-browser retirement phase by replacing or removing runtime code and pointing users at goja-site.
+- Consider adding a reusable smoke script under goja-site if these examples will be tested in CI.
+
+### Code review instructions
+
+- Review the migrated READMEs first to confirm the user-facing commands are correct.
+- Review `examples/db-browser/yaml-dashboard/scripts/app.js` for the updated YAML path.
+- Review `pkg/app/server.go` and `pkg/app/modules_test.go` for the YAML module change.
+- Review `examples/verbs/builtin/*.js` to confirm the package path avoids embedded duplicate commands.
+- Validate with:
+  - `cd 2026-05-03--goja-hosting-site && go test ./... -count=1`
+  - `cd 2026-05-03--goja-hosting-site && GOWORK=off go test ./... -count=1`
+  - `cd 2026-05-03--goja-hosting-site && golangci-lint run ./pkg/app ./cmd/goja-site`
+  - live `goja-site serve --db-policy simple --readonly` smoke tests for the three migrated web examples.
+
+### Technical details
+
+- Migrated web examples now live under `examples/db-browser/...`.
+- Local verb examples now use `__package__({ parents: ["examples"], name: "local-builtin" })`.
+- `goja-site verbs --repository examples/verbs/builtin list` now shows both embedded `examples builtin ...` and local `examples local-builtin ...` commands.
+- The web runtime middleware now enables `fs`, `path`, `time`, `timer`, and `yaml`.
+
 ## 2026-05-08 - Add goja-site database policy selection
 
 Implemented the unified database policy layer for the canonical goja-site shell. The app can now keep its existing guarded `dbguard` behavior while also serving db-browser-style SQLite tools through a simple read/write-gated policy.

--- a/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/log/01-implementation-diary.md
+++ b/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/log/01-implementation-diary.md
@@ -1,0 +1,138 @@
+---
+Title: Implementation Diary
+Ticket: GO-GO-GOJA-EXPRESS-UIDSL-MODULES
+Status: active
+Topics:
+    - goja
+    - ui-dsl
+    - web-ui
+    - documentation
+DocType: log
+Intent: long-term
+Owners: []
+RelatedFiles: []
+ExternalSources: []
+Summary: "Implementation diary for upstreaming gojahttp, express, and ui.dsl modules, migrating db-browser/goja-hosting-site, and merging their shells."
+LastUpdated: 2026-05-08T22:45:00-04:00
+WhatFor: "Use this to understand what was moved, which validations passed, and what remains."
+WhenToUse: "Read before continuing Express/ui.dsl upstreaming or downstream cleanup work."
+---
+
+# Implementation Diary
+
+## 2026-05-08 - Shell merge design and task setup
+
+Created the design plan for merging the remaining `db-browser` and `goja-hosting-site` web shells after the shared runtime extraction. The design locks in the requested options: retire/delete `db-browser` as an independent shell, and keep both the existing `dbguard` policy and a simple read/write-gated database policy in the unified goja-site shell.
+
+This step did not change runtime behavior. It created the blueprint and task breakdown for the next implementation phases, including jsverbs CLI migration, multi-script loading, database policy selection, db-browser example migration, and db-browser retirement.
+
+### Prompt Context
+
+**User prompt (verbatim):** "create a design document.\n\noption choices: \n\n### Option A — deleted/retired\n#### Option C - both dbguard and normal\n\nAdd detailed list of tasks to the ticket, then work on them one by one, commit at appropriate intervals, and keep a diary as you owork"
+
+**Assistant interpretation:** Create a docmgr design document for shell unification, record the selected options, expand the ticket task list, and continue work in small committed steps with diary updates.
+
+**Inferred user intent:** Collapse the now-similar web shells into one canonical implementation while preserving clear project management and review history.
+
+**Commit (code):** pending — design/task setup has been written and is ready to commit with the current baseline.
+
+### What I did
+
+- Added `design-doc/02-merge-db-browser-and-goja-hosting-site-web-shells.md` to the ticket.
+- Added T10–T18 task sections covering baseline commits, jsverbs extraction, `goja-site verbs`, multi-script loading, DB policy selection, example migration, and db-browser retirement.
+- Related the design doc, diary, and task file to the ticket index.
+- Updated the ticket changelog.
+
+### Why
+
+- The prior extraction made `db-browser` and `goja-hosting-site` thin enough that the remaining duplication is shell/product wiring rather than core runtime logic.
+- The selected options need to be explicit before changing package ownership or deleting the db-browser shell.
+
+### What worked
+
+- `docmgr doc add` created the new design doc cleanly.
+- `docmgr doc relate` and `docmgr changelog update` updated the ticket metadata/changelog.
+- The task list now has small commit-sized phases.
+
+### What didn't work
+
+- I accidentally checked tasks 45–47 before the baseline commits were created. I will satisfy those by committing the baseline immediately rather than leaving them stale.
+
+### What I learned
+
+- The shell merge should keep route scripts and jsverbs repositories separate concepts even if they share runtime modules.
+- The database policy choice is the main semantic difference left between the two shells.
+
+### What was tricky to build
+
+- The task numbering is generated from markdown checkboxes, so adding new sections required verifying the numeric IDs with `docmgr task list` before checking the intended items.
+- Because previous upstream/downstream code changes were already uncommitted, the next commit boundary needs to establish that baseline before deeper shell-merge work starts.
+
+### What warrants a second pair of eyes
+
+- Whether jsverbs CLI/repository plumbing should go directly to `go-go-goja/pkg/jsverbscli` and `pkg/jsverbrepos` or start in `goja-hosting-site/pkg` first.
+- Whether `dbguard` should honor the same `--readonly` / `--allow-writes` flags as the simple policy.
+
+### What should be done in the future
+
+- Commit the current upstream/downstream baseline.
+- Start T12 by extracting neutral jsverbs repository discovery.
+
+### Code review instructions
+
+- Start with `design-doc/02-merge-db-browser-and-goja-hosting-site-web-shells.md`.
+- Then review T10–T18 in `tasks.md`.
+- Validate ticket hygiene with `docmgr doctor --ticket GO-GO-GOJA-EXPRESS-UIDSL-MODULES --stale-after 30`.
+
+### Technical details
+
+- Selected retirement option: Option A — deleted/retired `db-browser`.
+- Selected DB policy option: Option C — both `dbguard` and normal/simple policy.
+
+## 2026-05-08 - Initial upstream implementation and downstream unification
+
+Implemented the first upstream pass directly in the workspace:
+
+- Created `pkg/gojahttp` in `go-go-goja` from db-browser's `internal/web`, excluding the Express module adapter.
+- Renamed the HTTP host package from `web` to `gojahttp`.
+- Kept the host renderer-neutral through `HostOptions.Renderer`; `pkg/gojahttp` does not import `modules/uidsl`.
+- Changed the default session cookie name from `goja_site_session` to `go_go_goja_session` and updated the session comment to refer to go-go-goja.
+- Created `modules/express` with `NewRegistrar(host *gojahttp.Host, opts ...Option)`, `WithName`, and runtime-scoped registration of `require("express")`.
+- Created `modules/uidsl` from db-browser's richer `internal/uidsl` implementation, preserving `RenderAny`, `Loader`, `NewRegistrar`, and the `ui.dsl` / `ui` aliases.
+- Added TypeScript declaration descriptors for the runtime registrars where practical.
+- Added go-go-goja help docs for the Express-style module and `ui.dsl`.
+
+Downstream unification:
+
+- Updated db-browser to import `gojahttp`, `modules/express`, and `modules/uidsl` from go-go-goja.
+- Deleted db-browser's copied `internal/web` and `internal/uidsl` packages.
+- Updated goja-hosting-site to import the same upstream packages.
+- Updated goja-hosting-site Kanban DSL code/tests to use upstream `uidsl` node types and renderer.
+- Deleted goja-hosting-site's copied `pkg/web` and `pkg/uidsl` packages.
+- Updated workspace `go.work` to `go 1.26.1` so it matches the modules.
+- Updated db-browser's local `go.mod` with a replace to `../go-go-goja` for standalone validation before an upstream tag exists.
+- Updated db-browser validation scripts that referenced `internal/uidsl` so they now test `github.com/go-go-golems/go-go-goja/modules/uidsl`.
+
+Validation performed:
+
+```text
+cd go-go-goja && go test ./pkg/gojahttp ./modules/express ./modules/uidsl -count=1
+cd go-go-goja && go test ./... -count=1
+cd go-go-goja && GOWORK=off go test ./pkg/gojahttp ./modules/express ./modules/uidsl -count=1
+cd go-go-goja && GOWORK=off go test ./... -count=1
+cd 2026-05-07--db-browser && go test ./... -count=1
+cd 2026-05-07--db-browser && GOWORK=off go test ./... -count=1
+cd 2026-05-03--goja-hosting-site && go test ./... -count=1
+cd 2026-05-03--goja-hosting-site && GOWORK=off go test ./... -count=1
+cd 2026-05-07--db-browser && bash ttmp/2026/05/07/DB-BROWSER-UIDSL-COMPONENTS--ui-dsl-component-spec-for-code-blocks-badges-and-tabs/scripts/001-uidsl-components-smoke.sh
+cd 2026-05-07--db-browser && bash ttmp/2026/05/07/DB-BROWSER-JSVERBS-DESIGN--goja-jsverbs-database-browser-web-app-design/scripts/011-final-validation.sh
+```
+
+One validation script initially failed because it still ran `go test ./internal/uidsl` after the package was deleted. I updated the script to test the upstream `modules/uidsl` package instead. The rich-table validation also had an exact class-string assertion that did not include the now-rendered `ui-table--filters` class; I updated that assertion to match current output.
+
+Remaining follow-ups:
+
+- Decide whether `ui.dsl` should also be default-registered as a global native module.
+- Decide when to remove local replace directives after go-go-goja is tagged/released.
+- Run lint if desired.
+- Commit the upstream and downstream changes together or split into separate commits/PRs.

--- a/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/log/01-implementation-diary.md
+++ b/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/log/01-implementation-diary.md
@@ -807,3 +807,49 @@ Remaining follow-ups:
 - Decide when to remove local replace directives after go-go-goja is tagged/released.
 - Run lint if desired.
 - Commit the upstream and downstream changes together or split into separate commits/PRs.
+
+## 2026-05-09 - gosec findings cleanup
+
+Ran `make gosec` after the PR #36 review fixes and addressed the reported security scanner findings in `go-go-goja`.
+
+What changed:
+
+- Added an explicit `pkg/gojahttp` request-body cap before parsing JSON, form, or multipart route bodies.
+- Kept multipart parsing with `ParseMultipartForm`, but documented the bounded body and memory budget for gosec's G120 finding.
+- Documented intentional scanner exceptions for configurable localhost session cookies, caller-selected generator output paths, operator-selected repl essay UI dist directories, benchmark task execution, the explicit `exec` JS module, and the protobuf generator tool install step.
+
+Validation performed:
+
+```text
+cd go-go-goja && gofmt -w pkg/gojahttp/body.go pkg/gojahttp/session.go pkg/replessay/handler.go cmd/gen-dts/main.go pkg/hashiplugin/contract/internal/cmd/generate/main.go modules/exec/exec.go cmd/goja-perf/phase1_run_command.go
+cd go-go-goja && go test ./pkg/gojahttp ./modules/express ./modules/exec ./cmd/gen-dts ./cmd/goja-perf ./pkg/replessay ./pkg/hashiplugin/contract/internal/cmd/generate -count=1
+cd go-go-goja && make gosec
+```
+
+Result: `make gosec` passes with zero issues.
+
+## 2026-05-09 - CI follow-up for replsession await timeout flake
+
+CI reported an intermittent `TestServiceRawAwaitPromiseTimeoutUsesEvalDeadline` failure where a raw top-level `await` that timed out was not marked as awaited.
+
+Root cause:
+
+- Raw top-level await is rewritten to an async IIFE before execution.
+- On a tight eval deadline, the evaluation can time out before `executeRaw` observes and waits on the returned Promise.
+- In that path, the status is correctly `timeout`, but the `Awaited` marker could stay false because it was only set after seeing the Promise object.
+
+Fix:
+
+- `evaluateRaw` now marks executions as awaited whenever the original cell source is a top-level await expression and top-level await support is enabled, even if timeout happens before Promise observation.
+- Added a small helper, `isTopLevelAwaitExpression`, and reused it in the raw await wrapper path.
+- Moved gosec suppressions for the cookie and multipart parser findings onto the flagged statement lines to make them robust across CI scanner versions.
+
+Validation performed:
+
+```text
+cd go-go-goja && go test ./pkg/replsession -run TestServiceRawAwaitPromiseTimeoutUsesEvalDeadline -count=100
+cd go-go-goja && go test ./pkg/gojahttp ./pkg/replsession -count=1
+cd go-go-goja && make gosec
+```
+
+Result: the previously flaky timeout test passed 100 consecutive runs and gosec still reports zero issues.

--- a/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/log/01-implementation-diary.md
+++ b/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/log/01-implementation-diary.md
@@ -20,6 +20,77 @@ WhenToUse: "Read before continuing Express/ui.dsl upstreaming or downstream clea
 
 # Implementation Diary
 
+## 2026-05-08 - Add `goja-site verbs`
+
+Wired the reusable jsverbs CLI shell into `goja-hosting-site`, making `goja-site verbs` available as the canonical command for repository-scanned JavaScript verbs. This is the first visible shell merge: goja-site can now run the built-in verbs that previously belonged to db-browser's command surface.
+
+The integration is intentionally small because the prior two steps moved discovery and command/runtime invocation into go-go-goja. goja-site only imports `pkg/jsverbscli` and adds the lazy command to its Cobra root.
+
+### Prompt Context
+
+**User prompt (verbatim):** (same as previous steps)
+
+**Assistant interpretation:** Continue task-by-task by integrating the extracted jsverbs shell into goja-site and validating built-in verbs.
+
+**Inferred user intent:** Make goja-site absorb db-browser's jsverbs command behavior so db-browser can later be retired.
+
+**Commit (code):** d62fa16c71d2f6567bca53915888910247667d3a — "Add jsverbs command to goja-site"
+
+### What I did
+
+- Added `github.com/go-go-golems/go-go-goja/pkg/jsverbscli` to `cmd/goja-site/main.go`.
+- Added `root.AddCommand(jsverbscli.NewLazyCommand())`.
+- Ran `go test ./... -count=1` in goja-hosting-site.
+- Validated:
+  - `go run ./cmd/goja-site verbs list --output json`.
+  - `go run ./cmd/goja-site verbs examples builtin hello --name Manuel`.
+  - `go run ./cmd/goja-site verbs examples builtin yaml-keys --text ...`.
+  - `go run ./cmd/goja-site verbs examples builtin render-sample-table`.
+  - `go run ./cmd/goja-site verbs --db "$DB" examples builtin tables` with a temp SQLite DB.
+
+### Why
+
+- This proves the extracted jsverbs packages are usable by the canonical shell.
+- It gives goja-site the most important db-browser-only CLI behavior before retiring db-browser.
+
+### What worked
+
+- The lazy command integrated with the existing root command without needing additional plumbing.
+- Built-in non-DB and DB-backed verbs all ran successfully.
+
+### What didn't work
+
+- N/A.
+
+### What I learned
+
+- The dynamic verb command already works with persistent flags such as `--db` before the dynamic verb path.
+- The built-in `renderSampleTable` confirms `ui.dsl` is useful in CLI contexts.
+
+### What was tricky to build
+
+- The command must stay lazy because repository flags and discovered verb paths are dynamic. Adding the lazy command at the root preserves the existing behavior from db-browser.
+
+### What warrants a second pair of eyes
+
+- Whether goja-site should expose extra help text documenting neutral repository config names now, or whether that should wait until db-browser examples/docs move.
+
+### What should be done in the future
+
+- Generalize goja-site web script loading from one scripts directory to multiple script directories.
+- Add database policy flags for serving so goja-site can cover db-browser's read-only generic SQLite browser use case.
+
+### Code review instructions
+
+- Review `cmd/goja-site/main.go` for command registration.
+- Review `go-go-goja/pkg/jsverbscli` if behavior questions arise.
+- Validate with the built-in `goja-site verbs` commands listed above.
+
+### Technical details
+
+- The command name is `verbs`.
+- Built-in verb paths currently include `examples builtin hello`, `examples builtin yaml-keys`, `examples builtin render-sample-table`, and `examples builtin tables`.
+
 ## 2026-05-08 - Extract reusable jsverbs CLI shell
 
 Continued the shell merge by extracting db-browser's jsverbs CLI command construction and runtime invocation layer into `go-go-goja/pkg/jsverbscli`. This package now builds the dynamic `verbs` Cobra/Glazed command tree on top of the reusable `pkg/jsverbs` scanner and the new `pkg/jsverbrepos` repository discovery package.

--- a/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/log/01-implementation-diary.md
+++ b/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/log/01-implementation-diary.md
@@ -20,6 +20,81 @@ WhenToUse: "Read before continuing Express/ui.dsl upstreaming or downstream clea
 
 # Implementation Diary
 
+## 2026-05-08 - Extract reusable jsverbs repository discovery
+
+Started the shell merge implementation by extracting db-browser's verb repository discovery into `go-go-goja`. This creates a neutral reusable package for discovering built-in, config-file, environment, and CLI-specified verb repositories without depending on db-browser.
+
+The extracted package keeps the same behavior but renames db-browser-specific configuration to goja-neutral names. It is now ready for the next step: moving the jsverbs CLI/runtime command layer to use this reusable repository package.
+
+### Prompt Context
+
+**User prompt (verbatim):** (same as previous step)
+
+**Assistant interpretation:** Continue the task list one item at a time, committing a focused reusable repository-discovery extraction.
+
+**Inferred user intent:** Move unique db-browser shell behavior into reusable/canonical locations so db-browser can later be retired.
+
+**Commit (code):** d4aec1568fa1278d2a612780f2c68de27c46a7db — "Add reusable jsverbs repository discovery"
+
+### What I did
+
+- Copied db-browser `internal/verbrepos` into `go-go-goja/pkg/jsverbrepos`.
+- Renamed the package to `jsverbrepos`.
+- Renamed configuration/env constants:
+  - `DB_BROWSER_VERB_REPOSITORIES` → `GOJA_VERB_REPOSITORIES`.
+  - `.db-browser.yml` → `.goja-verbs.yml`.
+  - `.db-browser.override.yml` → `.goja-verbs.override.yml`.
+- Moved embedded built-in verbs into `pkg/jsverbrepos/builtin`.
+- Updated tests for the neutral package names.
+- Ran `go test ./pkg/jsverbrepos -count=1`.
+- Committed the package; the go-go-goja pre-commit hook also ran lint, generate, and `go test ./...` successfully.
+
+### Why
+
+- Repository discovery is not db-browser-specific; it is part of a reusable jsverbs shell.
+- Neutral package/config names are needed before `goja-site verbs` can consume the behavior cleanly.
+
+### What worked
+
+- The package copied cleanly because it only depends on the standard library, `embed`, and `gopkg.in/yaml.v3`.
+- Existing tests were easy to adapt to the new package name and neutral constants.
+- Full go-go-goja pre-commit validation passed.
+
+### What didn't work
+
+- N/A.
+
+### What I learned
+
+- `verbrepos` was already well factored: it has no dependency on db-browser runtime/app code.
+- This makes the upcoming `verbcli` extraction more likely to be straightforward, with import rewrites as the main change.
+
+### What was tricky to build
+
+- Avoiding compatibility aliases was intentional because the selected retirement path does not require preserving db-browser-specific config names unless requested later.
+- The embedded built-in scripts had user-facing text mentioning db-browser; I changed those descriptions to neutral goja wording.
+
+### What warrants a second pair of eyes
+
+- Whether we should add temporary aliases for `DB_BROWSER_VERB_REPOSITORIES` and `.db-browser.yml` despite the no-compatibility default.
+- Whether the built-in verbs belong in `go-go-goja/pkg/jsverbrepos` long-term or should become goja-site examples instead.
+
+### What should be done in the future
+
+- Extract `internal/verbcli` into a reusable `go-go-goja/pkg/jsverbscli` package and point it at `pkg/jsverbrepos`.
+
+### Code review instructions
+
+- Start with `pkg/jsverbrepos/bootstrap.go` constants and discovery order.
+- Review `pkg/jsverbrepos/bootstrap_test.go` for expected behavior.
+- Validate with `go test ./pkg/jsverbrepos -count=1`.
+
+### Technical details
+
+- Discovery order remains: built-in, config, env, CLI.
+- Duplicate repositories are deduped by embedded identity or cleaned absolute path.
+- CLI flags remain `--repository` and `--verb-repository`.
+
 ## 2026-05-08 - Shell merge design and task setup
 
 Created the design plan for merging the remaining `db-browser` and `goja-hosting-site` web shells after the shared runtime extraction. The design locks in the requested options: retire/delete `db-browser` as an independent shell, and keep both the existing `dbguard` policy and a simple read/write-gated database policy in the unified goja-site shell.

--- a/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/log/01-implementation-diary.md
+++ b/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/log/01-implementation-diary.md
@@ -20,6 +20,100 @@ WhenToUse: "Read before continuing Express/ui.dsl upstreaming or downstream clea
 
 # Implementation Diary
 
+## 2026-05-08 - Add goja-site database policy selection
+
+Implemented the unified database policy layer for the canonical goja-site shell. The app can now keep its existing guarded `dbguard` behavior while also serving db-browser-style SQLite tools through a simple read/write-gated policy.
+
+This completes the core runtime side of the shell merge: scripts can come from multiple directories, `goja-site verbs` exists, and `goja-site serve` can choose between `guarded` and `simple` DB policies explicitly.
+
+### Prompt Context
+
+**User prompt (verbatim):** "go ahead with T16, read docmgr + diary skills, keep a diary, commit at appropriat eintervals."
+
+**Assistant interpretation:** Continue with ticket phase T16 by implementing database policy selection, following docmgr/diary process, validating, and committing code plus documentation updates separately.
+
+**Inferred user intent:** Make goja-site capable of replacing db-browser's simple SQLite serving mode while preserving existing dbguard-backed goja-hosting-site behavior.
+
+**Commit (code):** 5142843b00c96415f0138e881c9edeadbd650ba9 — "Add goja-site database policy selection"
+
+### What I did
+
+- Re-read the `docmgr` and `diary` skills before changing code.
+- Added `DBPolicy` to `pkg/app.Config` with `simple` and `guarded` values.
+- Added `pkg/app/database.go` to build database module specs and runtime registrars based on the selected policy.
+- Implemented the simple policy with a lightweight read/write gate around `database` and `db`.
+- Preserved guarded mode with `dbguard.NewMeteredDB` and the `db.guard` runtime module registrar.
+- Added `goja-site serve` flags: `--db-policy`, `--readonly`, and `--allow-writes`.
+- Extended multi-site `SiteConfig` with `dbPolicy`, `readonly`, and `allowWrites` fields.
+- Updated deploy YAML to make current sites explicitly `dbPolicy: guarded`.
+- Added tests for simple read-only rejection, simple write allowance, guarded `db.guard` registration, policy normalization, and multi-site policy normalization.
+- Ran `go test ./... -count=1`, `GOWORK=off go test ./... -count=1`, `go run ./cmd/goja-site serve --help`, and `golangci-lint run ./pkg/app ./cmd/goja-site`.
+
+### Why
+
+- The merge design selected Option C: keep both database policies instead of forcing generic SQLite browser workflows through dbguard or removing dbguard from existing goja-site apps.
+- Explicit policy flags make database write behavior visible at the CLI boundary.
+
+### What worked
+
+- Runtime construction factored into a small database-policy helper without changing script loading or HTTP dispatch.
+- Guarded mode stayed the default, preserving existing goja-site behavior.
+- Simple read-only mode rejects `db.exec(...)` writes while still allowing read queries.
+- The new tests validated both modes without needing a long-running server process.
+
+### What didn't work
+
+- `GOWORK=off go test ./... -count=1` initially failed because goja-site's `go.sum` was missing tree-sitter checksums pulled in by the earlier `goja-site verbs` integration:
+  - `missing go.sum entry for module providing package github.com/tree-sitter/go-tree-sitter`
+  - `missing go.sum entry for module providing package github.com/tree-sitter/tree-sitter-javascript/bindings/go`
+- Running `go mod tidy` in goja-hosting-site fixed the standalone module metadata.
+- `golangci-lint run ./pkg/app ./cmd/goja-site` initially found:
+  - `errcheck` on an existing `defer srv.Close(context.Background())` in `multi_server_test.go`;
+  - `staticcheck` QF1001 on the SQL token classifier.
+- I fixed both before committing.
+
+### What I learned
+
+- Go slices of concrete `engine.NativeModuleSpec` cannot be expanded into `WithModules(...ModuleSpec)`, so the database helper returns `[]engine.ModuleSpec`.
+- The prior `goja-site verbs` integration compiled in workspace mode but needed tidy metadata for standalone `GOWORK=off` validation.
+- The simple policy can be kept intentionally small while still guarding `Query` against obvious mutating statements such as `INSERT ... RETURNING`.
+
+### What was tricky to build
+
+- The write-gate semantics needed to preserve guarded defaults while making simple policy safe by default. The resulting normalization keeps empty policy as `guarded`, and forces simple policy to read-only unless `AllowWrites` is set.
+- `db.guard` is runtime-scoped, so guarded policy construction has to return both preconfigured database module specs and the extra runtime registrar.
+- The simple SQL classifier is deliberately conservative and token-based, not a full SQL parser; reviewers should treat it as a safety belt rather than a complete sandbox.
+
+### What warrants a second pair of eyes
+
+- Whether `--readonly` should also affect guarded mode. This implementation keeps guarded mode behavior unchanged and applies the read/write gate only to simple mode.
+- Whether simple read-only should allow `PRAGMA` in `Query`; it currently does, because db-browser-style inspection needs schema metadata.
+- Whether the CLI text should more strongly say that `--allow-writes` only matters for `--db-policy simple`.
+
+### What should be done in the future
+
+- Migrate db-browser examples to goja-site and make them use `--db-policy simple --readonly` by default.
+- Consider exposing the simple policy wrapper from a reusable package if jsverbs and web serving should share exactly the same DB gate.
+
+### Code review instructions
+
+- Start with `pkg/app/config.go` and `pkg/app/database.go` for policy semantics.
+- Review `pkg/app/server.go` to see how module specs and runtime registrars are assembled.
+- Review `cmd/goja-site/serve.go` for user-facing flags.
+- Review `pkg/app/database_test.go` for behavioral examples.
+- Validate with:
+  - `cd 2026-05-03--goja-hosting-site && go test ./... -count=1`
+  - `cd 2026-05-03--goja-hosting-site && GOWORK=off go test ./... -count=1`
+  - `cd 2026-05-03--goja-hosting-site && golangci-lint run ./pkg/app ./cmd/goja-site`
+
+### Technical details
+
+- `DBPolicyGuarded` remains the default when `DBPolicy` is empty.
+- `DBPolicySimple` exposes the same `database` and `db` modules but does not register `db.guard`.
+- `DBPolicyGuarded` exposes `database`, `db`, and `db.guard`.
+- Simple writes are allowed only when `AllowWrites && !ReadOnly`.
+- Simple read-only `Query` allows `SELECT`, `WITH`, `PRAGMA`, and `EXPLAIN`; other leading tokens are rejected.
+
 ## 2026-05-08 - Generalize goja-site script loading
 
 Updated goja-site so the web shell can load route scripts from multiple script directories instead of exactly one. This removes one of the main remaining differences called out before the shell merge: goja-site can now compose shared script roots and app-specific script roots in a deterministic order.

--- a/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/log/01-implementation-diary.md
+++ b/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/log/01-implementation-diary.md
@@ -20,6 +20,90 @@ WhenToUse: "Read before continuing Express/ui.dsl upstreaming or downstream clea
 
 # Implementation Diary
 
+## 2026-05-08 - Extract reusable jsverbs CLI shell
+
+Continued the shell merge by extracting db-browser's jsverbs CLI command construction and runtime invocation layer into `go-go-goja/pkg/jsverbscli`. This package now builds the dynamic `verbs` Cobra/Glazed command tree on top of the reusable `pkg/jsverbs` scanner and the new `pkg/jsverbrepos` repository discovery package.
+
+This step makes the next goja-site integration small: `cmd/goja-site` can import `pkg/jsverbscli` and add `jsverbscli.NewLazyCommand()` instead of copying db-browser internals.
+
+### Prompt Context
+
+**User prompt (verbatim):** (same as previous steps)
+
+**Assistant interpretation:** Continue the task list by moving the jsverbs command/runtime layer to a reusable package and committing it separately.
+
+**Inferred user intent:** Make `goja-site verbs` possible without keeping db-browser as the owner of jsverbs shell code.
+
+**Commit (code):** d84a38f177a6e5e9cf375b14d1d7fb1f90fc4ae9 — "Add reusable jsverbs CLI shell"
+
+### What I did
+
+- Copied db-browser `internal/verbcli` into `go-go-goja/pkg/jsverbscli`.
+- Renamed the package to `jsverbscli`.
+- Replaced db-browser repository imports with `github.com/go-go-golems/go-go-goja/pkg/jsverbrepos`.
+- Kept the per-invocation runtime factory with common modules, `ui.dsl`, and optional `database`/`db` modules.
+- Updated runtime setup to use `UseModuleMiddleware(engine.MiddlewareOnly(...))` instead of deprecated `engine.DefaultRegistryModulesNamed`.
+- Ran `go test ./pkg/jsverbscli -count=1` and `golangci-lint run ./pkg/jsverbscli`.
+- Committed the package; the go-go-goja pre-commit hook also ran full lint/generate/tests successfully.
+
+### Why
+
+- The `verbs` command is a generic Goja/jsverbs shell feature, not db-browser-specific behavior.
+- Moving it to go-go-goja lets goja-site add `verbs` with a very small integration change.
+
+### What worked
+
+- The command/list/runtime code was already mostly decoupled from db-browser.
+- Existing tests copied over and passed once imports were updated.
+- Full pre-commit validation passed after replacing deprecated module registration.
+
+### What didn't work
+
+- First commit attempt failed lint with:
+
+```text
+pkg/jsverbscli/runtime.go:54:3: SA1019: engine.DefaultRegistryModulesNamed is deprecated: Use UseModuleMiddleware with MiddlewareOnly instead.
+```
+
+I fixed this by switching the builder to:
+
+```go
+UseModuleMiddleware(engine.MiddlewareOnly("fs", "path", "time", "timer", "yaml"))
+```
+
+and keeping `WithModules(...)` only for configured database aliases.
+
+### What I learned
+
+- The extracted CLI package can stay independent of any web host; it only needs the jsverbs registry require loader and runtime modules.
+- `ui.dsl` is useful in CLI verbs too because built-in `renderSampleTable` renders HTML text.
+
+### What was tricky to build
+
+- The original db-browser runtime used a deprecated convenience module spec. In the reusable package, lint enforces the newer middleware path, so default module registration had to be split from explicit database module specs.
+
+### What warrants a second pair of eyes
+
+- Whether `RuntimeSettings` should be exported/configurable enough for goja-site before wiring the command.
+- Whether the CLI runtime should optionally register goja-site-specific modules like `kanban.dsl` later.
+
+### What should be done in the future
+
+- Wire `jsverbscli.NewLazyCommand()` into `cmd/goja-site/main.go`.
+- Validate `goja-site verbs list`, built-in non-DB verbs, and the DB-backed `tables` verb.
+
+### Code review instructions
+
+- Start with `pkg/jsverbscli/command.go` for lazy discovery and command generation.
+- Review `pkg/jsverbscli/runtime.go` for module registration and database write policy.
+- Validate with `go test ./pkg/jsverbscli -count=1`.
+
+### Technical details
+
+- `verbs` still supports leading `--repository` / `--verb-repository` flags before the dynamic verb path.
+- Each verb invocation gets a new runtime and closes it after invocation.
+- Filesystem repositories add repo and parent `node_modules` folders as require global folders.
+
 ## 2026-05-08 - Extract reusable jsverbs repository discovery
 
 Started the shell merge implementation by extracting db-browser's verb repository discovery into `go-go-goja`. This creates a neutral reusable package for discovering built-in, config-file, environment, and CLI-specified verb repositories without depending on db-browser.

--- a/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/log/01-implementation-diary.md
+++ b/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/log/01-implementation-diary.md
@@ -20,6 +20,80 @@ WhenToUse: "Read before continuing Express/ui.dsl upstreaming or downstream clea
 
 # Implementation Diary
 
+## 2026-05-08 - Generalize goja-site script loading
+
+Updated goja-site so the web shell can load route scripts from multiple script directories instead of exactly one. This removes one of the main remaining differences called out before the shell merge: goja-site can now compose shared script roots and app-specific script roots in a deterministic order.
+
+This step intentionally changes the app config and multi-site config shape to use script lists. It does not add compatibility aliases for the old single `scriptsDir` field because the selected direction is a cleanup/retirement path rather than preserving two shell APIs.
+
+### Prompt Context
+
+**User prompt (verbatim):** (same as previous steps)
+
+**Assistant interpretation:** Continue the merge tasks by replacing goja-site's single scripts directory model with multi-directory script loading.
+
+**Inferred user intent:** Make goja-site flexible enough to absorb db-browser examples and shared script libraries.
+
+**Commit (code):** 67eff77dfa48f5fe4d521fef9cfd5aae99414051 — "Support multiple goja-site script directories"
+
+### What I did
+
+- Changed `app.Config` from `ScriptsDir string` to `ScriptDirs []string`.
+- Added `pkg/app/scripts.go` with deterministic multi-directory script discovery.
+- Added tests for directory order, sorting within directories, deduplication, missing dirs, and non-directory paths.
+- Updated `LoadScripts` to use the new helper.
+- Updated `goja-site serve --scripts` to use `fields.TypeStringList` and accept repeatable script directories.
+- Updated multi-site config to use `scripts:` lists per site.
+- Updated `deploy/sites.yaml` and `deploy/sites.local.yaml` to the new shape.
+- Ran `go test ./... -count=1` in goja-hosting-site.
+
+### Why
+
+- The single-directory script model was one of the explicit remaining limitations before merging the shells.
+- Multiple script dirs allow shared libraries plus app-specific route scripts without copying files.
+
+### What worked
+
+- Script loading factored cleanly out of `server.go` into `scripts.go`.
+- Existing multi-site tests adapted cleanly to script lists.
+- Full goja-hosting-site tests passed.
+
+### What didn't work
+
+- N/A.
+
+### What I learned
+
+- The previous script loader was self-contained, so moving it into a helper avoided touching runtime construction.
+- Glazed already supports repeatable string-list flags with `fields.TypeStringList`.
+
+### What was tricky to build
+
+- Deduplication is done by cleaned absolute file path so repeating a directory does not double-load the same route script.
+- The helper preserves directory-order semantics while sorting only within each directory.
+
+### What warrants a second pair of eyes
+
+- Whether returning absolute paths to `vm.RunScript` is acceptable for script names in stack traces. It improves uniqueness but exposes absolute paths in errors.
+- Whether the multi-site config field should be named `scripts` or `scriptDirs` for clarity.
+
+### What should be done in the future
+
+- Add database policy selection so goja-site can serve db-browser-style read-only SQLite tools safely.
+
+### Code review instructions
+
+- Start with `pkg/app/scripts.go` and `pkg/app/scripts_test.go`.
+- Review `cmd/goja-site/serve.go` for `--scripts` flag decoding.
+- Review `pkg/app/multi_config.go` and deploy YAML for config shape changes.
+- Validate with `go test ./... -count=1` in goja-hosting-site.
+
+### Technical details
+
+- Empty script list defaults to `[]string{"./scripts"}` at the server/CLI boundary.
+- Missing directories and non-directory paths are hard errors.
+- Loading still only includes `.js` files.
+
 ## 2026-05-08 - Add `goja-site verbs`
 
 Wired the reusable jsverbs CLI shell into `goja-hosting-site`, making `goja-site verbs` available as the canonical command for repository-scanned JavaScript verbs. This is the first visible shell merge: goja-site can now run the built-in verbs that previously belonged to db-browser's command surface.

--- a/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/log/01-implementation-diary.md
+++ b/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/log/01-implementation-diary.md
@@ -34,7 +34,7 @@ This step did not change runtime behavior. It created the blueprint and task bre
 
 **Inferred user intent:** Collapse the now-similar web shells into one canonical implementation while preserving clear project management and review history.
 
-**Commit (code):** pending — design/task setup has been written and is ready to commit with the current baseline.
+**Commit (code):** 229fd920786ae83dc96bac1732bf80eda4c68307 — "Add upstream express and ui DSL modules"
 
 ### What I did
 
@@ -42,6 +42,9 @@ This step did not change runtime behavior. It created the blueprint and task bre
 - Added T10–T18 task sections covering baseline commits, jsverbs extraction, `goja-site verbs`, multi-script loading, DB policy selection, example migration, and db-browser retirement.
 - Related the design doc, diary, and task file to the ticket index.
 - Updated the ticket changelog.
+- Committed go-go-goja baseline/design as `229fd920786ae83dc96bac1732bf80eda4c68307`.
+- Committed goja-hosting-site migration as `dda6fa41cee1048b7e54087f535eed99432c1cbc`.
+- Committed db-browser migration as `4e3009f8ee68e119d31aa08f451644ace896fbee`.
 
 ### Why
 
@@ -56,7 +59,7 @@ This step did not change runtime behavior. It created the blueprint and task bre
 
 ### What didn't work
 
-- I accidentally checked tasks 45–47 before the baseline commits were created. I will satisfy those by committing the baseline immediately rather than leaving them stale.
+- I accidentally checked tasks 45–47 before the baseline commits were created. I then satisfied those tasks by committing the goja-hosting-site and db-browser migration baselines and recording the commit hashes here.
 
 ### What I learned
 
@@ -75,7 +78,6 @@ This step did not change runtime behavior. It created the blueprint and task bre
 
 ### What should be done in the future
 
-- Commit the current upstream/downstream baseline.
 - Start T12 by extracting neutral jsverbs repository discovery.
 
 ### Code review instructions

--- a/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/log/01-implementation-diary.md
+++ b/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/log/01-implementation-diary.md
@@ -20,6 +20,100 @@ WhenToUse: "Read before continuing Express/ui.dsl upstreaming or downstream clea
 
 # Implementation Diary
 
+## 2026-05-08 - Retire db-browser shell
+
+Retired `db-browser` as an independent Go shell now that its reusable pieces, command surface, database policies, and examples have moved to `go-go-goja` and `goja-site`. The repository now contains a small retirement marker package and a README pointing users at the replacement commands.
+
+This completes the Option A path selected in the merge design: `db-browser` no longer carries a duplicate runtime stack, duplicate examples, or validation scripts that target the old shell.
+
+### Prompt Context
+
+**User prompt (verbatim):** (same as previous step: "continue")
+
+**Assistant interpretation:** Continue from example migration into the final retirement phase for db-browser.
+
+**Inferred user intent:** Finish the shell merge by removing the redundant db-browser implementation and validating the remaining canonical repos.
+
+**Commit (code):** 1b9e06350efcc0fd6e967311966859f689b61766 — "Retire db-browser shell"
+
+**Related commit:** 48f5420d094b23c4cdf208a39fd7f94859ce7b52 — "Tidy goja-site standalone dependencies"
+
+### What I did
+
+- Replaced `db-browser/README.md` with a retirement notice and goja-site migration commands.
+- Reduced `db-browser/go.mod` to a minimal module marker.
+- Added `db-browser/retired.go` so `go test ./...` still has a package to test.
+- Removed the old duplicated shell/runtime code:
+  - `cmd/db-browser`
+  - `internal/app`
+  - `internal/doc`
+  - `internal/verbcli`
+  - `internal/verbrepos`
+- Removed migrated examples from db-browser:
+  - `examples/generic-browser`
+  - `examples/yaml-dashboard`
+  - `examples/playwright-smoke`
+  - `examples/builtin-verbs`
+- Removed old db-browser validation script directories that targeted the retired runtime.
+- Ran final validation across the active repos:
+  - `cd go-go-goja && go test ./... -count=1`
+  - `cd 2026-05-03--goja-hosting-site && go test ./... -count=1`
+  - `cd 2026-05-03--goja-hosting-site && GOWORK=off go test ./... -count=1`
+  - `cd 2026-05-07--db-browser && go test ./... -count=1`
+
+### Why
+
+- Keeping db-browser's implementation after migrating its features would reintroduce exactly the shell duplication the design set out to remove.
+- A minimal marker package makes the retired repo explicit while keeping basic Go tooling healthy.
+
+### What worked
+
+- The retired db-browser module now tests cleanly with no runtime implementation.
+- go-go-goja and goja-site final test suites passed after the retirement.
+- The README is now the single entry point for users who land in the old repo.
+
+### What didn't work
+
+- After retiring db-browser, a standalone goja-site validation reported that `go.mod` needed tidy updates for transitive versions:
+  - `github.com/rs/zerolog v1.35.1`
+  - `github.com/yuin/goldmark v1.8.2`
+- Running `go mod tidy` in goja-site produced the minimal metadata update, which was committed separately as `48f5420d094b23c4cdf208a39fd7f94859ce7b52`.
+- A first attempt to leave db-browser with no Go packages made `go test ./...` exit with `go: warning: "./..." matched no packages`; adding `retired.go` fixed that.
+
+### What I learned
+
+- Retiring a Go module cleanly is nicer with a tiny marker package than with an empty module.
+- Keeping old ttmp validation scripts after removing their target runtime would be misleading, so deleting those scripts is clearer than preserving broken commands.
+
+### What was tricky to build
+
+- This was primarily deletion work, but the important constraint was keeping workspace and standalone Go tooling usable after removing packages and dependencies.
+- The goja-site tidy change was separate from the db-browser retirement but necessary for the final `GOWORK=off` validation to stay green.
+
+### What warrants a second pair of eyes
+
+- Whether any historical db-browser docs under `docs/` should also be archived, edited, or removed. I left them as historical reference.
+- Whether the db-browser repo should eventually be physically archived/deleted outside git, since this commit only retires the implementation in-place.
+- Whether old db-browser ttmp docs should be marked retired more aggressively.
+
+### What should be done in the future
+
+- Remove local `replace github.com/go-go-golems/go-go-goja => ../go-go-goja` directives after go-go-goja is tagged and downstream modules can depend on a released version.
+- Consider adding CI coverage for the migrated goja-site examples.
+
+### Code review instructions
+
+- Review `2026-05-07--db-browser/README.md` and `retired.go` first.
+- Confirm removed `cmd/`, `internal/`, and `examples/` content exists in `go-go-goja` and `goja-hosting-site` commits from earlier phases.
+- Review `2026-05-03--goja-hosting-site/go.mod` and `go.sum` for the minimal tidy update.
+- Validate with the final validation commands listed above.
+
+### Technical details
+
+- db-browser is still a valid Go module: `module github.com/go-go-golems/db-browser`, `go 1.26.1`.
+- The marker package is named `dbbrowser` because Go package names cannot contain hyphens.
+- Historical `docs/` and ticket documents remain in place for reference.
+
 ## 2026-05-08 - Migrate db-browser examples to goja-site
 
 Moved the db-browser example apps into goja-hosting-site so the canonical shell now carries the generic SQLite browser, YAML dashboard, Playwright smoke app, and editable verb examples. The migrated web examples all document and validate the new `goja-site serve --db-policy simple --readonly` flow.

--- a/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/log/01-implementation-diary.md
+++ b/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/log/01-implementation-diary.md
@@ -20,6 +20,91 @@ WhenToUse: "Read before continuing Express/ui.dsl upstreaming or downstream clea
 
 # Implementation Diary
 
+## 2026-05-08 - Fix Kanban empty filter option and add Playwright smoke
+
+Added a repeatable browser-level smoke test for the Kanban example and fixed the empty-value rendering bug it exposed. The important regression was that the `All columns` option rendered without `value=""`, so submitting the search form sent `status=All columns` and filtered every card out.
+
+The new smoke script starts `goja-site`, drives Chromium via Playwright, checks seeded board counts, adds a card, searches for it, and moves it to Done through the precise-move UI.
+
+### Prompt Context
+
+**User prompt (verbatim):** "ok, 1. and 2."
+
+**Assistant interpretation:** Fix the Kanban empty select value bug and add repeatable Playwright coverage for the Kanban example.
+
+**Inferred user intent:** Turn the manual Playwright finding into a regression fix and an executable E2E test.
+
+**Commit (code):** bcf26bc4f84e55decb4c634d7eec1573edab4bf4 — "Preserve empty value attributes in ui DSL"
+
+**Commit (test/script):** c53ebdcb013203be568e344293ba4afb1c97cf59 — "Add Kanban Playwright smoke test"
+
+### What I did
+
+- Fixed upstream `ui.dsl` attribute rendering so `value=""` is preserved for empty value attributes.
+- Added `modules/uidsl/render_attrs_test.go` covering `ui.option({ value: "", selected: true }, "All columns")`.
+- Added `2026-05-03--goja-hosting-site/scripts/playwright-kanban-smoke.sh`.
+- Updated `examples/kanban/README.md` with the smoke-test command and scope.
+- Ran the Playwright smoke script successfully.
+- Ran focused and full validations:
+  - `cd go-go-goja && go test ./modules/uidsl -count=1`
+  - `cd go-go-goja && golangci-lint run ./modules/uidsl`
+  - `cd 2026-05-03--goja-hosting-site && ./scripts/playwright-kanban-smoke.sh`
+  - `cd 2026-05-03--goja-hosting-site && go test ./... -count=1`
+  - `cd 2026-05-03--goja-hosting-site && GOWORK=off go test ./... -count=1`
+  - `cd 2026-05-03--goja-hosting-site && golangci-lint run ./pkg/app ./cmd/goja-site`
+
+### Why
+
+- The manual Playwright Kanban test found a real browser-form regression.
+- The bug belonged in upstream `ui.dsl` rendering because empty `value` attributes are valid and important HTML, especially for select options.
+- A repeatable smoke script keeps the Kanban workflow covered without requiring a committed Node dependency tree.
+
+### What worked
+
+- Preserving `value=""` fixed the `status=All columns` query bug.
+- The smoke script can install Playwright in a temporary npm workspace and leave the Go repo clean.
+- The script exercises the route runtime, SQLite persistence, `kanban.dsl`, browser DOM, form submission, and the Kanban precise-move client script.
+
+### What didn't work
+
+- The first smoke-script run failed because port `19111` was still occupied by a manually started test server.
+- A later script revision initially asserted `Done = 4` while still on a filtered/fragment-updated view and saw `Done = 0`; the fix was to navigate back to `/` after the move before asserting the full-board counts.
+
+### What I learned
+
+- The generic attribute renderer had been dropping all empty-string attributes, which is too aggressive for `value`.
+- The Kanban precise-move action updates a fragment in-place, so E2E assertions should be explicit about whether they expect filtered fragment state or full-page state.
+
+### What was tricky to build
+
+- Playwright is not a repo dependency, so the script creates a temp npm workspace and installs `playwright` there for the run.
+- The smoke test needs deterministic state, so it uses a fresh temp SQLite database each run.
+- The script must clean up the background `goja-site` process and report logs on failure.
+
+### What warrants a second pair of eyes
+
+- Whether `renderAttrs` should preserve other empty attributes besides `value`; currently the fix is intentionally narrow.
+- Whether the Playwright script should become CI coverage or remain a manual smoke due to browser/npm install time.
+- Whether `PORT` default `19111` is acceptable or should randomize and discover a free port.
+
+### What should be done in the future
+
+- Consider adding similar Playwright smoke scripts for the db-browser migrated examples.
+- If CI adopts this, cache Playwright dependencies or preinstall browsers in the CI image.
+
+### Code review instructions
+
+- Review `go-go-goja/modules/uidsl/render.go` first for the empty-value change.
+- Review `go-go-goja/modules/uidsl/render_attrs_test.go` for the regression test.
+- Review `2026-05-03--goja-hosting-site/scripts/playwright-kanban-smoke.sh` for process cleanup and browser assertions.
+- Validate with the commands listed above.
+
+### Technical details
+
+- The smoke script accepts `PORT`, `DB_PATH`, `LOG_PATH`, `KEEP_DB`, `PLAYWRIGHT_VERSION`, and `PLAYWRIGHT_TMP` environment overrides.
+- It defaults to Playwright `1.59.1` and port `19111`.
+- It asserts browser console warnings/errors are absent.
+
 ## 2026-05-08 - Retire db-browser shell
 
 Retired `db-browser` as an independent Go shell now that its reusable pieces, command surface, database policies, and examples have moved to `go-go-goja` and `goja-site`. The repository now contains a small retirement marker package and a README pointing users at the replacement commands.

--- a/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/tasks.md
+++ b/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/tasks.md
@@ -1,0 +1,73 @@
+# Tasks
+
+## GO-GO-GOJA-EXPRESS-UIDSL-MODULES
+
+### T01 — Ticket and initial design
+
+- [x] Create docmgr ticket workspace.
+- [x] Store initial upstreaming analysis and design guide.
+- [x] Add implementation task plan.
+- [ ] Commit ticket planning docs.
+
+### T02 — Upstream `pkg/gojahttp`
+
+- [ ] In `/home/manuel/code/wesen/corporate-headquarters/go-go-goja`, create `pkg/gojahttp`.
+- [ ] Copy host infrastructure from db-browser `internal/web`, excluding `express_module.go`.
+- [ ] Rename package from `web` to `gojahttp`.
+- [ ] Rename/update session cookie comments and default naming.
+- [ ] Keep renderer injection and avoid importing `modules/uidsl`.
+- [ ] Move/adapt route, body, session, request/response, and host tests.
+- [ ] Run `go test ./pkg/gojahttp -count=1`.
+
+### T03 — Add `modules/express`
+
+- [ ] Create `modules/express` in go-go-goja.
+- [ ] Move/adapt the Express registrar from db-browser `internal/web/express_module.go`.
+- [ ] Implement `NewRegistrar(host *gojahttp.Host, opts ...Option)`.
+- [ ] Keep `express` runtime-scoped via `engine.RuntimeModuleRegistrar`.
+- [ ] Do not default-register `express` with `modules.Register` in the first version.
+- [ ] Add runtime integration tests using `require("express")` and `httptest`.
+
+### T04 — Add `modules/uidsl`
+
+- [ ] Copy db-browser `internal/uidsl` into go-go-goja `modules/uidsl`.
+- [ ] Keep `RenderAny`, `Loader`, and `NewRegistrar` public.
+- [ ] Register aliases `ui.dsl` and `ui` through the registrar.
+- [ ] Move/adapt render, table, filters, links, and component tests.
+- [ ] Run `go test ./modules/uidsl -count=1`.
+
+### T05 — Documentation and TypeScript declarations
+
+- [ ] Add go-go-goja docs for the Express-style module.
+- [ ] Add go-go-goja docs for the `ui.dsl` module.
+- [ ] Add TypeScript declarations or declaration descriptors for `express`.
+- [ ] Add TypeScript declarations or declaration descriptors for `ui.dsl`.
+- [ ] Document that `express` is Express-style, not full Express-compatible.
+
+### T06 — Upstream validation
+
+- [ ] Run `go test ./pkg/gojahttp ./modules/express ./modules/uidsl -count=1`.
+- [ ] Run `go test ./... -count=1` in go-go-goja.
+- [ ] Run `GOWORK=off go test ./... -count=1` in go-go-goja.
+- [ ] Run lint if practical.
+
+### T07 — Migrate goja-hosting-site
+
+- [ ] Replace local `pkg/web` and `pkg/uidsl` imports with upstream go-go-goja packages.
+- [ ] Validate goja-hosting-site tests.
+- [ ] Delete or deprecate local packages once green.
+
+### T08 — Migrate db-browser
+
+- [ ] Replace `internal/web` with `pkg/gojahttp` + `modules/express` imports.
+- [ ] Replace `internal/uidsl` with `modules/uidsl` imports.
+- [ ] Validate `go test ./...`.
+- [ ] Run db-browser final validation and component smoke scripts.
+- [ ] Delete local copied packages if no local behavior remains.
+
+### T09 — Follow-ups after migration
+
+- [ ] Decide whether `ui.dsl` should become a default registry module.
+- [ ] Decide whether scoped table query state should be implemented upstream or first in db-browser.
+- [ ] Consider static theme asset support after the upstream packages are stable.
+- [ ] Consider server-interactive UI events as a separate project after the host boundary is stable.

--- a/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/tasks.md
+++ b/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/tasks.md
@@ -126,14 +126,14 @@
 
 ### T16 — Add unified database policy selection
 
-- [ ] Add `DBPolicy` with `simple` and `guarded` modes to goja-site app config.
-- [ ] Implement simple read/write-gated DB wrapper for generic SQLite browser use.
-- [ ] Preserve guarded `dbguard` behavior and `db.guard` module registration.
-- [ ] Add CLI flags `--db-policy`, `--readonly`, and `--allow-writes` to `goja-site serve`.
-- [ ] Extend multi-site config with database policy fields.
-- [ ] Add tests for simple read-only rejection and guarded policy registration.
-- [ ] Validate and commit.
-- [ ] Update diary and changelog with commit hash.
+- [x] Add `DBPolicy` with `simple` and `guarded` modes to goja-site app config.
+- [x] Implement simple read/write-gated DB wrapper for generic SQLite browser use.
+- [x] Preserve guarded `dbguard` behavior and `db.guard` module registration.
+- [x] Add CLI flags `--db-policy`, `--readonly`, and `--allow-writes` to `goja-site serve`.
+- [x] Extend multi-site config with database policy fields.
+- [x] Add tests for simple read-only rejection and guarded policy registration.
+- [x] Validate and commit.
+- [x] Update diary and changelog with commit hash.
 
 ### T17 — Migrate db-browser examples into goja-hosting-site
 

--- a/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/tasks.md
+++ b/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/tasks.md
@@ -74,7 +74,7 @@
 
 ### T10 — Commit upstream extraction baseline
 
-- [ ] Review and commit go-go-goja upstream packages/docs/docmgr updates.
+- [x] Review and commit go-go-goja upstream packages/docs/docmgr updates.
 - [x] Review and commit goja-hosting-site migration to upstream `gojahttp`, `express`, and `uidsl`.
 - [x] Review and commit db-browser migration to upstream `gojahttp`, `express`, and `uidsl`.
 - [x] Record baseline commit hashes in the implementation diary.
@@ -85,7 +85,7 @@
 - [x] Record selected options: Option A retire/delete db-browser; Option C support both dbguard and normal/simple DB policy.
 - [x] Add detailed implementation task list to the ticket.
 - [x] Relate design and diary files to the ticket.
-- [ ] Commit design/task/diary setup.
+- [x] Commit design/task/diary setup.
 
 ### T12 — Extract reusable jsverbs repository discovery
 

--- a/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/tasks.md
+++ b/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/tasks.md
@@ -116,13 +116,13 @@
 
 ### T15 — Generalize goja-site script loading
 
-- [ ] Add `ScriptDirs []string` to `pkg/app.Config`.
-- [ ] Refactor script discovery/loading into deterministic multi-directory helper.
-- [ ] Update `goja-site serve` to accept repeated `--scripts` values, replacing the single-directory-only model.
-- [ ] Update `serve-multi` config parsing to support script lists per site.
-- [ ] Add tests for multi-directory load ordering, missing dirs, non-dir paths, and duplicate files.
-- [ ] Validate and commit.
-- [ ] Update diary and changelog with commit hash.
+- [x] Add `ScriptDirs []string` to `pkg/app.Config`.
+- [x] Refactor script discovery/loading into deterministic multi-directory helper.
+- [x] Update `goja-site serve` to accept repeated `--scripts` values, replacing the single-directory-only model.
+- [x] Update `serve-multi` config parsing to support script lists per site.
+- [x] Add tests for multi-directory load ordering, missing dirs, non-dir paths, and duplicate files.
+- [x] Validate and commit.
+- [x] Update diary and changelog with commit hash.
 
 ### T16 — Add unified database policy selection
 

--- a/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/tasks.md
+++ b/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/tasks.md
@@ -137,14 +137,14 @@
 
 ### T17 — Migrate db-browser examples into goja-hosting-site
 
-- [ ] Move db-browser generic browser example to `goja-hosting-site/examples/db-browser/generic-browser`.
-- [ ] Move db-browser YAML dashboard example to `goja-hosting-site/examples/db-browser/yaml-dashboard`.
-- [ ] Move db-browser Playwright smoke example to `goja-hosting-site/examples/db-browser/playwright-smoke`.
-- [ ] Move/adapt built-in verb examples to `goja-hosting-site/examples/verbs` if they should be user-visible outside the embedded package.
-- [ ] Update paths in smoke scripts and documentation.
-- [ ] Validate migrated examples with `goja-site serve` and `goja-site verbs`.
-- [ ] Commit example migration.
-- [ ] Update diary and changelog with commit hash.
+- [x] Move db-browser generic browser example to `goja-hosting-site/examples/db-browser/generic-browser`.
+- [x] Move db-browser YAML dashboard example to `goja-hosting-site/examples/db-browser/yaml-dashboard`.
+- [x] Move db-browser Playwright smoke example to `goja-hosting-site/examples/db-browser/playwright-smoke`.
+- [x] Move/adapt built-in verb examples to `goja-hosting-site/examples/verbs` if they should be user-visible outside the embedded package.
+- [x] Update paths in smoke scripts and documentation.
+- [x] Validate migrated examples with `goja-site serve` and `goja-site verbs`.
+- [x] Commit example migration.
+- [x] Update diary and changelog with commit hash.
 
 ### T18 — Retire db-browser as an independent shell
 

--- a/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/tasks.md
+++ b/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/tasks.md
@@ -89,12 +89,12 @@
 
 ### T12 — Extract reusable jsverbs repository discovery
 
-- [ ] Move db-browser `internal/verbrepos` into reusable package location (`go-go-goja/pkg/jsverbrepos` preferred, or `goja-hosting-site/pkg/verbrepos` if blocked).
-- [ ] Rename db-browser-specific constants to neutral names (`GOJA_VERB_REPOSITORIES`, `.goja-verbs.yml`, `.goja-verbs.override.yml`).
-- [ ] Move embedded built-in verb scripts with the package.
-- [ ] Update repository discovery tests for the new package and neutral names.
-- [ ] Validate focused tests and commit.
-- [ ] Update diary and changelog with commit hash.
+- [x] Move db-browser `internal/verbrepos` into reusable package location (`go-go-goja/pkg/jsverbrepos` preferred, or `goja-hosting-site/pkg/verbrepos` if blocked).
+- [x] Rename db-browser-specific constants to neutral names (`GOJA_VERB_REPOSITORIES`, `.goja-verbs.yml`, `.goja-verbs.override.yml`).
+- [x] Move embedded built-in verb scripts with the package.
+- [x] Update repository discovery tests for the new package and neutral names.
+- [x] Validate focused tests and commit.
+- [x] Update diary and changelog with commit hash.
 
 ### T13 — Extract reusable jsverbs CLI/runtime invocation
 

--- a/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/tasks.md
+++ b/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/tasks.md
@@ -148,9 +148,9 @@
 
 ### T18 — Retire db-browser as an independent shell
 
-- [ ] Remove or archive db-browser runtime packages after goja-site covers serve and verbs workflows.
-- [ ] Add a retirement README or repo-level note pointing users to goja-site, unless the repo is deleted outright.
-- [ ] Remove redundant db-browser validation scripts after equivalent goja-site scripts exist.
-- [ ] Run final validation across go-go-goja and goja-hosting-site.
-- [ ] Commit db-browser retirement.
-- [ ] Update diary and changelog with commit hash.
+- [x] Remove or archive db-browser runtime packages after goja-site covers serve and verbs workflows.
+- [x] Add a retirement README or repo-level note pointing users to goja-site, unless the repo is deleted outright.
+- [x] Remove redundant db-browser validation scripts after equivalent goja-site scripts exist.
+- [x] Run final validation across go-go-goja and goja-hosting-site.
+- [x] Commit db-browser retirement.
+- [x] Update diary and changelog with commit hash.

--- a/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/tasks.md
+++ b/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/tasks.md
@@ -98,12 +98,12 @@
 
 ### T13 — Extract reusable jsverbs CLI/runtime invocation
 
-- [ ] Move db-browser `internal/verbcli` into reusable package location (`go-go-goja/pkg/jsverbscli` preferred, or `goja-hosting-site/pkg/verbcli` if blocked).
-- [ ] Update imports from db-browser `verbrepos` to the new neutral repository package.
-- [ ] Keep runtime invocation support for common modules, `ui.dsl`, and optional `database`/`db`.
-- [ ] Add or adapt command/list/runtime tests.
-- [ ] Validate focused tests and commit.
-- [ ] Update diary and changelog with commit hash.
+- [x] Move db-browser `internal/verbcli` into reusable package location (`go-go-goja/pkg/jsverbscli` preferred, or `goja-hosting-site/pkg/verbcli` if blocked).
+- [x] Update imports from db-browser `verbrepos` to the new neutral repository package.
+- [x] Keep runtime invocation support for common modules, `ui.dsl`, and optional `database`/`db`.
+- [x] Add or adapt command/list/runtime tests.
+- [x] Validate focused tests and commit.
+- [x] Update diary and changelog with commit hash.
 
 ### T14 — Add `goja-site verbs`
 

--- a/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/tasks.md
+++ b/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/tasks.md
@@ -107,12 +107,12 @@
 
 ### T14 — Add `goja-site verbs`
 
-- [ ] Wire the migrated jsverbs CLI command into `cmd/goja-site/main.go`.
-- [ ] Ensure command help and logging integrate with existing goja-site root command.
-- [ ] Validate built-in verbs without a DB (`list`, `hello`, `yamlKeys`, `renderSampleTable`).
-- [ ] Validate DB-backed `tables` verb with a temp SQLite database.
-- [ ] Commit goja-site verbs integration.
-- [ ] Update diary and changelog with commit hash.
+- [x] Wire the migrated jsverbs CLI command into `cmd/goja-site/main.go`.
+- [x] Ensure command help and logging integrate with existing goja-site root command.
+- [x] Validate built-in verbs without a DB (`list`, `hello`, `yamlKeys`, `renderSampleTable`).
+- [x] Validate DB-backed `tables` verb with a temp SQLite database.
+- [x] Commit goja-site verbs integration.
+- [x] Update diary and changelog with commit hash.
 
 ### T15 — Generalize goja-site script loading
 

--- a/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/tasks.md
+++ b/ttmp/2026/05/08/GO-GO-GOJA-EXPRESS-UIDSL-MODULES--upstream-express-and-ui-dsl-modules-into-go-go-goja/tasks.md
@@ -11,59 +11,59 @@
 
 ### T02 — Upstream `pkg/gojahttp`
 
-- [ ] In `/home/manuel/code/wesen/corporate-headquarters/go-go-goja`, create `pkg/gojahttp`.
-- [ ] Copy host infrastructure from db-browser `internal/web`, excluding `express_module.go`.
-- [ ] Rename package from `web` to `gojahttp`.
-- [ ] Rename/update session cookie comments and default naming.
-- [ ] Keep renderer injection and avoid importing `modules/uidsl`.
-- [ ] Move/adapt route, body, session, request/response, and host tests.
-- [ ] Run `go test ./pkg/gojahttp -count=1`.
+- [x] In `/home/manuel/code/wesen/corporate-headquarters/go-go-goja`, create `pkg/gojahttp`.
+- [x] Copy host infrastructure from db-browser `internal/web`, excluding `express_module.go`.
+- [x] Rename package from `web` to `gojahttp`.
+- [x] Rename/update session cookie comments and default naming.
+- [x] Keep renderer injection and avoid importing `modules/uidsl`.
+- [x] Move/adapt route, body, session, request/response, and host tests.
+- [x] Run `go test ./pkg/gojahttp -count=1`.
 
 ### T03 — Add `modules/express`
 
-- [ ] Create `modules/express` in go-go-goja.
-- [ ] Move/adapt the Express registrar from db-browser `internal/web/express_module.go`.
-- [ ] Implement `NewRegistrar(host *gojahttp.Host, opts ...Option)`.
-- [ ] Keep `express` runtime-scoped via `engine.RuntimeModuleRegistrar`.
-- [ ] Do not default-register `express` with `modules.Register` in the first version.
-- [ ] Add runtime integration tests using `require("express")` and `httptest`.
+- [x] Create `modules/express` in go-go-goja.
+- [x] Move/adapt the Express registrar from db-browser `internal/web/express_module.go`.
+- [x] Implement `NewRegistrar(host *gojahttp.Host, opts ...Option)`.
+- [x] Keep `express` runtime-scoped via `engine.RuntimeModuleRegistrar`.
+- [x] Do not default-register `express` with `modules.Register` in the first version.
+- [x] Add runtime integration tests using `require("express")` and `httptest`.
 
 ### T04 — Add `modules/uidsl`
 
-- [ ] Copy db-browser `internal/uidsl` into go-go-goja `modules/uidsl`.
-- [ ] Keep `RenderAny`, `Loader`, and `NewRegistrar` public.
-- [ ] Register aliases `ui.dsl` and `ui` through the registrar.
-- [ ] Move/adapt render, table, filters, links, and component tests.
-- [ ] Run `go test ./modules/uidsl -count=1`.
+- [x] Copy db-browser `internal/uidsl` into go-go-goja `modules/uidsl`.
+- [x] Keep `RenderAny`, `Loader`, and `NewRegistrar` public.
+- [x] Register aliases `ui.dsl` and `ui` through the registrar.
+- [x] Move/adapt render, table, filters, links, and component tests.
+- [x] Run `go test ./modules/uidsl -count=1`.
 
 ### T05 — Documentation and TypeScript declarations
 
-- [ ] Add go-go-goja docs for the Express-style module.
-- [ ] Add go-go-goja docs for the `ui.dsl` module.
-- [ ] Add TypeScript declarations or declaration descriptors for `express`.
-- [ ] Add TypeScript declarations or declaration descriptors for `ui.dsl`.
-- [ ] Document that `express` is Express-style, not full Express-compatible.
+- [x] Add go-go-goja docs for the Express-style module.
+- [x] Add go-go-goja docs for the `ui.dsl` module.
+- [x] Add TypeScript declarations or declaration descriptors for `express`.
+- [x] Add TypeScript declarations or declaration descriptors for `ui.dsl`.
+- [x] Document that `express` is Express-style, not full Express-compatible.
 
 ### T06 — Upstream validation
 
-- [ ] Run `go test ./pkg/gojahttp ./modules/express ./modules/uidsl -count=1`.
-- [ ] Run `go test ./... -count=1` in go-go-goja.
-- [ ] Run `GOWORK=off go test ./... -count=1` in go-go-goja.
-- [ ] Run lint if practical.
+- [x] Run `go test ./pkg/gojahttp ./modules/express ./modules/uidsl -count=1`.
+- [x] Run `go test ./... -count=1` in go-go-goja.
+- [x] Run `GOWORK=off go test ./... -count=1` in go-go-goja.
+- [x] Run lint if practical.
 
 ### T07 — Migrate goja-hosting-site
 
-- [ ] Replace local `pkg/web` and `pkg/uidsl` imports with upstream go-go-goja packages.
-- [ ] Validate goja-hosting-site tests.
-- [ ] Delete or deprecate local packages once green.
+- [x] Replace local `pkg/web` and `pkg/uidsl` imports with upstream go-go-goja packages.
+- [x] Validate goja-hosting-site tests.
+- [x] Delete or deprecate local packages once green.
 
 ### T08 — Migrate db-browser
 
-- [ ] Replace `internal/web` with `pkg/gojahttp` + `modules/express` imports.
-- [ ] Replace `internal/uidsl` with `modules/uidsl` imports.
-- [ ] Validate `go test ./...`.
-- [ ] Run db-browser final validation and component smoke scripts.
-- [ ] Delete local copied packages if no local behavior remains.
+- [x] Replace `internal/web` with `pkg/gojahttp` + `modules/express` imports.
+- [x] Replace `internal/uidsl` with `modules/uidsl` imports.
+- [x] Validate `go test ./...`.
+- [x] Run db-browser final validation and component smoke scripts.
+- [x] Delete local copied packages if no local behavior remains.
 
 ### T09 — Follow-ups after migration
 
@@ -71,3 +71,86 @@
 - [ ] Decide whether scoped table query state should be implemented upstream or first in db-browser.
 - [ ] Consider static theme asset support after the upstream packages are stable.
 - [ ] Consider server-interactive UI events as a separate project after the host boundary is stable.
+
+### T10 — Commit upstream extraction baseline
+
+- [ ] Review and commit go-go-goja upstream packages/docs/docmgr updates.
+- [x] Review and commit goja-hosting-site migration to upstream `gojahttp`, `express`, and `uidsl`.
+- [x] Review and commit db-browser migration to upstream `gojahttp`, `express`, and `uidsl`.
+- [x] Record baseline commit hashes in the implementation diary.
+
+### T11 — Shell merge design and task setup
+
+- [x] Add design document for merging db-browser and goja-hosting-site shells.
+- [x] Record selected options: Option A retire/delete db-browser; Option C support both dbguard and normal/simple DB policy.
+- [x] Add detailed implementation task list to the ticket.
+- [x] Relate design and diary files to the ticket.
+- [ ] Commit design/task/diary setup.
+
+### T12 — Extract reusable jsverbs repository discovery
+
+- [ ] Move db-browser `internal/verbrepos` into reusable package location (`go-go-goja/pkg/jsverbrepos` preferred, or `goja-hosting-site/pkg/verbrepos` if blocked).
+- [ ] Rename db-browser-specific constants to neutral names (`GOJA_VERB_REPOSITORIES`, `.goja-verbs.yml`, `.goja-verbs.override.yml`).
+- [ ] Move embedded built-in verb scripts with the package.
+- [ ] Update repository discovery tests for the new package and neutral names.
+- [ ] Validate focused tests and commit.
+- [ ] Update diary and changelog with commit hash.
+
+### T13 — Extract reusable jsverbs CLI/runtime invocation
+
+- [ ] Move db-browser `internal/verbcli` into reusable package location (`go-go-goja/pkg/jsverbscli` preferred, or `goja-hosting-site/pkg/verbcli` if blocked).
+- [ ] Update imports from db-browser `verbrepos` to the new neutral repository package.
+- [ ] Keep runtime invocation support for common modules, `ui.dsl`, and optional `database`/`db`.
+- [ ] Add or adapt command/list/runtime tests.
+- [ ] Validate focused tests and commit.
+- [ ] Update diary and changelog with commit hash.
+
+### T14 — Add `goja-site verbs`
+
+- [ ] Wire the migrated jsverbs CLI command into `cmd/goja-site/main.go`.
+- [ ] Ensure command help and logging integrate with existing goja-site root command.
+- [ ] Validate built-in verbs without a DB (`list`, `hello`, `yamlKeys`, `renderSampleTable`).
+- [ ] Validate DB-backed `tables` verb with a temp SQLite database.
+- [ ] Commit goja-site verbs integration.
+- [ ] Update diary and changelog with commit hash.
+
+### T15 — Generalize goja-site script loading
+
+- [ ] Add `ScriptDirs []string` to `pkg/app.Config`.
+- [ ] Refactor script discovery/loading into deterministic multi-directory helper.
+- [ ] Update `goja-site serve` to accept repeated `--scripts` values, replacing the single-directory-only model.
+- [ ] Update `serve-multi` config parsing to support script lists per site.
+- [ ] Add tests for multi-directory load ordering, missing dirs, non-dir paths, and duplicate files.
+- [ ] Validate and commit.
+- [ ] Update diary and changelog with commit hash.
+
+### T16 — Add unified database policy selection
+
+- [ ] Add `DBPolicy` with `simple` and `guarded` modes to goja-site app config.
+- [ ] Implement simple read/write-gated DB wrapper for generic SQLite browser use.
+- [ ] Preserve guarded `dbguard` behavior and `db.guard` module registration.
+- [ ] Add CLI flags `--db-policy`, `--readonly`, and `--allow-writes` to `goja-site serve`.
+- [ ] Extend multi-site config with database policy fields.
+- [ ] Add tests for simple read-only rejection and guarded policy registration.
+- [ ] Validate and commit.
+- [ ] Update diary and changelog with commit hash.
+
+### T17 — Migrate db-browser examples into goja-hosting-site
+
+- [ ] Move db-browser generic browser example to `goja-hosting-site/examples/db-browser/generic-browser`.
+- [ ] Move db-browser YAML dashboard example to `goja-hosting-site/examples/db-browser/yaml-dashboard`.
+- [ ] Move db-browser Playwright smoke example to `goja-hosting-site/examples/db-browser/playwright-smoke`.
+- [ ] Move/adapt built-in verb examples to `goja-hosting-site/examples/verbs` if they should be user-visible outside the embedded package.
+- [ ] Update paths in smoke scripts and documentation.
+- [ ] Validate migrated examples with `goja-site serve` and `goja-site verbs`.
+- [ ] Commit example migration.
+- [ ] Update diary and changelog with commit hash.
+
+### T18 — Retire db-browser as an independent shell
+
+- [ ] Remove or archive db-browser runtime packages after goja-site covers serve and verbs workflows.
+- [ ] Add a retirement README or repo-level note pointing users to goja-site, unless the repo is deleted outright.
+- [ ] Remove redundant db-browser validation scripts after equivalent goja-site scripts exist.
+- [ ] Run final validation across go-go-goja and goja-hosting-site.
+- [ ] Commit db-browser retirement.
+- [ ] Update diary and changelog with commit hash.

--- a/ttmp/vocabulary.yaml
+++ b/ttmp/vocabulary.yaml
@@ -91,6 +91,10 @@ topics:
       description: Single module implementation and module-level API work.
     - slug: go-go-goja
       description: go-go-goja JavaScript runtime project
+    - slug: ui-dsl
+      description: Server-rendered UI DSL modules and components
+    - slug: web-ui
+      description: Web user interface and HTTP UI concerns
 docTypes:
     - slug: index
       description: Ticket index documents


### PR DESCRIPTION
This pull request introduces a comprehensive set of packages for building and
serving web applications and command-line tools with Goja. It includes an
Express-style HTTP framework, a server-side HTML rendering DSL, and a new
framework for discovering and running JavaScript "verbs" from the command
line.

### Express-style HTTP Hosting (`pkg/gojahttp` and `modules/express`)

*   Introduces `pkg/gojahttp`, a new backend for hosting Goja-based HTTP
    servers.
*   Adds a new `express` module that provides a familiar JavaScript API
    for defining routes (`app.get`, `app.post`, etc.).
*   Supports route matching with parameters (`/users/:id`) and wildcards.
*   Includes automatic request body parsing for JSON and form data.
*   Provides simple, cookie-based session management.
*   Allows serving static files via `app.static(prefix, dir)`.

### Server-Side UI DSL (`modules/uidsl`)

*   Adds a new `ui.dsl` module (aliased as `ui`) for safely building
    server-rendered HTML.
*   Exports functions for all standard HTML tags (`ui.div`, `ui.p`, `ui.a`).
*   Content is escaped by default to prevent XSS vulnerabilities. `ui.raw()` is
    available for trusted HTML.
*   Includes rich, zero-dependency components for building internal tools:
    *   `ui.table`: A powerful data table with support for server-side
      pagination, sorting, filtering, and custom column definitions.
    *   `ui.codeBlock`, `ui.sql`, `ui.jsonBlock`: Components for syntax-
      highlighted code display.
    *   `ui.tabs`, `ui.badge`: Common UI elements for better organization and
      visual feedback.

### JS Verbs CLI Framework (`pkg/jsverbrepos` and `pkg/jsverbscli`)

*   Adds a new system for discovering and running JavaScript scripts, or
    "verbs," from the command line.
*   Verbs are loaded from repositories defined via CLI flags (`--repository`),
    environment variables, or a local `.goja-verbs.yml` config file.
*   Dynamically generates a Cobra CLI from the discovered verbs.
*   Ships with a `builtin` verb repository that includes examples for `ui.dsl`
    and database access.