### PR TITLE
Fix logcopter exports formatting

### DIFF
--- a/modules/exports.go
+++ b/modules/exports.go
@@ -1,7 +1,5 @@
 package modules
 
-import ()
-
 // SetExport attaches a Go value to module exports.
 func SetExport(exports settableObject, moduleName, name string, fn interface{}) {
 	if err := exports.Set(name, fn); err != nil {


### PR DESCRIPTION
Fixes the generated logcopter rollout lint failure by removing an empty import block left after replacing the package-level zerolog logger.\n\nValidation:\n- GOWORK=off go test ./...