### PR TITLE
Feat: Support bundling help documents in xgoja binaries

### DIFF
--- a/cmd/xgoja/doc/02-user-guide.md
+++ b/cmd/xgoja/doc/02-user-guide.md
@@ -236,7 +236,7 @@ Use help sources for API references, tutorials, troubleshooting guides, and pack
 
 ### Provider-shipped help source
 
-Use this when documentation lives inside a provider package. This is the preferred mode for package-owned API references because the docs live with the code that owns the API.
+Use this when documentation lives inside a provider package. This is the preferred mode for package-owned API references because the docs live with the code that owns the API. See `examples/xgoja/09-provider-shipped-help-docs` for a smoke-tested Loupedeck provider example.
 
 ```yaml
 help:

--- a/cmd/xgoja/doc/02-user-guide.md
+++ b/cmd/xgoja/doc/02-user-guide.md
@@ -1,12 +1,13 @@
 ---
 Title: "xgoja user guide and buildspec reference"
 Slug: user-guide
-Short: "Reference for xgoja.yaml packages, runtimes, commands, targets, and jsverb source modes."
+Short: "Reference for xgoja.yaml packages, runtimes, commands, targets, help docs, and jsverb source modes."
 Topics:
 - xgoja
 - buildspec
 - providers
 - jsverbs
+- help-system
 - goja
 Commands:
 - xgoja build
@@ -25,7 +26,7 @@ ShowPerDefault: true
 SectionType: GeneralTopic
 ---
 
-An `xgoja.yaml` file describes the generated binary. It names the output program, selects provider packages, defines runtime profiles, enables commands, and configures JavaScript verb sources.
+An `xgoja.yaml` file describes the generated binary. It names the output program, selects provider packages, defines runtime profiles, enables commands, configures JavaScript verb sources, and optionally bundles Glazed help entries.
 
 A minimal shape looks like this:
 
@@ -81,6 +82,8 @@ commands:
 `commands` enables generated command families and points them at runtime profiles.
 
 `jsverbs` configures JavaScript verb sources that are mounted under the generated jsverbs command.
+
+`help.sources` configures additional Glazed help pages loaded into the generated binary's `help` command.
 
 `commandProviders` mounts Glazed command sets supplied by provider packages.
 
@@ -223,6 +226,75 @@ Adapter packages expose a function compatible with:
 Build(context.Context, *app.Host) (*cobra.Command, error)
 ```
 
+## Help document sources
+
+Generated xgoja binaries always include generic xgoja runtime help, such as `runtime-overview`. The optional `help.sources` section adds package-specific or project-specific Glazed help pages to the same help system.
+
+Use help sources for API references, tutorials, troubleshooting guides, and package-specific runtime documentation. For example, a Loupedeck-oriented generated binary can include the Loupedeck JavaScript API reference and expose it as `help loupedeck-js-api-reference`.
+
+`help.sources` supports three source modes.
+
+### Provider-shipped help source
+
+Use this when documentation lives inside a provider package. This is the preferred mode for package-owned API references because the docs live with the code that owns the API.
+
+```yaml
+help:
+  sources:
+    - id: loupedeck-runtime-api
+      package: loupedeck
+      source: runtime-api
+```
+
+The provider must register the source with an `fs.FS`:
+
+```go
+import helpdoc "github.com/go-go-golems/loupedeck/docs/help"
+
+func Register(registry *providerapi.Registry) error {
+    return registry.Package("loupedeck",
+        providerapi.HelpSource{
+            Name:        "runtime-api",
+            Description: "Loupedeck JavaScript runtime API reference and tutorials",
+            FS:          helpdoc.FS(),
+            Root:        ".",
+        },
+    )
+}
+```
+
+### Embedded local help source
+
+Use this when project-local Markdown files should become part of the generated binary.
+
+```yaml
+help:
+  sources:
+    - id: project-docs
+      path: ./docs/help
+      embed: true
+```
+
+At build time, xgoja copies the directory into the generated workspace under `xgoja_embed/help/<id>/`. Generated source embeds it with `go:embed`, and the generated root loads the pages into the Glazed help system.
+
+The original path must exist when `xgoja build` runs. It does not need to exist when the generated binary runs.
+
+### Runtime filesystem help source
+
+Use this during documentation development when the generated binary should read pages from disk at runtime.
+
+```yaml
+help:
+  sources:
+    - id: dev-docs
+      path: ./docs/help
+      embed: false
+```
+
+The files must exist when the generated binary runs. Prefer `embed: true` for distributed binaries.
+
+Every Markdown file must be a Glazed help entry with frontmatter fields such as `Title`, `Slug`, `Short`, `Topics`, `Commands`, `Flags`, `IsTopLevel`, `IsTemplate`, `ShowPerDefault`, and `SectionType`. Slugs are global within one generated binary, so avoid collisions between built-in, provider, and local docs.
+
 ## JavaScript verb sources
 
 `jsverbs` supports three distinct source modes.
@@ -289,16 +361,18 @@ Run validation before building:
 xgoja doctor -f xgoja.yaml
 ```
 
-The validator checks supported target kinds, package uniqueness, known runtime package IDs, duplicate runtime aliases, enabled command runtime references, command provider package/runtime references, jsverb source IDs, and local paths for embedded sources.
+The validator checks supported target kinds, package uniqueness, known runtime package IDs, duplicate runtime aliases, enabled command runtime references, command provider package/runtime references, jsverb source IDs, help source IDs, provider help source package references, and local paths for embedded sources.
 
 ## Troubleshooting
 
 | Problem | Cause | Solution |
 | --- | --- | --- |
-| `unknown package id` | A runtime or jsverb source references a package not listed in `packages`. | Add the package entry or fix the ID. |
+| `unknown package id` | A runtime, jsverb source, command provider, or help source references a package not listed in `packages`. | Add the package entry or fix the ID. |
 | `duplicate alias` | Two modules in one runtime resolve to the same `require()` name. | Set distinct `as` values. |
 | embedded source path error | `embed: true` uses a path missing at build time. | Fix `path` relative to the spec file or use an absolute path. |
 | provider verb source has no filesystem | The provider registered metadata but no `FS`. | Register `providerapi.VerbSource{FS: ..., Root: ...}`. |
+| provider help source not found | `help.sources[].package` or `help.sources[].source` does not match a registered `providerapi.HelpSource`. | Verify the provider registration and the buildspec package/source names. |
+| help topic not found | The docs were not selected, the slug is different, or the page failed to load due to a duplicate slug. | Run `help` to list visible topics and inspect the Markdown frontmatter. |
 | command provider not mounted | `commandProviders[].package` or `commandProviders[].name` does not match a registered command set provider, or mounting failed during generated command construction. | Verify the provider registration and run the generated binary with `--help` to inspect the command tree. |
 | generated build cannot resolve `github.com/go-go-golems/go-go-goja v0.0.0` | You are running xgoja from source, so no released module version is recorded in the binary. | Pass `--xgoja-replace /path/to/go-go-goja` while developing locally, or build with a released xgoja binary. |
 | generated build fails | The generated module cannot resolve imports or replacements. | Re-run with `--keep-work` and inspect generated `go.mod` and `main.go`. |

--- a/cmd/xgoja/doc/06-buildspec-reference.md
+++ b/cmd/xgoja/doc/06-buildspec-reference.md
@@ -10,6 +10,7 @@ Commands:
 - xgoja
 - xgoja build
 - xgoja doctor
+- help
 IsTopLevel: true
 IsTemplate: false
 ShowPerDefault: true
@@ -41,7 +42,24 @@ commands:
   run:
     enabled: true
     runtime: main
+help:
+  sources:
+    - id: project-docs
+      path: ./docs/help
+      embed: true
 ```
+
+Help sources add Glazed Markdown pages to the generated binary's `help` command. Use provider-shipped docs for package API references:
+
+```yaml
+help:
+  sources:
+    - id: loupedeck-runtime-api
+      package: loupedeck
+      source: runtime-api
+```
+
+Use embedded local docs for project-specific tutorials. The local directory is copied into `xgoja_embed/help/<id>/` during generation and does not need to exist when the generated binary runs.
 
 Validate and build with:
 

--- a/cmd/xgoja/doc/06-buildspec-reference.md
+++ b/cmd/xgoja/doc/06-buildspec-reference.md
@@ -59,7 +59,7 @@ help:
       source: runtime-api
 ```
 
-Use embedded local docs for project-specific tutorials. The local directory is copied into `xgoja_embed/help/<id>/` during generation and does not need to exist when the generated binary runs.
+Use embedded local docs for project-specific tutorials. The local directory is copied into `xgoja_embed/help/<id>/` during generation and does not need to exist when the generated binary runs. For a runnable provider-shipped help example, see `examples/xgoja/09-provider-shipped-help-docs`.
 
 Validate and build with:
 

--- a/cmd/xgoja/doc/08-playbook-adding-xgoja-support.md
+++ b/cmd/xgoja/doc/08-playbook-adding-xgoja-support.md
@@ -7,6 +7,7 @@ Topics:
 - providers
 - modules
 - command-providers
+- help-system
 - runtime
 - migration
 Commands:
@@ -35,6 +36,7 @@ The first decision is not where to put files. The first decision is what kind of
 | Module-only provider | JavaScript should call Go-backed functions with `require(...)`. | `providerapi.ModuleDescriptor` |
 | Command provider | The generated binary should mount repository-owned commands. | `providerapi.CommandSetProvider` returning Glazed commands |
 | Runtime/session integration | The repository owns runtime resources that need flags, initialization, and cleanup. | package capabilities with config sections and runtime initializers |
+| Help documentation provider | Generated binaries should include package-owned API references or tutorials. | `providerapi.HelpSource` |
 
 Most production integrations use more than one shape. For example, a hardware-oriented repository may expose `require("device/ui")`, provide a `devices` command provider, and install a runtime initializer that opens and closes the physical device.
 
@@ -292,7 +294,68 @@ defer rt.Close(context.Background())
 
 This API intentionally differs from the lower-level engine API. `providerapi.RuntimeFactory.NewRuntime(ctx, profile, ...)` chooses a named xgoja runtime profile. The engine factory uses explicit runtime options.
 
-## 9. Add a generated xgoja example
+## 9. Register package-owned help docs
+
+Provider packages can ship Glazed help pages for API references, tutorials, and troubleshooting. This is the right place for documentation that belongs to the package API rather than to one generated application.
+
+Create or reuse a docs package that embeds Markdown help entries:
+
+```go
+package doc
+
+import (
+    "embed"
+    "io/fs"
+
+    "github.com/go-go-golems/glazed/pkg/help"
+)
+
+//go:embed topics/*.md tutorials/*.md
+var docFS embed.FS
+
+func FS() fs.FS { return docFS }
+
+func AddDocToHelpSystem(helpSystem *help.HelpSystem) error {
+    return helpSystem.LoadSectionsFromFS(docFS, ".")
+}
+```
+
+Then register that filesystem from the xgoja provider:
+
+```go
+import helpdoc "example.com/my-repo/docs/help"
+
+func Register(registry *providerapi.Registry) error {
+    return registry.Package(PackageID,
+        providerapi.HelpSource{
+            Name:        "runtime-api",
+            Description: "JavaScript runtime API reference and tutorials",
+            FS:          helpdoc.FS(),
+            Root:        ".",
+        },
+    )
+}
+```
+
+Generated binary authors opt into the docs from `xgoja.yaml`:
+
+```yaml
+help:
+  sources:
+    - id: my-repo-runtime-api
+      package: my-repo
+      source: runtime-api
+```
+
+After building, validate with:
+
+```bash
+./dist/myapp help my-repo-js-api-reference
+```
+
+Keep slugs unique across all built-in, provider, and local help pages. If two selected docs use the same slug, Glazed help loading should fail rather than silently choosing one.
+
+## 10. Add a generated xgoja example
 
 A provider is not complete until a generated binary can load it. Add a small example under the repository:
 
@@ -350,7 +413,7 @@ commandProviders:
     runtimeProfile: default
 ```
 
-## 10. Make the smoke test exercise the generated path
+## 11. Make the smoke test exercise the generated path
 
 A package-level test is useful, but it does not prove the generated xgoja path. The smoke test should prove that xgoja can build a binary, load the provider, list the selected modules, mount configured commands, and execute one successful command or script.
 
@@ -385,7 +448,7 @@ clean:
 
 For hardware, browser, cloud, or live-network integrations, keep `make smoke` deterministic and CI-safe. Add a separate target such as `make hardware`, `make browser`, or `make live` for interactive validation.
 
-## 11. Validate the repository
+## 12. Validate the repository
 
 Run focused package tests first:
 
@@ -408,7 +471,7 @@ rg -n 'runtimebridge\.(Bindings|CurrentContext|OwnerRunner)|runtimeowner\.Runner
 
 Expected matches should be zero, except for migration documentation or unrelated uses of the word `bindings` in parser or REPL code.
 
-## 12. Commit in reviewable phases
+## 13. Commit in reviewable phases
 
 Small commits make xgoja integrations easier to review. A useful sequence is:
 

