### PR TITLE
Propagate call context and optimize UI DSL attributes

### DIFF
--- a/engine/factory.go
+++ b/engine/factory.go
@@ -15,6 +15,14 @@ import (
 	"github.com/go-go-golems/go-go-goja/pkg/runtimeowner"
 )
 
+type runtimebridgeOwner struct {
+	owner runtimeowner.Runner
+}
+
+func (o runtimebridgeOwner) Post(ctx context.Context, op string, fn func(context.Context, *goja.Runtime)) error {
+	return o.owner.Post(ctx, op, runtimeowner.PostFunc(fn))
+}
+
 // FactoryBuilder composes explicit module and runtime initializer configuration
 // before producing an immutable Factory.
 type FactoryBuilder struct {
@@ -218,7 +226,7 @@ func (f *Factory) NewRuntime(ctx context.Context) (*Runtime, error) {
 	runtimebridge.Store(vm, runtimebridge.Bindings{
 		Context: runtimeCtx,
 		Loop:    loop,
-		Owner:   owner,
+		Owner:   runtimebridgeOwner{owner: owner},
 	})
 
 	reg := require.NewRegistry(f.settings.requireOptions...)

--- a/modules/database/database.go
+++ b/modules/database/database.go
@@ -1,12 +1,14 @@
 package databasemod
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"time"
 
 	"github.com/dop251/goja"
 	"github.com/go-go-golems/go-go-goja/modules"
+	"github.com/go-go-golems/go-go-goja/pkg/runtimebridge"
 	"github.com/go-go-golems/go-go-goja/pkg/tsgen/spec"
 	_ "github.com/mattn/go-sqlite3" // Driver for sqlite3
 	"github.com/rs/zerolog/log"
@@ -15,6 +17,11 @@ import (
 type QueryExecer interface {
 	Query(query string, args ...any) (*sql.Rows, error)
 	Exec(query string, args ...any) (sql.Result, error)
+}
+
+type QueryExecerContext interface {
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	ExecContext(ctx context.Context, query string, args ...any) (sql.Result, error)
 }
 
 type Option func(*DBModule)
@@ -154,8 +161,12 @@ This module is preconfigured by Go and does not allow configure().
 func (m *DBModule) Loader(vm *goja.Runtime, moduleObj *goja.Object) {
 	exports := moduleObj.Get("exports").(*goja.Object)
 	modules.SetExport(exports, m.Name(), "configure", m.Configure)
-	modules.SetExport(exports, m.Name(), "query", m.Query)
-	modules.SetExport(exports, m.Name(), "exec", m.Exec)
+	modules.SetExport(exports, m.Name(), "query", func(query string, args ...any) ([]map[string]any, error) {
+		return m.QueryContext(runtimebridge.CurrentContext(vm), query, args...)
+	})
+	modules.SetExport(exports, m.Name(), "exec", func(query string, args ...any) (map[string]any, error) {
+		return m.ExecContext(runtimebridge.CurrentContext(vm), query, args...)
+	})
 	modules.SetExport(exports, m.Name(), "close", m.Close)
 }
 
@@ -194,14 +205,22 @@ func (m *DBModule) Close() error {
 
 // Query executes a SQL query and returns results as JavaScript objects.
 func (m *DBModule) Query(query string, args ...any) ([]map[string]any, error) {
+	return m.QueryContext(context.Background(), query, args...)
+}
+
+// QueryContext executes a SQL query with ctx and returns results as JavaScript objects.
+func (m *DBModule) QueryContext(ctx context.Context, query string, args ...any) ([]map[string]any, error) {
 	if m == nil || m.queryExecer == nil {
 		return nil, fmt.Errorf("database not configured, call require('%s').configure(...) first", m.Name())
+	}
+	if ctx == nil {
+		ctx = context.Background()
 	}
 
 	startTime := time.Now()
 	log.Debug().Str("module", m.Name()).Str("query", query).Msg("database: executing query")
 
-	rows, err := m.queryExecer.Query(query, flattenArgs(args)...)
+	rows, err := queryRows(ctx, m.queryExecer, query, flattenArgs(args)...)
 	if err != nil {
 		log.Error().Str("module", m.Name()).Str("query", query).Err(err).Msg("database: query error")
 		return nil, err
@@ -249,14 +268,22 @@ func (m *DBModule) Query(query string, args ...any) ([]map[string]any, error) {
 
 // Exec executes a SQL statement without returning rows.
 func (m *DBModule) Exec(query string, args ...any) (map[string]any, error) {
+	return m.ExecContext(context.Background(), query, args...)
+}
+
+// ExecContext executes a SQL statement with ctx without returning rows.
+func (m *DBModule) ExecContext(ctx context.Context, query string, args ...any) (map[string]any, error) {
 	if m == nil || m.queryExecer == nil {
 		return nil, fmt.Errorf("database not configured, call require('%s').configure(...) first", m.Name())
+	}
+	if ctx == nil {
+		ctx = context.Background()
 	}
 
 	startTime := time.Now()
 	log.Debug().Str("module", m.Name()).Str("query", query).Msg("database: executing exec")
 
-	result, err := m.queryExecer.Exec(query, flattenArgs(args)...)
+	result, err := execResult(ctx, m.queryExecer, query, flattenArgs(args)...)
 	if err != nil {
 		log.Error().Str("module", m.Name()).Str("query", query).Err(err).Msg("database: exec error")
 		return map[string]any{
@@ -292,6 +319,26 @@ func (m *DBModule) closeOwnedConnection() error {
 	m.closeFn = nil
 	m.queryExecer = nil
 	return nil
+}
+
+func queryRows(ctx context.Context, qe QueryExecer, query string, args ...any) (*sql.Rows, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if qec, ok := qe.(QueryExecerContext); ok {
+		return qec.QueryContext(ctx, query, args...)
+	}
+	return qe.Query(query, args...)
+}
+
+func execResult(ctx context.Context, qe QueryExecer, query string, args ...any) (sql.Result, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if qec, ok := qe.(QueryExecerContext); ok {
+		return qec.ExecContext(ctx, query, args...)
+	}
+	return qe.Exec(query, args...)
 }
 
 func flattenArgs(args []any) []any {

--- a/modules/database/database_test.go
+++ b/modules/database/database_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/dop251/goja"
 	gggengine "github.com/go-go-golems/go-go-goja/engine"
@@ -129,6 +130,79 @@ func TestPreconfiguredModuleExecReceivesOwnerCallContext(t *testing.T) {
 		return value.Export(), nil
 	})
 	require.NoError(t, err)
+	require.Equal(t, "from-request", db.got.Value(key))
+}
+
+func TestPreconfiguredModuleExecAfterAwaitReceivesOriginalCallContext(t *testing.T) {
+	type contextKey string
+	const key contextKey = "request-id"
+
+	db := &contextRecordingDB{}
+	module := databasemod.New(
+		databasemod.WithName("site-db"),
+		databasemod.WithPreconfiguredDB(db),
+	)
+
+	factory, err := gggengine.NewBuilder().
+		WithModules(gggengine.NativeModuleSpec{
+			ModuleID:   "test-site-db-async-context",
+			ModuleName: module.Name(),
+			Loader:     module.Loader,
+		}).
+		Build()
+	require.NoError(t, err)
+
+	rt, err := factory.NewRuntime(context.Background())
+	require.NoError(t, err)
+	defer func() { require.NoError(t, rt.Close(context.Background())) }()
+
+	ctx := context.WithValue(context.Background(), key, "from-request")
+	ret, err := rt.Owner.Call(ctx, "database.context.async-start", func(_ context.Context, vm *goja.Runtime) (any, error) {
+		value, err := rt.VM.RunString(`
+			(async () => {
+				const timer = require("timer");
+				const siteDB = require("site-db");
+				await timer.sleep(1);
+				return siteDB.exec("INSERT INTO widgets(name) VALUES (?)", "Ada").success;
+			})();
+		`)
+		if err != nil {
+			return nil, err
+		}
+		return value.Export(), nil
+	})
+	require.NoError(t, err)
+	promise, ok := ret.(*goja.Promise)
+	require.True(t, ok, "async IIFE should return a Promise")
+
+	var result any
+	deadline := time.After(time.Second)
+	for result == nil {
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for async database exec promise")
+		default:
+		}
+
+		result, err = rt.Owner.Call(context.Background(), "database.context.async-poll", func(_ context.Context, _ *goja.Runtime) (any, error) {
+			switch promise.State() {
+			case goja.PromiseStatePending:
+				return nil, nil
+			case goja.PromiseStateRejected:
+				return nil, fmt.Errorf("promise rejected: %s", promise.Result().String())
+			case goja.PromiseStateFulfilled:
+				return promise.Result().Export(), nil
+			default:
+				return nil, fmt.Errorf("unknown promise state: %v", promise.State())
+			}
+		})
+		require.NoError(t, err)
+		if result == nil {
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+
+	require.Equal(t, true, result)
 	require.Equal(t, "from-request", db.got.Value(key))
 }
 

--- a/modules/database/database_test.go
+++ b/modules/database/database_test.go
@@ -3,6 +3,7 @@ package databasemod_test
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -92,6 +93,97 @@ func TestPreconfiguredModuleRejectsConfigure(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "preconfigured")
 }
+
+func TestPreconfiguredModuleExecReceivesOwnerCallContext(t *testing.T) {
+	type contextKey string
+	const key contextKey = "request-id"
+
+	db := &contextRecordingDB{}
+	module := databasemod.New(
+		databasemod.WithName("site-db"),
+		databasemod.WithPreconfiguredDB(db),
+	)
+
+	factory, err := gggengine.NewBuilder().
+		WithModules(gggengine.NativeModuleSpec{
+			ModuleID:   "test-site-db-context",
+			ModuleName: module.Name(),
+			Loader:     module.Loader,
+		}).
+		Build()
+	require.NoError(t, err)
+
+	rt, err := factory.NewRuntime(context.Background())
+	require.NoError(t, err)
+	defer func() { require.NoError(t, rt.Close(context.Background())) }()
+
+	ctx := context.WithValue(context.Background(), key, "from-request")
+	_, err = rt.Owner.Call(ctx, "database.context", func(_ context.Context, vm *goja.Runtime) (any, error) {
+		value, err := rt.VM.RunString(`
+			const siteDB = require("site-db");
+			siteDB.exec("INSERT INTO widgets(name) VALUES (?)", "Ada").success;
+		`)
+		if err != nil {
+			return nil, err
+		}
+		return value.Export(), nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, "from-request", db.got.Value(key))
+}
+
+func TestDBModuleExecContextFallsBackToLegacyQueryExecer(t *testing.T) {
+	db := &legacyRecordingDB{}
+	module := databasemod.New(databasemod.WithPreconfiguredDB(db))
+
+	ret, err := module.ExecContext(context.Background(), "CREATE TABLE widgets(name TEXT)")
+	require.NoError(t, err)
+	require.Equal(t, true, ret["success"])
+	require.Equal(t, int64(1), db.execCalls)
+}
+
+type contextRecordingDB struct {
+	got context.Context
+}
+
+func (db *contextRecordingDB) Query(string, ...any) (*sql.Rows, error) {
+	return nil, fmt.Errorf("unexpected legacy Query call")
+}
+
+func (db *contextRecordingDB) Exec(string, ...any) (sql.Result, error) {
+	return nil, fmt.Errorf("unexpected legacy Exec call")
+}
+
+func (db *contextRecordingDB) QueryContext(ctx context.Context, _ string, _ ...any) (*sql.Rows, error) {
+	db.got = ctx
+	return nil, fmt.Errorf("unexpected QueryContext call")
+}
+
+func (db *contextRecordingDB) ExecContext(ctx context.Context, _ string, _ ...any) (sql.Result, error) {
+	db.got = ctx
+	return fakeResult{rowsAffected: 1}, nil
+}
+
+type legacyRecordingDB struct {
+	execCalls int64
+}
+
+func (db *legacyRecordingDB) Query(string, ...any) (*sql.Rows, error) {
+	return nil, fmt.Errorf("unexpected Query call")
+}
+
+func (db *legacyRecordingDB) Exec(string, ...any) (sql.Result, error) {
+	db.execCalls++
+	return fakeResult{rowsAffected: 1}, nil
+}
+
+type fakeResult struct {
+	lastInsertID int64
+	rowsAffected int64
+}
+
+func (r fakeResult) LastInsertId() (int64, error) { return r.lastInsertID, nil }
+func (r fakeResult) RowsAffected() (int64, error) { return r.rowsAffected, nil }
 
 func openSQLiteDB(t *testing.T) *sql.DB {
 	t.Helper()

--- a/modules/fs/fs_async.go
+++ b/modules/fs/fs_async.go
@@ -10,21 +10,25 @@ import (
 
 func asyncValue(vm *goja.Runtime, bindings runtimebridge.Bindings, op string, fn func() (any, error)) goja.Value {
 	promise, resolve, reject := vm.NewPromise()
+	callCtx := runtimebridge.CurrentContext(vm)
+	runtimeCtx := bindingContext(bindings)
 	go func() {
 		select {
-		case <-bindings.Context.Done():
+		case <-callCtx.Done():
+			return
+		case <-runtimeCtx.Done():
 			return
 		default:
 		}
 
 		value, err := fn()
 		if err != nil {
-			_ = bindings.Owner.Post(bindings.Context, op+".reject", func(context.Context, *goja.Runtime) {
+			_ = bindings.Owner.Post(callCtx, op+".reject", func(context.Context, *goja.Runtime) {
 				_ = reject(fsErrorValue(vm, err))
 			})
 			return
 		}
-		_ = bindings.Owner.Post(bindings.Context, op+".resolve", func(context.Context, *goja.Runtime) {
+		_ = bindings.Owner.Post(callCtx, op+".resolve", func(context.Context, *goja.Runtime) {
 			if value == nil {
 				_ = resolve(goja.Undefined())
 				return
@@ -37,25 +41,36 @@ func asyncValue(vm *goja.Runtime, bindings runtimebridge.Bindings, op string, fn
 
 func asyncReadFile(vm *goja.Runtime, bindings runtimebridge.Bindings, path string, enc goja.Value) goja.Value {
 	promise, resolve, reject := vm.NewPromise()
+	callCtx := runtimebridge.CurrentContext(vm)
+	runtimeCtx := bindingContext(bindings)
 	go func() {
 		select {
-		case <-bindings.Context.Done():
+		case <-callCtx.Done():
+			return
+		case <-runtimeCtx.Done():
 			return
 		default:
 		}
 
 		data, err := readFileBytes(path)
 		if err != nil {
-			_ = bindings.Owner.Post(bindings.Context, "fs.readFile.reject", func(context.Context, *goja.Runtime) {
+			_ = bindings.Owner.Post(callCtx, "fs.readFile.reject", func(context.Context, *goja.Runtime) {
 				_ = reject(fsErrorValue(vm, err))
 			})
 			return
 		}
-		_ = bindings.Owner.Post(bindings.Context, "fs.readFile.resolve", func(context.Context, *goja.Runtime) {
+		_ = bindings.Owner.Post(callCtx, "fs.readFile.resolve", func(context.Context, *goja.Runtime) {
 			_ = resolve(buffer.EncodeBytes(vm, data, enc))
 		})
 	}()
 	return vm.ToValue(promise)
+}
+
+func bindingContext(bindings runtimebridge.Bindings) context.Context {
+	if bindings.Context != nil {
+		return bindings.Context
+	}
+	return context.Background()
 }
 
 func asyncWriteFile(vm *goja.Runtime, bindings runtimebridge.Bindings, path string, data []byte, mode uint32) goja.Value {

--- a/modules/timer/timer.go
+++ b/modules/timer/timer.go
@@ -36,9 +36,14 @@ func (mod m) Loader(vm *goja.Runtime, moduleObj *goja.Object) {
 			panic(vm.NewGoError(fmt.Errorf("timer module requires runtime owner bindings")))
 		}
 
+		callCtx := runtimebridge.CurrentContext(vm)
+		runtimeCtx := bindings.Context
+		if runtimeCtx == nil {
+			runtimeCtx = context.Background()
+		}
 		go func() {
 			if ms < 0 {
-				_ = bindings.Owner.Post(bindings.Context, "timer.sleep.reject", func(context.Context, *goja.Runtime) {
+				_ = bindings.Owner.Post(callCtx, "timer.sleep.reject", func(context.Context, *goja.Runtime) {
 					_ = reject(vm.ToValue("timer.sleep: duration must be >= 0"))
 				})
 				return
@@ -48,10 +53,12 @@ func (mod m) Loader(vm *goja.Runtime, moduleObj *goja.Object) {
 			defer timer.Stop()
 
 			select {
-			case <-bindings.Context.Done():
+			case <-callCtx.Done():
+				return
+			case <-runtimeCtx.Done():
 				return
 			case <-timer.C:
-				_ = bindings.Owner.Post(bindings.Context, "timer.sleep.resolve", func(context.Context, *goja.Runtime) {
+				_ = bindings.Owner.Post(callCtx, "timer.sleep.resolve", func(context.Context, *goja.Runtime) {
 					_ = resolve(goja.Undefined())
 				})
 			}

--- a/modules/uidsl/attrs_bench_test.go
+++ b/modules/uidsl/attrs_bench_test.go
@@ -56,7 +56,7 @@ func BenchmarkRenderAttrsAttrs9(b *testing.B) {
 		"role":       "listitem",
 		"tabindex":   "0",
 	}
-	el := &Element{Tag: "div", Attrs: attrs, Children: []Node{&Text{Value: "node-1"}}}
+	el := &Element{Tag: "div", Attrs: attrsFromMap(attrs), Children: []Node{&Text{Value: "node-1"}}}
 	vm := goja.New()
 	value := vm.ToValue(el)
 	b.ReportAllocs()

--- a/modules/uidsl/attrs_bench_test.go
+++ b/modules/uidsl/attrs_bench_test.go
@@ -1,0 +1,138 @@
+package uidsl
+
+import (
+	"testing"
+
+	"github.com/dop251/goja"
+)
+
+func benchmarkUIRuntime(b *testing.B) (*goja.Runtime, *goja.Object) {
+	b.Helper()
+	vm := goja.New()
+	obj := vm.NewObject()
+	exports := vm.NewObject()
+	if err := obj.Set("exports", exports); err != nil {
+		b.Fatal(err)
+	}
+	Loader(vm, obj)
+	return vm, exports
+}
+
+func BenchmarkElementFromCallAttrs9(b *testing.B) {
+	vm, exports := benchmarkUIRuntime(b)
+	divFn, ok := goja.AssertFunction(exports.Get("div"))
+	if !ok {
+		b.Fatal("div export is not callable")
+	}
+	attrs := vm.NewObject()
+	_ = attrs.Set("class", "attr-node state-1")
+	_ = attrs.Set("id", "attr-node-1")
+	_ = attrs.Set("data-index", "1")
+	_ = attrs.Set("data-kind", "benchmark")
+	_ = attrs.Set("data-group", "1")
+	_ = attrs.Set("data-label", "attribute heavy node 1")
+	_ = attrs.Set("aria-label", "Attribute heavy node 1")
+	_ = attrs.Set("role", "listitem")
+	_ = attrs.Set("tabindex", "0")
+	child := vm.ToValue("node-1")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := divFn(goja.Undefined(), attrs, child); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkRenderAttrsAttrs9(b *testing.B) {
+	attrs := map[string]any{
+		"class":      "attr-node state-1",
+		"id":         "attr-node-1",
+		"data-index": "1",
+		"data-kind":  "benchmark",
+		"data-group": "1",
+		"data-label": "attribute heavy node 1",
+		"aria-label": "Attribute heavy node 1",
+		"role":       "listitem",
+		"tabindex":   "0",
+	}
+	el := &Element{Tag: "div", Attrs: attrs, Children: []Node{&Text{Value: "node-1"}}}
+	vm := goja.New()
+	value := vm.ToValue(el)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, err := RenderAny(vm, value); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkRenderPageAttrs1000(b *testing.B) {
+	vm, exports := benchmarkUIRuntime(b)
+	_ = vm.Set("ui", exports)
+	_, err := vm.RunString(`function attrsPage() {
+	const children = [];
+	for (let i = 0; i < 1000; i++) {
+		children.push(ui.div({
+			class: "attr-node state-" + (i % 5),
+			id: "attr-node-" + i,
+			"data-index": String(i),
+			"data-kind": "benchmark",
+			"data-group": String(i % 17),
+			"data-label": "attribute heavy node " + i,
+			"aria-label": "Attribute heavy node " + i,
+			role: "listitem",
+			tabindex: "0"
+		}, ui.span({ class: "label" }, "node-" + i)));
+	}
+	return ui.html(ui.body(ui.main(ui.section({ class: "attr-root", role: "list" }, children))));
+}`)
+	if err != nil {
+		b.Fatal(err)
+	}
+	fn, ok := goja.AssertFunction(vm.Get("attrsPage"))
+	if !ok {
+		b.Fatal("attrsPage is not callable")
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		value, err := fn(goja.Undefined())
+		if err != nil {
+			b.Fatal(err)
+		}
+		if _, err := RenderAny(vm, value); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkRenderPageFlat1000(b *testing.B) {
+	vm, exports := benchmarkUIRuntime(b)
+	_ = vm.Set("ui", exports)
+	_, err := vm.RunString(`function flatPage() {
+	const children = [];
+	for (let i = 0; i < 1000; i++) {
+		children.push(ui.div({ class: "flat-node", "data-index": String(i) }, "node-" + i));
+	}
+	return ui.html(ui.body(ui.main(ui.section({ class: "flat-root" }, children))));
+}`)
+	if err != nil {
+		b.Fatal(err)
+	}
+	fn, ok := goja.AssertFunction(vm.Get("flatPage"))
+	if !ok {
+		b.Fatal("flatPage is not callable")
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		value, err := fn(goja.Undefined())
+		if err != nil {
+			b.Fatal(err)
+		}
+		if _, err := RenderAny(vm, value); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/modules/uidsl/attrs_compat_test.go
+++ b/modules/uidsl/attrs_compat_test.go
@@ -1,0 +1,64 @@
+package uidsl
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestUIDSLAttributeCompatibility(t *testing.T) {
+	html := renderJS(t, `ui.div({
+		class: ["base", false, "extra", ""],
+		style: { color: "red", "font-weight": "bold" },
+		id: "node-1",
+		"data-index": 7,
+		"aria-label": "A <B>",
+		hidden: true,
+		draggable: false,
+		value: "",
+		title: null,
+		role: undefined
+	}, "hello")`)
+	for _, want := range []string{
+		`aria-label="A &lt;B&gt;"`,
+		`class="base extra"`,
+		`data-index="7"`,
+		`hidden`,
+		`id="node-1"`,
+		`style="color:red;font-weight:bold"`,
+		`value=""`,
+		`>hello</div>`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("missing %q in %s", want, html)
+		}
+	}
+	for _, notWant := range []string{`draggable=`, `title=`, `role=`} {
+		if strings.Contains(html, notWant) {
+			t.Fatalf("unexpected %q in %s", notWant, html)
+		}
+	}
+}
+
+func TestUIDSLChildVsAttrsDisambiguation(t *testing.T) {
+	cases := []struct {
+		name   string
+		script string
+		want   string
+	}{
+		{"text", `ui.div("text")`, `<div>text</div>`},
+		{"number", `ui.div(42)`, `<div>42</div>`},
+		{"bool", `ui.div(true)`, `<div>true</div>`},
+		{"node", `ui.div(ui.span("child"))`, `<div><span>child</span></div>`},
+		{"array", `ui.div([ui.span("child")])`, `<div><span>child</span></div>`},
+		{"fragment", `ui.div(ui.fragment(ui.span("child")))`, `<div><span>child</span></div>`},
+		{"empty attrs", `ui.div({})`, `<div></div>`},
+		{"attrs", `ui.div({ class: "x" })`, `<div class="x"></div>`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := renderJS(t, tc.script); got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/modules/uidsl/components.go
+++ b/modules/uidsl/components.go
@@ -51,22 +51,22 @@ func codeBlockNode(language string, source any, opts map[string]any) Node {
 		preAttrs["style"] = map[string]any{"max-height": options.MaxHeight, "overflow": "auto"}
 	}
 	sourceText := stringifySource(source)
-	code := &Element{Tag: "code", Attrs: map[string]any{"class": "language-" + lang}, Children: highlightCode(lang, sourceText)}
+	code := &Element{Tag: "code", Attrs: attrsFromMap(map[string]any{"class": "language-" + lang}), Children: highlightCode(lang, sourceText)}
 	if options.Title == "" && !options.Copy {
 		preAttrs["class"] = classes
-		return &Element{Tag: "pre", Attrs: preAttrs, Children: []Node{code}}
+		return &Element{Tag: "pre", Attrs: attrsFromMap(preAttrs), Children: []Node{code}}
 	}
 	captionChildren := []Node{}
 	if options.Title != "" {
-		captionChildren = append(captionChildren, &Element{Tag: "span", Attrs: map[string]any{"class": "ui-codeblock__title"}, Children: []Node{&Text{Value: options.Title}}})
+		captionChildren = append(captionChildren, &Element{Tag: "span", Attrs: attrsFromMap(map[string]any{"class": "ui-codeblock__title"}), Children: []Node{&Text{Value: options.Title}}})
 	}
 	if options.Copy {
-		captionChildren = append(captionChildren, &Element{Tag: "button", Attrs: map[string]any{"class": "ui-codeblock__copy", "type": "button"}, Children: []Node{&Text{Value: "Copy"}}})
+		captionChildren = append(captionChildren, &Element{Tag: "button", Attrs: attrsFromMap(map[string]any{"class": "ui-codeblock__copy", "type": "button"}), Children: []Node{&Text{Value: "Copy"}}})
 	}
 	preAttrs["class"] = "ui-codeblock__pre"
-	return &Element{Tag: "figure", Attrs: map[string]any{"class": classes}, Children: []Node{
-		&Element{Tag: "figcaption", Attrs: map[string]any{"class": "ui-codeblock__caption"}, Children: captionChildren},
-		&Element{Tag: "pre", Attrs: preAttrs, Children: []Node{code}},
+	return &Element{Tag: "figure", Attrs: attrsFromMap(map[string]any{"class": classes}), Children: []Node{
+		&Element{Tag: "figcaption", Attrs: attrsFromMap(map[string]any{"class": "ui-codeblock__caption"}), Children: captionChildren},
+		&Element{Tag: "pre", Attrs: attrsFromMap(preAttrs), Children: []Node{code}},
 	}}
 }
 
@@ -95,7 +95,7 @@ func badgeNode(value any, opts map[string]any) Node {
 	if title := stringFromAny(opts["title"]); title != "" {
 		attrs["title"] = title
 	}
-	return &Element{Tag: "span", Attrs: attrs, Children: []Node{&Text{Value: text}}}
+	return &Element{Tag: "span", Attrs: attrsFromMap(attrs), Children: []Node{&Text{Value: text}}}
 }
 
 type tabSpec struct {
@@ -112,7 +112,7 @@ func tabsNode(id string, value goja.Value, opts map[string]any) (Node, error) {
 		return nil, err
 	}
 	if len(tabs) == 0 {
-		return &Element{Tag: "div", Attrs: map[string]any{"class": []any{"ui-tabs", stringFromAny(opts["class"])}, "id": baseID}}, nil
+		return &Element{Tag: "div", Attrs: attrsFromMap(map[string]any{"class": []any{"ui-tabs", stringFromAny(opts["class"])}, "id": baseID})}, nil
 	}
 	assignTabIDs(tabs)
 	selected := selectedTabIndex(tabs, opts["selected"])
@@ -122,17 +122,17 @@ func tabsNode(id string, value goja.Value, opts map[string]any) (Node, error) {
 	}
 	children := []Node{tabsStyleNode(baseID, tabs)}
 	children = append(children, tabInputNodes(baseID, tabs, selected)...)
-	children = append(children, &Element{Tag: "div", Attrs: map[string]any{"class": "ui-tabs__tablist", "role": "tablist"}, Children: tabLabelNodes(baseID, tabs)})
+	children = append(children, &Element{Tag: "div", Attrs: attrsFromMap(map[string]any{"class": "ui-tabs__tablist", "role": "tablist"}), Children: tabLabelNodes(baseID, tabs)})
 	panels := make([]Node, 0, len(tabs))
 	for i, tab := range tabs {
 		panelClasses := []any{"ui-tabs__panel"}
 		if i == selected {
 			panelClasses = append(panelClasses, "ui-tabs__panel--active")
 		}
-		panels = append(panels, &Element{Tag: "section", Attrs: map[string]any{"class": panelClasses, "data-tab": tab.ID}, Children: []Node{tab.Content}})
+		panels = append(panels, &Element{Tag: "section", Attrs: attrsFromMap(map[string]any{"class": panelClasses, "data-tab": tab.ID}), Children: []Node{tab.Content}})
 	}
-	children = append(children, &Element{Tag: "div", Attrs: map[string]any{"class": "ui-tabs__panels"}, Children: panels})
-	return &Element{Tag: "div", Attrs: map[string]any{"class": classes, "id": baseID}, Children: children}, nil
+	children = append(children, &Element{Tag: "div", Attrs: attrsFromMap(map[string]any{"class": "ui-tabs__panels"}), Children: panels})
+	return &Element{Tag: "div", Attrs: attrsFromMap(map[string]any{"class": classes, "id": baseID}), Children: children}, nil
 }
 
 func parseTabs(value goja.Value) ([]tabSpec, error) {
@@ -214,7 +214,7 @@ func tabInputNodes(baseID string, tabs []tabSpec, selected int) []Node {
 		if tab.Disabled {
 			inputAttrs["disabled"] = true
 		}
-		children = append(children, &Element{Tag: "input", Attrs: inputAttrs})
+		children = append(children, &Element{Tag: "input", Attrs: attrsFromMap(inputAttrs)})
 	}
 	return children
 }
@@ -227,7 +227,7 @@ func tabLabelNodes(baseID string, tabs []tabSpec) []Node {
 		if tab.Disabled {
 			labelClasses = append(labelClasses, "ui-tabs__tab--disabled")
 		}
-		children = append(children, &Element{Tag: "label", Attrs: map[string]any{"class": labelClasses, "for": inputID}, Children: []Node{&Text{Value: tab.Label}}})
+		children = append(children, &Element{Tag: "label", Attrs: attrsFromMap(map[string]any{"class": labelClasses, "for": inputID}), Children: []Node{&Text{Value: tab.Label}}})
 	}
 	return children
 }
@@ -241,7 +241,7 @@ func tabsStyleNode(baseID string, tabs []tabSpec) Node {
 		fmt.Fprintf(&b, "#%s:checked~.ui-tabs__panels>[data-tab=\"%s\"]{display:block;}\n", inputID, tab.ID)
 		fmt.Fprintf(&b, "#%s:checked~.ui-tabs__tablist>label[for=\"%s\"]{background:#fff;font-weight:900;}\n", inputID, inputID)
 	}
-	return &Element{Tag: "style", Attrs: map[string]any{"class": "ui-tabs__style"}, Children: []Node{&RawHTML{Value: b.String()}}}
+	return &Element{Tag: "style", Attrs: attrsFromMap(map[string]any{"class": "ui-tabs__style"}), Children: []Node{&RawHTML{Value: b.String()}}}
 }
 
 func jsonBlockSource(value goja.Value) string {
@@ -393,7 +393,7 @@ func highlightJSON(source string) []Node {
 }
 
 func tokenNode(kind string, text string) Node {
-	return &Element{Tag: "span", Attrs: map[string]any{"class": []any{"ui-codeblock__token", "ui-codeblock__token--" + kind}}, Children: []Node{&Text{Value: text}}}
+	return &Element{Tag: "span", Attrs: attrsFromMap(map[string]any{"class": []any{"ui-codeblock__token", "ui-codeblock__token--" + kind}}), Children: []Node{&Text{Value: text}}}
 }
 
 func scanString(source string, i int) int {

--- a/modules/uidsl/module.go
+++ b/modules/uidsl/module.go
@@ -25,7 +25,7 @@ func Loader(vm *goja.Runtime, moduleObj *goja.Object) {
 	exports := moduleObj.Get("exports").(*goja.Object)
 	for _, tag := range tags {
 		tag := tag
-		_ = exports.Set(tag, func(call goja.FunctionCall) goja.Value { return vm.ToValue(elementFromCall(tag, call)) })
+		_ = exports.Set(tag, func(call goja.FunctionCall) goja.Value { return vm.ToValue(elementFromCall(vm, tag, call)) })
 	}
 	_ = exports.Set("fragment", func(call goja.FunctionCall) goja.Value {
 		return vm.ToValue(&Fragment{Children: nodesFromArgs(call.Arguments)})
@@ -33,7 +33,7 @@ func Loader(vm *goja.Runtime, moduleObj *goja.Object) {
 	_ = exports.Set("text", func(v any) *Text { return &Text{Value: fmt.Sprint(v)} })
 	_ = exports.Set("raw", func(s string) *RawHTML { return &RawHTML{Value: s} })
 	_ = exports.Set("render", func(v goja.Value) (string, error) { return RenderAny(vm, v) })
-	_ = exports.Set("page", func(call goja.FunctionCall) goja.Value { return vm.ToValue(pageFromCall(call)) })
+	_ = exports.Set("page", func(call goja.FunctionCall) goja.Value { return vm.ToValue(pageFromCall(vm, call)) })
 	_ = exports.Set("codeBlock", func(language string, source goja.Value, options ...map[string]any) goja.Value {
 		return vm.ToValue(codeBlockNode(language, source.Export(), firstOptions(options)))
 	})
@@ -69,28 +69,28 @@ func Loader(vm *goja.Runtime, moduleObj *goja.Object) {
 	_ = exports.Set("table", tableValue)
 }
 
-func elementFromCall(tag string, call goja.FunctionCall) *Element {
-	attrs := map[string]any{}
+func elementFromCall(vm *goja.Runtime, tag string, call goja.FunctionCall) *Element {
+	var attrs map[string]any
 	args := call.Arguments
-	if len(args) > 0 && isAttrs(args[0]) {
-		if m, ok := args[0].Export().(map[string]any); ok {
-			attrs = m
+	if len(args) > 0 {
+		if decoded, ok := attrsFromValue(vm, args[0]); ok {
+			attrs = decoded
+			args = args[1:]
 		}
-		args = args[1:]
 	}
 	return &Element{Tag: tag, Attrs: attrs, Children: nodesFromArgs(args)}
 }
 
-func pageFromCall(call goja.FunctionCall) *Document {
+func pageFromCall(vm *goja.Runtime, call goja.FunctionCall) *Document {
 	title := ""
 	args := call.Arguments
-	if len(args) > 0 && isAttrs(args[0]) {
-		if m, ok := args[0].Export().(map[string]any); ok {
+	if len(args) > 0 {
+		if m, ok := attrsFromValue(vm, args[0]); ok {
 			if t, ok := m["title"]; ok {
 				title = fmt.Sprint(t)
 			}
+			args = args[1:]
 		}
-		args = args[1:]
 	}
 	children := nodesFromArgs(args)
 	doc := &Document{Title: title}
@@ -124,16 +124,16 @@ func nodesFromArgs(args []goja.Value) []Node {
 	return out
 }
 
-func isAttrs(v goja.Value) bool {
+func attrsFromValue(_ *goja.Runtime, v goja.Value) (map[string]any, bool) {
 	if v == nil || goja.IsUndefined(v) || goja.IsNull(v) {
-		return false
+		return nil, false
 	}
-	switch v.Export().(type) {
+	switch exported := v.Export().(type) {
 	case Node, string, []any, []Node, int, int64, float64, bool:
-		return false
+		return nil, false
 	case map[string]any:
-		return true
+		return exported, true
 	default:
-		return false
+		return nil, false
 	}
 }

--- a/modules/uidsl/module.go
+++ b/modules/uidsl/module.go
@@ -70,7 +70,7 @@ func Loader(vm *goja.Runtime, moduleObj *goja.Object) {
 }
 
 func elementFromCall(vm *goja.Runtime, tag string, call goja.FunctionCall) *Element {
-	var attrs map[string]any
+	var attrs []Attr
 	args := call.Arguments
 	if len(args) > 0 {
 		if decoded, ok := attrsFromValue(vm, args[0]); ok {
@@ -85,7 +85,7 @@ func pageFromCall(vm *goja.Runtime, call goja.FunctionCall) *Document {
 	title := ""
 	args := call.Arguments
 	if len(args) > 0 {
-		if m, ok := attrsFromValue(vm, args[0]); ok {
+		if m, ok := attrsMapFromValue(args[0]); ok {
 			if t, ok := m["title"]; ok {
 				title = fmt.Sprint(t)
 			}
@@ -124,7 +124,15 @@ func nodesFromArgs(args []goja.Value) []Node {
 	return out
 }
 
-func attrsFromValue(_ *goja.Runtime, v goja.Value) (map[string]any, bool) {
+func attrsFromValue(_ *goja.Runtime, v goja.Value) ([]Attr, bool) {
+	m, ok := attrsMapFromValue(v)
+	if !ok {
+		return nil, false
+	}
+	return attrsFromMap(m), true
+}
+
+func attrsMapFromValue(v goja.Value) (map[string]any, bool) {
 	if v == nil || goja.IsUndefined(v) || goja.IsNull(v) {
 		return nil, false
 	}

--- a/modules/uidsl/node.go
+++ b/modules/uidsl/node.go
@@ -11,9 +11,15 @@ type Document struct {
 
 func (*Document) isNode() {}
 
+type Attr struct {
+	Key   string
+	Value string
+	Bool  bool
+}
+
 type Element struct {
 	Tag      string
-	Attrs    map[string]any
+	Attrs    []Attr
 	Children []Node
 }
 

--- a/modules/uidsl/render.go
+++ b/modules/uidsl/render.go
@@ -125,9 +125,29 @@ func renderNode(b *bytes.Buffer, n Node) error {
 	return nil
 }
 
-func renderAttrs(b *bytes.Buffer, attrs map[string]any) {
+func renderAttrs(b *bytes.Buffer, attrs []Attr) {
+	for _, attr := range attrs {
+		if attr.Key == "" {
+			continue
+		}
+		b.WriteByte(' ')
+		b.WriteString(attr.Key)
+		if attr.Bool {
+			continue
+		}
+		b.WriteString("=\"")
+		b.WriteString(html.EscapeString(attr.Value))
+		b.WriteByte('"')
+	}
+}
+
+func Attrs(attrs map[string]any) []Attr {
+	return attrsFromMap(attrs)
+}
+
+func attrsFromMap(attrs map[string]any) []Attr {
 	if len(attrs) == 0 {
-		return
+		return nil
 	}
 	keys := make([]string, 0, len(attrs))
 	for k := range attrs {
@@ -136,6 +156,7 @@ func renderAttrs(b *bytes.Buffer, attrs map[string]any) {
 		}
 	}
 	sort.Strings(keys)
+	out := make([]Attr, 0, len(keys))
 	for _, k := range keys {
 		v := attrs[k]
 		if v == nil {
@@ -143,8 +164,7 @@ func renderAttrs(b *bytes.Buffer, attrs map[string]any) {
 		}
 		if bv, ok := v.(bool); ok {
 			if bv {
-				b.WriteByte(' ')
-				b.WriteString(k)
+				out = append(out, Attr{Key: k, Bool: true})
 			}
 			continue
 		}
@@ -152,12 +172,9 @@ func renderAttrs(b *bytes.Buffer, attrs map[string]any) {
 		if value == "" && k != "value" {
 			continue
 		}
-		b.WriteByte(' ')
-		b.WriteString(k)
-		b.WriteString("=\"")
-		b.WriteString(html.EscapeString(value))
-		b.WriteByte('"')
+		out = append(out, Attr{Key: k, Value: value})
 	}
+	return out
 }
 
 func attrValue(k string, v any) string {

--- a/modules/uidsl/render_test.go
+++ b/modules/uidsl/render_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestRenderEscapesTextAndAttributes(t *testing.T) {
 	vm := goja.New()
-	node := vm.ToValue(&Element{Tag: "div", Attrs: map[string]any{"class": "a&b", "hidden": true}, Children: []Node{&Text{Value: "<hello>"}}})
+	node := vm.ToValue(&Element{Tag: "div", Attrs: attrsFromMap(map[string]any{"class": "a&b", "hidden": true}), Children: []Node{&Text{Value: "<hello>"}}})
 	got, err := RenderAny(vm, node)
 	if err != nil {
 		t.Fatal(err)

--- a/modules/uidsl/table.go
+++ b/modules/uidsl/table.go
@@ -186,9 +186,9 @@ func (t *TableBuilder) node(vm *goja.Runtime, ctx RenderContext, rows []map[stri
 			if stringFromAny(ctx.Order["key"]) == column.Name && stringFromAny(ctx.Order["dir"]) == "asc" {
 				dir = "desc"
 			}
-			child = &Element{Tag: "a", Attrs: map[string]any{"href": queryHref(ctx.Query, map[string]any{"sort": column.Name, "dir": dir, "page": 1})}, Children: []Node{&Text{Value: label}}}
+			child = &Element{Tag: "a", Attrs: attrsFromMap(map[string]any{"href": queryHref(ctx.Query, map[string]any{"sort": column.Name, "dir": dir, "page": 1})}), Children: []Node{&Text{Value: label}}}
 		}
-		headCells = append(headCells, &Element{Tag: "th", Attrs: map[string]any{"data-column": column.Name}, Children: []Node{child}})
+		headCells = append(headCells, &Element{Tag: "th", Attrs: attrsFromMap(map[string]any{"data-column": column.Name}), Children: []Node{child}})
 	}
 	bodyRows := make([]Node, 0, len(rows))
 	for _, row := range rows {
@@ -198,20 +198,20 @@ func (t *TableBuilder) node(vm *goja.Runtime, ctx RenderContext, rows []map[stri
 			if column.Align != "" {
 				attrs["class"] = "align-" + column.Align
 			}
-			cells = append(cells, &Element{Tag: "td", Attrs: attrs, Children: []Node{cellNode(vm, row, row[column.Name], column)}})
+			cells = append(cells, &Element{Tag: "td", Attrs: attrsFromMap(attrs), Children: []Node{cellNode(vm, row, row[column.Name], column)}})
 		}
 		bodyRows = append(bodyRows, &Element{Tag: "tr", Children: cells})
 	}
 	if len(bodyRows) == 0 {
-		bodyRows = append(bodyRows, &Element{Tag: "tr", Attrs: map[string]any{"class": "ui-table-empty-row"}, Children: []Node{
-			&Element{Tag: "td", Attrs: map[string]any{"class": "ui-table-empty", "colspan": len(columns)}, Children: []Node{&Text{Value: "No rows match the current filters."}}},
+		bodyRows = append(bodyRows, &Element{Tag: "tr", Attrs: attrsFromMap(map[string]any{"class": "ui-table-empty-row"}), Children: []Node{
+			&Element{Tag: "td", Attrs: attrsFromMap(map[string]any{"class": "ui-table-empty", "colspan": len(columns)}), Children: []Node{&Text{Value: "No rows match the current filters."}}},
 		}})
 	}
 	attrs := map[string]any{"class": tableClass(t.features)}
 	if t.ID != "" {
 		attrs["id"] = t.ID
 	}
-	table := &Element{Tag: "table", Attrs: attrs, Children: []Node{
+	table := &Element{Tag: "table", Attrs: attrsFromMap(attrs), Children: []Node{
 		&Element{Tag: "thead", Children: []Node{&Element{Tag: "tr", Children: headCells}}},
 		&Element{Tag: "tbody", Children: bodyRows},
 	}}
@@ -417,12 +417,12 @@ func paginationNode(ctx RenderContext, total int) Node {
 	}
 	children := []Node{&Text{Value: fmt.Sprintf("Page %d of %d (%d rows)", page, pages, total)}}
 	if page > 1 {
-		children = append(children, &Text{Value: " "}, &Element{Tag: "a", Attrs: map[string]any{"href": queryHref(ctx.Query, map[string]any{"page": page - 1})}, Children: []Node{&Text{Value: "Previous"}}})
+		children = append(children, &Text{Value: " "}, &Element{Tag: "a", Attrs: attrsFromMap(map[string]any{"href": queryHref(ctx.Query, map[string]any{"page": page - 1})}), Children: []Node{&Text{Value: "Previous"}}})
 	}
 	if page < pages {
-		children = append(children, &Text{Value: " "}, &Element{Tag: "a", Attrs: map[string]any{"href": queryHref(ctx.Query, map[string]any{"page": page + 1})}, Children: []Node{&Text{Value: "Next"}}})
+		children = append(children, &Text{Value: " "}, &Element{Tag: "a", Attrs: attrsFromMap(map[string]any{"href": queryHref(ctx.Query, map[string]any{"page": page + 1})}), Children: []Node{&Text{Value: "Next"}}})
 	}
-	return &Element{Tag: "nav", Attrs: map[string]any{"class": "ui-table-pagination"}, Children: children}
+	return &Element{Tag: "nav", Attrs: attrsFromMap(map[string]any{"class": "ui-table-pagination"}), Children: children}
 }
 
 func cellNode(vm *goja.Runtime, row map[string]any, value any, col ColumnSpec) Node {
@@ -430,7 +430,7 @@ func cellNode(vm *goja.Runtime, row map[string]any, value any, col ColumnSpec) N
 	var child Node
 	switch col.Kind {
 	case "badge":
-		child = &Element{Tag: "span", Attrs: map[string]any{"class": []any{"ui-badge", "ui-badge--" + cssToken(text)}}, Children: []Node{&Text{Value: text}}}
+		child = &Element{Tag: "span", Attrs: attrsFromMap(map[string]any{"class": []any{"ui-badge", "ui-badge--" + cssToken(text)}}), Children: []Node{&Text{Value: text}}}
 	case "tags":
 		parts := splitTags(value)
 		children := make([]Node, 0, len(parts))
@@ -438,14 +438,14 @@ func cellNode(vm *goja.Runtime, row map[string]any, value any, col ColumnSpec) N
 			if i > 0 {
 				children = append(children, &Text{Value: " "})
 			}
-			children = append(children, &Element{Tag: "span", Attrs: map[string]any{"class": []any{"ui-tag", "ui-tag--" + cssToken(part)}}, Children: []Node{&Text{Value: part}}})
+			children = append(children, &Element{Tag: "span", Attrs: attrsFromMap(map[string]any{"class": []any{"ui-tag", "ui-tag--" + cssToken(part)}}), Children: []Node{&Text{Value: part}}})
 		}
 		child = &Fragment{Children: children}
 	default:
 		child = &Text{Value: text}
 	}
 	if href := linkHref(vm, row, value, col); href != "" {
-		return &Element{Tag: "a", Attrs: map[string]any{"href": href}, Children: []Node{child}}
+		return &Element{Tag: "a", Attrs: attrsFromMap(map[string]any{"href": href}), Children: []Node{child}}
 	}
 	return child
 }
@@ -483,11 +483,11 @@ func filtersNode(ctx RenderContext, columns []ColumnSpec) Node {
 	children := []Node{}
 	for _, key := range []string{"sort", "dir"} {
 		if value := stringFromAny(ctx.Query[key]); value != "" {
-			children = append(children, &Element{Tag: "input", Attrs: map[string]any{"type": "hidden", "name": key, "value": value}})
+			children = append(children, &Element{Tag: "input", Attrs: attrsFromMap(map[string]any{"type": "hidden", "name": key, "value": value})})
 		}
 	}
 	children = append(children,
-		&Element{Tag: "label", Children: []Node{&Text{Value: "Search "}, &Element{Tag: "input", Attrs: map[string]any{"type": "search", "name": "q", "value": stringFromAny(ctx.Filter["q"]), "placeholder": "all columns"}}}},
+		&Element{Tag: "label", Children: []Node{&Text{Value: "Search "}, &Element{Tag: "input", Attrs: attrsFromMap(map[string]any{"type": "search", "name": "q", "value": stringFromAny(ctx.Filter["q"]), "placeholder": "all columns"})}}},
 	)
 	for _, column := range columns {
 		if !column.Filterable {
@@ -498,14 +498,14 @@ func filtersNode(ctx RenderContext, columns []ColumnSpec) Node {
 			label = column.Name
 		}
 		name := "filter." + column.Name
-		children = append(children, &Element{Tag: "label", Children: []Node{&Text{Value: label + " "}, &Element{Tag: "input", Attrs: map[string]any{"type": "search", "name": name, "value": stringFromAny(ctx.Filter[column.Name])}}}})
+		children = append(children, &Element{Tag: "label", Children: []Node{&Text{Value: label + " "}, &Element{Tag: "input", Attrs: attrsFromMap(map[string]any{"type": "search", "name": name, "value": stringFromAny(ctx.Filter[column.Name])})}}})
 	}
 	children = append(children,
-		&Element{Tag: "button", Attrs: map[string]any{"type": "submit"}, Children: []Node{&Text{Value: "Filter"}}},
+		&Element{Tag: "button", Attrs: attrsFromMap(map[string]any{"type": "submit"}), Children: []Node{&Text{Value: "Filter"}}},
 		&Text{Value: " "},
-		&Element{Tag: "a", Attrs: map[string]any{"href": "?"}, Children: []Node{&Text{Value: "Clear"}}},
+		&Element{Tag: "a", Attrs: attrsFromMap(map[string]any{"href": "?"}), Children: []Node{&Text{Value: "Clear"}}},
 	)
-	return &Element{Tag: "form", Attrs: map[string]any{"class": "ui-table-filters", "method": "get"}, Children: children}
+	return &Element{Tag: "form", Attrs: attrsFromMap(map[string]any{"class": "ui-table-filters", "method": "get"}), Children: children}
 }
 
 func filterRows(rows []map[string]any, columns []ColumnSpec, filter map[string]any) []map[string]any {

--- a/pkg/runtimebridge/runtimebridge.go
+++ b/pkg/runtimebridge/runtimebridge.go
@@ -2,19 +2,29 @@ package runtimebridge
 
 import (
 	"context"
+	"errors"
 	"sync"
 
 	"github.com/dop251/goja"
 	"github.com/dop251/goja_nodejs/eventloop"
-	"github.com/go-go-golems/go-go-goja/pkg/runtimeowner"
 )
+
+// OwnerRunner is the owner-thread scheduling subset exposed to modules that
+// need to settle asynchronous JavaScript values from background goroutines.
+//
+// It intentionally lives in runtimebridge instead of importing
+// pkg/runtimeowner. That keeps runtimebridge usable from runtimeowner itself
+// for current-call context tracking without creating an import cycle.
+type OwnerRunner interface {
+	Post(ctx context.Context, op string, fn func(context.Context, *goja.Runtime)) error
+}
 
 // Bindings exposes runtime-owned scheduling primitives for modules that need
 // async owner-thread settlement.
 type Bindings struct {
 	Context context.Context
 	Loop    *eventloop.EventLoop
-	Owner   runtimeowner.Runner
+	Owner   OwnerRunner
 }
 
 var bindingsByVM sync.Map
@@ -49,4 +59,104 @@ func Delete(vm *goja.Runtime) {
 		return
 	}
 	bindingsByVM.Delete(vm)
+	callContextsByVM.Delete(vm)
+}
+
+type callContextStack struct {
+	mu    sync.Mutex
+	stack []context.Context
+}
+
+var callContextsByVM sync.Map
+
+// CurrentContext returns the context active for the current owner call on vm.
+// If no owner call context is active, it falls back to the runtime lifecycle
+// context stored in Bindings. If neither exists, it returns context.Background().
+//
+// Native modules can call this from JavaScript-exported functions to inherit
+// HTTP cancellation, deadlines, and OpenTelemetry parent spans without exposing
+// Go context objects to JavaScript authors.
+func CurrentContext(vm *goja.Runtime) context.Context {
+	if vm == nil {
+		return context.Background()
+	}
+	if st, ok := lookupCallContextStack(vm); ok {
+		if ctx, ok := st.peek(); ok && ctx != nil {
+			return ctx
+		}
+	}
+	if bindings, ok := Lookup(vm); ok && bindings.Context != nil {
+		return bindings.Context
+	}
+	return context.Background()
+}
+
+// WithCallContext makes ctx the current owner-call context for vm while fn
+// executes. Contexts are stored as a stack so nested owner calls restore the
+// outer context even when fn returns an error or panics.
+func WithCallContext(vm *goja.Runtime, ctx context.Context, fn func() (any, error)) (any, error) {
+	if vm == nil {
+		return nil, errors.New("runtimebridge: nil runtime")
+	}
+	if fn == nil {
+		return nil, errors.New("runtimebridge: nil function")
+	}
+	if ctx == nil {
+		ctx = CurrentContext(vm)
+	}
+	st := getCallContextStack(vm)
+	st.push(ctx)
+	defer st.pop()
+	return fn()
+}
+
+// WithCallContextVoid is the fire-and-forget form of WithCallContext.
+func WithCallContextVoid(vm *goja.Runtime, ctx context.Context, fn func() error) error {
+	if fn == nil {
+		return errors.New("runtimebridge: nil function")
+	}
+	_, err := WithCallContext(vm, ctx, func() (any, error) {
+		return nil, fn()
+	})
+	return err
+}
+
+func getCallContextStack(vm *goja.Runtime) *callContextStack {
+	value, _ := callContextsByVM.LoadOrStore(vm, &callContextStack{})
+	return value.(*callContextStack)
+}
+
+func lookupCallContextStack(vm *goja.Runtime) (*callContextStack, bool) {
+	value, ok := callContextsByVM.Load(vm)
+	if !ok {
+		return nil, false
+	}
+	st, ok := value.(*callContextStack)
+	return st, ok
+}
+
+func (s *callContextStack) push(ctx context.Context) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.stack = append(s.stack, ctx)
+}
+
+func (s *callContextStack) pop() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.stack) == 0 {
+		return
+	}
+	last := len(s.stack) - 1
+	s.stack[last] = nil
+	s.stack = s.stack[:last]
+}
+
+func (s *callContextStack) peek() (context.Context, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.stack) == 0 {
+		return nil, false
+	}
+	return s.stack[len(s.stack)-1], true
 }

--- a/pkg/runtimebridge/runtimebridge_test.go
+++ b/pkg/runtimebridge/runtimebridge_test.go
@@ -1,0 +1,73 @@
+package runtimebridge
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dop251/goja"
+)
+
+type contextKey string
+
+func TestCurrentContextFallsBackToLifecycleContext(t *testing.T) {
+	vm := goja.New()
+	defer Delete(vm)
+
+	ctx := context.WithValue(context.Background(), contextKey("lifecycle"), "runtime")
+	Store(vm, Bindings{Context: ctx})
+
+	got := CurrentContext(vm)
+	if got.Value(contextKey("lifecycle")) != "runtime" {
+		t.Fatalf("CurrentContext() = %#v, want lifecycle context", got)
+	}
+}
+
+func TestWithCallContextPushesAndRestoresNestedContext(t *testing.T) {
+	vm := goja.New()
+	defer Delete(vm)
+
+	outer := context.WithValue(context.Background(), contextKey("request"), "outer")
+	inner := context.WithValue(context.Background(), contextKey("request"), "inner")
+
+	_, err := WithCallContext(vm, outer, func() (any, error) {
+		if got := CurrentContext(vm).Value(contextKey("request")); got != "outer" {
+			t.Fatalf("outer CurrentContext() = %#v, want outer", got)
+		}
+		_, err := WithCallContext(vm, inner, func() (any, error) {
+			if got := CurrentContext(vm).Value(contextKey("request")); got != "inner" {
+				t.Fatalf("inner CurrentContext() = %#v, want inner", got)
+			}
+			return nil, nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		if got := CurrentContext(vm).Value(contextKey("request")); got != "outer" {
+			t.Fatalf("restored CurrentContext() = %#v, want outer", got)
+		}
+		return nil, nil
+	})
+	if err != nil {
+		t.Fatalf("WithCallContext() returned error: %v", err)
+	}
+}
+
+func TestWithCallContextPopsAfterPanic(t *testing.T) {
+	vm := goja.New()
+	defer Delete(vm)
+
+	lifecycle := context.WithValue(context.Background(), contextKey("scope"), "lifecycle")
+	call := context.WithValue(context.Background(), contextKey("scope"), "call")
+	Store(vm, Bindings{Context: lifecycle})
+
+	func() {
+		defer func() { _ = recover() }()
+		_, _ = WithCallContext(vm, call, func() (any, error) {
+			panic("boom")
+		})
+	}()
+
+	if got := CurrentContext(vm).Value(contextKey("scope")); got != "lifecycle" {
+		t.Fatalf("CurrentContext() after panic = %#v, want lifecycle", got)
+	}
+}

--- a/pkg/runtimeowner/runner.go
+++ b/pkg/runtimeowner/runner.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/dop251/goja"
+	"github.com/go-go-golems/go-go-goja/pkg/runtimebridge"
 )
 
 type ownerCtxKey struct{}
@@ -159,33 +160,38 @@ func (r *runner) Post(ctx context.Context, op string, fn PostFunc) error {
 }
 
 func (r *runner) invoke(ctx context.Context, op string, fn CallFunc) (any, error) {
-	if !r.opts.RecoverPanics {
-		return fn(ctx, r.vm)
-	}
+	return runtimebridge.WithCallContext(r.vm, ctx, func() (any, error) {
+		if !r.opts.RecoverPanics {
+			return fn(ctx, r.vm)
+		}
 
-	var (
-		ret any
-		err error
-	)
-	func() {
-		defer func() {
-			if rec := recover(); rec != nil {
-				err = fmt.Errorf("runtimeowner %s: %w: %v", op, ErrPanicked, rec)
-				ret = nil
-			}
+		var (
+			ret any
+			err error
+		)
+		func() {
+			defer func() {
+				if rec := recover(); rec != nil {
+					err = fmt.Errorf("runtimeowner %s: %w: %v", op, ErrPanicked, rec)
+					ret = nil
+				}
+			}()
+			ret, err = fn(ctx, r.vm)
 		}()
-		ret, err = fn(ctx, r.vm)
-	}()
-	return ret, err
+		return ret, err
+	})
 }
 
 func (r *runner) invokePost(ctx context.Context, op string, fn PostFunc) {
-	if r.opts.RecoverPanics {
-		defer func() {
-			_ = recover()
-		}()
-	}
-	fn(ctx, r.vm)
+	_ = runtimebridge.WithCallContextVoid(r.vm, ctx, func() error {
+		if r.opts.RecoverPanics {
+			defer func() {
+				_ = recover()
+			}()
+		}
+		fn(ctx, r.vm)
+		return nil
+	})
 }
 
 func normalizeContext(ctx context.Context) context.Context {

--- a/pkg/runtimeowner/runner_test.go
+++ b/pkg/runtimeowner/runner_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/dop251/goja"
+	"github.com/go-go-golems/go-go-goja/pkg/runtimebridge"
 )
 
 type queueScheduler struct {
@@ -144,6 +145,29 @@ func TestRunnerCallSuccess(t *testing.T) {
 	}
 	if got.(int) != 42 {
 		t.Fatalf("unexpected value: %v", got)
+	}
+}
+
+func TestRunnerCallSetsRuntimebridgeCurrentContext(t *testing.T) {
+	vm := goja.New()
+	s := newQueueScheduler(vm)
+	defer s.Close()
+	defer runtimebridge.Delete(vm)
+
+	type ctxKey string
+	ctx := context.WithValue(context.Background(), ctxKey("request"), "abc")
+	r := NewRunner(vm, s, Options{RecoverPanics: true})
+	got, err := r.Call(ctx, "test.current-context", func(callCtx context.Context, vm *goja.Runtime) (any, error) {
+		if callCtx.Value(ctxKey("request")) != "abc" {
+			t.Fatalf("call ctx value = %#v, want abc", callCtx.Value(ctxKey("request")))
+		}
+		return runtimebridge.CurrentContext(vm).Value(ctxKey("request")), nil
+	})
+	if err != nil {
+		t.Fatalf("Call returned error: %v", err)
+	}
+	if got != "abc" {
+		t.Fatalf("CurrentContext value = %#v, want abc", got)
 	}
 }
 


### PR DESCRIPTION
This pull request introduces two major improvements: a mechanism for
propagating `context.Context` into the runtime for use by native modules, and
a significant performance optimization for the UI DSL's attribute handling.

### Context Propagation

A new `runtimebridge` package provides a per-VM context stack. The `runtimeowner`
now automatically pushes the context from `Call` and `Post` operations onto this
stack, making it available to any code executing within that call.

- Native modules can now access the current call's context via
  `runtimebridge.CurrentContext(vm)`.
- This allows modules to respect cancellation, deadlines, and tracing
  information from the parent Go application (e.g., an HTTP request).
- The `database` module is updated to use this feature, preferring
  context-aware `QueryContext` and `ExecContext` methods when available.

### UI DSL Attribute Optimization

The internal representation of element attributes has been refactored to improve
rendering performance.

- `Element.Attrs` is changed from `map[string]any` to a pre-processed `[]Attr`
  slice.
- Attribute processing (key sorting, value stringification, handling of booleans
  and classes) is now performed once at element creation time, instead of on
  every render.
- This significantly reduces the work done during rendering, especially for
  pages with many elements.
- New benchmarks have been added to validate the performance improvements, and
  compatibility tests ensure existing behavior is preserved.