--- a/cmd/xgoja/doc/08-playbook-adding-xgoja-support.md
+++ b/cmd/xgoja/doc/08-playbook-adding-xgoja-support.md
@@ -353,6 +353,8 @@ After building, validate with:
 ./dist/myapp help my-repo-js-api-reference
 ```
 
+For a complete smoke-tested reference, inspect `examples/xgoja/09-provider-shipped-help-docs`. It builds a generated binary with the Loupedeck provider and verifies `help loupedeck-js-api-reference`.
+
 Keep slugs unique across all built-in, provider, and local help pages. If two selected docs use the same slug, Glazed help loading should fail rather than silently choosing one.
 
 ## 10. Add a generated xgoja example

--- a/cmd/xgoja/internal/buildspec/load_test.go
+++ b/cmd/xgoja/internal/buildspec/load_test.go
@@ -31,6 +31,11 @@ commands:
   eval:
     enabled: true
     runtime: repl
+help:
+  sources:
+    - id: provider-docs
+      package: core
+      source: docs
 jsverbs:
   - id: local
     path: ./verbs
@@ -57,6 +62,9 @@ jsverbs:
 	}
 	if spec.Runtimes["repl"].Modules[1].Alias() != "yml" {
 		t.Fatalf("module alias = %q", spec.Runtimes["repl"].Modules[1].Alias())
+	}
+	if len(spec.Help.Sources) != 1 || spec.Help.Sources[0].Source != "docs" {
+		t.Fatalf("help sources = %#v", spec.Help.Sources)
 	}
 }
 

--- a/cmd/xgoja/internal/buildspec/spec.go
+++ b/cmd/xgoja/internal/buildspec/spec.go
@@ -11,6 +11,7 @@ type Spec struct {
 	Commands         CommandsSpec              `yaml:"commands"`
 	CommandProviders []CommandProviderInstance `yaml:"commandProviders"`
 	JSVerbs          []JSVerbSourceSpec        `yaml:"jsverbs"`
+	Help             HelpSpec                  `yaml:"help"`
 	BaseDir          string                    `yaml:"-"`
 }
 
@@ -85,6 +86,18 @@ type CommandProviderInstance struct {
 }
 
 type JSVerbSourceSpec struct {
+	ID      string `yaml:"id" json:"id"`
+	Path    string `yaml:"path" json:"path,omitempty"`
+	Embed   bool   `yaml:"embed" json:"embed"`
+	Package string `yaml:"package" json:"package,omitempty"`
+	Source  string `yaml:"source" json:"source,omitempty"`
+}
+
+type HelpSpec struct {
+	Sources []HelpSourceSpec `yaml:"sources" json:"sources,omitempty"`
+}
+
+type HelpSourceSpec struct {
 	ID      string `yaml:"id" json:"id"`
 	Path    string `yaml:"path" json:"path,omitempty"`
 	Embed   bool   `yaml:"embed" json:"embed"`

--- a/cmd/xgoja/internal/buildspec/validate.go
+++ b/cmd/xgoja/internal/buildspec/validate.go
@@ -21,6 +21,7 @@ func Validate(spec *Spec) *Report {
 	validateCommands(report, spec)
 	validateCommandProviders(report, spec, packageIDs)
 	validateJSVerbs(report, spec, packageIDs)
+	validateHelp(report, spec, packageIDs)
 
 	return report
 }
@@ -234,23 +235,87 @@ func validateJSVerbs(report *Report, spec *Spec, packageIDs map[string]PackageSp
 	}
 }
 
+func validateHelp(report *Report, spec *Spec, packageIDs map[string]PackageSpec) {
+	ids := map[string]struct{}{}
+	for i, source := range spec.Help.Sources {
+		path := fmt.Sprintf("help.sources[%d]", i)
+		id := strings.TrimSpace(source.ID)
+		if id == "" {
+			report.AddError("help-source-id", path+".id", "help source id is required")
+		} else if _, ok := ids[id]; ok {
+			report.AddError("help-source-id", path+".id", fmt.Sprintf("duplicate help source id %q", id))
+		} else {
+			ids[id] = struct{}{}
+		}
+
+		hasProvider := strings.TrimSpace(source.Package) != "" || strings.TrimSpace(source.Source) != ""
+		hasPath := strings.TrimSpace(source.Path) != ""
+		if hasProvider && hasPath {
+			report.AddError("help-source-shape", path, "help source cannot combine provider source and filesystem path")
+			continue
+		}
+		if hasProvider {
+			if strings.TrimSpace(source.Package) == "" || strings.TrimSpace(source.Source) == "" {
+				report.AddError("help-provider-source", path, "provider help sources require both package and source")
+				continue
+			}
+			if _, ok := packageIDs[source.Package]; !ok {
+				report.AddError("help-provider-source", path+".package", fmt.Sprintf("unknown package id %q", source.Package))
+			} else {
+				report.AddOK("help-provider-source", path, fmt.Sprintf("provider source %s.%s", source.Package, source.Source))
+			}
+			continue
+		}
+		if !hasPath {
+			report.AddError("help-path", path+".path", "filesystem help source requires path")
+			continue
+		}
+		if source.Embed {
+			if err := requireExistingDir(spec.BaseDir, source.Path); err != nil {
+				report.AddError("help-path", path+".path", err.Error())
+			} else {
+				report.AddOK("help-path", path+".path", source.Path)
+			}
+		} else {
+			report.AddOK("help-path", path+".path", "runtime filesystem source")
+		}
+	}
+}
+
 func requireExistingPath(baseDir, rawPath string) error {
+	_, _, err := existingPathInfo(baseDir, rawPath)
+	return err
+}
+
+func requireExistingDir(baseDir, rawPath string) error {
+	path, info, err := existingPathInfo(baseDir, rawPath)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%s: not a directory", path)
+	}
+	return nil
+}
+
+func existingPathInfo(baseDir, rawPath string) (string, os.FileInfo, error) {
 	path := strings.TrimSpace(rawPath)
 	if path == "" {
-		return fmt.Errorf("path is empty")
+		return "", nil, fmt.Errorf("path is empty")
 	}
 	if path == "~" || strings.HasPrefix(path, "~/") {
 		home, err := os.UserHomeDir()
 		if err != nil {
-			return fmt.Errorf("resolve home directory: %w", err)
+			return "", nil, fmt.Errorf("resolve home directory: %w", err)
 		}
 		path = filepath.Join(home, strings.TrimPrefix(path, "~/"))
 	}
 	if !filepath.IsAbs(path) {
 		path = filepath.Join(baseDir, path)
 	}
-	if _, err := os.Stat(path); err != nil {
-		return fmt.Errorf("%s: %w", path, err)
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", nil, fmt.Errorf("%s: %w", path, err)
 	}
-	return nil
+	return path, info, nil
 }

--- a/cmd/xgoja/internal/buildspec/validate_test.go
+++ b/cmd/xgoja/internal/buildspec/validate_test.go
@@ -1,6 +1,10 @@
 package buildspec
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestValidateCommandProvidersAcceptsKnownPackageAndRuntime(t *testing.T) {
 	spec := validSpec()
@@ -34,6 +38,59 @@ func TestValidateCommandProvidersRejectsInvalidEntries(t *testing.T) {
 	assertCheck(t, report, StatusError, "command-provider-runtime", "commandProviders[0].runtimeProfile")
 	assertCheck(t, report, StatusError, "command-provider-id", "commandProviders[1].id")
 	assertCheck(t, report, StatusError, "command-provider-name", "commandProviders[1].name")
+}
+
+func TestValidateHelpSourcesAcceptsProviderAndEmbeddedLocalSources(t *testing.T) {
+	dir := t.TempDir()
+	helpDir := filepath.Join(dir, "docs", "help")
+	if err := os.MkdirAll(helpDir, 0o755); err != nil {
+		t.Fatalf("mkdir help dir: %v", err)
+	}
+	spec := validSpec()
+	spec.BaseDir = dir
+	spec.Help.Sources = []HelpSourceSpec{
+		{ID: "fixture-docs", Package: "fixture", Source: "docs"},
+		{ID: "local-docs", Path: "docs/help", Embed: true},
+		{ID: "dev-docs", Path: "../runtime-docs"},
+	}
+
+	report := Validate(spec)
+	if report.HasErrors() {
+		t.Fatalf("expected no validation errors, got %#v", report.Checks)
+	}
+	assertCheck(t, report, StatusOK, "help-provider-source", "help.sources[0]")
+	assertCheck(t, report, StatusOK, "help-path", "help.sources[1].path")
+	assertCheck(t, report, StatusOK, "help-path", "help.sources[2].path")
+}
+
+func TestValidateHelpSourcesRejectsInvalidEntries(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "not-a-dir.md")
+	if err := os.WriteFile(filePath, []byte("docs"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	spec := validSpec()
+	spec.BaseDir = dir
+	spec.Help.Sources = []HelpSourceSpec{
+		{ID: "dup", Package: "fixture"},
+		{ID: "dup", Package: "missing", Source: "docs"},
+		{ID: "mixed", Path: "docs", Package: "fixture", Source: "docs"},
+		{ID: "missing-path"},
+		{ID: "file", Path: "not-a-dir.md", Embed: true},
+		{Path: "docs"},
+	}
+
+	report := Validate(spec)
+	if !report.HasErrors() {
+		t.Fatalf("expected validation errors, got %#v", report.Checks)
+	}
+	assertCheck(t, report, StatusError, "help-provider-source", "help.sources[0]")
+	assertCheck(t, report, StatusError, "help-source-id", "help.sources[1].id")
+	assertCheck(t, report, StatusError, "help-provider-source", "help.sources[1].package")
+	assertCheck(t, report, StatusError, "help-source-shape", "help.sources[2]")
+	assertCheck(t, report, StatusError, "help-path", "help.sources[3].path")
+	assertCheck(t, report, StatusError, "help-path", "help.sources[4].path")
+	assertCheck(t, report, StatusError, "help-source-id", "help.sources[5].id")
 }
 
 func validSpec() *Spec {

--- a/cmd/xgoja/internal/generate/generate.go
+++ b/cmd/xgoja/internal/generate/generate.go
@@ -33,6 +33,9 @@ func WriteAll(dir string, spec *buildspec.Spec, opts Options) error {
 	if err := copyEmbeddedJSVerbs(dir, spec); err != nil {
 		return err
 	}
+	if err := copyEmbeddedHelpSources(dir, spec); err != nil {
+		return err
+	}
 	files := map[string]string{
 		"go.mod":         RenderGoMod(spec, opts),
 		"main.go":        RenderMain(spec),
@@ -60,6 +63,25 @@ func copyEmbeddedJSVerbs(dir string, spec *buildspec.Spec) error {
 		dst := filepath.Join(dir, filepath.FromSlash(root))
 		if err := copyDir(dst, src); err != nil {
 			return fmt.Errorf("copy embedded jsverb source %s: %w", source.ID, err)
+		}
+	}
+	return nil
+}
+
+func copyEmbeddedHelpSources(dir string, spec *buildspec.Spec) error {
+	roots := embeddedHelpRoots(spec)
+	for i, source := range spec.Help.Sources {
+		root := roots[i]
+		if root == "" {
+			continue
+		}
+		src, err := resolveSourcePath(spec.BaseDir, source.Path)
+		if err != nil {
+			return fmt.Errorf("resolve embedded help source %s: %w", source.ID, err)
+		}
+		dst := filepath.Join(dir, filepath.FromSlash(root))
+		if err := copyDir(dst, src); err != nil {
+			return fmt.Errorf("copy embedded help source %s: %w", source.ID, err)
 		}
 	}
 	return nil

--- a/cmd/xgoja/internal/generate/generate_test.go
+++ b/cmd/xgoja/internal/generate/generate_test.go
@@ -364,7 +364,7 @@ function embeddedGreet(name) {
 	}
 }
 
-func TestGeneratedProgramCompilesWithEmbeddedHelpSource(t *testing.T) {
+func TestGeneratedProgramLoadsEmbeddedHelpSource(t *testing.T) {
 	baseDir := t.TempDir()
 	helpDir := filepath.Join(baseDir, "docs", "help", "topics")
 	if err := os.MkdirAll(helpDir, 0o755); err != nil {
@@ -387,9 +387,9 @@ Local body.
 	spec := buildableSpec("xgoja", "", "")
 	spec.BaseDir = baseDir
 	spec.Help.Sources = []buildspec.HelpSourceSpec{{ID: "local", Path: "docs/help", Embed: true}}
-	dir, out := runGeneratedCommandWithOutput(t, spec, "eval", `require("hello").greet("intern")`)
-	if strings.TrimSpace(string(out)) != "hello intern" {
-		t.Fatalf("generated output = %q", out)
+	dir, out := runGeneratedCommandWithOutput(t, spec, "help", "local-api")
+	if !strings.Contains(string(out), "Local API") || !strings.Contains(string(out), "Local body") {
+		t.Fatalf("expected generated help output, got %q", out)
 	}
 	if _, err := os.Stat(filepath.Join(dir, "xgoja_embed", "help", "local", "topics", "01-local.md")); err != nil {
 		t.Fatalf("embedded help was not copied: %v", err)

--- a/cmd/xgoja/internal/generate/generate_test.go
+++ b/cmd/xgoja/internal/generate/generate_test.go
@@ -137,6 +137,52 @@ func TestRenderMainIncludesEmbeddedVerbFS(t *testing.T) {
 	}
 }
 
+func TestRenderMainIncludesEmbeddedHelpFS(t *testing.T) {
+	spec := buildableSpec("xgoja", "", "")
+	spec.Help.Sources = []buildspec.HelpSourceSpec{{ID: "local-docs", Path: "docs/help", Embed: true}}
+	got := RenderMain(spec)
+	for _, want := range []string{
+		`"embed"`,
+		`//go:embed xgoja_embed/help/*`,
+		`var embeddedHelp embed.FS`,
+		`EmbeddedHelp: embeddedHelp`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected main.go to contain %q, got:\n%s", want, got)
+		}
+	}
+	for _, notWant := range []string{
+		`var embeddedJSVerbs embed.FS`,
+		`EmbeddedJSVerbs: embeddedJSVerbs`,
+	} {
+		if strings.Contains(got, notWant) {
+			t.Fatalf("main.go should not contain %q for help-only embed:\n%s", notWant, got)
+		}
+	}
+	embeddedSpec := RenderEmbeddedSpec(spec)
+	if !strings.Contains(embeddedSpec, `"path": "xgoja_embed/help/local_docs"`) {
+		t.Fatalf("expected embedded spec to rewrite local help path, got:\n%s", embeddedSpec)
+	}
+}
+
+func TestRenderMainIncludesEmbeddedVerbAndHelpFS(t *testing.T) {
+	spec := buildableSpec("xgoja", "", "")
+	spec.Commands.JSVerbs = buildspec.CommandSpec{Enabled: true, Runtime: "repl", Name: "verbs"}
+	spec.JSVerbs = []buildspec.JSVerbSourceSpec{{ID: "local-verbs", Path: "verbs", Embed: true}}
+	spec.Help.Sources = []buildspec.HelpSourceSpec{{ID: "local-docs", Path: "docs/help", Embed: true}}
+	got := RenderMain(spec)
+	for _, want := range []string{
+		`var embeddedJSVerbs embed.FS`,
+		`var embeddedHelp embed.FS`,
+		`EmbeddedJSVerbs: embeddedJSVerbs`,
+		`EmbeddedHelp: embeddedHelp`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected main.go to contain %q, got:\n%s", want, got)
+		}
+	}
+}
+
 func TestRenderEmbeddedSpecAvoidsEmbeddedVerbRootCollisions(t *testing.T) {
 	spec := buildableSpec("xgoja", "", "")
 	spec.Commands.JSVerbs = buildspec.CommandSpec{Enabled: true, Runtime: "repl", Name: "verbs"}
@@ -148,6 +194,23 @@ func TestRenderEmbeddedSpecAvoidsEmbeddedVerbRootCollisions(t *testing.T) {
 	for _, want := range []string{
 		`"path": "xgoja_embed/jsverbs/local_dev"`,
 		`"path": "xgoja_embed/jsverbs/local_dev_2"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected embedded spec to contain %q, got:\n%s", want, got)
+		}
+	}
+}
+
+func TestRenderEmbeddedSpecAvoidsEmbeddedHelpRootCollisions(t *testing.T) {
+	spec := buildableSpec("xgoja", "", "")
+	spec.Help.Sources = []buildspec.HelpSourceSpec{
+		{ID: "local-docs", Path: "docs-a", Embed: true},
+		{ID: "local_docs", Path: "docs-b", Embed: true},
+	}
+	got := RenderEmbeddedSpec(spec)
+	for _, want := range []string{
+		`"path": "xgoja_embed/help/local_docs"`,
+		`"path": "xgoja_embed/help/local_docs_2"`,
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("expected embedded spec to contain %q, got:\n%s", want, got)
@@ -183,6 +246,37 @@ func TestWriteAllCopiesEmbeddedVerbSourcesToCollisionFreeRoots(t *testing.T) {
 	} {
 		if _, err := os.Stat(path); err != nil {
 			t.Fatalf("expected collision-free embedded verb copy %s: %v", path, err)
+		}
+	}
+}
+
+func TestWriteAllCopiesEmbeddedHelpSourcesToCollisionFreeRoots(t *testing.T) {
+	baseDir := t.TempDir()
+	for _, dir := range []string{"docs-a", "docs-b"} {
+		helpDir := filepath.Join(baseDir, dir, "topics")
+		if err := os.MkdirAll(helpDir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+		if err := os.WriteFile(filepath.Join(helpDir, "01-intro.md"), []byte("---\nTitle: Intro\nSlug: intro\n---\n"), 0o644); err != nil {
+			t.Fatalf("write %s help: %v", dir, err)
+		}
+	}
+	spec := buildableSpec("xgoja", "", "")
+	spec.BaseDir = baseDir
+	spec.Help.Sources = []buildspec.HelpSourceSpec{
+		{ID: "local-docs", Path: "docs-a", Embed: true},
+		{ID: "local_docs", Path: "docs-b", Embed: true},
+	}
+	dir := t.TempDir()
+	if err := WriteAll(dir, spec, Options{XGojaModuleVersion: "v0.1.0"}); err != nil {
+		t.Fatalf("write all: %v", err)
+	}
+	for _, path := range []string{
+		filepath.Join(dir, "xgoja_embed", "help", "local_docs", "topics", "01-intro.md"),
+		filepath.Join(dir, "xgoja_embed", "help", "local_docs_2", "topics", "01-intro.md"),
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected collision-free embedded help copy %s: %v", path, err)
 		}
 	}
 }
@@ -267,6 +361,38 @@ function embeddedGreet(name) {
 	dir := runGeneratedCommand(t, spec, "verbs", "tools", "embedded-greet", "--name", "intern")
 	if _, err := os.Stat(filepath.Join(dir, "xgoja_embed", "jsverbs", "local", "tools.js")); err != nil {
 		t.Fatalf("embedded verb was not copied: %v", err)
+	}
+}
+
+func TestGeneratedProgramCompilesWithEmbeddedHelpSource(t *testing.T) {
+	baseDir := t.TempDir()
+	helpDir := filepath.Join(baseDir, "docs", "help", "topics")
+	if err := os.MkdirAll(helpDir, 0o755); err != nil {
+		t.Fatalf("mkdir help: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(helpDir, "01-local.md"), []byte(`---
+Title: Local API
+Slug: local-api
+Short: Local docs.
+IsTopLevel: true
+IsTemplate: false
+ShowPerDefault: true
+SectionType: GeneralTopic
+---
+
+Local body.
+`), 0o644); err != nil {
+		t.Fatalf("write help: %v", err)
+	}
+	spec := buildableSpec("xgoja", "", "")
+	spec.BaseDir = baseDir
+	spec.Help.Sources = []buildspec.HelpSourceSpec{{ID: "local", Path: "docs/help", Embed: true}}
+	dir, out := runGeneratedCommandWithOutput(t, spec, "eval", `require("hello").greet("intern")`)
+	if strings.TrimSpace(string(out)) != "hello intern" {
+		t.Fatalf("generated output = %q", out)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "xgoja_embed", "help", "local", "topics", "01-local.md")); err != nil {
+		t.Fatalf("embedded help was not copied: %v", err)
 	}
 }
 

--- a/cmd/xgoja/internal/generate/main.go
+++ b/cmd/xgoja/internal/generate/main.go
@@ -18,6 +18,10 @@ func RenderMain(spec *buildspec.Spec) string {
 
 func RenderEmbeddedSpec(spec *buildspec.Spec) string {
 	spec = runtimeSpec(spec)
+	var helpSpec *buildspec.HelpSpec
+	if len(spec.Help.Sources) > 0 {
+		helpSpec = &spec.Help
+	}
 	payload := struct {
 		Name             string                              `json:"name"`
 		Target           buildspec.TargetSpec                `json:"target"`
@@ -26,6 +30,7 @@ func RenderEmbeddedSpec(spec *buildspec.Spec) string {
 		Commands         buildspec.CommandsSpec              `json:"commands"`
 		CommandProviders []buildspec.CommandProviderInstance `json:"commandProviders,omitempty"`
 		JSVerbs          []buildspec.JSVerbSourceSpec        `json:"jsverbs,omitempty"`
+		Help             *buildspec.HelpSpec                 `json:"help,omitempty"`
 	}{
 		Name:             spec.Name,
 		Target:           spec.Target,
@@ -34,6 +39,7 @@ func RenderEmbeddedSpec(spec *buildspec.Spec) string {
 		Commands:         spec.Commands,
 		CommandProviders: spec.CommandProviders,
 		JSVerbs:          spec.JSVerbs,
+		Help:             helpSpec,
 	}
 	data, err := json.MarshalIndent(payload, "", "  ")
 	if err != nil {
@@ -56,6 +62,15 @@ func runtimeSpec(spec *buildspec.Spec) *buildspec.Spec {
 			}
 		}
 	}
+	if len(spec.Help.Sources) > 0 {
+		clone.Help.Sources = append([]buildspec.HelpSourceSpec(nil), spec.Help.Sources...)
+		roots := embeddedHelpRoots(spec)
+		for i := range clone.Help.Sources {
+			if root := roots[i]; root != "" {
+				clone.Help.Sources[i].Path = root
+			}
+		}
+	}
 	return &clone
 }
 
@@ -64,6 +79,18 @@ func hasEmbeddedJSVerbSources(spec *buildspec.Spec) bool {
 		return false
 	}
 	for _, source := range spec.JSVerbs {
+		if source.Embed && source.Path != "" && source.Package == "" && source.Source == "" {
+			return true
+		}
+	}
+	return false
+}
+
+func hasEmbeddedHelpSources(spec *buildspec.Spec) bool {
+	if spec == nil {
+		return false
+	}
+	for _, source := range spec.Help.Sources {
 		if source.Embed && source.Path != "" && source.Package == "" && source.Source == "" {
 			return true
 		}
@@ -94,6 +121,33 @@ func embeddedJSVerbRoots(spec *buildspec.Spec) map[int]string {
 		}
 		used[name] = struct{}{}
 		roots[i] = "xgoja_embed/jsverbs/" + name
+	}
+	return roots
+}
+
+func embeddedHelpRoots(spec *buildspec.Spec) map[int]string {
+	roots := map[int]string{}
+	if spec == nil {
+		return roots
+	}
+	used := map[string]struct{}{}
+	for i, source := range spec.Help.Sources {
+		if !source.Embed || strings.TrimSpace(source.Path) == "" || strings.TrimSpace(source.Package) != "" || strings.TrimSpace(source.Source) != "" {
+			continue
+		}
+		base := sanitizeIdentifier(source.ID)
+		if base == "" {
+			base = "source"
+		}
+		name := base
+		for suffix := 2; ; suffix++ {
+			if _, ok := used[name]; !ok {
+				break
+			}
+			name = fmt.Sprintf("%s_%d", base, suffix)
+		}
+		used[name] = struct{}{}
+		roots[i] = "xgoja_embed/help/" + name
 	}
 	return roots
 }

--- a/cmd/xgoja/internal/generate/templates.go
+++ b/cmd/xgoja/internal/generate/templates.go
@@ -15,16 +15,18 @@ import (
 var templateFS embed.FS
 
 type mainTemplateData struct {
-	SpecJSON         string
-	HasEmbedded      bool
-	NeedsContext     bool
-	HasTargetImport  bool
-	TargetKind       string
-	TargetImport     string
-	TargetRoot       string
-	HostConstruction string
-	RootConstruction string
-	ProviderImports  []providerImport
+	SpecJSON          string
+	HasEmbedded       bool
+	HasEmbeddedJSVerb bool
+	HasEmbeddedHelp   bool
+	NeedsContext      bool
+	HasTargetImport   bool
+	TargetKind        string
+	TargetImport      string
+	TargetRoot        string
+	HostConstruction  string
+	RootConstruction  string
+	ProviderImports   []providerImport
 }
 
 type providerImport struct {
@@ -51,7 +53,9 @@ func renderMainTemplate(data mainTemplateData) (string, error) {
 
 func mainTemplateDataFromSpec(spec *buildspec.Spec) mainTemplateData {
 	aliases := importAliases(spec.Packages)
-	hasEmbedded := hasEmbeddedJSVerbSources(spec)
+	hasEmbeddedJSVerb := hasEmbeddedJSVerbSources(spec)
+	hasEmbeddedHelp := hasEmbeddedHelpSources(spec)
+	hasEmbedded := hasEmbeddedJSVerb || hasEmbeddedHelp
 	providers := make([]providerImport, 0, len(spec.Packages))
 	for _, pkg := range spec.Packages {
 		providers = append(providers, providerImport{
@@ -67,18 +71,28 @@ func mainTemplateDataFromSpec(spec *buildspec.Spec) mainTemplateData {
 	}
 
 	data := mainTemplateData{
-		SpecJSON:        escapeRawString(RenderEmbeddedSpec(spec)),
-		HasEmbedded:     hasEmbedded,
-		NeedsContext:    spec.Target.Kind == "adapter",
-		HasTargetImport: spec.Target.Kind == "adapter" || spec.Target.Kind == "cobra",
-		TargetKind:      spec.Target.Kind,
-		TargetImport:    spec.Target.Import,
-		TargetRoot:      rootFn,
-		ProviderImports: providers,
+		SpecJSON:          escapeRawString(RenderEmbeddedSpec(spec)),
+		HasEmbedded:       hasEmbedded,
+		HasEmbeddedJSVerb: hasEmbeddedJSVerb,
+		HasEmbeddedHelp:   hasEmbeddedHelp,
+		NeedsContext:      spec.Target.Kind == "adapter",
+		HasTargetImport:   spec.Target.Kind == "adapter" || spec.Target.Kind == "cobra",
+		TargetKind:        spec.Target.Kind,
+		TargetImport:      spec.Target.Import,
+		TargetRoot:        rootFn,
+		ProviderImports:   providers,
+	}
+	embeddedJSVerbArg := "nil"
+	if hasEmbeddedJSVerb {
+		embeddedJSVerbArg = "embeddedJSVerbs"
+	}
+	embeddedHelpArg := "nil"
+	if hasEmbeddedHelp {
+		embeddedHelpArg = "embeddedHelp"
 	}
 	if hasEmbedded {
-		data.HostConstruction = "host := app.NewHostWithOptions(registry, spec, app.HostOptions{EmbeddedJSVerbs: embeddedJSVerbs})"
-		data.RootConstruction = "root, err := app.NewRootCommand(app.Options{Providers: registry, SpecJSON: embeddedSpecJSON, EmbeddedJSVerbs: embeddedJSVerbs})"
+		data.HostConstruction = fmt.Sprintf("host := app.NewHostWithOptions(registry, spec, app.HostOptions{EmbeddedJSVerbs: %s, EmbeddedHelp: %s})", embeddedJSVerbArg, embeddedHelpArg)
+		data.RootConstruction = fmt.Sprintf("root, err := app.NewRootCommand(app.Options{Providers: registry, SpecJSON: embeddedSpecJSON, EmbeddedJSVerbs: %s, EmbeddedHelp: %s})", embeddedJSVerbArg, embeddedHelpArg)
 	} else {
 		data.HostConstruction = "host := app.NewHost(registry, spec)"
 		data.RootConstruction = "root, err := app.NewRootCommand(app.Options{Providers: registry, SpecJSON: embeddedSpecJSON})"

--- a/cmd/xgoja/internal/generate/templates/main.go.tmpl
+++ b/cmd/xgoja/internal/generate/templates/main.go.tmpl
@@ -24,9 +24,13 @@ import (
 
 const embeddedSpecJSON = `{{ .SpecJSON }}`
 
-{{- if .HasEmbedded }}
+{{- if .HasEmbeddedJSVerb }}
 //go:embed xgoja_embed/jsverbs/*
 var embeddedJSVerbs embed.FS
+{{ end }}
+{{- if .HasEmbeddedHelp }}
+//go:embed xgoja_embed/help/*
+var embeddedHelp embed.FS
 {{ end }}
 
 func main() {

--- a/examples/xgoja/09-provider-shipped-help-docs/Makefile
+++ b/examples/xgoja/09-provider-shipped-help-docs/Makefile
@@ -1,0 +1,26 @@
+.DEFAULT_GOAL := smoke
+
+REPO_ROOT := $(abspath ../../..)
+BIN := $(CURDIR)/dist/provider-shipped-help-docs
+XGOJA := cd $(REPO_ROOT) && GOWORK=off go run ./cmd/xgoja
+
+.PHONY: smoke doctor list build run clean
+
+smoke: doctor list build run
+
+doctor:
+	$(XGOJA) doctor -f $(CURDIR)/xgoja.yaml
+
+list:
+	$(XGOJA) list-modules -f $(CURDIR)/xgoja.yaml
+
+build:
+	$(XGOJA) build -f $(CURDIR)/xgoja.yaml --output $(BIN) --xgoja-replace $(REPO_ROOT) --keep-work
+
+run:
+	$(BIN) help loupedeck-js-api-reference | grep -F "Loupedeck JavaScript runtime API reference"
+	$(BIN) help loupedeck-js-api-reference | grep -F "loupedeck/state"
+	$(BIN) help loupedeck-js-first-live-script | grep -F "Build your first live Loupedeck JavaScript script"
+
+clean:
+	rm -rf $(CURDIR)/dist

--- a/examples/xgoja/09-provider-shipped-help-docs/README.md
+++ b/examples/xgoja/09-provider-shipped-help-docs/README.md
@@ -1,0 +1,30 @@
+# 09-provider-shipped-help-docs
+
+This example demonstrates provider-shipped Glazed help documents in a generated xgoja binary.
+
+The generated binary imports the Loupedeck xgoja provider and selects its `runtime-api` help source:
+
+```yaml
+help:
+  sources:
+    - id: loupedeck-runtime-api
+      package: loupedeck
+      source: runtime-api
+```
+
+That provider source is registered by the Loupedeck repository from its embedded `docs/help` package. The generated binary therefore exposes the Loupedeck JavaScript API reference without copying the Markdown files into this example.
+
+## Smoke test
+
+```bash
+make smoke
+```
+
+The smoke test validates the spec, builds the generated binary, and checks that these provider-shipped help topics render:
+
+```bash
+./dist/provider-shipped-help-docs help loupedeck-js-api-reference
+./dist/provider-shipped-help-docs help loupedeck-js-first-live-script
+```
+
+This example intentionally enables only a minimal `eval` command and selects only `loupedeck/state` in the runtime profile. The point is documentation bundling, not hardware access.

--- a/examples/xgoja/09-provider-shipped-help-docs/xgoja.yaml
+++ b/examples/xgoja/09-provider-shipped-help-docs/xgoja.yaml
@@ -1,0 +1,29 @@
+name: provider-shipped-help-docs
+target:
+  kind: xgoja
+  output: dist/provider-shipped-help-docs
+packages:
+  - id: loupedeck
+    import: github.com/go-go-golems/loupedeck/pkg/xgoja/provider
+    replace: ../../../../loupedeck
+runtimes:
+  docs:
+    modules:
+      - package: loupedeck
+        name: loupedeck/state
+        as: loupedeck/state
+commands:
+  eval:
+    enabled: true
+    runtime: docs
+  run:
+    enabled: false
+  jsverbs:
+    enabled: false
+  repl:
+    enabled: false
+help:
+  sources:
+    - id: loupedeck-runtime-api
+      package: loupedeck
+      source: runtime-api

--- a/examples/xgoja/README.md
+++ b/examples/xgoja/README.md
@@ -14,6 +14,7 @@ Each example directory has its own `README.md`, `Makefile`, and `xgoja.yaml`. St
 6. `06-runtime-filesystem/` — JS verbs stay on disk and are scanned by the generated binary at runtime.
 7. `07-embedded-jsverbs/` — local JS verbs are copied into the generated workspace and embedded into the binary.
 8. `08-provider-shipped-jsverbs/` — JS verbs live inside a Go provider package and are selected by `package`/`source`.
+9. `09-provider-shipped-help-docs/` — Glazed help pages live inside a Go provider package and are selected by `help.sources[].package`/`source`.
 
 The Discord bot xgoja example lives in the sibling `discord-bot` repository because it demonstrates inserting xgoja into an existing host-owned runner rather than a standalone generated binary.
 
@@ -28,7 +29,8 @@ for dir in \
   05-command-provider \
   06-runtime-filesystem \
   07-embedded-jsverbs \
-  08-provider-shipped-jsverbs; do
+  08-provider-shipped-jsverbs \
+  09-provider-shipped-help-docs; do
   make -C examples/xgoja/$dir smoke
 done
 ```

--- a/pkg/xgoja/app/framework.go
+++ b/pkg/xgoja/app/framework.go
@@ -2,17 +2,26 @@ package app
 
 import (
 	"fmt"
+	"io/fs"
+	"os"
+	"strings"
 
 	"github.com/go-go-golems/glazed/pkg/cmds/logging"
 	"github.com/go-go-golems/glazed/pkg/help"
 	help_cmd "github.com/go-go-golems/glazed/pkg/help/cmd"
 	xgojadoc "github.com/go-go-golems/go-go-goja/pkg/xgoja/doc"
+	"github.com/go-go-golems/go-go-goja/pkg/xgoja/providerapi"
 	"github.com/spf13/cobra"
 )
 
 const rootFrameworkInstalledAnnotation = "xgoja/root-framework-installed"
 
-func installRootFramework(root *cobra.Command, spec *Spec) error {
+type frameworkOptions struct {
+	Providers    *providerapi.Registry
+	EmbeddedHelp fs.FS
+}
+
+func installRootFramework(root *cobra.Command, spec *Spec, opts frameworkOptions) error {
 	if root == nil {
 		return fmt.Errorf("root command is nil")
 	}
@@ -36,8 +45,61 @@ func installRootFramework(root *cobra.Command, spec *Spec) error {
 	if err := xgojadoc.AddDocToHelpSystem(helpSystem); err != nil {
 		return fmt.Errorf("load generated xgoja help docs: %w", err)
 	}
+	if err := loadConfiguredHelpSources(helpSystem, spec, opts); err != nil {
+		return err
+	}
 	help_cmd.SetupCobraRootCommand(helpSystem, root)
 	root.Annotations[rootFrameworkInstalledAnnotation] = "true"
+	return nil
+}
+
+func loadConfiguredHelpSources(helpSystem *help.HelpSystem, spec *Spec, opts frameworkOptions) error {
+	if helpSystem == nil || spec == nil || len(spec.Help.Sources) == 0 {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	for _, source := range spec.Help.Sources {
+		id := strings.TrimSpace(source.ID)
+		if id == "" {
+			return fmt.Errorf("help source id is required")
+		}
+		if _, ok := seen[id]; ok {
+			return fmt.Errorf("duplicate help source %q", id)
+		}
+		seen[id] = struct{}{}
+
+		hasProvider := strings.TrimSpace(source.Package) != "" || strings.TrimSpace(source.Source) != ""
+		if hasProvider {
+			if opts.Providers == nil {
+				return fmt.Errorf("load help source %s: providers registry is required", id)
+			}
+			providerSource, ok := opts.Providers.ResolveHelpSource(source.Package, source.Source)
+			if !ok {
+				return fmt.Errorf("load help source %s: unknown provider help source %s.%s", id, source.Package, source.Source)
+			}
+			if err := helpSystem.LoadSectionsFromFS(providerSource.FS, providerSource.Root); err != nil {
+				return fmt.Errorf("load provider help source %s (%s.%s): %w", id, source.Package, source.Source, err)
+			}
+			continue
+		}
+
+		path := strings.TrimSpace(source.Path)
+		if path == "" {
+			return fmt.Errorf("load help source %s: path or provider source is required", id)
+		}
+		if source.Embed {
+			if opts.EmbeddedHelp == nil {
+				return fmt.Errorf("load help source %s: embedded help filesystem is not configured", id)
+			}
+			if err := helpSystem.LoadSectionsFromFS(opts.EmbeddedHelp, path); err != nil {
+				return fmt.Errorf("load embedded help source %s: %w", id, err)
+			}
+			continue
+		}
+		if err := helpSystem.LoadSectionsFromFS(os.DirFS(path), "."); err != nil {
+			return fmt.Errorf("load filesystem help source %s: %w", id, err)
+		}
+	}
 	return nil
 }
 

--- a/pkg/xgoja/app/host.go
+++ b/pkg/xgoja/app/host.go
@@ -13,11 +13,13 @@ type Host struct {
 	Spec            *Spec
 	Factory         *RuntimeFactory
 	EmbeddedJSVerbs fs.FS
+	EmbeddedHelp    fs.FS
 	Out             io.Writer
 }
 
 type HostOptions struct {
 	EmbeddedJSVerbs fs.FS
+	EmbeddedHelp    fs.FS
 	Out             io.Writer
 }
 
@@ -31,6 +33,7 @@ func NewHostWithOptions(providers *providerapi.Registry, spec *Spec, opts HostOp
 		Spec:            spec,
 		Factory:         NewRuntimeFactory(providers, spec),
 		EmbeddedJSVerbs: opts.EmbeddedJSVerbs,
+		EmbeddedHelp:    opts.EmbeddedHelp,
 		Out:             opts.Out,
 	}
 }

--- a/pkg/xgoja/app/host.go
+++ b/pkg/xgoja/app/host.go
@@ -42,7 +42,7 @@ func (h *Host) AttachDefaultCommands(root *cobra.Command) {
 	if root == nil || h == nil || h.Spec == nil {
 		return
 	}
-	if err := installRootFramework(root, h.Spec); err != nil {
+	if err := installRootFramework(root, h.Spec, frameworkOptions{Providers: h.Providers, EmbeddedHelp: h.EmbeddedHelp}); err != nil {
 		root.PersistentPreRunE = func(cmd *cobra.Command, args []string) error { return err }
 	}
 	if h.Spec.Commands.Eval.Enabled {

--- a/pkg/xgoja/app/root.go
+++ b/pkg/xgoja/app/root.go
@@ -27,6 +27,7 @@ type Options struct {
 	SpecJSON        string
 	Out             io.Writer
 	EmbeddedJSVerbs fs.FS
+	EmbeddedHelp    fs.FS
 }
 
 func NewRootCommand(opts Options) (*cobra.Command, error) {
@@ -37,7 +38,7 @@ func NewRootCommand(opts Options) (*cobra.Command, error) {
 	if err := json.Unmarshal([]byte(opts.SpecJSON), spec); err != nil {
 		return nil, fmt.Errorf("decode embedded xgoja spec: %w", err)
 	}
-	host := NewHostWithOptions(opts.Providers, spec, HostOptions{EmbeddedJSVerbs: opts.EmbeddedJSVerbs, Out: opts.Out})
+	host := NewHostWithOptions(opts.Providers, spec, HostOptions{EmbeddedJSVerbs: opts.EmbeddedJSVerbs, EmbeddedHelp: opts.EmbeddedHelp, Out: opts.Out})
 	root := &cobra.Command{
 		Use:   spec.Name,
 		Short: "Generated xgoja binary",

--- a/pkg/xgoja/app/root_test.go
+++ b/pkg/xgoja/app/root_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"testing/fstest"
 
+	"github.com/dop251/goja"
+	"github.com/dop251/goja_nodejs/require"
 	"github.com/go-go-golems/go-go-goja/pkg/xgoja/providerapi"
 	"github.com/go-go-golems/go-go-goja/pkg/xgoja/testprovider"
 )
@@ -134,6 +136,130 @@ func TestGeneratedRootInstallsHelpAndLogging(t *testing.T) {
 	}
 	if got := out.String(); !bytes.Contains([]byte(got), []byte("generated xgoja runtime overview")) {
 		t.Fatalf("expected generated help topic, got %q", got)
+	}
+}
+
+func TestGeneratedRootLoadsProviderHelpSource(t *testing.T) {
+	registry := providerapi.NewRegistry()
+	docs := fstest.MapFS{
+		"topics/01-fixture.md": {Data: []byte(`---
+Title: Fixture JavaScript API reference
+Slug: fixture-js-api-reference
+Short: Fixture provider docs.
+Topics:
+- fixture
+Commands:
+- fixture
+Flags: []
+IsTopLevel: true
+IsTemplate: false
+ShowPerDefault: true
+SectionType: GeneralTopic
+---
+
+Fixture provider help body.
+`)},
+	}
+	if err := registry.Package("fixture",
+		providerapi.Module{Name: "hello", New: noopAppModuleFactory},
+		providerapi.HelpSource{Name: "docs", FS: docs, Root: "."},
+	); err != nil {
+		t.Fatalf("register provider: %v", err)
+	}
+	specJSON := `{
+  "name": "fixture",
+  "target": {"kind": "xgoja", "output": "dist/fixture"},
+  "packages": [{"id": "fixture"}],
+  "runtimes": {
+    "repl": {"modules": [{"package": "fixture", "name": "hello", "as": "hello"}]}
+  },
+  "commands": {"eval": {"enabled": false}, "jsverbs": {"enabled": false}},
+  "help": {"sources": [{"id": "fixture-docs", "package": "fixture", "source": "docs"}]}
+}`
+	out := &bytes.Buffer{}
+	root, err := NewRootCommand(Options{Providers: registry, SpecJSON: specJSON, Out: out})
+	if err != nil {
+		t.Fatalf("new root: %v", err)
+	}
+	root.SetArgs([]string{"help", "fixture-js-api-reference"})
+	if err := root.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("execute help: %v", err)
+	}
+	if got := out.String(); !bytes.Contains([]byte(got), []byte("Fixture JavaScript API reference")) || !bytes.Contains([]byte(got), []byte("Fixture provider help body")) {
+		t.Fatalf("expected provider help topic, got %q", got)
+	}
+}
+
+func TestGeneratedRootLoadsEmbeddedLocalHelpSource(t *testing.T) {
+	registry := providerapi.NewRegistry()
+	if err := testprovider.Register(registry); err != nil {
+		t.Fatalf("register provider: %v", err)
+	}
+	embeddedHelp := fstest.MapFS{
+		"xgoja_embed/help/local/topics/01-local.md": {Data: []byte(`---
+Title: Local generated help
+Slug: local-generated-help
+Short: Local generated docs.
+Topics:
+- local
+Commands: []
+Flags: []
+IsTopLevel: true
+IsTemplate: false
+ShowPerDefault: true
+SectionType: GeneralTopic
+---
+
+Local generated help body.
+`)},
+	}
+	specJSON := `{
+  "name": "fixture",
+  "target": {"kind": "xgoja", "output": "dist/fixture"},
+  "packages": [{"id": "fixture"}],
+  "runtimes": {
+    "repl": {"modules": [{"package": "fixture", "name": "hello", "as": "hello"}]}
+  },
+  "commands": {"eval": {"enabled": false}, "jsverbs": {"enabled": false}},
+  "help": {"sources": [{"id": "local", "path": "xgoja_embed/help/local", "embed": true}]}
+}`
+	out := &bytes.Buffer{}
+	root, err := NewRootCommand(Options{Providers: registry, SpecJSON: specJSON, Out: out, EmbeddedHelp: embeddedHelp})
+	if err != nil {
+		t.Fatalf("new root: %v", err)
+	}
+	root.SetArgs([]string{"help", "local-generated-help"})
+	if err := root.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("execute help: %v", err)
+	}
+	if got := out.String(); !bytes.Contains([]byte(got), []byte("Local generated help")) || !bytes.Contains([]byte(got), []byte("Local generated help body")) {
+		t.Fatalf("expected embedded local help topic, got %q", got)
+	}
+}
+
+func TestGeneratedRootReportsMissingProviderHelpSource(t *testing.T) {
+	registry := providerapi.NewRegistry()
+	if err := testprovider.Register(registry); err != nil {
+		t.Fatalf("register provider: %v", err)
+	}
+	specJSON := `{
+  "name": "fixture",
+  "target": {"kind": "xgoja", "output": "dist/fixture"},
+  "packages": [{"id": "fixture"}],
+  "runtimes": {
+    "repl": {"modules": [{"package": "fixture", "name": "hello", "as": "hello"}]}
+  },
+  "commands": {"eval": {"enabled": false}, "jsverbs": {"enabled": false}},
+  "help": {"sources": [{"id": "missing", "package": "fixture", "source": "missing"}]}
+}`
+	root, err := NewRootCommand(Options{Providers: registry, SpecJSON: specJSON})
+	if err != nil {
+		t.Fatalf("new root should defer framework errors to execution, got %v", err)
+	}
+	root.SetArgs([]string{"help", "runtime-overview"})
+	err = root.ExecuteContext(context.Background())
+	if err == nil || !bytes.Contains([]byte(err.Error()), []byte("unknown provider help source fixture.missing")) {
+		t.Fatalf("expected missing provider help source error, got %v", err)
 	}
 }
 
@@ -399,4 +525,8 @@ func captureStdout(t *testing.T, fn func()) string {
 		t.Fatalf("read stdout: %v", err)
 	}
 	return string(data)
+}
+
+func noopAppModuleFactory(providerapi.ModuleContext) (require.ModuleLoader, error) {
+	return func(vm *goja.Runtime, module *goja.Object) {}, nil
 }

--- a/pkg/xgoja/app/spec.go
+++ b/pkg/xgoja/app/spec.go
@@ -8,6 +8,7 @@ type Spec struct {
 	Commands         CommandsSpec              `json:"commands"`
 	CommandProviders []CommandProviderInstance `json:"commandProviders,omitempty"`
 	JSVerbs          []JSVerbSourceSpec        `json:"jsverbs,omitempty"`
+	Help             HelpSpec                  `json:"help,omitempty"`
 }
 
 type TargetSpec struct {
@@ -63,6 +64,18 @@ type CommandProviderInstance struct {
 }
 
 type JSVerbSourceSpec struct {
+	ID      string `json:"id"`
+	Path    string `json:"path,omitempty"`
+	Embed   bool   `json:"embed"`
+	Package string `json:"package,omitempty"`
+	Source  string `json:"source,omitempty"`
+}
+
+type HelpSpec struct {
+	Sources []HelpSourceSpec `json:"sources,omitempty"`
+}
+
+type HelpSourceSpec struct {
 	ID      string `json:"id"`
 	Path    string `json:"path,omitempty"`
 	Embed   bool   `json:"embed"`

--- a/pkg/xgoja/providerapi/help.go
+++ b/pkg/xgoja/providerapi/help.go
@@ -1,0 +1,41 @@
+package providerapi
+
+import (
+	"fmt"
+	"io/fs"
+	"strings"
+)
+
+// HelpSource registers a package-owned Glazed help documentation tree.
+//
+// Provider packages use HelpSource for API references, tutorials, and other
+// user-facing docs that should be available from generated xgoja binaries when
+// selected by the buildspec. FS must contain Glazed markdown files and Root is
+// the directory passed to help.HelpSystem.LoadSectionsFromFS.
+type HelpSource struct {
+	Name        string
+	Description string
+	FS          fs.FS
+	Root        string
+}
+
+func (s HelpSource) applyToPackage(pkg *Package) error {
+	return pkg.addHelpSource(s)
+}
+
+func normalizeHelpSource(source HelpSource) (HelpSource, error) {
+	name := strings.TrimSpace(source.Name)
+	if name == "" {
+		return HelpSource{}, fmt.Errorf("help source name is required")
+	}
+	if source.FS == nil {
+		return HelpSource{}, fmt.Errorf("help source %q filesystem is required", name)
+	}
+	source.Name = name
+	source.Description = strings.TrimSpace(source.Description)
+	source.Root = strings.TrimSpace(source.Root)
+	if source.Root == "" {
+		source.Root = "."
+	}
+	return source, nil
+}

--- a/pkg/xgoja/providerapi/registry.go
+++ b/pkg/xgoja/providerapi/registry.go
@@ -19,6 +19,7 @@ type Package struct {
 	ID                  string
 	Modules             map[string]Module
 	VerbSources         map[string]VerbSource
+	HelpSources         map[string]HelpSource
 	PackageCapabilities map[string]PackageCapability
 	CommandSetProviders map[string]CommandSetProvider
 }
@@ -42,6 +43,7 @@ func (r *Registry) Package(id string, entries ...Entry) error {
 		ID:                  id,
 		Modules:             map[string]Module{},
 		VerbSources:         map[string]VerbSource{},
+		HelpSources:         map[string]HelpSource{},
 		PackageCapabilities: map[string]PackageCapability{},
 		CommandSetProviders: map[string]CommandSetProvider{},
 	}
@@ -91,6 +93,18 @@ func (r *Registry) ResolvePackageCapabilities(packageID string) ([]PackageCapabi
 		return nil, false
 	}
 	return pkg.sortedCapabilities(), true
+}
+
+func (r *Registry) ResolveHelpSource(packageID, sourceName string) (HelpSource, bool) {
+	if r == nil {
+		return HelpSource{}, false
+	}
+	pkg := r.packages[strings.TrimSpace(packageID)]
+	if pkg == nil {
+		return HelpSource{}, false
+	}
+	source, ok := pkg.HelpSources[strings.TrimSpace(sourceName)]
+	return source, ok
 }
 
 func (r *Registry) ResolveCommandSetProvider(packageID, providerName string) (CommandSetProvider, bool) {
@@ -173,6 +187,18 @@ func (p *Package) addCapability(capability PackageCapability) error {
 	return nil
 }
 
+func (p *Package) addHelpSource(source HelpSource) error {
+	source, err := normalizeHelpSource(source)
+	if err != nil {
+		return err
+	}
+	if _, ok := p.HelpSources[source.Name]; ok {
+		return fmt.Errorf("duplicate help source %q", source.Name)
+	}
+	p.HelpSources[source.Name] = source
+	return nil
+}
+
 func (p *Package) addCommandSetProvider(provider CommandSetProvider) error {
 	provider, err := normalizeCommandSetProvider(provider)
 	if err != nil {
@@ -190,6 +216,7 @@ func (p *Package) clone() Package {
 		ID:                  p.ID,
 		Modules:             map[string]Module{},
 		VerbSources:         map[string]VerbSource{},
+		HelpSources:         map[string]HelpSource{},
 		PackageCapabilities: map[string]PackageCapability{},
 		CommandSetProviders: map[string]CommandSetProvider{},
 	}
@@ -198,6 +225,9 @@ func (p *Package) clone() Package {
 	}
 	for name, source := range p.VerbSources {
 		out.VerbSources[name] = source
+	}
+	for name, source := range p.HelpSources {
+		out.HelpSources[name] = source
 	}
 	for name, capability := range p.PackageCapabilities {
 		out.PackageCapabilities[name] = capability

--- a/pkg/xgoja/providerapi/registry_test.go
+++ b/pkg/xgoja/providerapi/registry_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"testing/fstest"
 
 	"github.com/dop251/goja"
 	"github.com/dop251/goja_nodejs/require"
@@ -11,12 +12,14 @@ import (
 	"github.com/go-go-golems/glazed/pkg/cmds/values"
 )
 
-func TestRegistryPackageRegistersModulesVerbSourcesAndCapabilities(t *testing.T) {
+func TestRegistryPackageRegistersModulesVerbSourcesHelpSourcesAndCapabilities(t *testing.T) {
+	docs := fstest.MapFS{"topics/intro.md": {Data: []byte("docs")}}
 	registry := NewRegistry()
 	if err := registry.Package("core",
 		Module{Name: "fs", DefaultAs: "fs", New: noopFactory},
 		Module{Name: "yaml", DefaultAs: "yaml", New: noopFactory},
 		VerbSource{Name: "builtin", Root: "verbs"},
+		HelpSource{Name: "docs", Description: "Core docs", FS: docs, Root: "topics"},
 		WithPackageCapability(testCapability{id: "settings"}),
 	); err != nil {
 		t.Fatalf("register package: %v", err)
@@ -36,6 +39,13 @@ func TestRegistryPackageRegistersModulesVerbSourcesAndCapabilities(t *testing.T)
 	if source.Root != "verbs" {
 		t.Fatalf("verb source root = %q", source.Root)
 	}
+	helpSource, ok := registry.ResolveHelpSource("core", "docs")
+	if !ok {
+		t.Fatal("expected core docs help source")
+	}
+	if helpSource.Root != "topics" || helpSource.Description != "Core docs" || helpSource.FS == nil {
+		t.Fatalf("help source = %#v", helpSource)
+	}
 	capabilities, ok := registry.ResolvePackageCapabilities("core")
 	if !ok {
 		t.Fatal("expected core capabilities")
@@ -49,6 +59,9 @@ func TestRegistryPackageRegistersModulesVerbSourcesAndCapabilities(t *testing.T)
 	}
 	if len(packages[0].PackageCapabilities) != 1 {
 		t.Fatalf("cloned package capabilities = %#v", packages[0].PackageCapabilities)
+	}
+	if len(packages[0].HelpSources) != 1 {
+		t.Fatalf("cloned help sources = %#v", packages[0].HelpSources)
 	}
 }
 
@@ -72,6 +85,12 @@ func TestRegistryRejectsDuplicates(t *testing.T) {
 		t.Fatalf("expected duplicate verb source error, got %v", err)
 	}
 
+	docs := fstest.MapFS{"intro.md": {Data: []byte("docs")}}
+	err = NewRegistry().Package("docs", HelpSource{Name: "default", FS: docs}, HelpSource{Name: "default", FS: docs})
+	if err == nil || !strings.Contains(err.Error(), "duplicate help source") {
+		t.Fatalf("expected duplicate help source error, got %v", err)
+	}
+
 	err = NewRegistry().Package("caps", WithPackageCapability(testCapability{id: "settings"}), WithPackageCapability(testCapability{id: "settings"}))
 	if err == nil || !strings.Contains(err.Error(), "duplicate capability") {
 		t.Fatalf("expected duplicate capability error, got %v", err)
@@ -90,6 +109,12 @@ func TestRegistryRejectsInvalidEntries(t *testing.T) {
 	}
 	if err := NewRegistry().Package("core", VerbSource{Name: ""}); err == nil || !strings.Contains(err.Error(), "verb source name") {
 		t.Fatalf("expected verb source name error, got %v", err)
+	}
+	if err := NewRegistry().Package("core", HelpSource{Name: ""}); err == nil || !strings.Contains(err.Error(), "help source name") {
+		t.Fatalf("expected help source name error, got %v", err)
+	}
+	if err := NewRegistry().Package("core", HelpSource{Name: "docs"}); err == nil || !strings.Contains(err.Error(), "filesystem") {
+		t.Fatalf("expected help source filesystem error, got %v", err)
 	}
 	if err := NewRegistry().Package("core", WithPackageCapability(nil)); err == nil || !strings.Contains(err.Error(), "capability is nil") {
 		t.Fatalf("expected nil capability error, got %v", err)

--- a/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/README.md
+++ b/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/README.md
@@ -1,0 +1,21 @@
+# Add Glazed help documents to xgoja binaries
+
+This is the document workspace for ticket XGOJA-015.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr doc add --ticket XGOJA-015 --doc-type design-doc --title "My Design"`
+- Import sources: `docmgr import file --ticket XGOJA-015 --file /path/to/doc.md`
+- Update metadata: `docmgr meta update --ticket XGOJA-015 --field Status --value review`

--- a/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/changelog.md
+++ b/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/changelog.md
@@ -23,3 +23,24 @@ Recorded validation and reMarkable delivery evidence in the investigation diary.
 
 - /home/manuel/workspaces/2026-05-31/xgoja-docs/go-go-goja/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/reference/01-investigation-diary.md — Diary now includes docmgr doctor and reMarkable upload evidence
 
+
+## 2026-05-31
+
+Implemented Glazed help document support for xgoja binaries across providerapi, buildspec validation, generator embedding, generated root loading, Loupedeck provider docs registration, and xgoja help docs. go-go-goja commits: 13d30d0, e006c2c, 1dec2ba, 4c646d9, 2c6b112; loupedeck commit: b5825fa.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-05-31/xgoja-docs/go-go-goja/pkg/xgoja/app/framework.go — Loads configured help sources
+- /home/manuel/workspaces/2026-05-31/xgoja-docs/go-go-goja/pkg/xgoja/providerapi/help.go — New HelpSource API
+- /home/manuel/workspaces/2026-05-31/xgoja-docs/loupedeck/runtime/js/provider/provider.go — Registers loupedeck.runtime-api help source
+
+
+## 2026-05-31
+
+Finalized implementation diary/tasks after docmgr validation and reMarkable upload to /ai/2026/05/31/XGOJA-015/XGOJA-015 Glazed help docs implementation final.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-05-31/xgoja-docs/go-go-goja/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/reference/01-investigation-diary.md — Final validation and upload evidence
+- /home/manuel/workspaces/2026-05-31/xgoja-docs/go-go-goja/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/tasks.md — Implementation checklist status
+

--- a/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/changelog.md
+++ b/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/changelog.md
@@ -44,3 +44,13 @@ Finalized implementation diary/tasks after docmgr validation and reMarkable uplo
 - /home/manuel/workspaces/2026-05-31/xgoja-docs/go-go-goja/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/reference/01-investigation-diary.md — Final validation and upload evidence
 - /home/manuel/workspaces/2026-05-31/xgoja-docs/go-go-goja/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/tasks.md — Implementation checklist status
 
+
+## 2026-05-31
+
+Added examples/xgoja/09-provider-shipped-help-docs and manually smoke-tested a generated binary that loads Loupedeck provider-shipped help docs via help loupedeck-js-api-reference and help loupedeck-js-first-live-script.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-05-31/xgoja-docs/go-go-goja/examples/xgoja/09-provider-shipped-help-docs/Makefile — Manual smoke test target
+- /home/manuel/workspaces/2026-05-31/xgoja-docs/go-go-goja/examples/xgoja/09-provider-shipped-help-docs/xgoja.yaml — Reference buildspec for provider-shipped help docs
+

--- a/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/changelog.md
+++ b/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/changelog.md
@@ -1,0 +1,25 @@
+# Changelog
+
+## 2026-05-31
+
+- Initial workspace created
+
+
+## 2026-05-31
+
+Created research/design package for bundling Glazed help documents into generated xgoja binaries, including provider HelpSource API sketch, help.sources buildspec design, generation/app wiring plan, test strategy, and diary.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-05-31/xgoja-docs/go-go-goja/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/design-doc/01-glazed-help-documents-for-xgoja-binaries-implementation-guide.md — Primary XGOJA-015 design deliverable
+- /home/manuel/workspaces/2026-05-31/xgoja-docs/go-go-goja/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/reference/01-investigation-diary.md — Chronological investigation diary
+
+
+## 2026-05-31
+
+Recorded validation and reMarkable delivery evidence in the investigation diary.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-05-31/xgoja-docs/go-go-goja/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/reference/01-investigation-diary.md — Diary now includes docmgr doctor and reMarkable upload evidence
+

--- a/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/design-doc/01-glazed-help-documents-for-xgoja-binaries-implementation-guide.md
+++ b/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/design-doc/01-glazed-help-documents-for-xgoja-binaries-implementation-guide.md
@@ -21,6 +21,10 @@ RelatedFiles:
       Note: Generated main template that needs embedded help filesystem wiring
     - Path: go-go-goja/cmd/xgoja/root.go
       Note: Standalone xgoja Glazed help setup pattern
+    - Path: go-go-goja/examples/xgoja/09-provider-shipped-help-docs/Makefile
+      Note: Reusable smoke test for help loupedeck-js-api-reference
+    - Path: go-go-goja/examples/xgoja/09-provider-shipped-help-docs/xgoja.yaml
+      Note: Manual smoke-test buildspec for provider-shipped Loupedeck help docs
     - Path: go-go-goja/pkg/xgoja/app/framework.go
       Note: |-
         Generated binary root framework and current built-in help loader
@@ -43,6 +47,7 @@ LastUpdated: 2026-05-31T11:30:00-04:00
 WhatFor: Use when implementing support for additional Glazed help documents in generated xgoja binaries.
 WhenToUse: Read before changing xgoja buildspec parsing, code generation, provider registration, or generated root help wiring.
 ---
+
 
 
 

--- a/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/design-doc/01-glazed-help-documents-for-xgoja-binaries-implementation-guide.md
+++ b/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/design-doc/01-glazed-help-documents-for-xgoja-binaries-implementation-guide.md
@@ -1,0 +1,1290 @@
+---
+Title: Glazed Help Documents for xgoja Binaries Implementation Guide
+Ticket: XGOJA-015
+Status: active
+Topics:
+    - xgoja
+    - glazed
+    - help-system
+    - documentation
+DocType: design-doc
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: go-go-goja/cmd/xgoja/internal/buildspec/spec.go
+      Note: Buildspec schema that needs help.sources support
+    - Path: go-go-goja/cmd/xgoja/internal/generate/templates/main.go.tmpl
+      Note: Generated main template that needs embedded help filesystem wiring
+    - Path: go-go-goja/cmd/xgoja/root.go
+      Note: Standalone xgoja Glazed help setup pattern
+    - Path: go-go-goja/pkg/xgoja/app/framework.go
+      Note: Generated binary root framework and current built-in help loader
+    - Path: go-go-goja/pkg/xgoja/providerapi/registry.go
+      Note: Provider registry extension point for HelpSource
+    - Path: loupedeck/docs/help/topics/01-loupedeck-js-api-reference.md
+      Note: Example Glazed API reference to bundle into xgoja binaries
+    - Path: loupedeck/runtime/js/provider/provider.go
+      Note: Loupedeck provider registration point for provider-shipped docs
+ExternalSources: []
+Summary: Design and implementation guide for bundling project-local and provider-shipped Glazed help entries into generated xgoja binaries.
+LastUpdated: 2026-05-31T11:30:00-04:00
+WhatFor: Use when implementing support for additional Glazed help documents in generated xgoja binaries.
+WhenToUse: Read before changing xgoja buildspec parsing, code generation, provider registration, or generated root help wiring.
+---
+
+
+# Glazed Help Documents for xgoja Binaries Implementation Guide
+
+## Executive summary
+
+This guide explains how to extend `xgoja` so generated binaries can bundle extra Glazed help entries, such as API references and tutorials for the provider packages selected by `xgoja.yaml`. The motivating example is the Loupedeck API reference at `loupedeck/docs/help/topics/01-loupedeck-js-api-reference.md`, which is already written in Glazed help format and should become available from an xgoja-generated Loupedeck binary as `help loupedeck-js-api-reference`.
+
+The current system already has the right foundation. The standalone `xgoja` CLI loads embedded help pages from `cmd/xgoja/doc` and registers them with `help_cmd.SetupCobraRootCommand(...)` (`go-go-goja/cmd/xgoja/root.go:57-61`). Generated binaries also install a root framework that loads generic generated-runtime help pages from `pkg/xgoja/doc` (`go-go-goja/pkg/xgoja/app/framework.go:35-39`). Provider packages can currently contribute modules, JavaScript verb sources, package capabilities, and command sets through `providerapi.Registry` (`go-go-goja/pkg/xgoja/providerapi/registry.go:18-24`), but they cannot contribute help sources. The buildspec can currently declare `packages`, `runtimes`, `commands`, `commandProviders`, and `jsverbs`, but it has no `help` or `helpDocs` field (`go-go-goja/cmd/xgoja/internal/buildspec/spec.go:5-14`).
+
+The recommended implementation is to add one new documentation path that mirrors the existing JavaScript verb source path:
+
+1. A provider-facing `providerapi.HelpSource` entry that stores `fs.FS` + root directory metadata in the registry.
+2. A buildspec `help.sources` list that can point either at provider-shipped help sources or local filesystem help directories.
+3. A generated-binary embed path under `xgoja_embed/help/<source-id>` for local help directories that should be bundled into the binary.
+4. An app-layer loader that always loads generic xgoja docs first, then loads provider/spec help sources into the same `*help.HelpSystem`, then calls `help_cmd.SetupCobraRootCommand(...)` exactly once.
+
+The design keeps documentation close to the package that owns the API, while preserving xgoja's compile-time model. Provider packages describe their native modules and their documentation in one registration function. Application authors opt into the help sources they want in `xgoja.yaml`, just as they already opt into modules, command providers, and JavaScript verb sources.
+
+## Problem statement and scope
+
+Generated xgoja binaries are increasingly domain-specific. A Loupedeck-generated binary is not just a generic JavaScript shell; it exposes `loupedeck/state`, `loupedeck/ui`, `loupedeck/anim`, `loupedeck/easing`, scene verbs, hardware flags, and provider-owned commands. Users need a way to discover that API from the binary they are running, not by browsing the source repository.
+
+Today, the help story is split:
+
+- The `xgoja` builder CLI has its own embedded help docs.
+- Generated xgoja binaries have generic runtime help docs.
+- Domain repositories such as `loupedeck` already contain rich Glazed help docs, but those docs are wired only into their standalone CLI.
+- Provider registration exposes modules and commands to xgoja, but not documentation.
+
+The goal is **not** to invent a second documentation format. The goal is to make existing Glazed help entries bundle cleanly into generated xgoja binaries.
+
+In scope:
+
+- buildspec schema for declaring help sources,
+- provider API for provider-shipped help sources,
+- generation-time copying and embedding of local help directories,
+- generated root loading of built-in, provider, and local help entries,
+- tests and smoke commands to prove `help <slug>` works from generated binaries,
+- guidance for writing good Glazed help pages.
+
+Out of scope for the first implementation:
+
+- dynamic documentation fetched from a network service,
+- non-Markdown documentation formats,
+- a web documentation renderer,
+- automatic API extraction from Go or JavaScript source,
+- backwards-compatible aliases for old, undocumented config shapes.
+
+## System overview for a new intern
+
+### What Glazed help is
+
+Glazed help entries are Markdown files with YAML frontmatter. Each file becomes a searchable help section. The frontmatter gives the section a title, slug, short summary, tags, related commands, related flags, top-level visibility, and a section type.
+
+The Loupedeck API reference is a good example. Its first lines define a user-facing API reference with slug `loupedeck-js-api-reference`, topics such as `loupedeck`, `javascript`, and `goja`, command/flag tags, and `SectionType: GeneralTopic` (`loupedeck/docs/help/topics/01-loupedeck-js-api-reference.md:1-27`). The body then explains the runtime model in prose before listing module APIs (`loupedeck/docs/help/topics/01-loupedeck-js-api-reference.md:29-45`).
+
+A help package usually embeds Markdown files and exposes an `AddDocToHelpSystem` helper. Loupedeck does exactly this:
+
+```go
+// loupedeck/docs/help/doc.go
+//go:embed topics/*.md tutorials/*.md
+var docFS embed.FS
+
+func AddDocToHelpSystem(helpSystem *help.HelpSystem) error {
+    return helpSystem.LoadSectionsFromFS(docFS, ".")
+}
+```
+
+The standalone Loupedeck CLI creates a help system, loads those docs, and registers the enhanced help command on its Cobra root (`loupedeck/cmd/loupedeck/main.go:31-33`). That is the pattern xgoja should reproduce for generated binaries.
+
+### What xgoja is
+
+`xgoja` builds custom Goja-powered binaries from a declarative `xgoja.yaml`. The builder reads the spec, generates a temporary Go module, writes a generated `main.go`, embeds a normalized JSON spec, imports provider packages, calls provider registration functions, and then builds a binary with the Go toolchain.
+
+The generated binary has three important pieces:
+
+- a provider registry containing the packages that were compiled into the binary,
+- a runtime spec that says which provider modules are selected by each runtime profile,
+- a Cobra root command with built-in and provider-owned commands.
+
+At runtime, the generated binary does not discover arbitrary Go packages dynamically. The provider packages are normal Go imports in generated source. This compile-time model is why documentation should also be registered through provider packages or copied into the generated build workspace before compilation.
+
+### Current generated-binary startup flow
+
+The generated `main.go` template imports the selected providers, registers them, constructs the app root, and executes it (`go-go-goja/cmd/xgoja/internal/generate/templates/main.go.tmpl:32-54`). In pure xgoja target mode, it calls `app.NewRootCommand(...)` (`go-go-goja/cmd/xgoja/internal/generate/templates/main.go.tmpl:47-49`). In Cobra target mode, it builds a host and calls `host.AttachDefaultCommands(root)` (`go-go-goja/cmd/xgoja/internal/generate/templates/main.go.tmpl:42-46`).
+
+The app root decodes the embedded JSON spec, creates a `Host`, creates a Cobra root, and asks the host to attach the default commands (`go-go-goja/pkg/xgoja/app/root.go:25-49`). The host installs the root framework first, then attaches `eval`, `run`, `repl`, `modules`, `verbs`, and provider commands (`go-go-goja/pkg/xgoja/app/host.go:38-59`). The root framework adds logging flags and installs the help command (`go-go-goja/pkg/xgoja/app/framework.go:29-40`).
+
+Current flow:
+
+```text
+xgoja.yaml
+  -> buildspec.LoadFile + Validate
+  -> generate.WriteAll
+       -> generated go.mod
+       -> generated main.go
+       -> xgoja.gen.json
+       -> optional embedded JS verbs
+  -> go build
+  -> generated binary starts
+       -> providerapi.NewRegistry()
+       -> provider.Register(registry)
+       -> app.NewRootCommand(...) or host.AttachDefaultCommands(...)
+       -> installRootFramework(...)
+       -> load pkg/xgoja/doc only
+       -> help_cmd.SetupCobraRootCommand(...)
+```
+
+The missing piece is visible in `installRootFramework`: it loads only `pkg/xgoja/doc` (`go-go-goja/pkg/xgoja/app/framework.go:35-37`). It does not see the provider registry, the spec's desired documentation sources, or an embedded help filesystem.
+
+## Current-state evidence
+
+### xgoja already knows how to load embedded Glazed help
+
+The standalone builder CLI embeds Markdown help pages in `cmd/xgoja/doc` and exposes `AddDocToHelpSystem` (`go-go-goja/cmd/xgoja/doc/doc.go:9-13`). The root command then creates a `help.NewHelpSystem()`, loads the docs, and calls `help_cmd.SetupCobraRootCommand(helpSystem, root)` (`go-go-goja/cmd/xgoja/root.go:57-61`).
+
+Generated binaries use the same idea through `pkg/xgoja/doc` and `installRootFramework` (`go-go-goja/pkg/xgoja/app/framework.go:35-39`). This means the new work does not need to teach xgoja what Glazed help is. It needs to broaden which docs are loaded before the one existing `SetupCobraRootCommand` call.
+
+### The provider registry has extensible package entries, but no help entry
+
+The registry package currently stores four maps per package: modules, verb sources, package capabilities, and command set providers (`go-go-goja/pkg/xgoja/providerapi/registry.go:18-24`). It can resolve verb sources and command set providers by package/name (`go-go-goja/pkg/xgoja/providerapi/registry.go:73-106`). It has validation helpers for duplicate verb sources and command set providers (`go-go-goja/pkg/xgoja/providerapi/registry.go:149-185`).
+
+That shape is ideal for help sources: provider-shipped help documents should be another package entry, just like `VerbSource` (`go-go-goja/pkg/xgoja/providerapi/verbs.go:5-13`).
+
+### The buildspec has a source-list pattern already
+
+The buildspec already has `JSVerbSourceSpec`, which can reference a filesystem path or a provider source (`go-go-goja/cmd/xgoja/internal/buildspec/spec.go:87-93`). Validation enforces IDs, provider source shape, known packages, and filesystem path existence for embedded sources (`go-go-goja/cmd/xgoja/internal/buildspec/validate.go:197-235`). Generation copies embedded JS verb directories into `xgoja_embed/jsverbs/<source-id>` (`go-go-goja/cmd/xgoja/internal/generate/generate.go:49-65`) and rewrites the embedded runtime spec so the generated binary points at the embedded path.
+
+Help docs can reuse this pattern almost exactly, with one important difference: help docs are loaded during root initialization, not when a JavaScript verb command is invoked.
+
+### Loupedeck has the target documentation already
+
+The Loupedeck provider registers runtime modules and a command set under package ID `loupedeck` (`loupedeck/runtime/js/provider/provider.go:49-68`). Its docs live in `loupedeck/docs/help`, and the standalone CLI already loads them (`loupedeck/docs/help/doc.go:9-13`, `loupedeck/cmd/loupedeck/main.go:31-33`). The design should let this same documentation package be surfaced through the xgoja provider without copying the Markdown into go-go-goja.
+
+## Gap analysis
+
+The current system lacks four contracts:
+
+1. **Provider documentation contract.** There is no `providerapi.HelpSource` equivalent to `providerapi.VerbSource`.
+2. **Buildspec documentation contract.** There is no `help.sources` list for local or provider-shipped help docs.
+3. **Generated embed path.** The generator embeds JavaScript verb directories, but not help directories (`go-go-goja/cmd/xgoja/internal/generate/templates/main.go.tmpl:27-30`).
+4. **Root help loading context.** `installRootFramework` currently receives only `root` and `spec`; it needs provider registry and embedded help filesystem information to load additional docs.
+
+These gaps explain why `loupedeck help loupedeck-js-api-reference` works in the standalone CLI while a generated xgoja Loupedeck binary cannot show the same page.
+
+## Proposed architecture
+
+### Design principle
+
+Treat documentation as a first-class xgoja package contribution, but keep user choice in the buildspec.
+
+Provider packages should be able to say, "I have a help source named `runtime-api`." The generated binary author should then be able to say, "Include `loupedeck.runtime-api` in this binary." This keeps large or specialized docs opt-in while making them easy to wire.
+
+### New concepts
+
+| Concept | Owner | Purpose |
+|---|---|---|
+| Built-in generated help | `go-go-goja/pkg/xgoja/doc` | Generic help for all generated xgoja binaries. |
+| Provider help source | Provider package | Package-owned docs such as Loupedeck API references. |
+| Local help source | `xgoja.yaml` author | Project-specific docs shipped with one generated binary. |
+| Embedded help filesystem | Generated `main.go` | Bundled copy of local docs under `xgoja_embed/help/...`. |
+| Help loader | `pkg/xgoja/app` | Merges built-in, provider, and local docs into one Glazed help system. |
+
+### Target user experience
+
+A Loupedeck-oriented `xgoja.yaml` should be able to declare:
+
+```yaml
+name: loupedeck-workbench
+packages:
+  - id: loupedeck
+    import: github.com/go-go-golems/loupedeck/pkg/xgoja/provider
+    version: v0.0.0
+
+runtimes:
+  scene:
+    modules:
+      - package: loupedeck
+        name: loupedeck/state
+        as: loupedeck/state
+      - package: loupedeck
+        name: loupedeck/ui
+        as: loupedeck/ui
+
+commands:
+  run:
+    enabled: true
+    runtime: scene
+
+help:
+  sources:
+    - id: loupedeck-runtime-api
+      package: loupedeck
+      source: runtime-api
+```
+
+After building, the generated binary should support:
+
+```bash
+./loupedeck-workbench help
+./loupedeck-workbench help loupedeck-js-api-reference
+./loupedeck-workbench help type:tutorial
+./loupedeck-workbench run --help
+```
+
+For project-local docs:
+
+```yaml
+help:
+  sources:
+    - id: project-tutorials
+      path: ./docs/help
+      embed: true
+```
+
+The generated build workspace should contain:
+
+```text
+xgoja_embed/
+  help/
+    project_tutorials/
+      topics/
+        01-api.md
+      tutorials/
+        01-getting-started.md
+```
+
+The embedded runtime spec should point at `xgoja_embed/help/project_tutorials`, so the generated app loader can load it from `embeddedHelp`.
+
+### Architecture diagram
+
+```mermaid
+flowchart TD
+    Spec[xgoja.yaml] --> Load[buildspec.LoadFile]
+    Load --> Validate[buildspec.Validate]
+    Validate --> Generate[generate.WriteAll]
+    Generate --> Main[generated main.go]
+    Generate --> HelpCopy[xgoja_embed/help/...]
+    Main --> Registry[providerapi.Registry]
+    Registry --> ProviderRegister[provider Register functions]
+    ProviderRegister --> ProviderHelp[providerapi.HelpSource entries]
+    Main --> AppRoot[app.NewRootCommand or Host.AttachDefaultCommands]
+    AppRoot --> Framework[installRootFramework]
+    Framework --> BuiltinDocs[pkg/xgoja/doc]
+    Framework --> ProviderHelp
+    Framework --> EmbeddedHelp[embedded local help FS]
+    BuiltinDocs --> HelpSystem[glazed help.HelpSystem]
+    ProviderHelp --> HelpSystem
+    EmbeddedHelp --> HelpSystem
+    HelpSystem --> CobraHelp[help_cmd.SetupCobraRootCommand]
+```
+
+### Sequence diagram
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Binary as generated binary
+    participant Registry as providerapi.Registry
+    participant App as pkg/xgoja/app
+    participant Help as Glazed HelpSystem
+
+    User->>Binary: ./tool help loupedeck-js-api-reference
+    Binary->>Registry: provider.Register(registry)
+    Registry-->>Binary: modules, commands, help sources
+    Binary->>App: NewRootCommand(... EmbeddedHelp ...)
+    App->>Help: Load pkg/xgoja/doc
+    App->>Help: Load provider help sources selected by spec
+    App->>Help: Load embedded local help sources selected by spec
+    App->>Binary: Cobra root with Glazed help command
+    Binary->>Help: GetSectionWithSlug("loupedeck-js-api-reference")
+    Help-->>User: Rendered API reference
+```
+
+## API design
+
+### Provider API: HelpSource
+
+Add a new file such as `pkg/xgoja/providerapi/help.go`:
+
+```go
+package providerapi
+
+import (
+    "fmt"
+    "io/fs"
+    "strings"
+)
+
+type HelpSource struct {
+    Name        string
+    Description string
+    FS          fs.FS
+    Root        string
+}
+
+func (s HelpSource) applyToPackage(pkg *Package) error {
+    return pkg.addHelpSource(s)
+}
+
+func normalizeHelpSource(source HelpSource) (HelpSource, error) {
+    name := strings.TrimSpace(source.Name)
+    if name == "" {
+        return HelpSource{}, fmt.Errorf("help source name is required")
+    }
+    if source.FS == nil {
+        return HelpSource{}, fmt.Errorf("help source %q filesystem is required", name)
+    }
+    source.Name = name
+    source.Description = strings.TrimSpace(source.Description)
+    source.Root = strings.TrimSpace(source.Root)
+    if source.Root == "" {
+        source.Root = "."
+    }
+    return source, nil
+}
+```
+
+Extend `Package` and `Registry`:
+
+```go
+type Package struct {
+    ID                  string
+    Modules             map[string]Module
+    VerbSources         map[string]VerbSource
+    HelpSources         map[string]HelpSource
+    PackageCapabilities map[string]PackageCapability
+    CommandSetProviders map[string]CommandSetProvider
+}
+
+func (r *Registry) ResolveHelpSource(packageID, sourceName string) (HelpSource, bool) {
+    if r == nil {
+        return HelpSource{}, false
+    }
+    pkg := r.packages[strings.TrimSpace(packageID)]
+    if pkg == nil {
+        return HelpSource{}, false
+    }
+    source, ok := pkg.HelpSources[strings.TrimSpace(sourceName)]
+    return source, ok
+}
+
+func (p *Package) addHelpSource(source HelpSource) error {
+    source, err := normalizeHelpSource(source)
+    if err != nil {
+        return err
+    }
+    if _, ok := p.HelpSources[source.Name]; ok {
+        return fmt.Errorf("duplicate help source %q", source.Name)
+    }
+    p.HelpSources[source.Name] = source
+    return nil
+}
+```
+
+Rationale:
+
+- This mirrors `VerbSource`, so provider authors learn one pattern.
+- It keeps provider docs package-owned and compile-time safe.
+- It avoids importing `github.com/go-go-golems/glazed/pkg/help` into provider registration code; the app layer owns loading into `HelpSystem`.
+- It gives the registry enough information to report duplicates early.
+
+### Buildspec API: help.sources
+
+Add to `cmd/xgoja/internal/buildspec/spec.go`:
+
+```go
+type Spec struct {
+    Name             string                    `yaml:"name"`
+    Go               GoSpec                    `yaml:"go"`
+    Target           TargetSpec                `yaml:"target"`
+    Packages         []PackageSpec             `yaml:"packages"`
+    Runtimes         map[string]Runtime        `yaml:"runtimes"`
+    Commands         CommandsSpec              `yaml:"commands"`
+    CommandProviders []CommandProviderInstance `yaml:"commandProviders"`
+    JSVerbs          []JSVerbSourceSpec        `yaml:"jsverbs"`
+    Help             HelpSpec                  `yaml:"help"`
+    BaseDir          string                    `yaml:"-"`
+}
+
+type HelpSpec struct {
+    Sources []HelpSourceSpec `yaml:"sources" json:"sources,omitempty"`
+}
+
+type HelpSourceSpec struct {
+    ID      string `yaml:"id" json:"id"`
+    Path    string `yaml:"path" json:"path,omitempty"`
+    Embed   bool   `yaml:"embed" json:"embed"`
+    Package string `yaml:"package" json:"package,omitempty"`
+    Source  string `yaml:"source" json:"source,omitempty"`
+}
+```
+
+Add corresponding runtime types to `pkg/xgoja/app/spec.go`:
+
+```go
+type Spec struct {
+    // existing fields...
+    Help HelpSpec `json:"help,omitempty"`
+}
+
+type HelpSpec struct {
+    Sources []HelpSourceSpec `json:"sources,omitempty"`
+}
+
+type HelpSourceSpec struct {
+    ID      string `json:"id"`
+    Path    string `json:"path,omitempty"`
+    Embed   bool   `json:"embed"`
+    Package string `json:"package,omitempty"`
+    Source  string `json:"source,omitempty"`
+}
+```
+
+Rationale:
+
+- `help.sources` leaves space for future help-level settings without flattening the top-level spec.
+- The source shape intentionally matches `JSVerbSourceSpec`; users can transfer their mental model.
+- `Package` + `Source` means "load a provider-registered help source".
+- `Path` + `Embed` means "load docs from a local directory, optionally bundled into the binary".
+
+### Provider docs package API
+
+Provider packages need access to an `fs.FS`. The existing Loupedeck docs package exposes only `AddDocToHelpSystem`, and its embedded `docFS` is private (`loupedeck/docs/help/doc.go:9-13`). Add one small export:
+
+```go
+package doc
+
+import "io/fs"
+
+func FS() fs.FS {
+    return docFS
+}
+```
+
+Then provider registration can include:
+
+```go
+import helpdoc "github.com/go-go-golems/loupedeck/docs/help"
+
+func Register(registry *providerapi.Registry) error {
+    hardware := newHardwareCapability()
+    return registry.Package(PackageID,
+        // existing modules/capabilities/command providers...
+        providerapi.HelpSource{
+            Name:        "runtime-api",
+            Description: "Loupedeck JavaScript runtime API reference and tutorials",
+            FS:          helpdoc.FS(),
+            Root:        ".",
+        },
+        providerapi.WithPackageCapability(hardware),
+    )
+}
+```
+
+Do not import the standalone `cmd/loupedeck` package from provider registration. The provider should depend on a small docs package, not on the application entrypoint.
+
+### App-layer loading API
+
+Extend app options:
+
+```go
+type Options struct {
+    Providers       *providerapi.Registry
+    SpecJSON        string
+    Out             io.Writer
+    EmbeddedJSVerbs fs.FS
+    EmbeddedHelp    fs.FS
+}
+
+type HostOptions struct {
+    EmbeddedJSVerbs fs.FS
+    EmbeddedHelp    fs.FS
+    Out             io.Writer
+}
+```
+
+Change `installRootFramework` so it can load selected provider/local help sources:
+
+```go
+type frameworkOptions struct {
+    Providers    *providerapi.Registry
+    EmbeddedHelp fs.FS
+}
+
+func installRootFramework(root *cobra.Command, spec *Spec, opts frameworkOptions) error {
+    // existing logging setup...
+
+    helpSystem := help.NewHelpSystem()
+    if err := xgojadoc.AddDocToHelpSystem(helpSystem); err != nil {
+        return fmt.Errorf("load generated xgoja help docs: %w", err)
+    }
+    if err := loadConfiguredHelpSources(helpSystem, spec, opts); err != nil {
+        return err
+    }
+    help_cmd.SetupCobraRootCommand(helpSystem, root)
+    return nil
+}
+```
+
+Loader pseudocode:
+
+```go
+func loadConfiguredHelpSources(hs *help.HelpSystem, spec *Spec, opts frameworkOptions) error {
+    if spec == nil {
+        return nil
+    }
+    seenIDs := map[string]struct{}{}
+
+    for _, source := range spec.Help.Sources {
+        id := strings.TrimSpace(source.ID)
+        if id == "" {
+            return fmt.Errorf("help source id is required")
+        }
+        if _, ok := seenIDs[id]; ok {
+            return fmt.Errorf("duplicate help source %q", id)
+        }
+        seenIDs[id] = struct{}{}
+
+        switch {
+        case source.Package != "" || source.Source != "":
+            if source.Package == "" || source.Source == "" {
+                return fmt.Errorf("help source %s: provider sources require both package and source", id)
+            }
+            providerSource, ok := opts.Providers.ResolveHelpSource(source.Package, source.Source)
+            if !ok {
+                return fmt.Errorf("help source %s: unknown provider help source %s.%s", id, source.Package, source.Source)
+            }
+            if err := hs.LoadSectionsFromFS(providerSource.FS, defaultRoot(providerSource.Root)); err != nil {
+                return fmt.Errorf("load provider help source %s (%s.%s): %w", id, source.Package, source.Source, err)
+            }
+
+        case source.Path != "" && source.Embed:
+            if opts.EmbeddedHelp == nil {
+                return fmt.Errorf("help source %s: embedded help filesystem is not configured", id)
+            }
+            if err := hs.LoadSectionsFromFS(opts.EmbeddedHelp, source.Path); err != nil {
+                return fmt.Errorf("load embedded help source %s: %w", id, err)
+            }
+
+        case source.Path != "":
+            if err := hs.LoadSectionsFromFS(os.DirFS(source.Path), "."); err != nil {
+                return fmt.Errorf("load filesystem help source %s: %w", id, err)
+            }
+
+        default:
+            return fmt.Errorf("help source %s: path or provider source is required", id)
+        }
+    }
+    return nil
+}
+```
+
+Important detail: for non-embedded filesystem paths, resolve relative paths at buildspec load time or store an absolute path in the runtime spec. A generated binary might run from a different working directory than the original `xgoja.yaml`. The safer first implementation is to support `embed: true` for local docs and treat non-embedded docs as a developer-only mode with an absolute path in the generated spec.
+
+### Code-generation API
+
+Split the current `HasEmbedded` boolean into purpose-specific booleans, because a generated binary can embed JS verbs, help docs, or both:
+
+```go
+type mainTemplateData struct {
+    SpecJSON          string
+    HasEmbedded       bool // any embed.FS needed
+    HasEmbeddedJSVerb bool
+    HasEmbeddedHelp   bool
+    // existing fields...
+}
+```
+
+Template sketch:
+
+```go
+{{- if .HasEmbeddedJSVerb }}
+//go:embed xgoja_embed/jsverbs/*
+var embeddedJSVerbs embed.FS
+{{- end }}
+
+{{- if .HasEmbeddedHelp }}
+//go:embed xgoja_embed/help/*
+var embeddedHelp embed.FS
+{{- end }}
+```
+
+Host construction sketch:
+
+```go
+host := app.NewHostWithOptions(registry, spec, app.HostOptions{
+    EmbeddedJSVerbs: embeddedJSVerbs,
+    EmbeddedHelp:    embeddedHelp,
+})
+
+root, err := app.NewRootCommand(app.Options{
+    Providers:       registry,
+    SpecJSON:        embeddedSpecJSON,
+    EmbeddedJSVerbs: embeddedJSVerbs,
+    EmbeddedHelp:    embeddedHelp,
+})
+```
+
+Generator changes mirror existing JS verb helpers:
+
+- `hasEmbeddedHelpSources(spec)`
+- `embeddedHelpRoots(spec)`
+- `copyEmbeddedHelpSources(dir, spec)`
+- `runtimeSpec(spec)` rewrites embedded local help paths to `xgoja_embed/help/<source-id>`
+- `RenderEmbeddedSpec` includes `Help` in the JSON payload
+
+### Buildspec validation
+
+Add `validateHelp(report, spec, packageIDs)` after `validateJSVerbs(...)` or next to it.
+
+Validation rules:
+
+1. Each help source requires a non-empty `id`.
+2. IDs must be unique within `help.sources`.
+3. A provider source requires both `package` and `source`.
+4. Provider package IDs must refer to declared packages.
+5. A filesystem source requires `path`.
+6. If `embed: true`, the path must exist and be a directory.
+7. If `embed: false`, warn/OK as "runtime filesystem source" and document that relative paths should be normalized.
+8. `package/source` and `path` should not be mixed in one entry.
+
+Pseudocode:
+
+```go
+func validateHelp(report *Report, spec *Spec, packageIDs map[string]PackageSpec) {
+    ids := map[string]struct{}{}
+    for i, source := range spec.Help.Sources {
+        path := fmt.Sprintf("help.sources[%d]", i)
+        id := strings.TrimSpace(source.ID)
+        // id checks...
+
+        hasProvider := strings.TrimSpace(source.Package) != "" || strings.TrimSpace(source.Source) != ""
+        hasPath := strings.TrimSpace(source.Path) != ""
+
+        if hasProvider && hasPath {
+            report.AddError("help-source-shape", path, "help source cannot combine provider source and filesystem path")
+            continue
+        }
+        if hasProvider {
+            // package/source checks...
+            continue
+        }
+        if !hasPath {
+            report.AddError("help-path", path+".path", "filesystem help source requires path")
+            continue
+        }
+        if source.Embed {
+            // requireExistingPath + directory check
+        }
+    }
+}
+```
+
+## Implementation plan
+
+### Phase 1: Add provider API support
+
+Files:
+
+- `go-go-goja/pkg/xgoja/providerapi/help.go` (new)
+- `go-go-goja/pkg/xgoja/providerapi/registry.go`
+- `go-go-goja/pkg/xgoja/providerapi/registry_test.go`
+
+Steps:
+
+1. Add `HelpSource` to `providerapi`.
+2. Add `HelpSources map[string]HelpSource` to `Package`.
+3. Initialize `HelpSources` in `Registry.Package` and `Package.clone`.
+4. Add `ResolveHelpSource`.
+5. Add duplicate-name tests.
+6. Add nil-filesystem tests.
+
+Expected test command:
+
+```bash
+cd go-go-goja
+go test ./pkg/xgoja/providerapi -count=1
+```
+
+### Phase 2: Add buildspec and runtime spec support
+
+Files:
+
+- `go-go-goja/cmd/xgoja/internal/buildspec/spec.go`
+- `go-go-goja/cmd/xgoja/internal/buildspec/validate.go`
+- `go-go-goja/cmd/xgoja/internal/buildspec/load_test.go`
+- `go-go-goja/pkg/xgoja/app/spec.go`
+
+Steps:
+
+1. Add `HelpSpec` and `HelpSourceSpec` to both buildspec and app runtime spec.
+2. Add `validateHelp(...)`.
+3. Add load tests for valid embedded local help source.
+4. Add validation tests for duplicate IDs, missing path, missing provider source, unknown provider package, and mixed path/provider source.
+5. Decide how non-embedded filesystem paths are normalized. The recommended first implementation is absolute-path normalization during `runtimeSpec` for `embed: false`, plus documentation warning that bundled binaries should use `embed: true`.
+
+Expected test command:
+
+```bash
+cd go-go-goja
+go test ./cmd/xgoja/internal/buildspec -count=1
+```
+
+### Phase 3: Add generator embedding support
+
+Files:
+
+- `go-go-goja/cmd/xgoja/internal/generate/generate.go`
+- `go-go-goja/cmd/xgoja/internal/generate/main.go`
+- `go-go-goja/cmd/xgoja/internal/generate/templates.go`
+- `go-go-goja/cmd/xgoja/internal/generate/templates/main.go.tmpl`
+- `go-go-goja/cmd/xgoja/internal/generate/generate_test.go`
+
+Steps:
+
+1. Add `copyEmbeddedHelpSources` and call it from `WriteAll` next to `copyEmbeddedJSVerbs`.
+2. Add `embeddedHelpRoots` using the same collision-avoidance scheme as `embeddedJSVerbRoots`.
+3. Include `Help` in `RenderEmbeddedSpec`.
+4. Rewrite embedded local help paths in `runtimeSpec`.
+5. Update template data to distinguish JS verb and help embeds.
+6. Add template tests for generated `embed` import, `//go:embed xgoja_embed/help/*`, `EmbeddedHelp: embeddedHelp`, and embedded spec path rewriting.
+7. Add `WriteAll` tests that a local help directory is copied into the generated workspace.
+
+Expected test command:
+
+```bash
+cd go-go-goja
+go test ./cmd/xgoja/internal/generate -count=1
+```
+
+### Phase 4: Load configured help sources in generated roots
+
+Files:
+
+- `go-go-goja/pkg/xgoja/app/root.go`
+- `go-go-goja/pkg/xgoja/app/host.go`
+- `go-go-goja/pkg/xgoja/app/framework.go`
+- `go-go-goja/pkg/xgoja/app/root_test.go`
+
+Steps:
+
+1. Add `EmbeddedHelp` to `app.Options`, `HostOptions`, and `Host`.
+2. Pass `Providers` and `EmbeddedHelp` into `installRootFramework`.
+3. Implement `loadConfiguredHelpSources`.
+4. Keep `help_cmd.SetupCobraRootCommand` in one place. Do not let provider commands call it independently.
+5. Add tests where a generated root loads:
+   - built-in `runtime-overview`,
+   - a provider help source from a test provider,
+   - an embedded local help source from `fstest.MapFS`.
+6. Test failure paths for unknown provider help sources.
+
+Expected test command:
+
+```bash
+cd go-go-goja
+go test ./pkg/xgoja/app -count=1
+```
+
+### Phase 5: Wire Loupedeck provider docs
+
+Files:
+
+- `loupedeck/docs/help/doc.go`
+- `loupedeck/runtime/js/provider/provider.go`
+- `loupedeck/pkg/xgoja/provider/provider.go` if the wrapper needs test coverage
+
+Steps:
+
+1. Export `FS() fs.FS` from `loupedeck/docs/help`.
+2. Add a `providerapi.HelpSource{Name: "runtime-api", ...}` entry to `loupedeck/runtime/js/provider.Register`.
+3. Confirm `loupedeck/pkg/xgoja/provider.Register` delegates correctly to the runtime provider.
+4. Add a provider test that resolves `loupedeck.runtime-api` from the registry.
+5. Build a generated fixture with `help.sources` referencing `loupedeck.runtime-api` and verify `help loupedeck-js-api-reference` includes the expected title.
+
+Expected test command:
+
+```bash
+cd loupedeck
+go test ./runtime/js/provider ./pkg/xgoja/provider -count=1
+```
+
+### Phase 6: Update docs and examples
+
+Files:
+
+- `go-go-goja/cmd/xgoja/doc/02-user-guide.md`
+- `go-go-goja/cmd/xgoja/doc/06-buildspec-reference.md`
+- `go-go-goja/cmd/xgoja/doc/08-playbook-adding-xgoja-support.md`
+- `go-go-goja/examples/xgoja/...` (new or existing help-docs example)
+
+Add documentation for:
+
+- `help.sources` schema,
+- local embedded help docs,
+- provider-shipped help docs,
+- expected Glazed help frontmatter,
+- how to test a help page with `help <slug>`,
+- Loupedeck-style API reference pages.
+
+Example help entry template:
+
+```markdown
+---
+Title: My package JavaScript API reference
+Slug: my-package-js-api-reference
+Short: Reference for modules exposed by the my-package xgoja provider.
+Topics:
+- my-package
+- javascript
+- goja
+- api
+Commands:
+- my-tool
+Flags: []
+IsTopLevel: true
+IsTemplate: false
+ShowPerDefault: true
+SectionType: GeneralTopic
+---
+
+This reference explains the JavaScript API available in generated xgoja binaries
+that include the `my-package` provider. It documents the current implemented
+surface, not brainstormed future APIs.
+```
+
+## File-by-file implementation checklist
+
+### `pkg/xgoja/providerapi/registry.go`
+
+Add storage and duplicate validation for help sources.
+
+Review focus:
+
+- initialization in `Registry.Package`,
+- clone behavior,
+- deterministic `Packages()` snapshots,
+- duplicate error wording.
+
+### `pkg/xgoja/providerapi/help.go`
+
+Add the new provider-facing API. Keep it close to `verbs.go` in style.
+
+Review focus:
+
+- nil `fs.FS` handling,
+- default `Root` behavior,
+- no dependency on concrete xgoja app types.
+
+### `cmd/xgoja/internal/buildspec/spec.go`
+
+Add YAML-facing spec types. Keep JSON tags because `RenderEmbeddedSpec` emits runtime JSON from the buildspec.
+
+Review focus:
+
+- field names match the intended YAML exactly,
+- no accidental collision with existing `commands` or `jsverbs` fields.
+
+### `cmd/xgoja/internal/buildspec/validate.go`
+
+Add schema validation before generation.
+
+Review focus:
+
+- filesystem sources and provider sources are mutually exclusive,
+- embedded local paths exist,
+- provider sources refer only to declared package IDs,
+- errors point to `help.sources[i]` paths.
+
+### `cmd/xgoja/internal/generate/main.go`
+
+Update runtime spec rendering and path rewriting.
+
+Review focus:
+
+- embedded help paths are rewritten only for local `embed: true` entries,
+- provider help entries remain `package/source`,
+- source ID sanitization avoids collisions.
+
+### `cmd/xgoja/internal/generate/generate.go`
+
+Copy local help directories into the build workspace.
+
+Review focus:
+
+- same path resolution semantics as JS verbs,
+- skips `.git`, dot directories, and `node_modules` consistently,
+- preserves nested help subdirectories such as `topics/` and `tutorials/`.
+
+### `cmd/xgoja/internal/generate/templates/main.go.tmpl`
+
+Embed help docs and pass the filesystem to app options.
+
+Review focus:
+
+- `embed` import appears if either JS verbs or help docs are embedded,
+- generated code compiles in all four combinations: neither, JS verbs only, help only, both,
+- adapter and cobra target modes receive `EmbeddedHelp` through `HostOptions`.
+
+### `pkg/xgoja/app/framework.go`
+
+Merge all help sources into one `HelpSystem`.
+
+Review focus:
+
+- `help_cmd.SetupCobraRootCommand` is still called once,
+- built-in generated docs always load first,
+- errors mention which configured source failed,
+- duplicate Glazed slugs fail during `LoadSectionsFromFS` and are not swallowed.
+
+### `loupedeck/docs/help/doc.go`
+
+Export the embedded filesystem for provider registration.
+
+Review focus:
+
+- keep `AddDocToHelpSystem` for the standalone CLI,
+- add `FS()` without changing existing CLI behavior.
+
+### `loupedeck/runtime/js/provider/provider.go`
+
+Register a `HelpSource` beside modules and commands.
+
+Review focus:
+
+- avoid importing `cmd/loupedeck`,
+- use a stable source name such as `runtime-api`,
+- include all existing topics/tutorials under root `.`.
+
+## Pseudocode: complete root help loader
+
+```go
+func installRootFramework(root *cobra.Command, spec *Spec, opts frameworkOptions) error {
+    if root == nil {
+        return fmt.Errorf("root command is nil")
+    }
+    if alreadyInstalled(root) {
+        return nil
+    }
+
+    appName := appNameFromSpec(spec)
+    if err := logging.AddLoggingSectionToRootCommand(root, appName); err != nil {
+        return err
+    }
+    chainPersistentPreRun(root, logging.InitLoggerFromCobra)
+
+    hs := help.NewHelpSystem()
+    if err := xgojadoc.AddDocToHelpSystem(hs); err != nil {
+        return fmt.Errorf("load generated xgoja help docs: %w", err)
+    }
+    if err := loadConfiguredHelpSources(hs, spec, opts); err != nil {
+        return err
+    }
+
+    help_cmd.SetupCobraRootCommand(hs, root)
+    markInstalled(root)
+    return nil
+}
+```
+
+## Pseudocode: generated `main.go` cases
+
+No embedded docs:
+
+```go
+root, err := app.NewRootCommand(app.Options{
+    Providers: registry,
+    SpecJSON:  embeddedSpecJSON,
+})
+```
+
+Help docs only:
+
+```go
+//go:embed xgoja_embed/help/*
+var embeddedHelp embed.FS
+
+root, err := app.NewRootCommand(app.Options{
+    Providers:    registry,
+    SpecJSON:     embeddedSpecJSON,
+    EmbeddedHelp: embeddedHelp,
+})
+```
+
+JS verbs and help docs:
+
+```go
+//go:embed xgoja_embed/jsverbs/*
+var embeddedJSVerbs embed.FS
+
+//go:embed xgoja_embed/help/*
+var embeddedHelp embed.FS
+
+root, err := app.NewRootCommand(app.Options{
+    Providers:       registry,
+    SpecJSON:        embeddedSpecJSON,
+    EmbeddedJSVerbs: embeddedJSVerbs,
+    EmbeddedHelp:    embeddedHelp,
+})
+```
+
+## Authoring guidance for help pages
+
+The Glazed help topics `glaze help how-to-write-good-documentation-pages` and `glaze help writing-help-entries` are the style authority. The key operational rules are:
+
+- Lead with why the page exists.
+- Keep one concept per section.
+- Make code examples runnable.
+- Use comments to explain why, not obvious mechanics.
+- End with troubleshooting and `See Also` sections for long tutorial/reference pages.
+- Use unique slugs; the slug is the `help <slug>` lookup key.
+- Do not add a top-level `#` heading in the content; Glazed renders the title.
+
+For xgoja provider API references, the Loupedeck page demonstrates the right level of specificity. It states that it documents the currently implemented runtime, warns against raw transport ownership, gives a runtime model diagram, then enumerates module exports. New provider docs should follow that pattern: describe the boundary first, then list the JavaScript API.
+
+Recommended provider API reference outline:
+
+```markdown
+---
+Title: <Provider> JavaScript runtime API reference
+Slug: <provider>-js-api-reference
+Short: Reference for modules exposed by the <provider> xgoja provider.
+Topics:
+- <provider>
+- xgoja
+- javascript
+- goja
+- api
+Commands:
+- <generated command or provider command>
+Flags: []
+IsTopLevel: true
+IsTemplate: false
+ShowPerDefault: true
+SectionType: GeneralTopic
+---
+
+This reference documents the currently implemented JavaScript API for generated
+xgoja binaries that include the `<provider>` package. It intentionally describes
+runtime behavior and failure modes, not planned future APIs.
+
+## Runtime model
+
+```text
+script -> goja runtime -> require("<module>") -> Go provider -> host resources
+```
+
+## Module overview
+
+| Module | Purpose | Main exports |
+|---|---|---|
+| `<module>` | ... | ... |
+
+## `<module>`
+
+Explain what the module is, why it exists, when to use it, examples, and failure modes.
+
+## Troubleshooting
+
+| Problem | Cause | Solution |
+|---|---|---|
+| `Cannot find module` | Runtime profile did not select the module. | Add the module to `runtimes.<name>.modules`. |
+
+## See also
+
+- `help runtime-overview`
+- `help buildspec-reference`
+```
+
+## Testing and validation strategy
+
+### Unit tests
+
+Run these after each phase:
+
+```bash
+cd go-go-goja
+go test ./pkg/xgoja/providerapi -count=1
+go test ./cmd/xgoja/internal/buildspec -count=1
+go test ./cmd/xgoja/internal/generate -count=1
+go test ./pkg/xgoja/app -count=1
+```
+
+### Generated binary integration test
+
+Add a fixture provider help source in `pkg/xgoja/testprovider`, then extend generation tests:
+
+```go
+func TestGeneratedProgramLoadsProviderHelpSource(t *testing.T) {
+    spec := buildableSpec("xgoja", "", "")
+    spec.Help.Sources = []buildspec.HelpSourceSpec{
+        {ID: "fixture-docs", Package: "fixture", Source: "docs"},
+    }
+    _, out := runGeneratedCommandWithOutput(t, spec, "help", "fixture-js-api-reference")
+    if !strings.Contains(string(out), "Fixture JavaScript API reference") {
+        t.Fatalf("expected provider help page, got %s", out)
+    }
+}
+```
+
+Add an embedded local docs test:
+
+```go
+func TestGeneratedProgramLoadsEmbeddedLocalHelpSource(t *testing.T) {
+    baseDir := t.TempDir()
+    writeHelpPage(baseDir, "docs/help/topics/01-local.md", `---
+Title: Local API
+Slug: local-api
+Short: Local help.
+IsTopLevel: true
+IsTemplate: false
+ShowPerDefault: true
+SectionType: GeneralTopic
+---
+
+Local body.
+`)
+
+    spec := buildableSpec("xgoja", "", "")
+    spec.BaseDir = baseDir
+    spec.Help.Sources = []buildspec.HelpSourceSpec{
+        {ID: "local-docs", Path: "docs/help", Embed: true},
+    }
+
+    dir, out := runGeneratedCommandWithOutput(t, spec, "help", "local-api")
+    assertContains(t, string(out), "Local API")
+    assertFileExists(t, filepath.Join(dir, "xgoja_embed", "help", "local_docs", "topics", "01-local.md"))
+}
+```
+
+### Manual smoke test with Loupedeck
+
+After Loupedeck registers a help source, create a local spec:
+
+```yaml
+name: loupedeck-help-smoke
+packages:
+  - id: loupedeck
+    import: github.com/go-go-golems/loupedeck/pkg/xgoja/provider
+    replace: ../../loupedeck
+runtimes:
+  scene:
+    modules:
+      - package: loupedeck
+        name: loupedeck/state
+        as: loupedeck/state
+commands:
+  run:
+    enabled: true
+    runtime: scene
+help:
+  sources:
+    - id: loupedeck-runtime-api
+      package: loupedeck
+      source: runtime-api
+```
+
+Smoke commands:
+
+```bash
+cd go-go-goja
+GOWORK=off go run ./cmd/xgoja build -f /tmp/loupedeck-help-smoke.yaml \
+  --xgoja-replace "$(pwd)" \
+  --output /tmp/loupedeck-help-smoke \
+  --keep-work
+
+/tmp/loupedeck-help-smoke help loupedeck-js-api-reference
+/tmp/loupedeck-help-smoke help type:generaltopic
+```
+
+Expected result:
+
+- The first command prints the Loupedeck JavaScript runtime API reference title.
+- The output includes the runtime model text from the Loupedeck help page.
+- Generic `runtime-overview` help still works.
+
+## Risks and review notes
+
+### Slug collisions
+
+Glazed help slugs are global within one `HelpSystem`. If `pkg/xgoja/doc`, provider docs, and local docs all define the same slug, loading should fail loudly. Do not silently override sections. A generated binary with ambiguous help would be worse than a build/test failure.
+
+### Duplicate source IDs versus duplicate help slugs
+
+Source IDs are xgoja config identifiers. Slugs are Glazed help identifiers inside Markdown frontmatter. Validate source IDs in `buildspec.Validate`. Let `LoadSectionsFromFS` report duplicate slugs when it parses docs.
+
+### Root framework idempotence
+
+`installRootFramework` has an annotation guard (`go-go-goja/pkg/xgoja/app/framework.go:13-23`). Keep that guard. Cobra target mode and adapter mode should not install multiple `help` commands if a host calls xgoja attachment more than once.
+
+### Runtime filesystem docs
+
+Non-embedded local docs are useful during development, but they weaken the "bundle into the binary" goal. Prefer `embed: true` in examples and docs. If non-embedded mode is kept, normalize relative paths to absolute paths before embedding the runtime JSON, or document that paths are resolved relative to the generated binary's working directory.
+
+### Provider package dependencies
+
+Provider registration should import docs packages, not command entrypoints. For Loupedeck, import `github.com/go-go-golems/loupedeck/docs/help`, not `cmd/loupedeck`.
+
+### Template combinations
+
+Generated code must compile for all embed combinations:
+
+| JS verbs embedded | Help embedded | Expected import/vars |
+|---|---|---|
+| no | no | no `embed` import |
+| yes | no | `embeddedJSVerbs` only |
+| no | yes | `embeddedHelp` only |
+| yes | yes | both vars |
+
+This deserves explicit tests because Go fails builds on unused imports and unused variables.
+
+## Alternatives considered
+
+### Alternative 1: Copy provider docs into go-go-goja
+
+This would place pages such as the Loupedeck API reference under `go-go-goja/pkg/xgoja/doc`. It is simple but wrong ownership. The Loupedeck package owns its JavaScript API and should update docs when the API changes. Copying docs into go-go-goja creates drift.
+
+### Alternative 2: Automatically load all provider docs
+
+The provider registry could load every provider help source automatically. This is convenient but too broad. Some generated binaries may want small help output, or provider packages may ship multiple doc sets for different audiences. Keep provider docs opt-in through `help.sources`.
+
+### Alternative 3: Reuse `jsverbs` for docs
+
+Glazed help docs are not JavaScript verb definitions. Reusing `jsverbs` would confuse users and code. The source shape can be similar, but the buildspec field and app loader should be explicit.
+
+### Alternative 4: Let provider command sets install help themselves
+
+A provider command set could receive a root command and call `SetupCobraRootCommand`. This breaks the one-root-one-help-system invariant and risks duplicate `help` commands. The app layer should remain the single owner of help system installation.
+
+### Alternative 5: Store `func(*help.HelpSystem) error` in providerapi
+
+This is flexible and matches existing `AddDocToHelpSystem` helpers, but `fs.FS` is more inspectable, testable, and consistent with `VerbSource`. Start with `fs.FS`. If a future provider needs dynamic help generation, add a second capability deliberately.
+
+## Open questions
+
+1. Should the buildspec field be named `help` or `helpDocs`? This guide recommends `help` with nested `sources` because it reads naturally and leaves room for future help-level settings.
+2. Should provider help sources be opt-in only, or should selected command providers imply help sources? This guide recommends opt-in only for the first implementation.
+3. Should runtime filesystem docs (`embed: false`) be supported in the first implementation? If schedule is tight, implement only `embed: true` and provider docs; add non-embedded docs later.
+4. Should `docs/help/doc.go` packages standardize on `FS() fs.FS` across repositories? This guide recommends yes, but existing `AddDocToHelpSystem` should remain for standalone CLIs.
+
+## References
+
+- `go-go-goja/cmd/xgoja/root.go:57-61` — standalone xgoja help system setup.
+- `go-go-goja/cmd/xgoja/doc/doc.go:9-13` — embedded docs loader pattern.
+- `go-go-goja/pkg/xgoja/app/framework.go:35-39` — generated-binary root help setup.
+- `go-go-goja/pkg/xgoja/app/host.go:38-59` — generated host command attachment sequence.
+- `go-go-goja/cmd/xgoja/internal/buildspec/spec.go:5-14` — current top-level buildspec fields.
+- `go-go-goja/cmd/xgoja/internal/buildspec/validate.go:197-235` — existing source-list validation pattern for JS verbs.
+- `go-go-goja/cmd/xgoja/internal/generate/generate.go:49-65` — current embedded source copying pattern.
+- `go-go-goja/cmd/xgoja/internal/generate/templates/main.go.tmpl:27-49` — current generated embed/root construction template.
+- `go-go-goja/pkg/xgoja/providerapi/registry.go:18-24` — provider package contribution maps.
+- `go-go-goja/pkg/xgoja/providerapi/verbs.go:5-13` — minimal provider source entry pattern.
+- `loupedeck/docs/help/doc.go:9-13` — Loupedeck embedded Glazed help package.
+- `loupedeck/cmd/loupedeck/main.go:31-33` — Loupedeck standalone CLI help setup.
+- `loupedeck/docs/help/topics/01-loupedeck-js-api-reference.md:1-45` — target API reference style and frontmatter.
+- `loupedeck/runtime/js/provider/provider.go:49-68` — Loupedeck xgoja provider registration point.

--- a/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/design-doc/01-glazed-help-documents-for-xgoja-binaries-implementation-guide.md
+++ b/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/design-doc/01-glazed-help-documents-for-xgoja-binaries-implementation-guide.md
@@ -11,26 +11,39 @@ DocType: design-doc
 Intent: long-term
 Owners: []
 RelatedFiles:
+    - Path: go-go-goja/cmd/xgoja/doc/02-user-guide.md
+      Note: User-facing help.sources documentation
     - Path: go-go-goja/cmd/xgoja/internal/buildspec/spec.go
       Note: Buildspec schema that needs help.sources support
+    - Path: go-go-goja/cmd/xgoja/internal/generate/main.go
+      Note: Runtime spec help path rewriting
     - Path: go-go-goja/cmd/xgoja/internal/generate/templates/main.go.tmpl
       Note: Generated main template that needs embedded help filesystem wiring
     - Path: go-go-goja/cmd/xgoja/root.go
       Note: Standalone xgoja Glazed help setup pattern
     - Path: go-go-goja/pkg/xgoja/app/framework.go
-      Note: Generated binary root framework and current built-in help loader
+      Note: |-
+        Generated binary root framework and current built-in help loader
+        Generated root help source loader
+    - Path: go-go-goja/pkg/xgoja/providerapi/help.go
+      Note: New provider-facing HelpSource API
     - Path: go-go-goja/pkg/xgoja/providerapi/registry.go
       Note: Provider registry extension point for HelpSource
+    - Path: loupedeck/docs/help/doc.go
+      Note: Loupedeck docs filesystem export
     - Path: loupedeck/docs/help/topics/01-loupedeck-js-api-reference.md
       Note: Example Glazed API reference to bundle into xgoja binaries
     - Path: loupedeck/runtime/js/provider/provider.go
-      Note: Loupedeck provider registration point for provider-shipped docs
+      Note: |-
+        Loupedeck provider registration point for provider-shipped docs
+        Loupedeck runtime-api help source registration
 ExternalSources: []
 Summary: Design and implementation guide for bundling project-local and provider-shipped Glazed help entries into generated xgoja binaries.
 LastUpdated: 2026-05-31T11:30:00-04:00
 WhatFor: Use when implementing support for additional Glazed help documents in generated xgoja binaries.
 WhenToUse: Read before changing xgoja buildspec parsing, code generation, provider registration, or generated root help wiring.
 ---
+
 
 
 # Glazed Help Documents for xgoja Binaries Implementation Guide

--- a/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/index.md
+++ b/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/index.md
@@ -1,0 +1,54 @@
+---
+Title: Add Glazed help documents to xgoja binaries
+Ticket: XGOJA-015
+Status: active
+Topics:
+    - xgoja
+    - glazed
+    - help-system
+    - documentation
+DocType: index
+Intent: long-term
+Owners: []
+RelatedFiles: []
+ExternalSources: []
+Summary: "Ticket for designing provider-shipped and project-local Glazed help document bundling in generated xgoja binaries."
+LastUpdated: 2026-05-31T11:36:00-04:00
+WhatFor: "Track the design and future implementation of xgoja help document bundling."
+WhenToUse: "Use before implementing or reviewing XGOJA-015."
+---
+
+# Add Glazed help documents to xgoja binaries
+
+## Overview
+
+This ticket designs how generated xgoja binaries should bundle additional Glazed help entries, including provider-owned API references and tutorials. The immediate motivating example is the Loupedeck JavaScript API reference in `loupedeck/docs/help/topics/01-loupedeck-js-api-reference.md`.
+
+The recommended design adds provider-registered help sources plus a `help.sources` buildspec section for selecting provider-shipped or project-local help docs. Local help directories can be copied into the generated build workspace and embedded into the final binary.
+
+## Key Links
+
+- [Design guide](./design-doc/01-glazed-help-documents-for-xgoja-binaries-implementation-guide.md)
+- [Investigation diary](./reference/01-investigation-diary.md)
+- [Tasks](./tasks.md)
+- [Changelog](./changelog.md)
+
+## Status
+
+Current status: **active**. The research and design package is complete; implementation remains as follow-up work.
+
+## Topics
+
+- xgoja
+- glazed
+- help-system
+- documentation
+
+## Structure
+
+- `design-doc/` - Architecture and implementation guide.
+- `reference/` - Investigation diary and reusable context.
+- `playbooks/` - Command sequences and test procedures, if added later.
+- `scripts/` - Temporary code and tooling, if needed later.
+- `various/` - Working notes.
+- `archive/` - Deprecated or reference-only artifacts.

--- a/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/reference/01-investigation-diary.md
+++ b/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/reference/01-investigation-diary.md
@@ -17,7 +17,7 @@ RelatedFiles:
       Note: Loupedeck embedded docs package inspected for provider help source design
 ExternalSources: []
 Summary: Chronological diary for researching and designing Glazed help document support in generated xgoja binaries.
-LastUpdated: 2026-05-31T12:32:00-04:00
+LastUpdated: 2026-05-31T12:44:00-04:00
 WhatFor: Use to understand what was inspected, what decisions were made, and how to continue implementation.
 WhenToUse: Read before implementing XGOJA-015 or reviewing the design guide.
 ---
@@ -633,4 +633,117 @@ root, err := app.NewRootCommand(app.Options{
     EmbeddedJSVerbs: nil,
     EmbeddedHelp:    embeddedHelp,
 })
+```
+
+## Step 6: Loaded configured help sources into generated roots
+
+This step connected the previously added provider API, buildspec, and generator pieces to the generated root help system. Generated binaries now merge built-in xgoja runtime help, selected provider help sources, embedded local help sources, and optional runtime filesystem help sources into one Glazed `HelpSystem` before installing the Cobra help command.
+
+The implementation keeps the single-owner invariant: `help_cmd.SetupCobraRootCommand(...)` remains in the root framework and is still called exactly once. Providers contribute filesystems; the app layer decides loading order and error reporting.
+
+### Prompt Context
+
+**User prompt (verbatim):** (see Step 3)
+
+**Assistant interpretation:** Continue the implementation checklist by wiring generated root help loading and proving it with app and generated-binary tests.
+
+**Inferred user intent:** Make the new `help.sources` config observable from generated binaries through `help <slug>`.
+
+**Commit (code):** pending at time of diary entry — generated root loading phase prepared for commit.
+
+### What I did
+
+- Updated `pkg/xgoja/app/framework.go` to accept `frameworkOptions` with provider registry and embedded help filesystem.
+- Added `loadConfiguredHelpSources(...)` to load:
+  - provider help sources via `Registry.ResolveHelpSource`,
+  - embedded local help sources via `EmbeddedHelp`,
+  - non-embedded filesystem help sources via `os.DirFS`.
+- Updated `pkg/xgoja/app/host.go` to pass providers and embedded help into `installRootFramework`.
+- Added app tests for:
+  - provider help source lookup and rendering,
+  - embedded local help source lookup and rendering,
+  - missing provider help source errors.
+- Upgraded the generator integration test from "compiles with embedded help" to "generated binary loads embedded help via `help local-api`".
+- Ran:
+
+```bash
+cd go-go-goja
+gofmt -w pkg/xgoja/app/framework.go \
+  pkg/xgoja/app/host.go \
+  pkg/xgoja/app/root_test.go \
+  cmd/xgoja/internal/generate/generate_test.go
+go test ./pkg/xgoja/app ./cmd/xgoja/internal/generate -count=1
+```
+
+### Why
+
+- Until this phase, docs could be declared and embedded but were not visible from generated binaries.
+- Loading all selected docs into one help system preserves Glazed search/query behavior and avoids duplicate `help` commands.
+
+### What worked
+
+- Focused app and generator tests passed:
+
+```text
+ok  	github.com/go-go-golems/go-go-goja/pkg/xgoja/app	0.108s
+ok  	github.com/go-go-golems/go-go-goja/cmd/xgoja/internal/generate	17.302s
+```
+
+- The generated-binary test now calls `help local-api` and verifies the embedded page content.
+
+### What didn't work
+
+- My first missing-provider test expected `NewRootCommand` to return the framework error immediately. Existing host behavior stores root framework install errors in `PersistentPreRunE`, so `NewRootCommand` returned `nil` error.
+- The failed test output was:
+
+```text
+--- FAIL: TestGeneratedRootReportsMissingProviderHelpSource (0.00s)
+    root_test.go:257: expected missing provider help source error, got <nil>
+```
+
+- I adjusted the test to execute a command and assert that execution returns the missing provider help source error. This matches the current `AttachDefaultCommands` error-defer behavior.
+
+### What I learned
+
+- Generated root framework errors are currently deferred to command execution, not returned from `NewRootCommand`, because `Host.AttachDefaultCommands` converts install errors into a `PersistentPreRunE` error.
+- The loader can keep simple runtime semantics: provider entries use provider `fs.FS`, embedded entries use generated `EmbeddedHelp`, and non-embedded entries use `os.DirFS(path)`.
+
+### What was tricky to build
+
+- The tricky part was preserving existing root framework behavior while testing errors. Changing `AttachDefaultCommands` to return errors would be a larger API change, so the test follows current behavior instead of changing it as part of help docs support.
+
+### What warrants a second pair of eyes
+
+- Review whether framework installation errors should continue to be deferred through `PersistentPreRunE` or whether a future cleanup should make `AttachDefaultCommands` return errors.
+- Review non-embedded filesystem help source path semantics. They are currently runtime working-directory relative unless the generated spec contains an absolute path.
+
+### What should be done in the future
+
+- Wire a real provider, starting with Loupedeck, to register a provider help source.
+- Update user-facing xgoja docs to describe `help.sources`.
+
+### Code review instructions
+
+- Start in `pkg/xgoja/app/framework.go`, especially `loadConfiguredHelpSources`.
+- Then review `pkg/xgoja/app/root_test.go` and the generated integration test in `cmd/xgoja/internal/generate/generate_test.go`.
+- Validate with:
+
+```bash
+go test ./pkg/xgoja/app ./cmd/xgoja/internal/generate -count=1
+```
+
+### Technical details
+
+Runtime loading cases:
+
+```go
+// Provider-shipped docs
+providerSource, ok := opts.Providers.ResolveHelpSource(source.Package, source.Source)
+helpSystem.LoadSectionsFromFS(providerSource.FS, providerSource.Root)
+
+// Embedded local docs
+helpSystem.LoadSectionsFromFS(opts.EmbeddedHelp, source.Path)
+
+// Runtime filesystem docs
+helpSystem.LoadSectionsFromFS(os.DirFS(source.Path), ".")
 ```

--- a/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/reference/01-investigation-diary.md
+++ b/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/reference/01-investigation-diary.md
@@ -17,7 +17,7 @@ RelatedFiles:
       Note: Loupedeck embedded docs package inspected for provider help source design
 ExternalSources: []
 Summary: Chronological diary for researching and designing Glazed help document support in generated xgoja binaries.
-LastUpdated: 2026-05-31T12:05:00-04:00
+LastUpdated: 2026-05-31T12:18:00-04:00
 WhatFor: Use to understand what was inspected, what decisions were made, and how to continue implementation.
 WhenToUse: Read before implementing XGOJA-015 or reviewing the design guide.
 ---
@@ -405,4 +405,119 @@ providerapi.HelpSource{
     FS:          docs.FS(),
     Root:        ".",
 }
+```
+
+## Step 4: Added `help.sources` to the buildspec and runtime spec
+
+This step added the declarative configuration layer for help documents. The buildspec now has a `help.sources` section that can describe provider-shipped docs or local filesystem docs, and the generated runtime spec has matching JSON types so later phases can pass that configuration into generated binaries.
+
+The validation logic follows the existing `jsverbs` source-list pattern but is stricter about local embedded docs being directories. That matters because Glazed help docs are usually a tree of `topics/`, `tutorials/`, and related directories, not a single file.
+
+### Prompt Context
+
+**User prompt (verbatim):** (see Step 3)
+
+**Assistant interpretation:** Continue implementing the detailed task list phase by phase, with validation and diary updates.
+
+**Inferred user intent:** Land small reviewable implementation increments rather than one large change.
+
+**Commit (code):** pending at time of diary entry — buildspec/runtime spec phase prepared for commit.
+
+### What I did
+
+- Added `HelpSpec` and `HelpSourceSpec` to `cmd/xgoja/internal/buildspec/spec.go`.
+- Added matching `HelpSpec` and `HelpSourceSpec` to `pkg/xgoja/app/spec.go`.
+- Added `validateHelp(...)` to `cmd/xgoja/internal/buildspec/validate.go`.
+- Refactored path existence helpers so embedded help sources can require an existing directory.
+- Extended `load_test.go` to parse a provider help source from YAML.
+- Added `validate_test.go` coverage for:
+  - valid provider help sources,
+  - valid embedded local help directories,
+  - valid non-embedded runtime filesystem sources,
+  - duplicate help source IDs,
+  - missing provider source fields,
+  - unknown package IDs,
+  - mixed provider/path sources,
+  - missing paths,
+  - embedded paths that are files instead of directories,
+  - missing source IDs.
+- Ran:
+
+```bash
+cd go-go-goja
+gofmt -w cmd/xgoja/internal/buildspec/spec.go \
+  cmd/xgoja/internal/buildspec/validate.go \
+  cmd/xgoja/internal/buildspec/validate_test.go \
+  cmd/xgoja/internal/buildspec/load_test.go \
+  pkg/xgoja/app/spec.go
+go test ./cmd/xgoja/internal/buildspec -count=1
+```
+
+### Why
+
+- The provider API alone cannot make docs selectable. `xgoja.yaml` needs a stable schema so generated binary authors can decide which provider or local help docs to include.
+- Matching runtime JSON types are needed because the generated binary decodes an embedded runtime spec into `pkg/xgoja/app.Spec`.
+
+### What worked
+
+- The focused buildspec test passed:
+
+```text
+ok  	github.com/go-go-golems/go-go-goja/cmd/xgoja/internal/buildspec	0.003s
+```
+
+### What didn't work
+
+- The first test run failed because I refactored `existingPathInfo` to return three values but left `requireExistingPath` expecting two:
+
+```text
+# github.com/go-go-golems/go-go-goja/cmd/xgoja/internal/buildspec [github.com/go-go-golems/go-go-goja/cmd/xgoja/internal/buildspec.test]
+cmd/xgoja/internal/buildspec/validate.go:286:12: assignment mismatch: 2 variables but existingPathInfo returns 3 values
+FAIL	github.com/go-go-golems/go-go-goja/cmd/xgoja/internal/buildspec [build failed]
+```
+
+- I fixed `requireExistingPath` to discard both the resolved path and file info, then re-ran tests successfully.
+
+### What I learned
+
+- The existing validation report model is enough for `help.sources`; no new reporting abstraction was needed.
+- Keeping provider and path source shapes mutually exclusive makes validation messages clearer and avoids ambiguous runtime behavior.
+
+### What was tricky to build
+
+- The tricky bit was preserving existing `jsverbs` path behavior while adding directory-specific validation for help docs. I avoided changing `requireExistingPath` semantics for JS verbs and added `requireExistingDir` for help sources.
+
+### What warrants a second pair of eyes
+
+- Confirm that non-embedded runtime filesystem help sources should be accepted without requiring the path to exist at build time. This matches the current `jsverbs` non-embedded behavior, but bundled docs should generally use `embed: true`.
+- Confirm that `help.sources` is the final desired YAML field name.
+
+### What should be done in the future
+
+- Add generator support so embedded local help paths are copied and rewritten into the runtime JSON.
+- Add app loading support so provider and local help sources are read into the generated root help system.
+
+### Code review instructions
+
+- Review `cmd/xgoja/internal/buildspec/spec.go` and `pkg/xgoja/app/spec.go` together to ensure YAML and runtime JSON shapes stay aligned.
+- Review `validateHelp(...)` in `cmd/xgoja/internal/buildspec/validate.go` for error paths.
+- Validate with:
+
+```bash
+go test ./cmd/xgoja/internal/buildspec -count=1
+```
+
+### Technical details
+
+Supported YAML shape:
+
+```yaml
+help:
+  sources:
+    - id: provider-docs
+      package: loupedeck
+      source: runtime-api
+    - id: local-docs
+      path: ./docs/help
+      embed: true
 ```

--- a/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/reference/01-investigation-diary.md
+++ b/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/reference/01-investigation-diary.md
@@ -17,7 +17,7 @@ RelatedFiles:
       Note: Loupedeck embedded docs package inspected for provider help source design
 ExternalSources: []
 Summary: Chronological diary for researching and designing Glazed help document support in generated xgoja binaries.
-LastUpdated: 2026-05-31T11:45:00-04:00
+LastUpdated: 2026-05-31T12:05:00-04:00
 WhatFor: Use to understand what was inspected, what decisions were made, and how to continue implementation.
 WhenToUse: Read before implementing XGOJA-015 or reviewing the design guide.
 ---
@@ -295,4 +295,114 @@ Upload verification command:
 
 ```bash
 remarquee cloud ls /ai/2026/05/31/XGOJA-015 --long --non-interactive
+```
+
+## Step 3: Added provider-level HelpSource support
+
+This step implemented the provider-facing documentation source primitive. The registry can now store package-owned Glazed help sources alongside modules, JavaScript verb sources, package capabilities, and command set providers. This is the first code-level building block for generated xgoja binaries to load provider-shipped help pages.
+
+The implementation intentionally mirrors the existing `VerbSource` pattern: providers contribute an `fs.FS` plus a root directory and a stable source name. The app layer will later decide which registered source to load based on `help.sources` in `xgoja.yaml`.
+
+### Prompt Context
+
+**User prompt (verbatim):** "add detailed tasks to the ticket, and then implement them one by one, keeping a detailed diary, and committing at appropriate intervals."
+
+**Assistant interpretation:** Expand the ticket tasks into implementation phases, then begin implementing and committing the phases with diary updates.
+
+**Inferred user intent:** Move from research/design into code while keeping the ticket usable for review and continuation.
+
+**Commit (code):** pending at time of diary entry — provider API phase prepared for commit.
+
+### What I did
+
+- Expanded `tasks.md` into detailed phase-by-phase implementation tasks.
+- Added `pkg/xgoja/providerapi/help.go` with `HelpSource` and normalization.
+- Extended `pkg/xgoja/providerapi/registry.go` with:
+  - `Package.HelpSources`,
+  - `Registry.ResolveHelpSource`,
+  - `Package.addHelpSource`,
+  - clone support for help source snapshots.
+- Extended `pkg/xgoja/providerapi/registry_test.go` to cover:
+  - successful help source registration and lookup,
+  - cloned package snapshots containing help sources,
+  - duplicate help source rejection,
+  - missing help source name rejection,
+  - missing help source filesystem rejection.
+- Ran:
+
+```bash
+cd go-go-goja
+gofmt -w pkg/xgoja/providerapi/help.go pkg/xgoja/providerapi/registry.go pkg/xgoja/providerapi/registry_test.go
+go test ./pkg/xgoja/providerapi -count=1
+```
+
+### Why
+
+- Provider-owned documentation needs a stable provider API entry before the buildspec or generated app can refer to it.
+- Keeping the API as `fs.FS` + root makes it consistent with existing Glazed loading and with provider-owned verb source registration.
+
+### What worked
+
+- The focused providerapi test passed:
+
+```text
+ok  	github.com/go-go-golems/go-go-goja/pkg/xgoja/providerapi	0.014s
+```
+
+### What didn't work
+
+- My first edit to `registry_test.go` accidentally inserted malformed text into the import block:
+
+```text
+"github.com/dop251/goja"},{
+```
+
+- `gofmt` reported the issue exactly:
+
+```text
+pkg/xgoja/providerapi/registry_test.go:9:26: missing import path
+```
+
+- I fixed the import block to separate `github.com/dop251/goja` and `github.com/dop251/goja_nodejs/require`, then re-ran `gofmt` and tests successfully.
+
+### What I learned
+
+- The provider registry was already well-shaped for another package entry type.
+- The least surprising API is almost identical to `VerbSource`, with the additional validation that `FS` must be non-nil because help loading cannot work without it.
+
+### What was tricky to build
+
+- The tricky part was keeping the provider API independent from the app help loader. `HelpSource` should not take a `*help.HelpSystem`; if it did, provider registration would own too much root-level behavior. Storing `fs.FS` keeps registration declarative and leaves loading order/error handling in the app layer.
+
+### What warrants a second pair of eyes
+
+- Confirm that requiring `FS != nil` at provider registration time is preferable to allowing a placeholder help source. The current implementation fails early.
+- Confirm that defaulting empty `Root` to `.` is the right convention for provider docs packages.
+
+### What should be done in the future
+
+- Wire `HelpSource` into the buildspec and generated app loader.
+- Add a test provider help source for generated binary integration tests.
+
+### Code review instructions
+
+- Start in `pkg/xgoja/providerapi/help.go` and verify the provider-facing contract.
+- Then review `pkg/xgoja/providerapi/registry.go` for map initialization, lookup, duplicate checking, and cloning.
+- Validate with:
+
+```bash
+go test ./pkg/xgoja/providerapi -count=1
+```
+
+### Technical details
+
+New provider registration shape:
+
+```go
+providerapi.HelpSource{
+    Name:        "runtime-api",
+    Description: "Provider API reference and tutorials",
+    FS:          docs.FS(),
+    Root:        ".",
+}
 ```

--- a/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/reference/01-investigation-diary.md
+++ b/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/reference/01-investigation-diary.md
@@ -17,7 +17,7 @@ RelatedFiles:
       Note: Loupedeck embedded docs package inspected for provider help source design
 ExternalSources: []
 Summary: Chronological diary for researching and designing Glazed help document support in generated xgoja binaries.
-LastUpdated: 2026-05-31T12:54:00-04:00
+LastUpdated: 2026-05-31T13:04:00-04:00
 WhatFor: Use to understand what was inspected, what decisions were made, and how to continue implementation.
 WhenToUse: Read before implementing XGOJA-015 or reviewing the design guide.
 ---
@@ -865,4 +865,146 @@ help:
     - id: loupedeck-runtime-api
       package: loupedeck
       source: runtime-api
+```
+
+## Step 8: Updated xgoja help docs and ran focused validation
+
+This step updated the user-facing xgoja help pages so the new feature is discoverable from `xgoja help`. The docs now explain `help.sources`, provider-shipped help docs, embedded local help docs, and runtime filesystem help docs.
+
+This step also ran focused validation in both affected repositories. The go-go-goja tests cover provider API, buildspec validation, generator output, app help loading, and xgoja CLI docs. The Loupedeck tests cover provider registration of the real `runtime-api` help source.
+
+### Prompt Context
+
+**User prompt (verbatim):** (see Step 3)
+
+**Assistant interpretation:** Document the implemented feature and run the focused validation suite before final ticket bookkeeping.
+
+**Inferred user intent:** Ensure the implementation is usable and documented, not just internally wired.
+
+**Commit (code):** pending at time of diary entry — xgoja docs/final validation phase prepared for commit.
+
+### What I did
+
+- Updated `cmd/xgoja/doc/02-user-guide.md` with:
+  - `help.sources` as a top-level buildspec field,
+  - provider-shipped help source examples,
+  - embedded local help source examples,
+  - runtime filesystem help source examples,
+  - validation and troubleshooting notes.
+- Updated `cmd/xgoja/doc/06-buildspec-reference.md` with quick-reference `help.sources` examples.
+- Updated `cmd/xgoja/doc/08-playbook-adding-xgoja-support.md` with provider-owned help docs registration guidance.
+- Ran xgoja docs/package validation:
+
+```bash
+cd go-go-goja
+go test ./cmd/xgoja/... -count=1
+```
+
+- Ran focused go-go-goja validation:
+
+```bash
+cd go-go-goja
+go test ./pkg/xgoja/providerapi ./cmd/xgoja/internal/buildspec ./cmd/xgoja/internal/generate ./pkg/xgoja/app ./cmd/xgoja/... -count=1
+```
+
+- Ran focused Loupedeck validation:
+
+```bash
+cd loupedeck
+go test ./runtime/js/provider ./pkg/xgoja/provider -count=1
+```
+
+### Why
+
+- A buildspec feature must be documented in the CLI's own help system, or users will have to reverse-engineer it from tests.
+- Running focused tests in both repositories catches cross-repo API drift before finalizing the ticket.
+
+### What worked
+
+- xgoja docs/package tests passed:
+
+```text
+ok  	github.com/go-go-golems/go-go-goja/cmd/xgoja	6.184s
+?   	github.com/go-go-golems/go-go-goja/cmd/xgoja/doc	[no test files]
+?   	github.com/go-go-golems/go-go-goja/cmd/xgoja/internal/buildexec	[no test files]
+ok  	github.com/go-go-golems/go-go-goja/cmd/xgoja/internal/buildspec	0.005s
+ok  	github.com/go-go-golems/go-go-goja/cmd/xgoja/internal/generate	23.735s
+```
+
+- Focused go-go-goja validation passed:
+
+```text
+ok  	github.com/go-go-golems/go-go-goja/pkg/xgoja/providerapi	0.019s
+ok  	github.com/go-go-golems/go-go-goja/cmd/xgoja/internal/buildspec	0.006s
+ok  	github.com/go-go-golems/go-go-goja/cmd/xgoja/internal/generate	27.319s
+ok  	github.com/go-go-golems/go-go-goja/pkg/xgoja/app	0.177s
+ok  	github.com/go-go-golems/go-go-goja/cmd/xgoja	7.740s
+?   	github.com/go-go-golems/go-go-goja/cmd/xgoja/doc	[no test files]
+?   	github.com/go-go-golems/go-go-goja/cmd/xgoja/internal/buildexec	[no test files]
+```
+
+- Focused Loupedeck validation passed:
+
+```text
+ok  	github.com/go-go-golems/loupedeck/runtime/js/provider	0.087s
+?   	github.com/go-go-golems/loupedeck/pkg/xgoja/provider	[no test files]
+```
+
+### What didn't work
+
+- N/A. The documentation updates and focused validation passed.
+
+### What I learned
+
+- The xgoja help docs already had the right structure for adding another source family next to JavaScript verb sources.
+- The feature is easiest to explain by mirroring `jsverbs`: provider-shipped source, embedded local source, runtime filesystem source.
+
+### What was tricky to build
+
+- The trickiest documentation point was distinguishing provider-owned documentation from project-local documentation. Provider docs should live with the package API; project docs should live next to the generated app spec.
+
+### What warrants a second pair of eyes
+
+- Review the help docs for terminology: `help.sources`, `HelpSource`, and `runtime-api` should read consistently.
+- Check that the playbook's provider registration example matches the final providerapi signatures.
+
+### What should be done in the future
+
+- Consider adding a small standalone `examples/xgoja` directory dedicated to help docs if users need a copy/paste runnable sample beyond the tests and help pages.
+
+### Code review instructions
+
+- Start with `cmd/xgoja/doc/02-user-guide.md` to review the end-user buildspec docs.
+- Then review `cmd/xgoja/doc/08-playbook-adding-xgoja-support.md` for provider author guidance.
+- Validate with:
+
+```bash
+go test ./pkg/xgoja/providerapi ./cmd/xgoja/internal/buildspec ./cmd/xgoja/internal/generate ./pkg/xgoja/app ./cmd/xgoja/... -count=1
+```
+
+### Technical details
+
+The docs describe three help source modes:
+
+```yaml
+# Provider-shipped docs
+help:
+  sources:
+    - id: loupedeck-runtime-api
+      package: loupedeck
+      source: runtime-api
+
+# Embedded local docs
+help:
+  sources:
+    - id: project-docs
+      path: ./docs/help
+      embed: true
+
+# Runtime filesystem docs
+help:
+  sources:
+    - id: dev-docs
+      path: ./docs/help
+      embed: false
 ```

--- a/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/reference/01-investigation-diary.md
+++ b/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/reference/01-investigation-diary.md
@@ -1,0 +1,298 @@
+---
+Title: Investigation Diary
+Ticket: XGOJA-015
+Status: active
+Topics:
+    - xgoja
+    - glazed
+    - help-system
+    - documentation
+DocType: reference
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: go-go-goja/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/design-doc/01-glazed-help-documents-for-xgoja-binaries-implementation-guide.md
+      Note: Primary design produced during this investigation
+    - Path: loupedeck/docs/help/doc.go
+      Note: Loupedeck embedded docs package inspected for provider help source design
+ExternalSources: []
+Summary: Chronological diary for researching and designing Glazed help document support in generated xgoja binaries.
+LastUpdated: 2026-05-31T11:45:00-04:00
+WhatFor: Use to understand what was inspected, what decisions were made, and how to continue implementation.
+WhenToUse: Read before implementing XGOJA-015 or reviewing the design guide.
+---
+
+
+# Diary
+
+## Goal
+
+This diary captures the setup, investigation, design writing, validation, and delivery work for XGOJA-015: adding support for bundling Glazed help entries into generated xgoja binaries.
+
+## Step 1: Created the ticket and mapped the help/documentation architecture
+
+This step created a new docmgr ticket and gathered evidence from the xgoja builder, generated-binary app layer, provider API, generator, and Loupedeck help docs. The intent was to avoid designing from memory: the report is anchored in concrete files and line-level behavior.
+
+The main conclusion is that xgoja already has a working Glazed help installation path for built-in docs, and it already has source-list patterns for provider-owned JavaScript verbs. The missing abstraction is a provider/spec help source path that can merge provider-shipped and project-local help entries into the generated binary's one Glazed help system.
+
+### Prompt Context
+
+**User prompt (verbatim):** "Create a new docmgr ticket to add glazed help document support to xgoja binaries. What I want to do is extend xgoja so that we can easily bundle glazed help entries (for example api references or tutorials on how to use the different packages we are adding). Examine @loupedeck/docs/help/topics/01-loupedeck-js-api-reference.md for example.
+
+Create  a detailed analysis / design / implementation guide that is for a new intern, explaining all the parts of the system needed to understand what it is, with prose paragraphs and bullet point sand pseudocode and diagrams and api references and file references. It should be very clear and technical. Store in the ticket and the nupload to remarkable.
+
+Keep a diary as you work."
+
+**Assistant interpretation:** Create a new docmgr ticket, research how xgoja and Glazed help are currently wired, write a detailed intern-friendly design/implementation guide, keep a diary, validate the ticket, and upload the resulting bundle to reMarkable.
+
+**Inferred user intent:** Make the next implementation pass straightforward by giving an intern enough system context, concrete APIs, pseudocode, file references, and validation steps to add bundled Glazed help documents to generated xgoja binaries.
+
+**Commit (code):** N/A — no code changes were made; this step produced documentation and ticket bookkeeping only.
+
+### What I did
+
+- Created docmgr ticket `XGOJA-015` with title `Add Glazed help documents to xgoja binaries`.
+- Added the primary design document:
+  - `go-go-goja/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/design-doc/01-glazed-help-documents-for-xgoja-binaries-implementation-guide.md`
+- Added this diary document:
+  - `go-go-goja/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/reference/01-investigation-diary.md`
+- Read the Glazed help authoring skill and the ticket research writing checklist.
+- Inspected the user-specified example:
+  - `loupedeck/docs/help/topics/01-loupedeck-js-api-reference.md`
+- Inspected current xgoja help loading:
+  - `go-go-goja/cmd/xgoja/doc/doc.go`
+  - `go-go-goja/cmd/xgoja/root.go`
+  - `go-go-goja/pkg/xgoja/doc/doc.go`
+  - `go-go-goja/pkg/xgoja/app/framework.go`
+  - `go-go-goja/pkg/xgoja/app/host.go`
+  - `go-go-goja/pkg/xgoja/app/root.go`
+- Inspected current source-list and embed patterns:
+  - `go-go-goja/cmd/xgoja/internal/buildspec/spec.go`
+  - `go-go-goja/cmd/xgoja/internal/buildspec/validate.go`
+  - `go-go-goja/cmd/xgoja/internal/generate/generate.go`
+  - `go-go-goja/cmd/xgoja/internal/generate/main.go`
+  - `go-go-goja/cmd/xgoja/internal/generate/templates.go`
+  - `go-go-goja/cmd/xgoja/internal/generate/templates/main.go.tmpl`
+- Inspected provider API extension points:
+  - `go-go-goja/pkg/xgoja/providerapi/registry.go`
+  - `go-go-goja/pkg/xgoja/providerapi/verbs.go`
+  - `go-go-goja/pkg/xgoja/providerapi/commands.go`
+  - `go-go-goja/pkg/xgoja/providerapi/capabilities.go`
+- Inspected the Loupedeck provider and docs wiring:
+  - `loupedeck/docs/help/doc.go`
+  - `loupedeck/cmd/loupedeck/main.go`
+  - `loupedeck/runtime/js/provider/provider.go`
+  - `loupedeck/pkg/xgoja/provider/provider.go`
+- Queried current Glazed help authoring guidance:
+  - `glaze help how-to-write-good-documentation-pages`
+  - `glaze help writing-help-entries`
+- Ran a focused current-state test command:
+  - `cd go-go-goja && go test ./cmd/xgoja/internal/buildspec ./cmd/xgoja/internal/generate ./pkg/xgoja/app -count=1`
+
+### Why
+
+- The design needed to explain the current architecture before proposing changes.
+- The Loupedeck example matters because it is already a high-quality Glazed help page and is the concrete target for provider-shipped docs.
+- The existing `jsverbs` embedding path is the nearest implementation pattern for local filesystem source bundling.
+- The provider registry is the natural home for package-owned docs because generated binaries already call provider registration functions at startup.
+
+### What worked
+
+- Ticket creation and document creation succeeded with `docmgr`.
+- The current architecture was coherent: built-in help loading, generated root framework installation, source-list validation, generated embed copying, and provider registration all had clear extension points.
+- The focused current-state test command passed:
+
+```text
+ok  	github.com/go-go-golems/go-go-goja/cmd/xgoja/internal/buildspec	0.016s
+ok  	github.com/go-go-golems/go-go-goja/cmd/xgoja/internal/generate	17.317s
+ok  	github.com/go-go-golems/go-go-goja/pkg/xgoja/app	0.070s
+```
+
+### What didn't work
+
+- `git status --short && git rev-parse --show-toplevel` failed from the workspace root because `/home/manuel/workspaces/2026-05-31/xgoja-docs` is a multi-repository workspace, not a Git repository itself:
+
+```text
+fatal: not a git repository (or any of the parent directories): .git
+```
+
+- A broad `rg` command across `go-go-goja`, `loupedeck`, and `glazed` produced more output than useful in one pass and was truncated. I switched to targeted file reads and targeted `nl -ba` snippets for line references.
+
+### What I learned
+
+- Generated xgoja binaries already install Glazed help, but only for generic generated-runtime docs from `pkg/xgoja/doc`.
+- The provider registry currently has maps for modules, verb sources, package capabilities, and command set providers; help sources can fit the same package-entry model.
+- The buildspec/generator already solve most of the path-copying and collision-avoidance problems for embedded JavaScript verb sources.
+- Loupedeck's standalone CLI has exactly the desired help loading pattern, but its docs package currently exposes only `AddDocToHelpSystem`, not the underlying `fs.FS` that a provider registry entry would need.
+
+### What was tricky to build
+
+- The main design tension was where docs should be owned. Copying Loupedeck docs into `go-go-goja` would be easy but would create drift. Letting providers register help sources keeps ownership correct, but requires changes in providerapi, buildspec, generation, and app root loading.
+- Another subtle point was root help installation. `help_cmd.SetupCobraRootCommand` should remain a single app-layer operation. Provider command sets should not install their own help command, or generated binaries risk duplicate help commands and fragmented help search.
+- Embedded local docs and provider-shipped docs have different mechanics. Local docs must be copied into the generated workspace and embedded by generated `main.go`; provider docs are already compiled into provider packages and only need to be selected and loaded.
+
+### What warrants a second pair of eyes
+
+- Confirm the buildspec field name. The design recommends `help.sources`; `helpDocs.sources` is an alternative if maintainers want to avoid overloading the common word `help`.
+- Confirm whether non-embedded filesystem docs should be supported in the first implementation. The design supports it conceptually but recommends prioritizing `embed: true` and provider docs.
+- Confirm whether provider help sources should be opt-in only or automatically loaded when a provider package is selected. The design recommends opt-in only.
+
+### What should be done in the future
+
+- Implement XGOJA-015 in the phases described by the design guide.
+- Add at least one generated-program integration test that proves `help <provider-slug>` works from a generated binary.
+- Standardize provider docs packages on an exported `FS() fs.FS` helper while keeping existing `AddDocToHelpSystem` helpers for standalone CLIs.
+
+### Code review instructions
+
+- Start with the design guide's "File-by-file implementation checklist".
+- For implementation review, begin in `go-go-goja/pkg/xgoja/providerapi/registry.go` and the proposed new `providerapi/help.go`, then follow the data flow through `cmd/xgoja/internal/buildspec`, `cmd/xgoja/internal/generate`, and `pkg/xgoja/app/framework.go`.
+- Validate the current baseline with:
+
+```bash
+cd go-go-goja
+go test ./cmd/xgoja/internal/buildspec ./cmd/xgoja/internal/generate ./pkg/xgoja/app -count=1
+```
+
+- After implementation, add providerapi, buildspec, generate, app, and Loupedeck provider tests as described in the design guide.
+
+### Technical details
+
+Key current-state references:
+
+- `go-go-goja/cmd/xgoja/root.go:57-61` — standalone xgoja help setup.
+- `go-go-goja/pkg/xgoja/app/framework.go:35-39` — generated-binary help setup.
+- `go-go-goja/cmd/xgoja/internal/buildspec/spec.go:5-14` — current top-level buildspec fields.
+- `go-go-goja/cmd/xgoja/internal/buildspec/validate.go:197-235` — existing `jsverbs` source validation pattern.
+- `go-go-goja/cmd/xgoja/internal/generate/generate.go:49-65` — existing embedded source copy pattern.
+- `go-go-goja/pkg/xgoja/providerapi/registry.go:18-24` — current provider package entry maps.
+- `loupedeck/docs/help/topics/01-loupedeck-js-api-reference.md:1-45` — target Glazed help entry style.
+- `loupedeck/runtime/js/provider/provider.go:49-68` — likely place to register Loupedeck provider help sources.
+
+## Step 2: Validated the ticket and uploaded the design bundle to reMarkable
+
+This step finalized the docmgr bookkeeping and delivered the design package to reMarkable. The work was intentionally documentation-only: the implementation remains for a follow-up coding pass, while the ticket now contains the guide, diary, tasks, changelog, related files, and upload evidence.
+
+The important outcome is that the ticket passes `docmgr doctor`, and the uploaded PDF bundle contains the index, design guide, diary, tasks, and changelog. This makes the design readable both from the repository workspace and from the reMarkable device.
+
+### Prompt Context
+
+**User prompt (verbatim):** (same as Step 1)
+
+**Assistant interpretation:** Finish ticket validation and publish the documentation bundle to reMarkable.
+
+**Inferred user intent:** Make the design package easy to review away from the terminal and ensure docmgr metadata is healthy.
+
+**Commit (code):** N/A — no code changes were made.
+
+### What I did
+
+- Related key source files to the design doc with `docmgr doc relate`.
+- Related the design document and Loupedeck docs package to the diary with `docmgr doc relate`.
+- Updated the changelog with `docmgr changelog update`.
+- Ran ticket validation:
+
+```bash
+docmgr doctor --ticket XGOJA-015 --stale-after 30
+```
+
+- Checked reMarkable CLI/account status:
+
+```bash
+remarquee status
+remarquee cloud account --non-interactive
+```
+
+- Ran bundle dry-run upload:
+
+```bash
+remarquee upload bundle --dry-run \
+  index.md \
+  design-doc/01-glazed-help-documents-for-xgoja-binaries-implementation-guide.md \
+  reference/01-investigation-diary.md \
+  tasks.md \
+  changelog.md \
+  --name "XGOJA-015 Glazed help docs design" \
+  --remote-dir "/ai/2026/05/31/XGOJA-015" \
+  --toc-depth 2
+```
+
+- Uploaded the real bundle and verified the remote listing.
+
+### Why
+
+- `docmgr doctor` catches broken ticket structure, stale metadata, and vocabulary issues before delivery.
+- The dry run prevents accidental upload path/name mistakes.
+- The remote listing confirms that the uploaded document is visible under the expected reMarkable destination.
+
+### What worked
+
+- `docmgr doctor` passed:
+
+```text
+## Doctor Report (1 findings)
+
+### XGOJA-015
+
+- ✅ All checks passed
+```
+
+- `remarquee status` and account lookup succeeded:
+
+```text
+remarquee: ok
+user=wesen@ruinwesen.com sync_version=1.5
+```
+
+- Dry-run upload planned the expected bundle and destination.
+- Real upload succeeded:
+
+```text
+OK: uploaded XGOJA-015 Glazed help docs design.pdf -> /ai/2026/05/31/XGOJA-015
+```
+
+- Remote listing verified the file:
+
+```text
+[f]	XGOJA-015 Glazed help docs design
+```
+
+### What didn't work
+
+- N/A. The validation and upload path succeeded on the first attempt.
+
+### What I learned
+
+- The reMarkable bundle workflow works cleanly for docmgr ticket packages when the index, design doc, diary, tasks, and changelog are uploaded together.
+- The design doc is large enough that bundle upload is preferable to uploading individual PDFs; the table of contents matters for navigation.
+
+### What was tricky to build
+
+- The only subtle point was choosing the bundle inputs. Including `tasks.md` and `changelog.md` alongside the design and diary makes the PDF more reviewable because the reader can see both the future implementation checklist and the delivery history.
+
+### What warrants a second pair of eyes
+
+- Confirm whether the uploaded bundle should include only the design doc for a shorter reading experience, or whether the current full ticket bundle is preferred.
+
+### What should be done in the future
+
+- If the implementation pass creates more docs or changes the design, re-run `docmgr doctor` and upload a fresh bundle under the same remote directory with a distinct name.
+
+### Code review instructions
+
+- Review the uploaded PDF at `/ai/2026/05/31/XGOJA-015/XGOJA-015 Glazed help docs design`.
+- In the workspace, start with `go-go-goja/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/design-doc/01-glazed-help-documents-for-xgoja-binaries-implementation-guide.md`.
+
+### Technical details
+
+Validated command:
+
+```bash
+docmgr doctor --ticket XGOJA-015 --stale-after 30
+```
+
+Upload verification command:
+
+```bash
+remarquee cloud ls /ai/2026/05/31/XGOJA-015 --long --non-interactive
+```

--- a/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/reference/01-investigation-diary.md
+++ b/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/reference/01-investigation-diary.md
@@ -11,16 +11,29 @@ DocType: reference
 Intent: long-term
 Owners: []
 RelatedFiles:
+    - Path: go-go-goja/cmd/xgoja/doc/02-user-guide.md
+      Note: Step 8 user documentation (commit 2c6b112)
+    - Path: go-go-goja/cmd/xgoja/internal/buildspec/spec.go
+      Note: Step 4 buildspec schema (commit e006c2c)
+    - Path: go-go-goja/cmd/xgoja/internal/generate/templates/main.go.tmpl
+      Note: Step 5 generated embed wiring (commit 1dec2ba)
+    - Path: go-go-goja/pkg/xgoja/app/framework.go
+      Note: Step 6 generated root loading (commit 4c646d9)
+    - Path: go-go-goja/pkg/xgoja/providerapi/help.go
+      Note: Step 3 implementation (commit 13d30d0)
     - Path: go-go-goja/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/design-doc/01-glazed-help-documents-for-xgoja-binaries-implementation-guide.md
       Note: Primary design produced during this investigation
     - Path: loupedeck/docs/help/doc.go
       Note: Loupedeck embedded docs package inspected for provider help source design
+    - Path: loupedeck/runtime/js/provider/provider.go
+      Note: Step 7 Loupedeck provider docs registration (commit b5825fa)
 ExternalSources: []
 Summary: Chronological diary for researching and designing Glazed help document support in generated xgoja binaries.
-LastUpdated: 2026-05-31T13:04:00-04:00
+LastUpdated: 2026-05-31T13:12:00-04:00
 WhatFor: Use to understand what was inspected, what decisions were made, and how to continue implementation.
 WhenToUse: Read before implementing XGOJA-015 or reviewing the design guide.
 ---
+
 
 
 # Diary
@@ -311,7 +324,7 @@ The implementation intentionally mirrors the existing `VerbSource` pattern: prov
 
 **Inferred user intent:** Move from research/design into code while keeping the ticket usable for review and continuation.
 
-**Commit (code):** pending at time of diary entry — provider API phase prepared for commit.
+**Commit (code):** `13d30d0e3332a635e507af1e3e3a0ae93cdab5a1` — "XGOJA: add provider help sources"
 
 ### What I did
 
@@ -421,7 +434,7 @@ The validation logic follows the existing `jsverbs` source-list pattern but is s
 
 **Inferred user intent:** Land small reviewable implementation increments rather than one large change.
 
-**Commit (code):** pending at time of diary entry — buildspec/runtime spec phase prepared for commit.
+**Commit (code):** `e006c2ca0140d1248c185c85a70b1b53a13647bf` — "XGOJA: add help sources to buildspec"
 
 ### What I did
 
@@ -536,7 +549,7 @@ The generated app still does not load the configured help docs into the Glazed h
 
 **Inferred user intent:** Make incremental progress while preserving reviewability and test evidence.
 
-**Commit (code):** pending at time of diary entry — generator embedding phase prepared for commit.
+**Commit (code):** `1dec2badd6a854638c03442edc36eafd3da7ca43` — "XGOJA: embed generated help sources"
 
 ### What I did
 
@@ -649,7 +662,7 @@ The implementation keeps the single-owner invariant: `help_cmd.SetupCobraRootCom
 
 **Inferred user intent:** Make the new `help.sources` config observable from generated binaries through `help <slug>`.
 
-**Commit (code):** pending at time of diary entry — generated root loading phase prepared for commit.
+**Commit (code):** `4c646d937fd046457b939dfb1d3b3d67a48431ec` — "XGOJA: load configured help sources"
 
 ### What I did
 
@@ -881,7 +894,7 @@ This step also ran focused validation in both affected repositories. The go-go-g
 
 **Inferred user intent:** Ensure the implementation is usable and documented, not just internally wired.
 
-**Commit (code):** pending at time of diary entry — xgoja docs/final validation phase prepared for commit.
+**Commit (code):** `2c6b1128693bf28f16353f5238ac40beb8fe4792` — "Docs: document xgoja help sources"
 
 ### What I did
 
@@ -1007,4 +1020,120 @@ help:
     - id: dev-docs
       path: ./docs/help
       embed: false
+```
+
+## Step 9: Final ticket validation and implementation upload
+
+This step closed the ticket work loop by updating docmgr relations/changelog, running `docmgr doctor`, uploading a final implementation bundle to reMarkable, and verifying the remote listing. The code work had already been committed in focused increments; this step records the final delivery evidence.
+
+The final reMarkable bundle is named `XGOJA-015 Glazed help docs implementation final` and includes the ticket index, design guide, diary, task list, and changelog.
+
+### Prompt Context
+
+**User prompt (verbatim):** (see Step 3)
+
+**Assistant interpretation:** Finish ticket bookkeeping, validate the documentation workspace, and upload the final implementation package.
+
+**Inferred user intent:** Leave a complete audit trail and review packet after implementation.
+
+**Commit (code):** pending at time of diary entry — final ticket documentation prepared for commit.
+
+### What I did
+
+- Added doc relations for the implemented source files and docs.
+- Updated the ticket changelog with the implementation summary and commit hashes.
+- Ran:
+
+```bash
+docmgr doctor --ticket XGOJA-015 --stale-after 30
+```
+
+- Uploaded the final reMarkable bundle with dry-run first:
+
+```bash
+remarquee upload bundle --dry-run ... \
+  --name "XGOJA-015 Glazed help docs implementation final" \
+  --remote-dir "/ai/2026/05/31/XGOJA-015" \
+  --toc-depth 2
+
+remarquee upload bundle ... \
+  --name "XGOJA-015 Glazed help docs implementation final" \
+  --remote-dir "/ai/2026/05/31/XGOJA-015" \
+  --toc-depth 2
+```
+
+- Verified the reMarkable listing:
+
+```bash
+remarquee cloud ls /ai/2026/05/31/XGOJA-015 --long --non-interactive
+```
+
+### Why
+
+- The implementation touched two repositories and multiple conceptual layers, so final ticket metadata needed to point reviewers to the right files.
+- The final reMarkable bundle supersedes the earlier design-only bundle for implementation review.
+
+### What worked
+
+- `docmgr doctor` passed:
+
+```text
+## Doctor Report (1 findings)
+
+### XGOJA-015
+
+- ✅ All checks passed
+```
+
+- Final upload succeeded:
+
+```text
+OK: uploaded XGOJA-015 Glazed help docs implementation final.pdf -> /ai/2026/05/31/XGOJA-015
+```
+
+- Remote listing verified:
+
+```text
+[f]	XGOJA-015 Glazed help docs design
+[f]	XGOJA-015 Glazed help docs design final
+[f]	XGOJA-015 Glazed help docs implementation final
+```
+
+### What didn't work
+
+- N/A. Final validation and upload succeeded.
+
+### What I learned
+
+- The docmgr + reMarkable bundle workflow works well for cross-repository implementation tasks because the diary can include both repositories' commits and validation commands.
+
+### What was tricky to build
+
+- The final bookkeeping was mostly about keeping cross-repository evidence clear. The go-go-goja ticket records both go-go-goja commits and the Loupedeck commit so the implementation can be reviewed as one feature even though it spans two repositories.
+
+### What warrants a second pair of eyes
+
+- Confirm that the earlier design-only PDFs can remain in the reMarkable folder, or remove/archive them manually if only the final implementation bundle should be visible.
+
+### What should be done in the future
+
+- If a PR is opened, include the go-go-goja and Loupedeck commit ranges in the PR description and point reviewers at this ticket.
+
+### Code review instructions
+
+- Review commits in order:
+  - go-go-goja `13d30d0` provider API,
+  - go-go-goja `e006c2c` buildspec/runtime spec,
+  - go-go-goja `1dec2ba` generator embedding,
+  - go-go-goja `4c646d9` root help loading,
+  - loupedeck `b5825fa` provider docs,
+  - go-go-goja `2c6b112` docs.
+- Validate with the focused commands from Step 8.
+
+### Technical details
+
+Final reMarkable path:
+
+```text
+/ai/2026/05/31/XGOJA-015/XGOJA-015 Glazed help docs implementation final
 ```

--- a/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/reference/01-investigation-diary.md
+++ b/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/reference/01-investigation-diary.md
@@ -17,6 +17,10 @@ RelatedFiles:
       Note: Step 4 buildspec schema (commit e006c2c)
     - Path: go-go-goja/cmd/xgoja/internal/generate/templates/main.go.tmpl
       Note: Step 5 generated embed wiring (commit 1dec2ba)
+    - Path: go-go-goja/examples/xgoja/09-provider-shipped-help-docs/Makefile
+      Note: Step 10 smoke commands and assertions
+    - Path: go-go-goja/examples/xgoja/09-provider-shipped-help-docs/xgoja.yaml
+      Note: Step 10 manual smoke example
     - Path: go-go-goja/pkg/xgoja/app/framework.go
       Note: Step 6 generated root loading (commit 4c646d9)
     - Path: go-go-goja/pkg/xgoja/providerapi/help.go
@@ -29,10 +33,11 @@ RelatedFiles:
       Note: Step 7 Loupedeck provider docs registration (commit b5825fa)
 ExternalSources: []
 Summary: Chronological diary for researching and designing Glazed help document support in generated xgoja binaries.
-LastUpdated: 2026-05-31T13:12:00-04:00
+LastUpdated: 2026-05-31T13:35:00-04:00
 WhatFor: Use to understand what was inspected, what decisions were made, and how to continue implementation.
 WhenToUse: Read before implementing XGOJA-015 or reviewing the design guide.
 ---
+
 
 
 
@@ -1136,4 +1141,141 @@ Final reMarkable path:
 
 ```text
 /ai/2026/05/31/XGOJA-015/XGOJA-015 Glazed help docs implementation final
+```
+
+## Step 10: Added a manual Loupedeck provider help smoke example
+
+This step answered the follow-up request for a real manual smoke test rather than only unit and generated-program fixture tests. I added `examples/xgoja/09-provider-shipped-help-docs`, which imports the actual Loupedeck xgoja provider, selects the provider-shipped `runtime-api` help source, builds a generated binary, and runs `help` against real Loupedeck help slugs.
+
+The example now doubles as reference material: future provider authors can copy the `help.sources` shape, the provider `replace` pattern, and the Makefile smoke commands when they need to prove package-owned Glazed docs are visible from a generated xgoja binary.
+
+### Prompt Context
+
+**User prompt (verbatim):** "ok, do a manual smoke test with an example goja.yaml within go-go-goja, which can then also serve as reference for later on. Also, update any documentation that is relevant to mention that functionality."
+
+**Assistant interpretation:** Add a reusable example under `go-go-goja/examples/xgoja`, run it manually, and update xgoja documentation to point users at it.
+
+**Inferred user intent:** Strengthen validation with a real generated Loupedeck binary path and leave behind a concrete reference example for future work.
+
+**Commit (code):** pending at time of diary entry — manual smoke example/docs prepared for commit.
+
+### What I did
+
+- Added `examples/xgoja/09-provider-shipped-help-docs/xgoja.yaml`.
+  - It imports `github.com/go-go-golems/loupedeck/pkg/xgoja/provider`.
+  - It uses `replace: ../../../../loupedeck` for local workspace development.
+  - It selects `help.sources[].package: loupedeck` and `source: runtime-api`.
+- Added `examples/xgoja/09-provider-shipped-help-docs/Makefile`.
+  - `doctor` validates the spec.
+  - `list` shows selected modules.
+  - `build` creates the generated binary with `--xgoja-replace`.
+  - `run` verifies `help loupedeck-js-api-reference` and `help loupedeck-js-first-live-script`.
+- Added `examples/xgoja/09-provider-shipped-help-docs/README.md` explaining the example and smoke commands.
+- Updated `examples/xgoja/README.md` to include the new ninth example in the learning path and all-example loop.
+- Updated xgoja docs to point at the new example:
+  - `cmd/xgoja/doc/02-user-guide.md`
+  - `cmd/xgoja/doc/06-buildspec-reference.md`
+  - `cmd/xgoja/doc/08-playbook-adding-xgoja-support.md`
+- Ran:
+
+```bash
+cd go-go-goja
+go test ./cmd/xgoja/... -count=1
+make -C examples/xgoja/09-provider-shipped-help-docs smoke
+rm -rf examples/xgoja/09-provider-shipped-help-docs/dist
+```
+
+### Why
+
+- The previous generated-binary smoke coverage proved embedded local help docs, but the real Loupedeck provider path needed a manual end-to-end check.
+- A committed example is better than an ad-hoc `/tmp` smoke spec because future maintainers can rerun it and use it as a template.
+
+### What worked
+
+- The new example's `doctor` step validated the provider help source:
+
+```text
+| help-provider-source | ok | help.sources[0] | ... | provider source loupedeck.runtime-api |
+```
+
+- The build succeeded:
+
+```text
+xgoja build ok: /home/manuel/workspaces/2026-05-31/xgoja-docs/go-go-goja/examples/xgoja/09-provider-shipped-help-docs/dist/provider-shipped-help-docs
+```
+
+- The generated binary rendered the Loupedeck API reference:
+
+```text
+provider-shipped-help-docs help loupedeck-js-api-reference | grep -F "Loupedeck JavaScript runtime API reference"
+  # Loupedeck JavaScript runtime API reference:
+```
+
+- The generated binary rendered the Loupedeck first-script tutorial:
+
+```text
+provider-shipped-help-docs help loupedeck-js-first-live-script | grep -F "Build your first live Loupedeck JavaScript script"
+  # Build your first live Loupedeck JavaScript script:
+```
+
+- `go test ./cmd/xgoja/... -count=1` passed before the manual smoke run.
+
+### What didn't work
+
+- My first Makefile used the wrong tutorial slug:
+
+```text
+Unknown help topic [`tutorial-build-your-first-live-loupedeck-js-script`]
+make: *** [Makefile:23: run] Error 1
+```
+
+- I checked `loupedeck/docs/help/tutorials/01-build-your-first-live-loupedeck-js-script.md` and found the correct slug:
+
+```yaml
+Slug: loupedeck-js-first-live-script
+```
+
+- I updated the Makefile and README, then reran the full smoke successfully.
+
+### What I learned
+
+- The manual Loupedeck path validates more than the unit tests: it proves generated `go.mod` replacement, provider registration, Glazed help loading, and real Loupedeck help slugs all work together.
+- Help slugs are the stable user-facing API. Example smoke tests should grep known title text but call the exact slug from frontmatter.
+
+### What was tricky to build
+
+- The relative replace path is easy to get wrong. From `go-go-goja/examples/xgoja/09-provider-shipped-help-docs`, the sibling Loupedeck repo is `../../../../loupedeck`.
+- The example needs a runtime profile even though the smoke focuses on help docs, because xgoja buildspec validation requires at least one runtime with at least one module. I selected `loupedeck/state` because it is safe and does not require hardware.
+
+### What warrants a second pair of eyes
+
+- Confirm the example should stay in the numbered learning path as `09-...` and that adding Loupedeck as a sibling-repo dependency is acceptable for the all-example loop in this workspace.
+- Confirm the Makefile should keep `--keep-work`; existing examples do, but it leaves `/tmp/xgoja-build-*` workspaces for inspection.
+
+### What should be done in the future
+
+- Consider adding a CI job that runs the numbered xgoja examples only in workspaces where sibling provider repositories are checked out.
+- If this example becomes too heavy for routine smoke loops, keep it documented as an optional cross-repo smoke test.
+
+### Code review instructions
+
+- Start with `examples/xgoja/09-provider-shipped-help-docs/xgoja.yaml`.
+- Review the Makefile `run` target to see the actual end-to-end assertions.
+- Validate with:
+
+```bash
+make -C examples/xgoja/09-provider-shipped-help-docs smoke
+rm -rf examples/xgoja/09-provider-shipped-help-docs/dist
+```
+
+### Technical details
+
+The key spec section is:
+
+```yaml
+help:
+  sources:
+    - id: loupedeck-runtime-api
+      package: loupedeck
+      source: runtime-api
 ```

--- a/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/reference/01-investigation-diary.md
+++ b/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/reference/01-investigation-diary.md
@@ -17,7 +17,7 @@ RelatedFiles:
       Note: Loupedeck embedded docs package inspected for provider help source design
 ExternalSources: []
 Summary: Chronological diary for researching and designing Glazed help document support in generated xgoja binaries.
-LastUpdated: 2026-05-31T12:44:00-04:00
+LastUpdated: 2026-05-31T12:54:00-04:00
 WhatFor: Use to understand what was inspected, what decisions were made, and how to continue implementation.
 WhenToUse: Read before implementing XGOJA-015 or reviewing the design guide.
 ---
@@ -746,4 +746,123 @@ helpSystem.LoadSectionsFromFS(opts.EmbeddedHelp, source.Path)
 
 // Runtime filesystem docs
 helpSystem.LoadSectionsFromFS(os.DirFS(source.Path), ".")
+```
+
+## Step 7: Registered Loupedeck help docs as an xgoja provider help source
+
+This step wired the motivating real provider. The Loupedeck docs package now exposes its embedded documentation filesystem, and the Loupedeck xgoja provider registers a `runtime-api` help source that contains the existing API reference and tutorials.
+
+This makes the user-specified page, `loupedeck/docs/help/topics/01-loupedeck-js-api-reference.md`, available to generated xgoja binaries that include the Loupedeck provider and select `help.sources: [{ package: loupedeck, source: runtime-api }]`.
+
+### Prompt Context
+
+**User prompt (verbatim):** (see Step 3)
+
+**Assistant interpretation:** Continue implementation with the Loupedeck provider integration phase and commit it separately in the Loupedeck repository.
+
+**Inferred user intent:** Prove the provider help source design works for the concrete package that motivated the ticket.
+
+**Commit (code):** `b5825faefbf648a8e22d2078865f7aa839e6ac0c` — "XGOJA: expose loupedeck help docs"
+
+### What I did
+
+- Updated `loupedeck/docs/help/doc.go` to export:
+
+```go
+func FS() fs.FS {
+    return docFS
+}
+```
+
+- Updated `loupedeck/runtime/js/provider/provider.go` to register:
+
+```go
+providerapi.HelpSource{
+    Name:        "runtime-api",
+    Description: "Loupedeck JavaScript runtime API reference and tutorials",
+    FS:          helpdoc.FS(),
+    Root:        ".",
+}
+```
+
+- Added `TestRegisterProviderHelpSource` in `loupedeck/runtime/js/provider/provider_test.go` to resolve `loupedeck.runtime-api` and verify the embedded API reference contains `Slug: loupedeck-js-api-reference`.
+- Ran:
+
+```bash
+cd loupedeck
+gofmt -w docs/help/doc.go runtime/js/provider/provider.go runtime/js/provider/provider_test.go
+go test ./runtime/js/provider ./pkg/xgoja/provider -count=1
+```
+
+- Committed the Loupedeck repo changes.
+
+### Why
+
+- The Loupedeck API reference is the concrete example requested in the prompt.
+- Exporting `FS()` keeps the standalone Loupedeck CLI's `AddDocToHelpSystem` behavior intact while allowing provider registration to expose the same docs to xgoja.
+
+### What worked
+
+- Focused Loupedeck tests passed:
+
+```text
+ok  	github.com/go-go-golems/loupedeck/runtime/js/provider	0.124s
+?   	github.com/go-go-golems/loupedeck/pkg/xgoja/provider	[no test files]
+```
+
+- The Loupedeck code committed successfully:
+
+```text
+[task/xgoja-docs b5825fa] XGOJA: expose loupedeck help docs
+ 3 files changed, 35 insertions(+)
+```
+
+### What didn't work
+
+- My first provider import used the default import name incorrectly. The package at `github.com/go-go-golems/loupedeck/docs/help` declares `package doc`, so I changed the import to an explicit alias:
+
+```go
+helpdoc "github.com/go-go-golems/loupedeck/docs/help"
+```
+
+- My first test sketch introduced unnecessary `json.Valid(...)` code to keep an import live, but `encoding/json` was already used elsewhere in the file. I replaced the custom byte helper with `bytes.Contains`.
+
+### What I learned
+
+- The docs package pattern can support both standalone CLIs and xgoja providers with a tiny exported `FS()` helper.
+- The `pkg/xgoja/provider` wrapper continues to work because it delegates to `runtime/js/provider.Register`.
+
+### What was tricky to build
+
+- The only sharp edge was Go's package-name behavior: import path base names and declared package names can differ. Explicit aliasing avoids ambiguity and makes the provider registration line read clearly as `helpdoc.FS()`.
+
+### What warrants a second pair of eyes
+
+- Confirm the provider source name `runtime-api` is broad enough for both API references and tutorials. If maintainers prefer narrower names, split docs into multiple sources later.
+- Confirm the source should load all `docs/help` entries (`Root: "."`) rather than only `topics/`.
+
+### What should be done in the future
+
+- Add an end-to-end generated xgoja binary example/spec using `loupedeck.runtime-api` after cross-repo test setup is convenient.
+- Update xgoja's own help docs to document provider help sources and Loupedeck-style references.
+
+### Code review instructions
+
+- In `loupedeck`, start at `docs/help/doc.go`, then inspect `runtime/js/provider/provider.go` registration.
+- Validate with:
+
+```bash
+go test ./runtime/js/provider ./pkg/xgoja/provider -count=1
+```
+
+### Technical details
+
+Buildspec selection shape for the new provider help source:
+
+```yaml
+help:
+  sources:
+    - id: loupedeck-runtime-api
+      package: loupedeck
+      source: runtime-api
 ```

--- a/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/reference/01-investigation-diary.md
+++ b/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/reference/01-investigation-diary.md
@@ -17,7 +17,7 @@ RelatedFiles:
       Note: Loupedeck embedded docs package inspected for provider help source design
 ExternalSources: []
 Summary: Chronological diary for researching and designing Glazed help document support in generated xgoja binaries.
-LastUpdated: 2026-05-31T12:18:00-04:00
+LastUpdated: 2026-05-31T12:32:00-04:00
 WhatFor: Use to understand what was inspected, what decisions were made, and how to continue implementation.
 WhenToUse: Read before implementing XGOJA-015 or reviewing the design guide.
 ---
@@ -520,4 +520,117 @@ help:
     - id: local-docs
       path: ./docs/help
       embed: true
+```
+
+## Step 5: Added generator support for embedded local help docs
+
+This step taught the xgoja generator how to carry `help.sources` into the generated runtime spec and how to copy local embedded help directories into the generated build workspace. Generated `main.go` now handles the four embed combinations: no embedded sources, JavaScript verbs only, help docs only, and both.
+
+The generated app still does not load the configured help docs into the Glazed help system yet; that is the next phase. This phase proves the code-generation layer can produce compiling generated programs with embedded help assets and can rewrite local help paths to stable `xgoja_embed/help/...` roots.
+
+### Prompt Context
+
+**User prompt (verbatim):** (see Step 3)
+
+**Assistant interpretation:** Continue implementing the next checklist phase, keep tests focused, and record what changed.
+
+**Inferred user intent:** Make incremental progress while preserving reviewability and test evidence.
+
+**Commit (code):** pending at time of diary entry — generator embedding phase prepared for commit.
+
+### What I did
+
+- Added `EmbeddedHelp fs.FS` fields to `app.Options`, `HostOptions`, and `Host` so generated code can pass embedded help docs forward.
+- Updated `cmd/xgoja/internal/generate/main.go` to:
+  - include `help.sources` in rendered runtime JSON only when non-empty,
+  - rewrite embedded local help paths to `xgoja_embed/help/<sanitized-id>`,
+  - avoid collisions with suffixes such as `_2`,
+  - detect whether a spec has embedded help sources.
+- Updated `cmd/xgoja/internal/generate/generate.go` to copy embedded help directories into the generated workspace.
+- Updated `cmd/xgoja/internal/generate/templates.go` and `templates/main.go.tmpl` so generated `main.go` embeds:
+  - only `xgoja_embed/jsverbs/*` when only JS verbs are embedded,
+  - only `xgoja_embed/help/*` when only help docs are embedded,
+  - both when both are embedded.
+- Added generator tests for:
+  - help-only template rendering,
+  - combined JS verb + help template rendering,
+  - embedded help path rewriting,
+  - collision-free embedded help roots,
+  - copied embedded help files,
+  - generated program compilation/execution with embedded help assets present.
+- Ran:
+
+```bash
+cd go-go-goja
+gofmt -w pkg/xgoja/app/root.go pkg/xgoja/app/host.go \
+  cmd/xgoja/internal/generate/generate.go \
+  cmd/xgoja/internal/generate/main.go \
+  cmd/xgoja/internal/generate/templates.go \
+  cmd/xgoja/internal/generate/generate_test.go
+go test ./cmd/xgoja/internal/generate -count=1
+```
+
+### Why
+
+- Local documentation directories must be physically present in the generated module before `go build` can embed them.
+- Generated code must avoid unused `embed` imports and unused variables across all combinations of embedded docs and embedded JS verbs.
+- Runtime JSON path rewriting lets the generated app refer to embedded paths instead of original source paths.
+
+### What worked
+
+- The focused generator test passed:
+
+```text
+ok  	github.com/go-go-golems/go-go-goja/cmd/xgoja/internal/generate	30.275s
+```
+
+- The generated program test with embedded help docs still executed `eval` successfully, proving that help-only embedding does not break generated builds.
+
+### What didn't work
+
+- N/A for this phase. The implementation and focused tests passed on the first run.
+
+### What I learned
+
+- Splitting template booleans into `HasEmbeddedJSVerb` and `HasEmbeddedHelp` is cleaner than overloading the old `HasEmbedded` flag.
+- `//go:embed xgoja_embed/help/*` works for the copied source roots because the pattern matches the per-source directories and Go embeds those directories recursively.
+
+### What was tricky to build
+
+- The subtle part was generated template construction. If generated code references `embeddedJSVerbs` when only help docs are embedded, compilation fails. If it imports `embed` when no embedded sources exist, compilation fails. The template data now computes source-specific variables and passes `nil` for absent embedded filesystems.
+
+### What warrants a second pair of eyes
+
+- Review whether generated `main.go` should pass `nil` explicitly for absent embedded filesystems or omit those fields. The current code is explicit and compiles.
+- Confirm that the path root `xgoja_embed/help/<source-id>` is the desired long-term generated workspace layout.
+
+### What should be done in the future
+
+- Implement app-layer loading so the embedded help docs are actually available through `help <slug>`.
+- Add an end-to-end generated binary test that calls `help local-api` after the loader phase lands.
+
+### Code review instructions
+
+- Start in `cmd/xgoja/internal/generate/main.go` for runtime spec rewriting.
+- Then inspect `templates.go` and `templates/main.go.tmpl` for generated code combinations.
+- Validate with:
+
+```bash
+go test ./cmd/xgoja/internal/generate -count=1
+```
+
+### Technical details
+
+Generated help-only shape:
+
+```go
+//go:embed xgoja_embed/help/*
+var embeddedHelp embed.FS
+
+root, err := app.NewRootCommand(app.Options{
+    Providers:       registry,
+    SpecJSON:        embeddedSpecJSON,
+    EmbeddedJSVerbs: nil,
+    EmbeddedHelp:    embeddedHelp,
+})
 ```

--- a/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/tasks.md
+++ b/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/tasks.md
@@ -21,15 +21,15 @@
 - [x] Validate duplicate help source names and missing help source filesystems.
 - [x] Extend providerapi tests for successful help source resolution and invalid entries.
 - [x] Run `go test ./pkg/xgoja/providerapi -count=1`.
-- [ ] Commit provider API support.
+- [x] Commit provider API support.
 
 ### Phase 2: Buildspec/runtime spec support
 
-- [ ] Add `help.sources` YAML schema to `cmd/xgoja/internal/buildspec`.
-- [ ] Add matching JSON runtime spec types to `pkg/xgoja/app`.
-- [ ] Add `validateHelp(...)` for duplicate IDs, missing IDs, missing paths, mixed provider/path sources, unknown package IDs, and embedded path existence.
-- [ ] Add buildspec tests for valid and invalid help source declarations.
-- [ ] Run `go test ./cmd/xgoja/internal/buildspec -count=1`.
+- [x] Add `help.sources` YAML schema to `cmd/xgoja/internal/buildspec`.
+- [x] Add matching JSON runtime spec types to `pkg/xgoja/app`.
+- [x] Add `validateHelp(...)` for duplicate IDs, missing IDs, missing paths, mixed provider/path sources, unknown package IDs, and embedded path existence.
+- [x] Add buildspec tests for valid and invalid help source declarations.
+- [x] Run `go test ./cmd/xgoja/internal/buildspec -count=1`.
 - [ ] Commit buildspec/runtime spec support.
 
 ### Phase 3: Generator embedding support

--- a/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/tasks.md
+++ b/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/tasks.md
@@ -30,22 +30,22 @@
 - [x] Add `validateHelp(...)` for duplicate IDs, missing IDs, missing paths, mixed provider/path sources, unknown package IDs, and embedded path existence.
 - [x] Add buildspec tests for valid and invalid help source declarations.
 - [x] Run `go test ./cmd/xgoja/internal/buildspec -count=1`.
-- [ ] Commit buildspec/runtime spec support.
+- [x] Commit buildspec/runtime spec support.
 
 ### Phase 3: Generator embedding support
 
-- [ ] Add generated runtime JSON rendering for `help.sources`.
-- [ ] Add embedded local help root rewriting under `xgoja_embed/help/<source-id>`.
-- [ ] Add `copyEmbeddedHelpSources(...)` to copy local help docs into generated workspaces.
-- [ ] Update generated `main.go` template to embed JS verbs, help docs, or both without unused imports/variables.
-- [ ] Pass `EmbeddedHelp` to `app.NewRootCommand` and `app.NewHostWithOptions` in all target modes.
-- [ ] Add generator tests for template output, collision-free root rewriting, copied help files, and generated binary help smoke coverage.
-- [ ] Run `go test ./cmd/xgoja/internal/generate -count=1`.
+- [x] Add generated runtime JSON rendering for `help.sources`.
+- [x] Add embedded local help root rewriting under `xgoja_embed/help/<source-id>`.
+- [x] Add `copyEmbeddedHelpSources(...)` to copy local help docs into generated workspaces.
+- [x] Update generated `main.go` template to embed JS verbs, help docs, or both without unused imports/variables.
+- [x] Pass `EmbeddedHelp` to `app.NewRootCommand` and `app.NewHostWithOptions` in all target modes.
+- [x] Add generator tests for template output, collision-free root rewriting, copied help files, and generated binary help smoke coverage.
+- [x] Run `go test ./cmd/xgoja/internal/generate -count=1`.
 - [ ] Commit generator embedding support.
 
 ### Phase 4: Generated root loading support
 
-- [ ] Add `EmbeddedHelp` to `app.Options`, `HostOptions`, and `Host`.
+- [x] Add `EmbeddedHelp` to `app.Options`, `HostOptions`, and `Host`.
 - [ ] Pass provider registry and embedded help FS into `installRootFramework`.
 - [ ] Load built-in generated docs, provider help sources, embedded local help sources, and optional runtime filesystem sources into one Glazed `HelpSystem`.
 - [ ] Keep `help_cmd.SetupCobraRootCommand(...)` called exactly once.

--- a/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/tasks.md
+++ b/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/tasks.md
@@ -41,16 +41,16 @@
 - [x] Pass `EmbeddedHelp` to `app.NewRootCommand` and `app.NewHostWithOptions` in all target modes.
 - [x] Add generator tests for template output, collision-free root rewriting, copied help files, and generated binary help smoke coverage.
 - [x] Run `go test ./cmd/xgoja/internal/generate -count=1`.
-- [ ] Commit generator embedding support.
+- [x] Commit generator embedding support.
 
 ### Phase 4: Generated root loading support
 
 - [x] Add `EmbeddedHelp` to `app.Options`, `HostOptions`, and `Host`.
-- [ ] Pass provider registry and embedded help FS into `installRootFramework`.
-- [ ] Load built-in generated docs, provider help sources, embedded local help sources, and optional runtime filesystem sources into one Glazed `HelpSystem`.
-- [ ] Keep `help_cmd.SetupCobraRootCommand(...)` called exactly once.
-- [ ] Add app tests for provider help source lookup, embedded local help lookup, and missing provider source errors.
-- [ ] Run `go test ./pkg/xgoja/app -count=1`.
+- [x] Pass provider registry and embedded help FS into `installRootFramework`.
+- [x] Load built-in generated docs, provider help sources, embedded local help sources, and optional runtime filesystem sources into one Glazed `HelpSystem`.
+- [x] Keep `help_cmd.SetupCobraRootCommand(...)` called exactly once.
+- [x] Add app tests for provider help source lookup, embedded local help lookup, and missing provider source errors.
+- [x] Run `go test ./pkg/xgoja/app -count=1`.
 - [ ] Commit generated root loading support.
 
 ### Phase 5: Loupedeck provider documentation support

--- a/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/tasks.md
+++ b/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/tasks.md
@@ -1,0 +1,74 @@
+# Tasks
+
+## Completed research/setup
+
+- [x] Create docmgr ticket XGOJA-015.
+- [x] Add primary design/implementation guide document.
+- [x] Add investigation diary document.
+- [x] Inspect xgoja builder help wiring and generated-binary help wiring.
+- [x] Inspect buildspec/generator patterns for embedded source directories.
+- [x] Inspect providerapi extension points for provider-owned resources.
+- [x] Inspect Loupedeck Glazed help docs and standalone CLI help setup.
+- [x] Write intern-friendly design with API sketches, pseudocode, diagrams, implementation phases, tests, and file references.
+
+## Implementation tasks
+
+### Phase 1: Provider API support
+
+- [ ] Add `providerapi.HelpSource` with `Name`, `Description`, `FS`, and `Root` fields.
+- [ ] Add `HelpSources` storage to `providerapi.Package` snapshots and registry clones.
+- [ ] Add `Registry.ResolveHelpSource(packageID, sourceName)`.
+- [ ] Validate duplicate help source names and missing help source filesystems.
+- [ ] Extend providerapi tests for successful help source resolution and invalid entries.
+- [ ] Run `go test ./pkg/xgoja/providerapi -count=1`.
+- [ ] Commit provider API support.
+
+### Phase 2: Buildspec/runtime spec support
+
+- [ ] Add `help.sources` YAML schema to `cmd/xgoja/internal/buildspec`.
+- [ ] Add matching JSON runtime spec types to `pkg/xgoja/app`.
+- [ ] Add `validateHelp(...)` for duplicate IDs, missing IDs, missing paths, mixed provider/path sources, unknown package IDs, and embedded path existence.
+- [ ] Add buildspec tests for valid and invalid help source declarations.
+- [ ] Run `go test ./cmd/xgoja/internal/buildspec -count=1`.
+- [ ] Commit buildspec/runtime spec support.
+
+### Phase 3: Generator embedding support
+
+- [ ] Add generated runtime JSON rendering for `help.sources`.
+- [ ] Add embedded local help root rewriting under `xgoja_embed/help/<source-id>`.
+- [ ] Add `copyEmbeddedHelpSources(...)` to copy local help docs into generated workspaces.
+- [ ] Update generated `main.go` template to embed JS verbs, help docs, or both without unused imports/variables.
+- [ ] Pass `EmbeddedHelp` to `app.NewRootCommand` and `app.NewHostWithOptions` in all target modes.
+- [ ] Add generator tests for template output, collision-free root rewriting, copied help files, and generated binary help smoke coverage.
+- [ ] Run `go test ./cmd/xgoja/internal/generate -count=1`.
+- [ ] Commit generator embedding support.
+
+### Phase 4: Generated root loading support
+
+- [ ] Add `EmbeddedHelp` to `app.Options`, `HostOptions`, and `Host`.
+- [ ] Pass provider registry and embedded help FS into `installRootFramework`.
+- [ ] Load built-in generated docs, provider help sources, embedded local help sources, and optional runtime filesystem sources into one Glazed `HelpSystem`.
+- [ ] Keep `help_cmd.SetupCobraRootCommand(...)` called exactly once.
+- [ ] Add app tests for provider help source lookup, embedded local help lookup, and missing provider source errors.
+- [ ] Run `go test ./pkg/xgoja/app -count=1`.
+- [ ] Commit generated root loading support.
+
+### Phase 5: Loupedeck provider documentation support
+
+- [ ] Export `FS() fs.FS` from `loupedeck/docs/help` without breaking `AddDocToHelpSystem`.
+- [ ] Register a `providerapi.HelpSource{Name: "runtime-api"}` in `loupedeck/runtime/js/provider.Register`.
+- [ ] Add Loupedeck provider tests that resolve `loupedeck.runtime-api` and verify its filesystem contains the API reference.
+- [ ] Run `go test ./runtime/js/provider ./pkg/xgoja/provider -count=1` in `loupedeck`.
+- [ ] Commit Loupedeck provider docs support.
+
+### Phase 6: End-to-end docs, diary, and validation
+
+- [ ] Update xgoja help docs with the new `help.sources` buildspec reference and provider docs guidance.
+- [ ] Add or update examples showing provider-shipped and embedded local help docs.
+- [ ] Run focused go-go-goja tests: `go test ./pkg/xgoja/providerapi ./cmd/xgoja/internal/buildspec ./cmd/xgoja/internal/generate ./pkg/xgoja/app ./cmd/xgoja/... -count=1`.
+- [ ] Run focused loupedeck tests after provider docs wiring.
+- [ ] Update diary after each phase with exact commands, failures, tricky parts, and review instructions.
+- [ ] Update docmgr changelog and related files after each meaningful milestone.
+- [ ] Run `docmgr doctor --ticket XGOJA-015 --stale-after 30`.
+- [ ] Upload final implementation bundle to reMarkable.
+- [ ] Commit final ticket documentation updates.

--- a/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/tasks.md
+++ b/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/tasks.md
@@ -63,10 +63,10 @@
 
 ### Phase 6: End-to-end docs, diary, and validation
 
-- [ ] Update xgoja help docs with the new `help.sources` buildspec reference and provider docs guidance.
-- [ ] Add or update examples showing provider-shipped and embedded local help docs.
-- [ ] Run focused go-go-goja tests: `go test ./pkg/xgoja/providerapi ./cmd/xgoja/internal/buildspec ./cmd/xgoja/internal/generate ./pkg/xgoja/app ./cmd/xgoja/... -count=1`.
-- [ ] Run focused loupedeck tests after provider docs wiring.
+- [x] Update xgoja help docs with the new `help.sources` buildspec reference and provider docs guidance.
+- [x] Add or update examples showing provider-shipped and embedded local help docs.
+- [x] Run focused go-go-goja tests: `go test ./pkg/xgoja/providerapi ./cmd/xgoja/internal/buildspec ./cmd/xgoja/internal/generate ./pkg/xgoja/app ./cmd/xgoja/... -count=1`.
+- [x] Run focused loupedeck tests after provider docs wiring.
 - [ ] Update diary after each phase with exact commands, failures, tricky parts, and review instructions.
 - [ ] Update docmgr changelog and related files after each meaningful milestone.
 - [ ] Run `docmgr doctor --ticket XGOJA-015 --stale-after 30`.

--- a/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/tasks.md
+++ b/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/tasks.md
@@ -15,12 +15,12 @@
 
 ### Phase 1: Provider API support
 
-- [ ] Add `providerapi.HelpSource` with `Name`, `Description`, `FS`, and `Root` fields.
-- [ ] Add `HelpSources` storage to `providerapi.Package` snapshots and registry clones.
-- [ ] Add `Registry.ResolveHelpSource(packageID, sourceName)`.
-- [ ] Validate duplicate help source names and missing help source filesystems.
-- [ ] Extend providerapi tests for successful help source resolution and invalid entries.
-- [ ] Run `go test ./pkg/xgoja/providerapi -count=1`.
+- [x] Add `providerapi.HelpSource` with `Name`, `Description`, `FS`, and `Root` fields.
+- [x] Add `HelpSources` storage to `providerapi.Package` snapshots and registry clones.
+- [x] Add `Registry.ResolveHelpSource(packageID, sourceName)`.
+- [x] Validate duplicate help source names and missing help source filesystems.
+- [x] Extend providerapi tests for successful help source resolution and invalid entries.
+- [x] Run `go test ./pkg/xgoja/providerapi -count=1`.
 - [ ] Commit provider API support.
 
 ### Phase 2: Buildspec/runtime spec support

--- a/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/tasks.md
+++ b/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/tasks.md
@@ -67,8 +67,8 @@
 - [x] Add or update examples showing provider-shipped and embedded local help docs.
 - [x] Run focused go-go-goja tests: `go test ./pkg/xgoja/providerapi ./cmd/xgoja/internal/buildspec ./cmd/xgoja/internal/generate ./pkg/xgoja/app ./cmd/xgoja/... -count=1`.
 - [x] Run focused loupedeck tests after provider docs wiring.
-- [ ] Update diary after each phase with exact commands, failures, tricky parts, and review instructions.
-- [ ] Update docmgr changelog and related files after each meaningful milestone.
-- [ ] Run `docmgr doctor --ticket XGOJA-015 --stale-after 30`.
-- [ ] Upload final implementation bundle to reMarkable.
-- [ ] Commit final ticket documentation updates.
+- [x] Update diary after each phase with exact commands, failures, tricky parts, and review instructions.
+- [x] Update docmgr changelog and related files after each meaningful milestone.
+- [x] Run `docmgr doctor --ticket XGOJA-015 --stale-after 30`.
+- [x] Upload final implementation bundle to reMarkable.
+- [x] Commit final ticket documentation updates.

--- a/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/tasks.md
+++ b/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/tasks.md
@@ -65,6 +65,8 @@
 
 - [x] Update xgoja help docs with the new `help.sources` buildspec reference and provider docs guidance.
 - [x] Add or update examples showing provider-shipped and embedded local help docs.
+- [x] Add `examples/xgoja/09-provider-shipped-help-docs` as a reusable Loupedeck provider help docs smoke test.
+- [x] Run `make -C examples/xgoja/09-provider-shipped-help-docs smoke` and verify `help loupedeck-js-api-reference` plus `help loupedeck-js-first-live-script`.
 - [x] Run focused go-go-goja tests: `go test ./pkg/xgoja/providerapi ./cmd/xgoja/internal/buildspec ./cmd/xgoja/internal/generate ./pkg/xgoja/app ./cmd/xgoja/... -count=1`.
 - [x] Run focused loupedeck tests after provider docs wiring.
 - [x] Update diary after each phase with exact commands, failures, tricky parts, and review instructions.

--- a/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/tasks.md
+++ b/ttmp/2026/05/31/XGOJA-015--add-glazed-help-documents-to-xgoja-binaries/tasks.md
@@ -51,15 +51,15 @@
 - [x] Keep `help_cmd.SetupCobraRootCommand(...)` called exactly once.
 - [x] Add app tests for provider help source lookup, embedded local help lookup, and missing provider source errors.
 - [x] Run `go test ./pkg/xgoja/app -count=1`.
-- [ ] Commit generated root loading support.
+- [x] Commit generated root loading support.
 
 ### Phase 5: Loupedeck provider documentation support
 
-- [ ] Export `FS() fs.FS` from `loupedeck/docs/help` without breaking `AddDocToHelpSystem`.
-- [ ] Register a `providerapi.HelpSource{Name: "runtime-api"}` in `loupedeck/runtime/js/provider.Register`.
-- [ ] Add Loupedeck provider tests that resolve `loupedeck.runtime-api` and verify its filesystem contains the API reference.
-- [ ] Run `go test ./runtime/js/provider ./pkg/xgoja/provider -count=1` in `loupedeck`.
-- [ ] Commit Loupedeck provider docs support.
+- [x] Export `FS() fs.FS` from `loupedeck/docs/help` without breaking `AddDocToHelpSystem`.
+- [x] Register a `providerapi.HelpSource{Name: "runtime-api"}` in `loupedeck/runtime/js/provider.Register`.
+- [x] Add Loupedeck provider tests that resolve `loupedeck.runtime-api` and verify its filesystem contains the API reference.
+- [x] Run `go test ./runtime/js/provider ./pkg/xgoja/provider -count=1` in `loupedeck`.
+- [x] Commit Loupedeck provider docs support.
 
 ### Phase 6: End-to-end docs, diary, and validation
 


### PR DESCRIPTION
This change introduces a comprehensive system for bundling Glazed help documents
into binaries generated by xgoja. Users can now include API references,
tutorials, and other documentation directly in their applications, accessible via
the standard `help` command.

Key changes include:

**Buildspec (`xgoja.yaml`)**
*   A new top-level `help.sources` section is added to `xgoja.yaml`.
*   It supports three modes for sourcing documentation:
    - **Provider-shipped**: Include docs from a provider package using `package`
      and `source` keys. Ideal for API documentation that lives with the
      provider code.
    - **Embedded local**: Embed a local directory of Markdown files into the
      binary using `path` and `embed: true`.
    - **Runtime filesystem**: Load docs from a local directory at runtime using
      `path` with `embed: false`. This is useful for development.

**Provider API**
*   A new `providerapi.HelpSource` type allows providers to register an `fs.FS`
  containing their help documents.
*   The provider registry is updated to manage these help sources.

**Generation and Runtime**
*   The `xgoja build` process validates the `help.sources` configuration,
  copies local files for embedding, and generates the necessary `go:embed`
  directives.
*   The application framework is updated to accept an `embed.FS` for help
  documents and load them into the Glazed help system at startup.

**Documentation and Testing**
*   The user guide and provider playbook are updated to cover the new feature.
*   A new example, `09-provider-shipped-help-docs`, demonstrates how to
  consume provider-shipped documentation.
*   Comprehensive unit and integration tests are added to validate the new
  functionality.