### PR TITLE
Feat(xgoja): Add environment and config file support for generated binaries

### DIFF
--- a/cmd/xgoja/doc/02-user-guide.md
+++ b/cmd/xgoja/doc/02-user-guide.md
@@ -26,7 +26,7 @@ ShowPerDefault: true
 SectionType: GeneralTopic
 ---
 
-An `xgoja.yaml` file describes the generated binary. It names the output program, selects provider packages, defines runtime profiles, enables commands, configures JavaScript verb sources, optionally embeds application assets, and optionally bundles Glazed help entries.
+An `xgoja.yaml` file describes the generated binary. It names the output program, selects provider packages, defines runtime profiles, enables commands, configures JavaScript verb sources, optionally embeds application assets, optionally bundles Glazed help entries, and can opt generated Glazed commands into environment-variable and config-file sources.
 
 A minimal shape looks like this:
 
@@ -71,6 +71,12 @@ commands:
 
 `name` is the generated application name. It defaults to `xgoja-app`.
 
+`appName` is an optional application identity used by the generated root framework and app-scoped config discovery. When omitted, framework setup falls back to `name`.
+
+`envPrefix` is an optional shell-safe environment namespace for generated command fields. If `envPrefix` is omitted and `appName` is set, xgoja derives one by uppercasing `appName`, converting separators such as `-`, `.`, `_`, and spaces to underscores, and prefixing leading digits with `APP_`.
+
+`config` optionally enables Glazed config-file loading for generated commands.
+
 `go` controls the generated module. `go.version` defaults to `1.26`, and `go.module` defaults to `example.com/generated/<name>`.
 
 `target` controls the generated binary shape and output path.
@@ -88,6 +94,62 @@ commands:
 `help.sources` configures additional Glazed help pages loaded into the generated binary's `help` command.
 
 `commandProviders` mounts Glazed command sets supplied by provider packages.
+
+## App identity, environment variables, and config files
+
+Generated commands normally read values from CLI flags, positional arguments, and field defaults. Add `appName`, `envPrefix`, or `config` when generated Glazed commands should also read environment variables or config files.
+
+```yaml
+name: config-env-demo
+appName: config-env-demo
+envPrefix: DEMO
+config:
+  enabled: true
+  layers:
+    - cwd
+    - explicit
+  fileName: config.yaml
+```
+
+### Environment variables
+
+If `envPrefix` is set, generated commands include Glazed's environment-variable source middleware. Environment variables use the generated prefix, the command section prefix, and the field name. For example, a provider field in section `fixture` with field `value` can be set as:
+
+```bash
+DEMO_FIXTURE_VALUE=from-env ./dist/config-env-demo eval 'fixtureValue'
+```
+
+If `envPrefix` is omitted but `appName: config-env-demo` is set, xgoja derives `CONFIG_ENV_DEMO`.
+
+### Config files
+
+Enable config files with `config.enabled: true`. Config files use Glazed's standard section-map shape:
+
+```yaml
+fixture:
+  value: from-config-file
+```
+
+Supported layers are:
+
+| Layer | Discovery |
+| --- | --- |
+| `system` | `/etc/<appName>/<fileName>` |
+| `xdg` | `$XDG_CONFIG_HOME/<appName>/<fileName>` |
+| `home` | `~/.<appName>/<fileName>` |
+| `git-root` | `<git-root>/<fileName>` |
+| `cwd` | `<current-working-directory>/<fileName>` |
+| `explicit` | Path supplied with `--config-file` |
+
+The app-scoped layers (`system`, `xdg`, `home`) require `appName`. Local layers (`cwd`, `git-root`, `explicit`) do not. The `--config-file` flag only loads a file when `explicit` appears in `config.layers`.
+
+Effective precedence is:
+
+```text
+field defaults < config files < environment variables < positional args / CLI flags
+```
+
+For a runnable example, see `examples/xgoja/11-config-env`.
 
 ## Packages
 

--- a/cmd/xgoja/doc/03-tutorial-using-xgoja-yaml.md
+++ b/cmd/xgoja/doc/03-tutorial-using-xgoja-yaml.md
@@ -138,7 +138,58 @@ For an interactive terminal session, run:
 
 The REPL command starts a Bubble Tea terminal UI backed by the same runtime-profile module policy.
 
-## 6. Add a runtime filesystem jsverb source
+## 6. Optional: enable env vars and config files for command fields
+
+Generated Glazed commands can read field values from config files and environment variables when the buildspec opts in.
+
+Add app identity, an environment prefix, and config layers to `xgoja.yaml`:
+
+```yaml
+name: fixture
+appName: fixture
+envPrefix: FIXTURE
+config:
+  enabled: true
+  layers:
+    - cwd
+    - explicit
+  fileName: config.yaml
+```
+
+Create `config.yaml` in the working directory where you run the generated binary. Config files use Glazed's section-map format:
+
+```yaml
+fixture:
+  value: from-config-file
+```
+
+Run with the current-directory config file:
+
+```bash
+./dist/fixture eval 'fixtureValue'
+```
+
+Override the same field with an environment variable:
+
+```bash
+FIXTURE_FIXTURE_VALUE=from-env ./dist/fixture eval 'fixtureValue'
+```
+
+Override both config and environment with a CLI flag:
+
+```bash
+FIXTURE_FIXTURE_VALUE=from-env ./dist/fixture eval --fixture-value from-flag 'fixtureValue'
+```
+
+Load an explicit config path only when `explicit` is present in `config.layers`:
+
+```bash
+./dist/fixture eval --config-file config.yaml 'fixtureValue'
+```
+
+The effective precedence is: field defaults, then config files, then environment variables, then positional args and CLI flags. For a runnable example, see `examples/xgoja/11-config-env`.
+
+## 7. Add a runtime filesystem jsverb source
 
 Create `verbs/tools.js`:
 
@@ -174,7 +225,7 @@ Build again and run:
 
 This mode scans `./verbs` from disk when the generated binary starts.
 
-## 7. Embed local jsverbs into the generated binary
+## 8. Embed local jsverbs into the generated binary
 
 Change the source to:
 
@@ -193,7 +244,7 @@ xgoja build -f xgoja.yaml --keep-work
 
 xgoja copies `./verbs` into the generated workspace and generated `main.go` embeds it with `go:embed`. The final binary no longer needs the original `./verbs` directory at runtime.
 
-## 8. Embed assets and read them through fs aliases
+## 9. Embed assets and read them through fs aliases
 
 Create an asset file:
 
@@ -241,7 +292,7 @@ Read the embedded file from JavaScript:
 
 For web/static asset trees, include dot directories such as `.well-known` directly in `./assets`; generated asset embeds use Go's `all:` pattern so those files are preserved. Do not use `include` or `exclude` fields in `assets:` yet. They are rejected until the generator enforces filtering.
 
-## 9. Serve embedded assets with the HTTP provider
+## 10. Serve embedded assets with the HTTP provider
 
 Add the HTTP provider package and select its `express` module in the same runtime profile as `fs:assets`:
 
@@ -290,7 +341,7 @@ Run it with `--keep-alive` so the generated runtime stays alive after registerin
 
 Open `http://127.0.0.1:8787/static/`. For a complete runnable project, see `examples/xgoja/10-embedded-assets-fs` or `xgoja help tutorial-static-assets-http-server`.
 
-## 10. Use provider-shipped jsverbs
+## 11. Use provider-shipped jsverbs
 
 Provider packages can ship JS verbs next to their native Go modules.
 
@@ -319,7 +370,7 @@ jsverbs:
 
 This scans the provider's embedded filesystem, not the local project filesystem.
 
-## 11. Debug generated builds
+## 12. Debug generated builds
 
 Use:
 

--- a/cmd/xgoja/doc/06-buildspec-reference.md
+++ b/cmd/xgoja/doc/06-buildspec-reference.md
@@ -161,6 +161,66 @@ ENV_FIXTURE_FIXTURE_VALUE=from-env ./dist/env-fixture eval 'fixtureValue'
 
 CLI flags still have higher precedence than environment variables.
 
+Generated binaries can also opt into Glazed-style config file loading:
+
+```yaml
+name: my-app
+appName: my-app
+config:
+  enabled: true
+  layers:
+    - cwd
+    - explicit
+  fileName: config.yaml
+```
+
+Config files use Glazed's standard section map shape:
+
+```yaml
+section-slug:
+  field-name: value
+```
+
+For example, if a provider contributes a section with slug `fixture`, prefix `fixture-`, and field `value`, a config file can set it with:
+
+```yaml
+fixture:
+  value: from-config-file
+```
+
+The equivalent environment variable for `envPrefix: DEMO` is:
+
+```bash
+DEMO_FIXTURE_VALUE=from-env
+```
+
+The equivalent CLI flag is:
+
+```bash
+./dist/my-app eval --fixture-value from-flag 'fixtureValue'
+```
+
+Config precedence is:
+
+```text
+field defaults < config files < environment variables < positional args / CLI flags
+```
+
+Supported `config.layers` values:
+
+| Layer | Discovery |
+| --- | --- |
+| `system` | `/etc/<appName>/config.yaml` |
+| `xdg` | `$XDG_CONFIG_HOME/<appName>/config.yaml` (usually `~/.config/<appName>/config.yaml`) |
+| `home` | `~/.<appName>/config.yaml` |
+| `git-root` | `<git-root>/<fileName>` |
+| `cwd` | `<current-working-directory>/<fileName>` |
+| `explicit` | Path supplied with the Glazed `--config-file` flag |
+
+The `system`, `xdg`, and `home` layers require `appName` because they are app-scoped locations. The `cwd`, `git-root`, and `explicit` layers can be used without `appName`. Explicit config files are only loaded when `explicit` is listed in `config.layers`; passing `--config-file` has no effect unless that layer is enabled.
+
+For a runnable config/env example, see `examples/xgoja/11-config-env`.
+
 Validate and build with:
 
 ```bash

--- a/cmd/xgoja/doc/06-buildspec-reference.md
+++ b/cmd/xgoja/doc/06-buildspec-reference.md
@@ -23,6 +23,8 @@ The most common `xgoja.yaml` shape is:
 
 ```yaml
 name: my-app
+appName: my-app      # optional: generated application identity for logging/config conventions
+envPrefix: MY_APP    # optional: enables MY_APP_* environment variables for command fields
 target:
   kind: xgoja
   output: dist/my-app
@@ -133,6 +135,31 @@ app.staticFromAssetsModule("/static", assets, "/app/public")
 ```
 
 Use `run --keep-alive` for server setup scripts so the runtime stays alive after route registration. See `examples/xgoja/10-embedded-assets-fs` and `xgoja help tutorial-static-assets-http-server`.
+
+Generated binaries can opt into Glazed-style environment variable parsing with `appName` or `envPrefix`:
+
+```yaml
+name: my-app
+appName: my-app
+# envPrefix defaults to MY_APP when omitted; set it explicitly when you need a stable namespace.
+envPrefix: MY_APP
+```
+
+`appName` is the human/application identity used by the generated root framework. `envPrefix` is the shell-safe environment namespace. If `envPrefix` is omitted and `appName` is set, xgoja derives a shell-safe prefix by uppercasing and converting separators such as `-`, `.`, `_`, and spaces to underscores. Existing specs with neither field keep the historical behavior: only CLI flags, positional arguments, and field defaults are parsed.
+
+Environment variables use Glazed's section-prefix plus field-name convention. For example, the fixture provider's `fixture` section has prefix `fixture-` and field `value`, so this YAML:
+
+```yaml
+appName: env-fixture
+```
+
+allows:
+
+```bash
+ENV_FIXTURE_FIXTURE_VALUE=from-env ./dist/env-fixture eval 'fixtureValue'
+```
+
+CLI flags still have higher precedence than environment variables.
 
 Validate and build with:
 

--- a/cmd/xgoja/internal/buildspec/load.go
+++ b/cmd/xgoja/internal/buildspec/load.go
@@ -85,6 +85,11 @@ func applyDefaults(spec *Spec) {
 	spec.Name = strings.TrimSpace(spec.Name)
 	spec.AppName = strings.TrimSpace(spec.AppName)
 	spec.EnvPrefix = strings.TrimSpace(spec.EnvPrefix)
+	if spec.Config != nil && spec.Config.Enabled {
+		if strings.TrimSpace(spec.Config.FileName) == "" {
+			spec.Config.FileName = "config.yaml"
+		}
+	}
 	if spec.Name == "" {
 		spec.Name = "xgoja-app"
 	}

--- a/cmd/xgoja/internal/buildspec/load.go
+++ b/cmd/xgoja/internal/buildspec/load.go
@@ -83,6 +83,8 @@ func applyDefaults(spec *Spec) {
 		return
 	}
 	spec.Name = strings.TrimSpace(spec.Name)
+	spec.AppName = strings.TrimSpace(spec.AppName)
+	spec.EnvPrefix = strings.TrimSpace(spec.EnvPrefix)
 	if spec.Name == "" {
 		spec.Name = "xgoja-app"
 	}

--- a/cmd/xgoja/internal/buildspec/load_test.go
+++ b/cmd/xgoja/internal/buildspec/load_test.go
@@ -191,3 +191,40 @@ jsverbs:
 		t.Fatalf("expected missing path error, got %v", err)
 	}
 }
+
+func TestLoadFileAppliesConfigDefaults(t *testing.T) {
+	dir := t.TempDir()
+	specPath := filepath.Join(dir, "xgoja.yaml")
+	if err := os.WriteFile(specPath, []byte(`
+name: config-test
+appName: config-test
+config:
+  enabled: true
+  layers:
+    - cwd
+packages:
+  - id: core
+    import: github.com/go-go-golems/go-go-goja/xgoja
+runtimes:
+  main:
+    modules:
+      - package: core
+        name: fs
+`), 0o644); err != nil {
+		t.Fatalf("write spec: %v", err)
+	}
+
+	spec, report, err := LoadFile(specPath)
+	if err != nil {
+		t.Fatalf("load spec: %v", err)
+	}
+	if report == nil || report.HasErrors() {
+		t.Fatalf("expected non-error report, got %#v", report)
+	}
+	if spec.Config == nil || !spec.Config.Enabled {
+		t.Fatalf("config not enabled")
+	}
+	if spec.Config.FileName != "config.yaml" {
+		t.Fatalf("config.FileName = %q, want config.yaml", spec.Config.FileName)
+	}
+}

--- a/cmd/xgoja/internal/buildspec/load_test.go
+++ b/cmd/xgoja/internal/buildspec/load_test.go
@@ -20,6 +20,8 @@ func TestLoadFileValidSpec(t *testing.T) {
 	specPath := filepath.Join(dir, "xgoja.yaml")
 	if err := os.WriteFile(specPath, []byte(`
 name: webrepl
+appName: webrepl-dev
+envPrefix: WEBREPL_DEV
 packages:
   - id: core
     import: github.com/go-go-golems/go-go-goja/xgoja
@@ -62,6 +64,12 @@ assets:
 	}
 	if spec.Name != "webrepl" {
 		t.Fatalf("name = %q", spec.Name)
+	}
+	if spec.AppName != "webrepl-dev" {
+		t.Fatalf("appName = %q", spec.AppName)
+	}
+	if spec.EnvPrefix != "WEBREPL_DEV" {
+		t.Fatalf("envPrefix = %q", spec.EnvPrefix)
 	}
 	if spec.Target.Kind != "xgoja" {
 		t.Fatalf("default target kind = %q", spec.Target.Kind)

--- a/cmd/xgoja/internal/buildspec/spec.go
+++ b/cmd/xgoja/internal/buildspec/spec.go
@@ -6,6 +6,7 @@ type Spec struct {
 	Name             string                    `yaml:"name"`
 	AppName          string                    `yaml:"appName"`
 	EnvPrefix        string                    `yaml:"envPrefix"`
+	Config           *ConfigSpec               `yaml:"config,omitempty"`
 	Go               GoSpec                    `yaml:"go"`
 	Target           TargetSpec                `yaml:"target"`
 	Packages         []PackageSpec             `yaml:"packages"`
@@ -16,6 +17,12 @@ type Spec struct {
 	Help             HelpSpec                  `yaml:"help"`
 	Assets           []AssetSourceSpec         `yaml:"assets"`
 	BaseDir          string                    `yaml:"-"`
+}
+
+type ConfigSpec struct {
+	Enabled  bool     `yaml:"enabled" json:"enabled"`
+	Layers   []string `yaml:"layers,omitempty" json:"layers,omitempty"`
+	FileName string   `yaml:"fileName,omitempty" json:"fileName,omitempty"`
 }
 
 type GoSpec struct {

--- a/cmd/xgoja/internal/buildspec/spec.go
+++ b/cmd/xgoja/internal/buildspec/spec.go
@@ -4,6 +4,8 @@ import "fmt"
 
 type Spec struct {
 	Name             string                    `yaml:"name"`
+	AppName          string                    `yaml:"appName"`
+	EnvPrefix        string                    `yaml:"envPrefix"`
 	Go               GoSpec                    `yaml:"go"`
 	Target           TargetSpec                `yaml:"target"`
 	Packages         []PackageSpec             `yaml:"packages"`

--- a/cmd/xgoja/internal/buildspec/validate.go
+++ b/cmd/xgoja/internal/buildspec/validate.go
@@ -15,6 +15,7 @@ func Validate(spec *Spec) *Report {
 	}
 
 	validateName(report, spec)
+	validateAppSettings(report, spec)
 	validateTarget(report, spec)
 	packageIDs := validatePackages(report, spec)
 	validateRuntimes(report, spec, packageIDs)
@@ -33,6 +34,41 @@ func validateName(report *Report, spec *Spec) {
 		return
 	}
 	report.AddOK("name", "name", fmt.Sprintf("spec name is %q", spec.Name))
+}
+
+func validateAppSettings(report *Report, spec *Spec) {
+	appName := strings.TrimSpace(spec.AppName)
+	if appName != "" {
+		report.AddOK("app-name", "appName", appName)
+	}
+	envPrefix := strings.TrimSpace(spec.EnvPrefix)
+	if envPrefix == "" {
+		return
+	}
+	if !isShellSafeEnvPrefix(envPrefix) {
+		report.AddError("env-prefix", "envPrefix", "envPrefix must match [A-Z][A-Z0-9_]*")
+		return
+	}
+	report.AddOK("env-prefix", "envPrefix", envPrefix)
+}
+
+func isShellSafeEnvPrefix(prefix string) bool {
+	if prefix == "" {
+		return false
+	}
+	for i, r := range prefix {
+		switch {
+		case r >= 'A' && r <= 'Z':
+			continue
+		case r >= '0' && r <= '9' && i > 0:
+			continue
+		case r == '_' && i > 0:
+			continue
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 func validateTarget(report *Report, spec *Spec) {

--- a/cmd/xgoja/internal/buildspec/validate.go
+++ b/cmd/xgoja/internal/buildspec/validate.go
@@ -77,10 +77,12 @@ func validateConfig(report *Report, spec *Spec) {
 		report.AddOK("config", "config", "config not enabled")
 		return
 	}
-	if strings.TrimSpace(spec.AppName) == "" {
-		report.AddError("config-app-name", "config", "config requires appName to be set")
-	} else {
-		report.AddOK("config-app-name", "config", "appName is set for config discovery")
+	if usesAppScopedConfigLayer(spec.Config.Layers) {
+		if strings.TrimSpace(spec.AppName) == "" {
+			report.AddError("config-app-name", "config", "config layers system, xdg, and home require appName to be set")
+		} else {
+			report.AddOK("config-app-name", "config", "appName is set for app-scoped config discovery")
+		}
 	}
 	if len(spec.Config.Layers) == 0 {
 		report.AddError("config-layers", "config.layers", "config.enabled requires at least one layer")
@@ -108,6 +110,16 @@ var knownConfigLayers = map[string]bool{
 
 func isKnownConfigLayer(layer string) bool {
 	return knownConfigLayers[layer]
+}
+
+func usesAppScopedConfigLayer(layers []string) bool {
+	for _, layer := range layers {
+		switch strings.TrimSpace(layer) {
+		case "system", "xdg", "home":
+			return true
+		}
+	}
+	return false
 }
 
 func validateTarget(report *Report, spec *Spec) {

--- a/cmd/xgoja/internal/buildspec/validate.go
+++ b/cmd/xgoja/internal/buildspec/validate.go
@@ -16,6 +16,7 @@ func Validate(spec *Spec) *Report {
 
 	validateName(report, spec)
 	validateAppSettings(report, spec)
+	validateConfig(report, spec)
 	validateTarget(report, spec)
 	packageIDs := validatePackages(report, spec)
 	validateRuntimes(report, spec, packageIDs)
@@ -69,6 +70,44 @@ func isShellSafeEnvPrefix(prefix string) bool {
 		}
 	}
 	return true
+}
+
+func validateConfig(report *Report, spec *Spec) {
+	if spec.Config == nil || !spec.Config.Enabled {
+		report.AddOK("config", "config", "config not enabled")
+		return
+	}
+	if strings.TrimSpace(spec.AppName) == "" {
+		report.AddError("config-app-name", "config", "config requires appName to be set")
+	} else {
+		report.AddOK("config-app-name", "config", "appName is set for config discovery")
+	}
+	if len(spec.Config.Layers) == 0 {
+		report.AddError("config-layers", "config.layers", "config.enabled requires at least one layer")
+		return
+	}
+	for i, layer := range spec.Config.Layers {
+		layer = strings.TrimSpace(layer)
+		if !isKnownConfigLayer(layer) {
+			report.AddError("config-layer", fmt.Sprintf("config.layers[%d]", i), fmt.Sprintf("unknown config layer %q", layer))
+		} else {
+			report.AddOK("config-layer", fmt.Sprintf("config.layers[%d]", i), layer)
+		}
+	}
+	report.AddOK("config", "config", fmt.Sprintf("%d config layer(s) declared", len(spec.Config.Layers)))
+}
+
+var knownConfigLayers = map[string]bool{
+	"system":   true,
+	"xdg":      true,
+	"home":     true,
+	"git-root": true,
+	"cwd":      true,
+	"explicit": true,
+}
+
+func isKnownConfigLayer(layer string) bool {
+	return knownConfigLayers[layer]
 }
 
 func validateTarget(report *Report, spec *Spec) {

--- a/cmd/xgoja/internal/buildspec/validate_test.go
+++ b/cmd/xgoja/internal/buildspec/validate_test.go
@@ -202,3 +202,51 @@ func TestValidateAppSettingsRejectsInvalidEnvPrefix(t *testing.T) {
 	}
 	assertCheck(t, report, StatusError, "env-prefix", "envPrefix")
 }
+
+func TestValidateConfigRequiresAppName(t *testing.T) {
+	spec := validSpec()
+	spec.Config = &ConfigSpec{Enabled: true, Layers: []string{"cwd"}}
+
+	report := Validate(spec)
+	if !report.HasErrors() {
+		t.Fatalf("expected validation errors, got %#v", report.Checks)
+	}
+	assertCheck(t, report, StatusError, "config-app-name", "config")
+}
+
+func TestValidateConfigRejectsUnknownLayers(t *testing.T) {
+	spec := validSpec()
+	spec.AppName = "my-app"
+	spec.Config = &ConfigSpec{Enabled: true, Layers: []string{"cwd", "unknown", "xdg"}}
+
+	report := Validate(spec)
+	if !report.HasErrors() {
+		t.Fatalf("expected validation errors, got %#v", report.Checks)
+	}
+	assertCheck(t, report, StatusError, "config-layer", "config.layers[1]")
+	assertCheck(t, report, StatusOK, "config-layer", "config.layers[0]")
+	assertCheck(t, report, StatusOK, "config-layer", "config.layers[2]")
+}
+
+func TestValidateConfigAcceptsValidLayers(t *testing.T) {
+	spec := validSpec()
+	spec.AppName = "my-app"
+	spec.Config = &ConfigSpec{Enabled: true, Layers: []string{"system", "xdg", "home", "git-root", "cwd", "explicit"}}
+
+	report := Validate(spec)
+	if report.HasErrors() {
+		t.Fatalf("expected no validation errors, got %#v", report.Checks)
+	}
+}
+
+func TestValidateConfigRequiresLayers(t *testing.T) {
+	spec := validSpec()
+	spec.AppName = "my-app"
+	spec.Config = &ConfigSpec{Enabled: true, Layers: []string{}}
+
+	report := Validate(spec)
+	if !report.HasErrors() {
+		t.Fatalf("expected validation errors, got %#v", report.Checks)
+	}
+	assertCheck(t, report, StatusError, "config-layers", "config.layers")
+}

--- a/cmd/xgoja/internal/buildspec/validate_test.go
+++ b/cmd/xgoja/internal/buildspec/validate_test.go
@@ -178,3 +178,27 @@ func assertCheck(t *testing.T, report *Report, status Status, name string, path 
 	}
 	t.Fatalf("missing %s check %s at %s in %#v", status, name, path, report.Checks)
 }
+
+func TestValidateAppSettingsAcceptsAppNameAndEnvPrefix(t *testing.T) {
+	spec := validSpec()
+	spec.AppName = "my-app"
+	spec.EnvPrefix = "MY_APP"
+
+	report := Validate(spec)
+	if report.HasErrors() {
+		t.Fatalf("expected no validation errors, got %#v", report.Checks)
+	}
+	assertCheck(t, report, StatusOK, "app-name", "appName")
+	assertCheck(t, report, StatusOK, "env-prefix", "envPrefix")
+}
+
+func TestValidateAppSettingsRejectsInvalidEnvPrefix(t *testing.T) {
+	spec := validSpec()
+	spec.EnvPrefix = "my-app"
+
+	report := Validate(spec)
+	if !report.HasErrors() {
+		t.Fatalf("expected validation errors, got %#v", report.Checks)
+	}
+	assertCheck(t, report, StatusError, "env-prefix", "envPrefix")
+}

--- a/cmd/xgoja/internal/buildspec/validate_test.go
+++ b/cmd/xgoja/internal/buildspec/validate_test.go
@@ -203,15 +203,25 @@ func TestValidateAppSettingsRejectsInvalidEnvPrefix(t *testing.T) {
 	assertCheck(t, report, StatusError, "env-prefix", "envPrefix")
 }
 
-func TestValidateConfigRequiresAppName(t *testing.T) {
+func TestValidateConfigRequiresAppNameForAppScopedLayers(t *testing.T) {
 	spec := validSpec()
-	spec.Config = &ConfigSpec{Enabled: true, Layers: []string{"cwd"}}
+	spec.Config = &ConfigSpec{Enabled: true, Layers: []string{"system"}}
 
 	report := Validate(spec)
 	if !report.HasErrors() {
 		t.Fatalf("expected validation errors, got %#v", report.Checks)
 	}
 	assertCheck(t, report, StatusError, "config-app-name", "config")
+}
+
+func TestValidateConfigAllowsLocalLayersWithoutAppName(t *testing.T) {
+	spec := validSpec()
+	spec.Config = &ConfigSpec{Enabled: true, Layers: []string{"cwd", "git-root", "explicit"}}
+
+	report := Validate(spec)
+	if report.HasErrors() {
+		t.Fatalf("expected no validation errors, got %#v", report.Checks)
+	}
 }
 
 func TestValidateConfigRejectsUnknownLayers(t *testing.T) {

--- a/cmd/xgoja/internal/generate/generate_test.go
+++ b/cmd/xgoja/internal/generate/generate_test.go
@@ -1,6 +1,7 @@
 package generate
 
 import (
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -9,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/go-go-golems/go-go-goja/cmd/xgoja/internal/buildspec"
+	"github.com/go-go-golems/go-go-goja/pkg/xgoja/app"
 )
 
 func TestRenderGoModDeterministic(t *testing.T) {
@@ -114,6 +116,33 @@ func TestRenderEmbeddedSpecStableShape(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Fatalf("expected embedded spec to contain %q, got:\n%s", want, got)
 		}
+	}
+}
+
+func TestRenderEmbeddedSpecIncludesRuntimeAppSettings(t *testing.T) {
+	spec := fixtureSpec()
+	spec.AppName = "my-app"
+	spec.EnvPrefix = "MY_APP"
+	spec.Config = &buildspec.ConfigSpec{Enabled: true, Layers: []string{"cwd", "explicit"}, FileName: "config.yaml"}
+
+	var embedded app.Spec
+	if err := json.Unmarshal([]byte(RenderEmbeddedSpec(spec)), &embedded); err != nil {
+		t.Fatalf("unmarshal embedded spec: %v", err)
+	}
+	if embedded.AppName != "my-app" {
+		t.Fatalf("appName = %q", embedded.AppName)
+	}
+	if embedded.EnvPrefix != "MY_APP" {
+		t.Fatalf("envPrefix = %q", embedded.EnvPrefix)
+	}
+	if embedded.Config == nil || !embedded.Config.Enabled {
+		t.Fatalf("embedded config missing or disabled: %#v", embedded.Config)
+	}
+	if got, want := strings.Join(embedded.Config.Layers, ","), "cwd,explicit"; got != want {
+		t.Fatalf("config layers = %q, want %q", got, want)
+	}
+	if embedded.Config.FileName != "config.yaml" {
+		t.Fatalf("config fileName = %q", embedded.Config.FileName)
 	}
 }
 

--- a/cmd/xgoja/internal/generate/main.go
+++ b/cmd/xgoja/internal/generate/main.go
@@ -24,6 +24,9 @@ func RenderEmbeddedSpec(spec *buildspec.Spec) string {
 	}
 	payload := struct {
 		Name             string                              `json:"name"`
+		AppName          string                              `json:"appName,omitempty"`
+		EnvPrefix        string                              `json:"envPrefix,omitempty"`
+		Config           *buildspec.ConfigSpec               `json:"config,omitempty"`
 		Target           buildspec.TargetSpec                `json:"target"`
 		Packages         []buildspec.PackageSpec             `json:"packages"`
 		Runtimes         map[string]buildspec.Runtime        `json:"runtimes"`
@@ -34,6 +37,9 @@ func RenderEmbeddedSpec(spec *buildspec.Spec) string {
 		Assets           []buildspec.AssetSourceSpec         `json:"assets,omitempty"`
 	}{
 		Name:             spec.Name,
+		AppName:          spec.AppName,
+		EnvPrefix:        spec.EnvPrefix,
+		Config:           spec.Config,
 		Target:           spec.Target,
 		Packages:         spec.Packages,
 		Runtimes:         spec.Runtimes,

--- a/examples/xgoja/11-config-env/README.md
+++ b/examples/xgoja/11-config-env/README.md
@@ -22,6 +22,14 @@ The included `config.yaml` sets `fixture.value = from-config-file`:
 
 Output: `hello from-config-file`
 
+You can also load an explicit config file when the `explicit` layer is enabled in `xgoja.yaml`:
+
+```bash
+./dist/config-env-demo run --config-file config.yaml script.js
+```
+
+The flag name is Glazed's `--config-file` (not `--config`).
+
 ## Override with environment variable
 
 ```bash

--- a/examples/xgoja/11-config-env/README.md
+++ b/examples/xgoja/11-config-env/README.md
@@ -1,0 +1,43 @@
+# Example: Config and Env Support
+
+This example demonstrates how a generated xgoja binary can read configuration from:
+
+1. A `config.yaml` file in the current working directory
+2. Environment variables with the `DEMO_` prefix
+3. CLI flags (highest precedence)
+
+## Build
+
+```bash
+xgoja build -f xgoja.yaml --xgoja-replace /path/to/go-go-goja
+```
+
+## Run with config file
+
+The included `config.yaml` sets `fixture.value = from-config-file`:
+
+```bash
+./dist/config-env-demo run script.js
+```
+
+Output: `hello from-config-file`
+
+## Override with environment variable
+
+```bash
+DEMO_FIXTURE_VALUE=from-env ./dist/config-env-demo run script.js
+```
+
+Output: `hello from-env`
+
+## Override with CLI flag (highest precedence)
+
+```bash
+DEMO_FIXTURE_VALUE=from-env ./dist/config-env-demo run --fixture-value from-flag script.js
+```
+
+Output: `hello from-flag`
+
+## Precedence
+
+Config file < Environment variables < CLI flags

--- a/examples/xgoja/11-config-env/config.yaml
+++ b/examples/xgoja/11-config-env/config.yaml
@@ -1,0 +1,2 @@
+fixture:
+  value: from-config-file

--- a/examples/xgoja/11-config-env/script.js
+++ b/examples/xgoja/11-config-env/script.js
@@ -1,0 +1,2 @@
+const hello = require("hello")
+console.log(hello.greet(fixtureValue))

--- a/examples/xgoja/11-config-env/xgoja.yaml
+++ b/examples/xgoja/11-config-env/xgoja.yaml
@@ -1,0 +1,31 @@
+name: config-env-demo
+appName: config-env-demo
+envPrefix: DEMO
+config:
+  enabled: true
+  layers:
+    - cwd
+  fileName: config.yaml
+target:
+  kind: xgoja
+  output: dist/config-env-demo
+packages:
+  - id: fixture
+    import: github.com/go-go-golems/go-go-goja/pkg/xgoja/testprovider
+    register: Register
+runtimes:
+  main:
+    modules:
+      - package: fixture
+        name: hello
+        as: hello
+commands:
+  eval:
+    enabled: true
+    runtime: main
+  run:
+    enabled: true
+    runtime: main
+  repl:
+    enabled: true
+    runtime: main

--- a/examples/xgoja/11-config-env/xgoja.yaml
+++ b/examples/xgoja/11-config-env/xgoja.yaml
@@ -5,6 +5,7 @@ config:
   enabled: true
   layers:
     - cwd
+    - explicit
   fileName: config.yaml
 target:
   kind: xgoja

--- a/pkg/xgoja/app/command_providers.go
+++ b/pkg/xgoja/app/command_providers.go
@@ -36,12 +36,19 @@ func (h *Host) AttachCommandProviders(root *cobra.Command) {
 			continue
 		}
 		commands := applyMountToCommands(set.Commands, mount)
+		middlewaresFunc := h.MiddlewaresFunc
+		if middlewaresFunc == nil {
+			middlewaresFunc = glazedcli.CobraCommandDefaultMiddlewares
+		}
 		parserConfig := glazedcli.CobraParserConfig{
 			ShortHelpSections: []string{schema.DefaultSlug},
-			MiddlewaresFunc:   glazedcli.CobraCommandDefaultMiddlewares,
+			MiddlewaresFunc:   middlewaresFunc,
 		}
 		if set.ParserConfig != nil {
 			parserConfig = *set.ParserConfig
+			if parserConfig.MiddlewaresFunc == nil {
+				parserConfig.MiddlewaresFunc = middlewaresFunc
+			}
 		}
 		if err := glazedcli.AddCommandsToRootCommand(root, commands, nil, glazedcli.WithParserConfig(parserConfig)); err != nil {
 			root.AddCommand(commandErrorStub(commandProviderUse(instance, mount), "Attach custom xgoja command provider", err))

--- a/pkg/xgoja/app/framework.go
+++ b/pkg/xgoja/app/framework.go
@@ -32,8 +32,12 @@ func installRootFramework(root *cobra.Command, spec *Spec, opts frameworkOptions
 		return nil
 	}
 	appName := "xgoja"
-	if spec != nil && spec.Name != "" {
-		appName = spec.Name
+	if spec != nil {
+		if strings.TrimSpace(spec.AppName) != "" {
+			appName = strings.TrimSpace(spec.AppName)
+		} else if strings.TrimSpace(spec.Name) != "" {
+			appName = strings.TrimSpace(spec.Name)
+		}
 	}
 	if err := logging.AddLoggingSectionToRootCommand(root, appName); err != nil {
 		return err

--- a/pkg/xgoja/app/glazed.go
+++ b/pkg/xgoja/app/glazed.go
@@ -7,11 +7,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func buildGlazedCobraCommand(command cmds.Command) (*cobra.Command, error) {
+func buildGlazedCobraCommand(command cmds.Command, middlewaresFuncs ...cli.CobraMiddlewaresFunc) (*cobra.Command, error) {
+	middlewaresFunc := cli.CobraCommandDefaultMiddlewares
+	if len(middlewaresFuncs) > 0 && middlewaresFuncs[0] != nil {
+		middlewaresFunc = middlewaresFuncs[0]
+	}
 	return cli.BuildCobraCommand(command,
 		cli.WithParserConfig(cli.CobraParserConfig{
 			ShortHelpSections: []string{schema.DefaultSlug},
-			MiddlewaresFunc:   cli.CobraCommandDefaultMiddlewares,
+			MiddlewaresFunc:   middlewaresFunc,
 		}),
 	)
 }

--- a/pkg/xgoja/app/host.go
+++ b/pkg/xgoja/app/host.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"io/fs"
 
+	"github.com/go-go-golems/glazed/pkg/cli"
 	"github.com/go-go-golems/go-go-goja/pkg/xgoja/providerapi"
 	"github.com/spf13/cobra"
 )
@@ -17,6 +18,7 @@ type Host struct {
 	EmbeddedAssets  fs.FS
 	Services        HostServices
 	Out             io.Writer
+	MiddlewaresFunc cli.CobraMiddlewaresFunc
 }
 
 type HostOptions struct {
@@ -24,6 +26,7 @@ type HostOptions struct {
 	EmbeddedHelp    fs.FS
 	EmbeddedAssets  fs.FS
 	Out             io.Writer
+	MiddlewaresFunc cli.CobraMiddlewaresFunc
 }
 
 func NewHost(providers *providerapi.Registry, spec *Spec) *Host {
@@ -32,6 +35,10 @@ func NewHost(providers *providerapi.Registry, spec *Spec) *Host {
 
 func NewHostWithOptions(providers *providerapi.Registry, spec *Spec, opts HostOptions) *Host {
 	services := HostServices{Assets: NewAssetStore(opts.EmbeddedAssets, spec)}
+	middlewaresFunc := opts.MiddlewaresFunc
+	if middlewaresFunc == nil {
+		middlewaresFunc = MiddlewaresFromSpec(spec)
+	}
 	return &Host{
 		Providers:       providers,
 		Spec:            spec,
@@ -41,6 +48,7 @@ func NewHostWithOptions(providers *providerapi.Registry, spec *Spec, opts HostOp
 		EmbeddedAssets:  opts.EmbeddedAssets,
 		Services:        services,
 		Out:             opts.Out,
+		MiddlewaresFunc: middlewaresFunc,
 	}
 }
 
@@ -75,7 +83,7 @@ func (h *Host) AttachEval(root *cobra.Command) {
 	if out == nil {
 		out = root.OutOrStdout()
 	}
-	cmd, err := buildGlazedCobraCommand(newEvalCommand(h.Factory, h.Spec, out))
+	cmd, err := buildGlazedCobraCommand(newEvalCommand(h.Factory, h.Spec, out), h.MiddlewaresFunc)
 	if err != nil {
 		root.AddCommand(commandErrorStub(commandName(h.Spec.Commands.Eval, "eval"), "Evaluate JavaScript in a generated xgoja runtime", err))
 		return
@@ -87,7 +95,7 @@ func (h *Host) AttachRun(root *cobra.Command) {
 	if root == nil || h == nil {
 		return
 	}
-	cmd, err := buildGlazedCobraCommand(newRunCommand(h.Factory, h.Spec))
+	cmd, err := buildGlazedCobraCommand(newRunCommand(h.Factory, h.Spec), h.MiddlewaresFunc)
 	if err != nil {
 		root.AddCommand(commandErrorStub(commandName(h.Spec.Commands.Run, "run"), "Execute a JavaScript file in a generated xgoja runtime", err))
 		return
@@ -99,7 +107,7 @@ func (h *Host) AttachRepl(root *cobra.Command) {
 	if root == nil || h == nil {
 		return
 	}
-	cmd, err := buildGlazedCobraCommand(newTUICommand(h.Factory, h.Spec))
+	cmd, err := buildGlazedCobraCommand(newTUICommand(h.Factory, h.Spec), h.MiddlewaresFunc)
 	if err != nil {
 		root.AddCommand(commandErrorStub(commandName(h.Spec.Commands.Repl, "repl"), "Run an interactive TUI REPL for a generated xgoja runtime", err))
 		return
@@ -111,7 +119,7 @@ func (h *Host) AttachModules(root *cobra.Command) {
 	if root == nil || h == nil {
 		return
 	}
-	cmd, err := buildGlazedCobraCommand(newModulesCommand(h.Providers, h.Spec))
+	cmd, err := buildGlazedCobraCommand(newModulesCommand(h.Providers, h.Spec), h.MiddlewaresFunc)
 	if err != nil {
 		root.AddCommand(commandErrorStub("modules", "List provider modules registered in this generated binary", err))
 		return
@@ -123,5 +131,5 @@ func (h *Host) AttachVerbs(root *cobra.Command) {
 	if root == nil || h == nil {
 		return
 	}
-	root.AddCommand(newVerbsCommand(h.Providers, h.Factory, h.Spec, h.EmbeddedJSVerbs))
+	root.AddCommand(newVerbsCommand(h.Providers, h.Factory, h.Spec, h.EmbeddedJSVerbs, h.MiddlewaresFunc))
 }

--- a/pkg/xgoja/app/middlewares.go
+++ b/pkg/xgoja/app/middlewares.go
@@ -1,0 +1,80 @@
+package app
+
+import (
+	"strings"
+
+	"github.com/go-go-golems/glazed/pkg/cli"
+	"github.com/go-go-golems/glazed/pkg/cmds/fields"
+	cmdsources "github.com/go-go-golems/glazed/pkg/cmds/sources"
+	"github.com/go-go-golems/glazed/pkg/cmds/values"
+	"github.com/spf13/cobra"
+)
+
+// MiddlewaresFromSpec returns the Glazed parser middleware chain for generated
+// xgoja commands. If the spec does not request an environment namespace, it
+// preserves the historical default chain: Cobra flags, positional arguments,
+// and field defaults only.
+func MiddlewaresFromSpec(spec *Spec) cli.CobraMiddlewaresFunc {
+	envPrefix := EffectiveEnvPrefix(spec)
+	if envPrefix == "" {
+		return cli.CobraCommandDefaultMiddlewares
+	}
+	return func(parsedCommandSections *values.Values, cmd *cobra.Command, args []string) ([]cmdsources.Middleware, error) {
+		return []cmdsources.Middleware{
+			cmdsources.FromCobra(cmd, fields.WithSource("cobra")),
+			cmdsources.FromArgs(args, fields.WithSource("arguments")),
+			cmdsources.FromEnv(envPrefix, fields.WithSource("env")),
+			cmdsources.FromDefaults(fields.WithSource(fields.SourceDefaults)),
+		}, nil
+	}
+}
+
+// EffectiveEnvPrefix returns the explicit envPrefix when present, otherwise a
+// shell-safe prefix derived from appName. The spec name is intentionally not
+// used as an implicit env namespace; existing specs without appName/envPrefix
+// must keep their historical flag/argument/default-only parser behavior.
+func EffectiveEnvPrefix(spec *Spec) string {
+	if spec == nil {
+		return ""
+	}
+	if prefix := strings.TrimSpace(spec.EnvPrefix); prefix != "" {
+		return strings.ToUpper(prefix)
+	}
+	return DefaultEnvPrefix(spec.AppName)
+}
+
+// DefaultEnvPrefix converts an application name into a shell-safe environment
+// variable namespace. It is deliberately stricter than Glazed's built-in
+// strings.ToUpper(AppName) behavior because generated binaries commonly use
+// hyphenated app names such as "my-app".
+func DefaultEnvPrefix(appName string) string {
+	appName = strings.TrimSpace(appName)
+	if appName == "" {
+		return ""
+	}
+	var b strings.Builder
+	lastUnderscore := false
+	for _, r := range appName {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r - 'a' + 'A')
+			lastUnderscore = false
+		case r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+			lastUnderscore = false
+		case r == '-' || r == '_' || r == '.' || r == ' ':
+			if b.Len() > 0 && !lastUnderscore {
+				b.WriteRune('_')
+				lastUnderscore = true
+			}
+		}
+	}
+	out := strings.Trim(b.String(), "_")
+	if out == "" {
+		return ""
+	}
+	if out[0] >= '0' && out[0] <= '9' {
+		out = "APP_" + out
+	}
+	return out
+}

--- a/pkg/xgoja/app/middlewares.go
+++ b/pkg/xgoja/app/middlewares.go
@@ -25,6 +25,9 @@ func MiddlewaresFromSpec(spec *Spec) cli.CobraMiddlewaresFunc {
 	}
 
 	return func(parsedCommandSections *values.Values, cmd *cobra.Command, args []string) ([]cmdsources.Middleware, error) {
+		// The returned slice is ordered from highest to lowest precedence because
+		// Glazed middlewares call next before applying their own source values.
+		// Effective precedence is: defaults < config < env < args < cobra flags.
 		middlewares := []cmdsources.Middleware{
 			cmdsources.FromCobra(cmd, fields.WithSource("cobra")),
 			cmdsources.FromArgs(args, fields.WithSource("arguments")),
@@ -90,11 +93,11 @@ func buildConfigPlan(config *ConfigSpec, appName string, parsed *values.Values) 
 			plan.Add(glazedconfig.GitRootFile(fileName).Named("git-root-config").Kind("local-file"))
 		case "cwd":
 			plan.Add(glazedconfig.WorkingDirFile(fileName).Named("cwd-config").Kind("local-file"))
+		case "explicit":
+			if explicit != "" {
+				plan.Add(glazedconfig.ExplicitFile(explicit).Named("explicit-config").Kind("explicit-file"))
+			}
 		}
-	}
-
-	if explicit != "" {
-		plan.Add(glazedconfig.ExplicitFile(explicit).Named("explicit-config").Kind("explicit-file"))
 	}
 
 	return plan, nil

--- a/pkg/xgoja/app/middlewares.go
+++ b/pkg/xgoja/app/middlewares.go
@@ -1,32 +1,103 @@
 package app
 
 import (
+	"context"
 	"strings"
 
 	"github.com/go-go-golems/glazed/pkg/cli"
 	"github.com/go-go-golems/glazed/pkg/cmds/fields"
 	cmdsources "github.com/go-go-golems/glazed/pkg/cmds/sources"
 	"github.com/go-go-golems/glazed/pkg/cmds/values"
+	glazedconfig "github.com/go-go-golems/glazed/pkg/config"
 	"github.com/spf13/cobra"
 )
 
 // MiddlewaresFromSpec returns the Glazed parser middleware chain for generated
-// xgoja commands. If the spec does not request an environment namespace, it
-// preserves the historical default chain: Cobra flags, positional arguments,
-// and field defaults only.
+// xgoja commands. If the spec does not request an environment namespace or
+// config file loading, it preserves the historical default chain: Cobra flags,
+// positional arguments, and field defaults only.
 func MiddlewaresFromSpec(spec *Spec) cli.CobraMiddlewaresFunc {
 	envPrefix := EffectiveEnvPrefix(spec)
-	if envPrefix == "" {
+	hasConfig := spec != nil && spec.Config != nil && spec.Config.Enabled
+
+	if envPrefix == "" && !hasConfig {
 		return cli.CobraCommandDefaultMiddlewares
 	}
+
 	return func(parsedCommandSections *values.Values, cmd *cobra.Command, args []string) ([]cmdsources.Middleware, error) {
-		return []cmdsources.Middleware{
+		middlewares := []cmdsources.Middleware{
 			cmdsources.FromCobra(cmd, fields.WithSource("cobra")),
 			cmdsources.FromArgs(args, fields.WithSource("arguments")),
-			cmdsources.FromEnv(envPrefix, fields.WithSource("env")),
+		}
+
+		if envPrefix != "" {
+			middlewares = append(middlewares, cmdsources.FromEnv(envPrefix, fields.WithSource("env")))
+		}
+
+		if hasConfig {
+			middlewares = append(middlewares,
+				cmdsources.FromConfigPlanBuilder(
+					func(_ context.Context, _ *values.Values) (*glazedconfig.Plan, error) {
+						return buildConfigPlan(spec.Config, spec.AppName, parsedCommandSections)
+					},
+					cmdsources.WithParseOptions(fields.WithSource("config")),
+				),
+			)
+		}
+
+		middlewares = append(middlewares,
 			cmdsources.FromDefaults(fields.WithSource(fields.SourceDefaults)),
-		}, nil
+		)
+
+		return middlewares, nil
 	}
+}
+
+func buildConfigPlan(config *ConfigSpec, appName string, parsed *values.Values) (*glazedconfig.Plan, error) {
+	explicit := ""
+	if parsed != nil {
+		commandSettings := &cli.CommandSettings{}
+		if err := parsed.DecodeSectionInto(cli.CommandSettingsSlug, commandSettings); err == nil {
+			explicit = strings.TrimSpace(commandSettings.ConfigFile)
+		}
+	}
+
+	fileName := strings.TrimSpace(config.FileName)
+	if fileName == "" {
+		fileName = "config.yaml"
+	}
+
+	plan := glazedconfig.NewPlan(
+		glazedconfig.WithLayerOrder(
+			glazedconfig.LayerSystem,
+			glazedconfig.LayerUser,
+			glazedconfig.LayerRepo,
+			glazedconfig.LayerCWD,
+			glazedconfig.LayerExplicit,
+		),
+		glazedconfig.WithDedupePaths(),
+	)
+
+	for _, layer := range config.Layers {
+		switch strings.TrimSpace(layer) {
+		case "system":
+			plan.Add(glazedconfig.SystemAppConfig(appName).Named("system-app-config").Kind("app-config"))
+		case "xdg":
+			plan.Add(glazedconfig.XDGAppConfig(appName).Named("xdg-app-config").Kind("app-config"))
+		case "home":
+			plan.Add(glazedconfig.HomeAppConfig(appName).Named("home-app-config").Kind("app-config"))
+		case "git-root":
+			plan.Add(glazedconfig.GitRootFile(fileName).Named("git-root-config").Kind("local-file"))
+		case "cwd":
+			plan.Add(glazedconfig.WorkingDirFile(fileName).Named("cwd-config").Kind("local-file"))
+		}
+	}
+
+	if explicit != "" {
+		plan.Add(glazedconfig.ExplicitFile(explicit).Named("explicit-config").Kind("explicit-file"))
+	}
+
+	return plan, nil
 }
 
 // EffectiveEnvPrefix returns the explicit envPrefix when present, otherwise a

--- a/pkg/xgoja/app/middlewares_test.go
+++ b/pkg/xgoja/app/middlewares_test.go
@@ -3,6 +3,8 @@ package app
 import (
 	"bytes"
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/go-go-golems/go-go-goja/pkg/xgoja/providerapi"
@@ -117,5 +119,168 @@ func TestGeneratedRootKeepsDefaultMiddlewaresWithoutAppSettings(t *testing.T) {
 	}
 	if got := out.String(); got != "true\n" {
 		t.Fatalf("eval output = %q, want true", got)
+	}
+}
+
+func TestGeneratedRootReadsConfigFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte("fixture:\n  value: from-config\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(oldWd); err != nil {
+			t.Logf("restore wd: %v", err)
+		}
+	}()
+
+	registry := providerapi.NewRegistry()
+	if err := testprovider.Register(registry); err != nil {
+		t.Fatalf("register provider: %v", err)
+	}
+	specJSON := `{
+  "name": "fixture",
+  "appName": "config-fixture",
+  "config": {"enabled": true, "layers": ["cwd"], "fileName": "config.yaml"},
+  "target": {"kind": "xgoja", "output": "dist/fixture"},
+  "packages": [{"id": "fixture"}],
+  "runtimes": {
+    "repl": {
+      "modules": [{"package": "fixture", "name": "hello", "as": "hello"}]
+    }
+  },
+  "commands": {
+    "eval": {"enabled": true, "runtime": "repl", "name": "eval"},
+    "jsverbs": {"enabled": false}
+  }
+}`
+	out := &bytes.Buffer{}
+	root, err := NewRootCommand(Options{Providers: registry, SpecJSON: specJSON, Out: out})
+	if err != nil {
+		t.Fatalf("new root: %v", err)
+	}
+	root.SetArgs([]string{"eval", "fixtureValue"})
+	if err := root.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("execute eval: %v", err)
+	}
+	if got := out.String(); got != "from-config\n" {
+		t.Fatalf("eval output = %q, want from-config", got)
+	}
+}
+
+func TestConfigPrecedenceEnvBeatsConfig(t *testing.T) {
+	t.Setenv("CONFIG_FIXTURE_FIXTURE_VALUE", "from-env")
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte("fixture:\n  value: from-config\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(oldWd); err != nil {
+			t.Logf("restore wd: %v", err)
+		}
+	}()
+
+	registry := providerapi.NewRegistry()
+	if err := testprovider.Register(registry); err != nil {
+		t.Fatalf("register provider: %v", err)
+	}
+	specJSON := `{
+  "name": "fixture",
+  "appName": "config-fixture",
+  "envPrefix": "CONFIG_FIXTURE",
+  "config": {"enabled": true, "layers": ["cwd"], "fileName": "config.yaml"},
+  "target": {"kind": "xgoja", "output": "dist/fixture"},
+  "packages": [{"id": "fixture"}],
+  "runtimes": {
+    "repl": {
+      "modules": [{"package": "fixture", "name": "hello", "as": "hello"}]
+    }
+  },
+  "commands": {
+    "eval": {"enabled": true, "runtime": "repl", "name": "eval"},
+    "jsverbs": {"enabled": false}
+  }
+}`
+	out := &bytes.Buffer{}
+	root, err := NewRootCommand(Options{Providers: registry, SpecJSON: specJSON, Out: out})
+	if err != nil {
+		t.Fatalf("new root: %v", err)
+	}
+	root.SetArgs([]string{"eval", "fixtureValue"})
+	if err := root.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("execute eval: %v", err)
+	}
+	if got := out.String(); got != "from-env\n" {
+		t.Fatalf("eval output = %q, want from-env", got)
+	}
+}
+
+func TestConfigPrecedenceFlagBeatsEnv(t *testing.T) {
+	t.Setenv("CONFIG_FIXTURE_FIXTURE_VALUE", "from-env")
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "config.yaml"), []byte("fixture:\n  value: from-config\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(oldWd); err != nil {
+			t.Logf("restore wd: %v", err)
+		}
+	}()
+
+	registry := providerapi.NewRegistry()
+	if err := testprovider.Register(registry); err != nil {
+		t.Fatalf("register provider: %v", err)
+	}
+	specJSON := `{
+  "name": "fixture",
+  "appName": "config-fixture",
+  "envPrefix": "CONFIG_FIXTURE",
+  "config": {"enabled": true, "layers": ["cwd"], "fileName": "config.yaml"},
+  "target": {"kind": "xgoja", "output": "dist/fixture"},
+  "packages": [{"id": "fixture"}],
+  "runtimes": {
+    "repl": {
+      "modules": [{"package": "fixture", "name": "hello", "as": "hello"}]
+    }
+  },
+  "commands": {
+    "eval": {"enabled": true, "runtime": "repl", "name": "eval"},
+    "jsverbs": {"enabled": false}
+  }
+}`
+	out := &bytes.Buffer{}
+	root, err := NewRootCommand(Options{Providers: registry, SpecJSON: specJSON, Out: out})
+	if err != nil {
+		t.Fatalf("new root: %v", err)
+	}
+	root.SetArgs([]string{"eval", "--fixture-value", "from-flag", "fixtureValue"})
+	if err := root.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("execute eval: %v", err)
+	}
+	if got := out.String(); got != "from-flag\n" {
+		t.Fatalf("eval output = %q, want from-flag", got)
 	}
 }

--- a/pkg/xgoja/app/middlewares_test.go
+++ b/pkg/xgoja/app/middlewares_test.go
@@ -1,0 +1,121 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/go-go-golems/go-go-goja/pkg/xgoja/providerapi"
+	"github.com/go-go-golems/go-go-goja/pkg/xgoja/testprovider"
+)
+
+func TestDefaultEnvPrefixNormalizesAppName(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "hyphen", in: "my-app", want: "MY_APP"},
+		{name: "dots spaces underscores", in: " my.app_name dev ", want: "MY_APP_NAME_DEV"},
+		{name: "repeated separators", in: "my---app", want: "MY_APP"},
+		{name: "leading digit", in: "123-app", want: "APP_123_APP"},
+		{name: "empty", in: " -- ", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DefaultEnvPrefix(tt.in); got != tt.want {
+				t.Fatalf("DefaultEnvPrefix(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGeneratedRootReadsModuleSectionFromDerivedEnvPrefix(t *testing.T) {
+	t.Setenv("ENV_FIXTURE_FIXTURE_VALUE", "from-env")
+	registry := providerapi.NewRegistry()
+	if err := testprovider.Register(registry); err != nil {
+		t.Fatalf("register provider: %v", err)
+	}
+	specJSON := `{
+  "name": "fixture",
+  "appName": "env-fixture",
+  "target": {"kind": "xgoja", "output": "dist/fixture"},
+  "packages": [{"id": "fixture"}],
+  "runtimes": {
+    "repl": {
+      "modules": [{"package": "fixture", "name": "hello", "as": "hello"}]
+    }
+  },
+  "commands": {
+    "eval": {"enabled": true, "runtime": "repl", "name": "eval"},
+    "jsverbs": {"enabled": false}
+  }
+}`
+	out := &bytes.Buffer{}
+	root, err := NewRootCommand(Options{Providers: registry, SpecJSON: specJSON, Out: out})
+	if err != nil {
+		t.Fatalf("new root: %v", err)
+	}
+	root.SetArgs([]string{"eval", "fixtureValue"})
+	if err := root.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("execute eval: %v", err)
+	}
+	if got := out.String(); got != "from-env\n" {
+		t.Fatalf("eval output = %q, want from-env", got)
+	}
+}
+
+func TestGeneratedRootReadsModuleSectionFromExplicitEnvPrefix(t *testing.T) {
+	t.Setenv("XGOJA_TEST_FIXTURE_VALUE", "explicit-env")
+	registry := providerapi.NewRegistry()
+	if err := testprovider.Register(registry); err != nil {
+		t.Fatalf("register provider: %v", err)
+	}
+	specJSON := `{
+  "name": "fixture",
+  "envPrefix": "XGOJA_TEST",
+  "target": {"kind": "xgoja", "output": "dist/fixture"},
+  "packages": [{"id": "fixture"}],
+  "runtimes": {
+    "repl": {
+      "modules": [{"package": "fixture", "name": "hello", "as": "hello"}]
+    }
+  },
+  "commands": {
+    "eval": {"enabled": true, "runtime": "repl", "name": "eval"},
+    "jsverbs": {"enabled": false}
+  }
+}`
+	out := &bytes.Buffer{}
+	root, err := NewRootCommand(Options{Providers: registry, SpecJSON: specJSON, Out: out})
+	if err != nil {
+		t.Fatalf("new root: %v", err)
+	}
+	root.SetArgs([]string{"eval", "fixtureValue"})
+	if err := root.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("execute eval: %v", err)
+	}
+	if got := out.String(); got != "explicit-env\n" {
+		t.Fatalf("eval output = %q, want explicit-env", got)
+	}
+}
+
+func TestGeneratedRootKeepsDefaultMiddlewaresWithoutAppSettings(t *testing.T) {
+	t.Setenv("FIXTURE_FIXTURE_VALUE", "ignored")
+	registry := providerapi.NewRegistry()
+	if err := testprovider.Register(registry); err != nil {
+		t.Fatalf("register provider: %v", err)
+	}
+	out := &bytes.Buffer{}
+	root, err := NewRootCommand(Options{Providers: registry, SpecJSON: fixtureSpecJSON, Out: out})
+	if err != nil {
+		t.Fatalf("new root: %v", err)
+	}
+	root.SetArgs([]string{"eval", "fixtureValue === ''"})
+	if err := root.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("execute eval: %v", err)
+	}
+	if got := out.String(); got != "true\n" {
+		t.Fatalf("eval output = %q, want true", got)
+	}
+}

--- a/pkg/xgoja/app/middlewares_test.go
+++ b/pkg/xgoja/app/middlewares_test.go
@@ -128,18 +128,7 @@ func TestGeneratedRootReadsConfigFile(t *testing.T) {
 		t.Fatalf("write config: %v", err)
 	}
 
-	oldWd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
-	defer func() {
-		if err := os.Chdir(oldWd); err != nil {
-			t.Logf("restore wd: %v", err)
-		}
-	}()
+	chdirForTest(t, dir)
 
 	registry := providerapi.NewRegistry()
 	if err := testprovider.Register(registry); err != nil {
@@ -182,18 +171,7 @@ func TestConfigPrecedenceEnvBeatsConfig(t *testing.T) {
 		t.Fatalf("write config: %v", err)
 	}
 
-	oldWd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
-	defer func() {
-		if err := os.Chdir(oldWd); err != nil {
-			t.Logf("restore wd: %v", err)
-		}
-	}()
+	chdirForTest(t, dir)
 
 	registry := providerapi.NewRegistry()
 	if err := testprovider.Register(registry); err != nil {
@@ -237,18 +215,7 @@ func TestConfigPrecedenceFlagBeatsEnv(t *testing.T) {
 		t.Fatalf("write config: %v", err)
 	}
 
-	oldWd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
-	defer func() {
-		if err := os.Chdir(oldWd); err != nil {
-			t.Logf("restore wd: %v", err)
-		}
-	}()
+	chdirForTest(t, dir)
 
 	registry := providerapi.NewRegistry()
 	if err := testprovider.Register(registry); err != nil {
@@ -283,4 +250,101 @@ func TestConfigPrecedenceFlagBeatsEnv(t *testing.T) {
 	if got := out.String(); got != "from-flag\n" {
 		t.Fatalf("eval output = %q, want from-flag", got)
 	}
+}
+
+func TestExplicitConfigFileRequiresExplicitLayer(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "explicit.yaml")
+	if err := os.WriteFile(configPath, []byte("fixture:\n  value: from-explicit\n"), 0o644); err != nil {
+		t.Fatalf("write explicit config: %v", err)
+	}
+
+	registry := providerapi.NewRegistry()
+	if err := testprovider.Register(registry); err != nil {
+		t.Fatalf("register provider: %v", err)
+	}
+	specJSON := `{
+  "name": "fixture",
+  "appName": "config-fixture",
+  "config": {"enabled": true, "layers": ["cwd"], "fileName": "config.yaml"},
+  "target": {"kind": "xgoja", "output": "dist/fixture"},
+  "packages": [{"id": "fixture"}],
+  "runtimes": {
+    "repl": {
+      "modules": [{"package": "fixture", "name": "hello", "as": "hello"}]
+    }
+  },
+  "commands": {
+    "eval": {"enabled": true, "runtime": "repl", "name": "eval"},
+    "jsverbs": {"enabled": false}
+  }
+}`
+	out := &bytes.Buffer{}
+	root, err := NewRootCommand(Options{Providers: registry, SpecJSON: specJSON, Out: out})
+	if err != nil {
+		t.Fatalf("new root: %v", err)
+	}
+	root.SetArgs([]string{"eval", "--config-file", configPath, "fixtureValue === ''"})
+	if err := root.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("execute eval: %v", err)
+	}
+	if got := out.String(); got != "true\n" {
+		t.Fatalf("eval output = %q, want true", got)
+	}
+}
+
+func TestExplicitConfigFileLoadsWithExplicitLayer(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "explicit.yaml")
+	if err := os.WriteFile(configPath, []byte("fixture:\n  value: from-explicit\n"), 0o644); err != nil {
+		t.Fatalf("write explicit config: %v", err)
+	}
+
+	registry := providerapi.NewRegistry()
+	if err := testprovider.Register(registry); err != nil {
+		t.Fatalf("register provider: %v", err)
+	}
+	specJSON := `{
+  "name": "fixture",
+  "config": {"enabled": true, "layers": ["explicit"], "fileName": "config.yaml"},
+  "target": {"kind": "xgoja", "output": "dist/fixture"},
+  "packages": [{"id": "fixture"}],
+  "runtimes": {
+    "repl": {
+      "modules": [{"package": "fixture", "name": "hello", "as": "hello"}]
+    }
+  },
+  "commands": {
+    "eval": {"enabled": true, "runtime": "repl", "name": "eval"},
+    "jsverbs": {"enabled": false}
+  }
+}`
+	out := &bytes.Buffer{}
+	root, err := NewRootCommand(Options{Providers: registry, SpecJSON: specJSON, Out: out})
+	if err != nil {
+		t.Fatalf("new root: %v", err)
+	}
+	root.SetArgs([]string{"eval", "--config-file", configPath, "fixtureValue"})
+	if err := root.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("execute eval: %v", err)
+	}
+	if got := out.String(); got != "from-explicit\n" {
+		t.Fatalf("eval output = %q, want from-explicit", got)
+	}
+}
+
+func chdirForTest(t *testing.T, dir string) {
+	t.Helper()
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(oldWd); err != nil {
+			t.Logf("restore wd: %v", err)
+		}
+	})
 }

--- a/pkg/xgoja/app/root.go
+++ b/pkg/xgoja/app/root.go
@@ -29,6 +29,7 @@ type Options struct {
 	EmbeddedJSVerbs fs.FS
 	EmbeddedHelp    fs.FS
 	EmbeddedAssets  fs.FS
+	MiddlewaresFunc glazedcli.CobraMiddlewaresFunc
 }
 
 func NewRootCommand(opts Options) (*cobra.Command, error) {
@@ -39,7 +40,7 @@ func NewRootCommand(opts Options) (*cobra.Command, error) {
 	if err := json.Unmarshal([]byte(opts.SpecJSON), spec); err != nil {
 		return nil, fmt.Errorf("decode embedded xgoja spec: %w", err)
 	}
-	host := NewHostWithOptions(opts.Providers, spec, HostOptions{EmbeddedJSVerbs: opts.EmbeddedJSVerbs, EmbeddedHelp: opts.EmbeddedHelp, EmbeddedAssets: opts.EmbeddedAssets, Out: opts.Out})
+	host := NewHostWithOptions(opts.Providers, spec, HostOptions{EmbeddedJSVerbs: opts.EmbeddedJSVerbs, EmbeddedHelp: opts.EmbeddedHelp, EmbeddedAssets: opts.EmbeddedAssets, Out: opts.Out, MiddlewaresFunc: opts.MiddlewaresFunc})
 	root := &cobra.Command{
 		Use:   spec.Name,
 		Short: "Generated xgoja binary",
@@ -196,7 +197,7 @@ func (c *modulesCommand) RunIntoGlazeProcessor(ctx context.Context, vals *values
 	return nil
 }
 
-func newVerbsCommand(providers *providerapi.Registry, factory *RuntimeFactory, spec *Spec, embeddedJSVerbs fs.FS) *cobra.Command {
+func newVerbsCommand(providers *providerapi.Registry, factory *RuntimeFactory, spec *Spec, embeddedJSVerbs fs.FS, middlewaresFunc glazedcli.CobraMiddlewaresFunc) *cobra.Command {
 	root := &cobra.Command{
 		Use:   commandName(spec.Commands.JSVerbs, "verbs"),
 		Short: "Run configured JavaScript verb commands",
@@ -217,8 +218,11 @@ func newVerbsCommand(providers *providerapi.Registry, factory *RuntimeFactory, s
 		},
 	}
 	root.AddCommand(list)
+	if middlewaresFunc == nil {
+		middlewaresFunc = glazedcli.CobraCommandDefaultMiddlewares
+	}
 	if err := glazedcli.AddCommandsToRootCommand(root, mounted, nil, glazedcli.WithParserConfig(glazedcli.CobraParserConfig{
-		MiddlewaresFunc: glazedcli.CobraCommandDefaultMiddlewares,
+		MiddlewaresFunc: middlewaresFunc,
 	})); err != nil {
 		root.RunE = func(cmd *cobra.Command, args []string) error { return err }
 	}

--- a/pkg/xgoja/app/spec.go
+++ b/pkg/xgoja/app/spec.go
@@ -2,6 +2,8 @@ package app
 
 type Spec struct {
 	Name             string                    `json:"name"`
+	AppName          string                    `json:"appName,omitempty"`
+	EnvPrefix        string                    `json:"envPrefix,omitempty"`
 	Target           TargetSpec                `json:"target"`
 	Packages         []PackageSpec             `json:"packages"`
 	Runtimes         map[string]Runtime        `json:"runtimes"`

--- a/pkg/xgoja/app/spec.go
+++ b/pkg/xgoja/app/spec.go
@@ -4,6 +4,7 @@ type Spec struct {
 	Name             string                    `json:"name"`
 	AppName          string                    `json:"appName,omitempty"`
 	EnvPrefix        string                    `json:"envPrefix,omitempty"`
+	Config           *ConfigSpec               `json:"config,omitempty"`
 	Target           TargetSpec                `json:"target"`
 	Packages         []PackageSpec             `json:"packages"`
 	Runtimes         map[string]Runtime        `json:"runtimes"`
@@ -12,6 +13,12 @@ type Spec struct {
 	JSVerbs          []JSVerbSourceSpec        `json:"jsverbs,omitempty"`
 	Help             HelpSpec                  `json:"help,omitempty"`
 	Assets           []AssetSourceSpec         `json:"assets,omitempty"`
+}
+
+type ConfigSpec struct {
+	Enabled  bool     `json:"enabled"`
+	Layers   []string `json:"layers,omitempty"`
+	FileName string   `json:"fileName,omitempty"`
 }
 
 type TargetSpec struct {

--- a/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/README.md
+++ b/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/README.md
@@ -1,0 +1,21 @@
+# Add env prefix / app name / glazed source middleware support to xgoja generated binaries
+
+This is the document workspace for ticket XGOJA-017.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr doc add --ticket XGOJA-017 --doc-type design-doc --title "My Design"`
+- Import sources: `docmgr import file --ticket XGOJA-017 --file /path/to/doc.md`
+- Update metadata: `docmgr meta update --ticket XGOJA-017 --field Status --value review`

--- a/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/analysis/01-review-of-intern-feature-plan-and-research-package.md
+++ b/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/analysis/01-review-of-intern-feature-plan-and-research-package.md
@@ -1,0 +1,790 @@
+---
+Title: Review of Intern Feature Plan and Research Package
+Ticket: XGOJA-017
+Status: active
+Topics:
+    - xgoja
+    - glazed
+    - configuration
+    - middleware
+    - design
+DocType: analysis
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: ../../../../../../../glazed/pkg/cmds/sources/update.go
+      Note: Review highlights env-prefix normalization behavior and shell-safety issue
+    - Path: pkg/xgoja/app/glazed.go
+      Note: Review identifies this as the key middleware chokepoint and recommends a narrower MVP
+    - Path: ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/design-doc/01-env-prefix-app-name-glazed-source-middleware-support-for-xgoja-generated-binaries.md
+      Note: Primary plan being reviewed
+    - Path: ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/reference/02-research-logbook.md
+      Note: Research package being reviewed
+ExternalSources: []
+Summary: Technical review of the XGOJA-017 design/research package, with coaching notes for the intern who produced it.
+LastUpdated: 2026-06-02T12:03:44.384504231-04:00
+WhatFor: Use this when reviewing or refining the XGOJA-017 implementation plan before coding.
+WhenToUse: Before implementing env-prefix/app-name/config/profile middleware support in xgoja, and as coaching material for future research/design tasks.
+---
+
+
+# Review of Intern Feature Plan and Research Package
+
+## Executive Summary
+
+Your research package is strong. You found the right architectural seam (`pkg/xgoja/app/glazed.go`), traced the build-time and runtime paths, compared xgoja with Glazed and Pinocchio, and produced an implementation plan that is detailed enough for a new engineer to start from. The design document is useful because it explains not just *what* to change, but *why* those files matter.
+
+The main improvement is that you sometimes moved from evidence to proposed API too quickly. The plan correctly identifies the problem, but it should be more cautious about public YAML shape, env-prefix normalization, config/profile semantics, and template complexity. Before coding, the next pass should convert the proposal into a smaller, testable MVP and explicitly validate assumptions with tiny probes.
+
+The most important correction: **do not blindly default `envPrefix` to `strings.ToUpper(appName)` if `appName` may contain hyphens.** Glazed's `updateFromEnv` uppercases the prefix but does not replace `-` with `_` in the prefix. An `appName` of `my-app` would produce env vars like `MY-APP_FIELD`, which are not normal shell variable names. The implementation must normalize or require a separate valid `envPrefix`.
+
+---
+
+## Overall Grade
+
+**Assessment:** Good research, good architecture mapping, good first design. Needs sharper API discipline before implementation.
+
+| Area | Rating | Notes |
+|---|---:|---|
+| Codebase orientation | Strong | You found the critical flow from YAML spec to generated binary. |
+| Evidence gathering | Strong | You read the right xgoja, Glazed, Pinocchio, and Geppetto files. |
+| Problem statement | Strong | The missing env/config/profile behavior is clearly described. |
+| Proposed API | Medium | Useful starting point, but too broad for first implementation. |
+| Risk analysis | Medium | Good risks listed, but missed env-prefix normalization and target-specific behavior details. |
+| Implementation sequencing | Good | Phases are logical, but Phase 1 should include assumption probes. |
+| Intern-readability | Strong | Clear prose, tables, diagrams, and pseudocode. |
+| Restraint / minimality | Medium-low | The plan expands into config, profiles, and arbitrary middlewares at once. |
+
+---
+
+## What You Did Well
+
+### 1. You found the right chokepoint
+
+The best part of the analysis is the identification of `pkg/xgoja/app/glazed.go` as the central chokepoint:
+
+```go
+func buildGlazedCobraCommand(command cmds.Command) (*cobra.Command, error) {
+    return cli.BuildCobraCommand(command,
+        cli.WithParserConfig(cli.CobraParserConfig{
+            ShortHelpSections: []string{schema.DefaultSlug},
+            MiddlewaresFunc:   cli.CobraCommandDefaultMiddlewares,
+        }),
+    )
+}
+```
+
+This is exactly the right starting point. It explains why generated xgoja commands currently only read flags, args, and defaults. It also avoids a common beginner mistake: trying to change every command individually instead of changing the shared builder.
+
+**Keep doing this:** when analyzing a feature, look for the smallest shared abstraction that explains the behavior.
+
+### 2. You traced the full lifecycle
+
+You followed the lifecycle:
+
+```text
+xgoja.yaml
+  -> buildspec.Spec
+  -> generate.WriteAll
+  -> main.go.tmpl
+  -> app.NewRootCommand / NewHostWithOptions
+  -> Host.AttachDefaultCommands
+  -> buildGlazedCobraCommand
+  -> Glazed middleware parsing
+```
+
+That chain is the backbone of the feature. A future implementer can now see which changes are build-time schema changes, which are generated-code changes, and which are runtime host changes.
+
+**Why this matters:** code generation features often fail when people only understand the generated output or only understand the generator. You covered both.
+
+### 3. You compared against the right reference implementation
+
+Pinocchio was the correct comparison point because it has:
+
+- A stable `AppName`.
+- A stable `EnvPrefix`.
+- A `ConfigPlanBuilder`.
+- A custom `MiddlewaresFunc`.
+- Profile/bootstrap machinery.
+
+The key file, `pinocchio/pkg/cmds/cobra.go`, is the right canonical reference for the middleware chain. You correctly extracted this pattern:
+
+```go
+sources.FromCobra(cmd, fields.WithSource("cobra"))
+sources.FromArgs(args, fields.WithSource("arguments"))
+sources.FromEnv(cfg.EnvPrefix, fields.WithSource("env"))
+sources.FromConfigPlanBuilder(...)
+sources.FromDefaults(fields.WithSource(fields.SourceDefaults))
+```
+
+### 4. You made precedence explicit
+
+You read `glazed/pkg/cmds/sources/middlewares.go` and explained the reversal behavior. That is important. Without understanding middleware execution order, it is easy to accidentally make config override flags or defaults override env.
+
+The design correctly communicates the intended effective precedence:
+
+```text
+Defaults < config files < environment variables < CLI flags
+```
+
+### 5. The research logbook is valuable
+
+The logbook is useful because it tells the next person which resources mattered and which did not. This is the kind of artifact that saves hours later.
+
+Especially good entries:
+
+- `pkg/xgoja/app/glazed.go` — identifies the critical chokepoint.
+- `glazed/pkg/cli/cobra-parser.go` — records the built-in parser path.
+- `pinocchio/pkg/cmds/cobra.go` — records the reference implementation.
+- `glazed/pkg/cmds/sources/update.go` — records env parsing mechanics.
+
+---
+
+## What Was Weak or Needs Correction
+
+### 1. The proposed YAML API is too broad for a first implementation
+
+The proposal includes all of these at once:
+
+```yaml
+appName: my-app
+envPrefix: MY_APP
+config:
+  enabled: true
+  layers: [system, xdg, home, git-root, cwd]
+profiles:
+  enabled: true
+middlewares:
+  - source: env
+  - source: config
+  - source: profiles
+```
+
+This is ambitious. It is good as a long-term vision, but risky as a first implementation. The feature request says:
+
+> add env prefix / app name / potentially glazed source middleware support
+
+The word **potentially** matters. It means arbitrary source middleware support is not necessarily required in the first cut.
+
+A safer MVP would be:
+
+```yaml
+appName: my-app
+envPrefix: MY_APP
+config:
+  enabled: true
+  layers:
+    - xdg
+    - home
+    - cwd
+    - explicit
+```
+
+Then add profiles and arbitrary middleware after env/config are proven.
+
+**What to do next time:** separate "MVP" from "future extensibility." Do not put them in the same required implementation path.
+
+### 2. The env-prefix default is probably wrong for hyphenated app names
+
+The design says:
+
+> `envPrefix` defaults to `UPPER(appName)` when `appName` is set.
+
+This copies Glazed's built-in behavior from `CobraParserConfig.AppName`, but you should have checked whether the prefix is shell-safe.
+
+In `glazed/pkg/cmds/sources/update.go`, `updateFromEnv` does this:
+
+```go
+envKey := strings.ToUpper(strings.ReplaceAll(base, "-", "_"))
+if prefix != "" {
+    envKey = strings.ToUpper(prefix) + "_" + envKey
+}
+```
+
+Notice the asymmetry:
+
+- The field/section part replaces `-` with `_`.
+- The prefix only gets `strings.ToUpper(prefix)`.
+- Therefore `appName: my-app` becomes prefix `MY-APP`, not `MY_APP`.
+
+That produces env names like:
+
+```text
+MY-APP_DEFAULT_RUNTIME
+```
+
+This is awkward or invalid in normal shell assignment syntax.
+
+**Correct design guidance:**
+
+- `appName` is a human/application identity and may contain hyphens.
+- `envPrefix` is an environment-variable namespace and should be validated as `[A-Z][A-Z0-9_]*`.
+- If `envPrefix` is omitted, derive it with a normalization function:
+
+```go
+func DefaultEnvPrefix(appName string) string {
+    s := strings.TrimSpace(appName)
+    s = strings.ReplaceAll(s, "-", "_")
+    s = strings.ReplaceAll(s, ".", "_")
+    s = strings.ToUpper(s)
+    s = collapseRepeatedUnderscores(s)
+    return strings.Trim(s, "_")
+}
+```
+
+Do **not** rely on Glazed's current `strings.ToUpper(appName)` if xgoja wants friendly generated binaries.
+
+### 3. You proposed generated closures too early
+
+The design leans toward emitting Go closures directly in `main.go.tmpl`:
+
+```go
+middlewaresFunc := func(parsedCommandSections *values.Values, cmd *cobra.Command, args []string) ([]cmd_sources.Middleware, error) {
+    // generated source
+}
+```
+
+That may work, but it is template-heavy. Generated Go templates become hard to maintain when they contain conditional imports, nested closures, and repeated source snippets.
+
+A cleaner alternative is to add runtime helper code in `pkg/xgoja/app`, for example:
+
+```go
+func MiddlewaresFromSpec(spec *Spec) cli.CobraMiddlewaresFunc
+```
+
+Then generated `main.go` only needs:
+
+```go
+root, err := app.NewRootCommand(app.Options{
+    Providers: registry,
+    SpecJSON: embeddedSpecJSON,
+})
+```
+
+And `NewRootCommand` can do:
+
+```go
+host := NewHostWithOptions(providers, spec, HostOptions{
+    MiddlewaresFunc: MiddlewaresFromSpec(spec),
+})
+```
+
+This keeps policy in tested Go code instead of generated templates.
+
+**What to keep in mind:** prefer templates for structural generation (imports, providers, embeds). Prefer ordinary Go packages for behavioral policy.
+
+### 4. You under-specified the difference between `target.kind: xgoja`, `cobra`, and `adapter`
+
+You noticed the target kinds, but the plan should say more about how middleware policy behaves for each one.
+
+Current generated modes:
+
+1. **`target.kind: xgoja`**
+   - xgoja creates the root command.
+   - xgoja controls all command building.
+   - Middleware support is straightforward.
+
+2. **`target.kind: cobra`**
+   - User-provided package creates the root command.
+   - xgoja attaches default commands to that root.
+   - Middleware support applies only to xgoja-attached commands unless we also modify the target root's own commands.
+
+3. **`target.kind: adapter`**
+   - User-provided adapter builds root from `Host`.
+   - Middleware support depends on whether adapter uses `host.AttachDefaultCommands` or builds commands manually.
+
+The review question a future implementer must answer is:
+
+> Does `appName/envPrefix/config` apply only to xgoja-provided commands, or also to target-provided commands?
+
+This matters because `target.kind: cobra` may already have its own middleware conventions.
+
+**Better documentation:** add a table in the design doc explaining behavior per target kind.
+
+### 5. Profile support was not investigated deeply enough
+
+You read `glazed/pkg/cmds/sources/profiles.go` and Pinocchio's profile bootstrap, but the proposal should be more cautious.
+
+There are at least three meanings of "profile":
+
+1. **Glazed profile file:** a YAML map of section values.
+2. **Geppetto engine profile:** a model/provider configuration profile.
+3. **xgoja runtime profile:** a named runtime under `runtimes:`.
+
+xgoja already uses the word "runtime profile" in several places. If you add `profiles:` to xgoja.yaml, readers may confuse it with `runtimes:`.
+
+Example confusion:
+
+```yaml
+runtimes:
+  prod:
+    modules: [...]
+
+profiles:
+  enabled: true
+  defaultProfile: prod
+```
+
+Does `prod` mean a Glazed config profile or an xgoja runtime profile? They are different concepts.
+
+**Recommendation:** defer profile support or name it more explicitly:
+
+```yaml
+parameterProfiles:
+  enabled: true
+```
+
+or:
+
+```yaml
+glazedProfiles:
+  enabled: true
+```
+
+### 6. The config file structure needs a clearer contract
+
+The design says config files can use Glazed's standard section map format, but it should give explicit examples tied to xgoja commands.
+
+For example, if the command is `eval` and its settings struct is:
+
+```go
+type evalSettings struct {
+    Source  string `glazed:"source"`
+    Runtime string `glazed:"runtime"`
+}
+```
+
+What config file sets the default runtime?
+
+Possibility A:
+
+```yaml
+default:
+  runtime: main
+```
+
+Possibility B:
+
+```yaml
+eval:
+  runtime: main
+```
+
+Possibility C:
+
+```yaml
+command:
+  runtime: main
+```
+
+The answer depends on section slugs and command descriptions. The design should point to the exact section slug for built-in commands and provider sections.
+
+**Next research task:** inspect generated command descriptions and confirm the section slugs for `eval`, `run`, `repl`, `modules`, JS verbs, and provider command sections.
+
+### 7. You did not propose a concrete first test fixture
+
+The plan says to add integration tests, but it should define a minimal test fixture that exercises the feature without depending on complex providers.
+
+A good fixture would be:
+
+```yaml
+name: env-config-fixture
+appName: env-config-fixture
+envPrefix: XGOJA_FIXTURE
+config:
+  enabled: true
+  layers: [cwd, explicit]
+
+target:
+  kind: xgoja
+  output: dist/env-config-fixture
+packages:
+  - id: fixture
+    import: github.com/go-go-golems/go-go-goja/pkg/xgoja/testprovider
+runtimes:
+  main:
+    modules:
+      - package: fixture
+        name: hello
+        as: hello
+  alternate:
+    modules:
+      - package: fixture
+        name: hello
+        as: hello
+commands:
+  eval:
+    enabled: true
+    runtime: main
+```
+
+Then test only the `eval.runtime` setting:
+
+```bash
+# defaults to main
+./dist/env-config-fixture eval 'require("hello").greet("x")'
+
+# config overrides default
+cat > config.yaml <<'EOF'
+default:
+  runtime: alternate
+EOF
+./dist/env-config-fixture eval '...'
+
+# env overrides config
+XGOJA_FIXTURE_RUNTIME=main ./dist/env-config-fixture eval '...'
+
+# flag overrides env
+XGOJA_FIXTURE_RUNTIME=alternate ./dist/env-config-fixture eval --runtime main '...'
+```
+
+This may reveal the exact section slug issue mentioned above.
+
+### 8. You should have looked at validation tests earlier
+
+The design says Phase 1 should update `validate.go`, `validate_test.go`, and `load_test.go`, but the research did not actually inspect those tests.
+
+That is a gap. Before implementing a schema change, you should inspect existing validation tests to understand:
+
+- Error message style.
+- Table-driven test patterns.
+- Existing validation helpers.
+- How strict the validator is about unknown or future fields.
+
+**What you should have looked at:**
+
+- `cmd/xgoja/internal/buildspec/validate.go`
+- `cmd/xgoja/internal/buildspec/validate_test.go`
+- `cmd/xgoja/internal/buildspec/load.go`
+- `cmd/xgoja/internal/buildspec/load_test.go`
+
+You read `spec.go`, but not the validator implementation deeply enough.
+
+---
+
+## What You Should Have Known or Checked
+
+### 1. Public YAML shape is an API
+
+Once `xgoja.yaml` supports a field, users will write it in repositories. Renaming it later becomes a migration problem. Therefore, public YAML fields require more caution than internal Go types.
+
+Before proposing top-level fields, ask:
+
+- Is the name clear to a user who does not know Glazed internals?
+- Will it conflict with existing or future xgoja concepts?
+- Can it be validated cleanly?
+- Does it compose with provider-defined commands?
+- Is it stable enough to document?
+
+### 2. "App name" and "env prefix" are not the same thing
+
+They overlap but have different constraints:
+
+| Concept | Purpose | Example | Valid characters |
+|---|---|---|---|
+| `name` | xgoja binary/spec name | `discord-bot` | user-facing, can contain hyphen |
+| `appName` | config/logging application identity | `discord-bot` | usually path-ish/name-ish |
+| `envPrefix` | environment variable namespace | `DISCORD_BOT` | shell-safe uppercase identifier |
+
+Do not collapse them without normalization.
+
+### 3. Generated code should be boring
+
+Generated code should be easy to inspect, but not full of complex logic. Ideally:
+
+- The template imports providers and embeds files.
+- Runtime packages implement behavior.
+- Tests cover behavior in normal Go code.
+
+If the template starts generating complex `ConfigPlanBuilder` code, debugging becomes harder.
+
+### 4. Target modes change ownership
+
+In generated-code systems, always ask: who owns the root command?
+
+- xgoja-owned root: xgoja can enforce middleware behavior.
+- target-owned root: xgoja can only control commands it attaches.
+- adapter-owned root: behavior depends on adapter code.
+
+This affects user expectations and documentation.
+
+### 5. Config semantics need concrete examples
+
+Do not describe config support only abstractly. Always show exact files:
+
+```yaml
+# ~/.config/my-app/config.yaml
+section-slug:
+  field-name: value
+```
+
+Then show the corresponding CLI flag and env var:
+
+```bash
+my-app command --field-name value
+MY_APP_SECTION_FIELD_NAME=value my-app command
+```
+
+If you cannot write the example confidently, the design is not yet precise enough.
+
+---
+
+## What They Should Have Looked At
+
+This list is not a criticism of the work already done; it is the next research checklist before coding.
+
+### 1. `cmd/xgoja/internal/buildspec/validate.go`
+
+Reason: The new fields require validation, and the existing validator likely has conventions for error aggregation and reporting.
+
+Questions to answer:
+
+- How are validation errors represented?
+- Does validation stop early or collect all issues?
+- How are unknown enum values reported?
+- Where should `envPrefix` validation live?
+
+### 2. `cmd/xgoja/internal/buildspec/validate_test.go`
+
+Reason: Tests show style and edge cases.
+
+Questions to answer:
+
+- Are tests table-driven?
+- Do they assert exact error strings?
+- Are there helper specs you can extend?
+
+### 3. `cmd/xgoja/internal/buildspec/load.go` and `load_test.go`
+
+Reason: New YAML fields must round-trip through load and report paths.
+
+Questions to answer:
+
+- Is unknown YAML allowed or rejected?
+- Is `BaseDir` set during loading?
+- Does `LoadFile` normalize paths or leave raw YAML values?
+
+### 4. `pkg/xgoja/app/command_providers.go`
+
+Reason: Provider commands may have their own sections and could be most affected by env/config support.
+
+Questions to answer:
+
+- Do provider commands use `buildGlazedCobraCommand`?
+- Are command sections modified with runtime module sections?
+- Does middleware config need to be passed through provider command builders?
+
+### 5. `pkg/xgoja/app/run.go` and `tui.go`
+
+Reason: Built-in commands may have command-specific section slugs or additional runtime/module sections.
+
+Questions to answer:
+
+- Which section slug controls `runtime`, `keep-alive`, etc.?
+- How do module-provided sections get attached?
+- Are there sensitive fields that env/config should parse?
+
+### 6. Glazed tests for env/config parsing
+
+Useful files to inspect:
+
+- `glazed/pkg/cli/cobra_parser_config_test.go`
+- `glazed/pkg/cmds/sources/config_files_test.go`
+- `glazed/pkg/cmds/sources/custom-profiles_test.go`
+
+Reason: These tests define the real expected behavior more precisely than prose docs.
+
+Questions to answer:
+
+- How exactly is `AppName` transformed into env vars?
+- Are hyphenated app names tested?
+- How does config precedence behave in assertions?
+
+---
+
+## Recommended Revision to the Feature Plan
+
+Before implementation, revise the plan into three tiers.
+
+### Tier 1: MVP — app name + env prefix only
+
+Goal: Let generated binaries read command fields from environment variables.
+
+YAML:
+
+```yaml
+appName: my-app
+envPrefix: MY_APP
+```
+
+Behavior:
+
+- If `envPrefix` is set, generated commands use `sources.FromEnv(envPrefix)`.
+- If `envPrefix` is omitted but `appName` is set, derive shell-safe prefix from `appName`.
+- CLI flags still override env.
+- Existing specs behave exactly as before.
+
+Implementation:
+
+- Add fields to buildspec and runtime spec.
+- Add middleware factory to `Host`.
+- Prefer `app.MiddlewaresFromSpec(spec)` over generated closures.
+- Add tests for env precedence.
+
+### Tier 2: Config files
+
+Goal: Let generated binaries read section maps from config files.
+
+YAML:
+
+```yaml
+config:
+  enabled: true
+  layers: [xdg, home, cwd, explicit]
+  fileName: config.yaml
+```
+
+Behavior:
+
+- Config values load below env and flags.
+- Missing discovered files are skipped.
+- Explicit config file errors if missing.
+- Config file format is documented with real xgoja command examples.
+
+Implementation:
+
+- Add `ConfigSpec`.
+- Add `ConfigPlanFromSpec` helper.
+- Add tests for config precedence.
+
+### Tier 3: Profiles and arbitrary source middleware
+
+Goal: Advanced users can load named profiles or opt into additional sources.
+
+YAML:
+
+```yaml
+glazedProfiles:
+  enabled: true
+  appName: my-app
+  defaultProfile: default
+```
+
+Arbitrary middleware should not be added until there is a concrete use case. It is harder to design safely because middleware order is behavior.
+
+---
+
+## Coaching Notes for Next Time
+
+### Start with the smallest useful behavior
+
+When a task says "potentially support X," do not turn X into a first-class requirement immediately. Write:
+
+- MVP
+- Follow-up
+- Future exploration
+
+This keeps the plan realistic.
+
+### Validate copied behavior before adopting it
+
+You copied Glazed's `strings.ToUpper(appName)` behavior as a proposed default. The copy was understandable, but it missed shell-safety. When copying a pattern, ask:
+
+- Does the source project have the same constraints?
+- Is the source behavior ideal or just historical?
+- Are there known edge cases?
+
+### Prefer helper functions over generated snippets
+
+Generated code is powerful, but every conditional branch in a template increases maintenance cost. If behavior can live in normal Go code, put it there.
+
+Bad first instinct:
+
+```gotemplate
+{{ if .Config.Enabled }}
+// emit many lines of config plan Go code
+{{ end }}
+```
+
+Better first instinct:
+
+```go
+middlewaresFunc := app.MiddlewaresFromSpec(spec)
+```
+
+### Always include one concrete config example
+
+A design about config parsing is incomplete until it shows:
+
+- YAML config file
+- equivalent CLI flag
+- equivalent env var
+- resulting parsed value
+
+### Explicitly mark unresolved semantics
+
+If you are not sure whether config applies to target-owned Cobra commands, write that uncertainty as a decision point. Do not let it hide inside implementation phases.
+
+---
+
+## Specific Review Comments on the Existing Documents
+
+### Design doc
+
+**Good:**
+
+- Excellent architecture trace.
+- Strong gap analysis table.
+- Useful decision records.
+- Clear file-level implementation plan.
+
+**Needs improvement:**
+
+- Split MVP vs future work.
+- Fix env-prefix derivation.
+- Add target-kind behavior table.
+- Add concrete config file examples.
+- Prefer helper package/function over generated closures.
+
+### Diary
+
+**Good:**
+
+- Captures commands and research sequence.
+- Records what was tricky.
+- Good final handoff summary.
+
+**Needs improvement:**
+
+- It states some upload and doctor results as if they were known before they happened in earlier draft sections. Keep diary entries strictly chronological and update them after the fact.
+- Add exact error for the first failed `remarquee upload bundle` with spaces in bundle name, then note the successful simpler name.
+
+### Research logbook
+
+**Good:**
+
+- Very useful list of resources.
+- Clearly identifies what each file contributed.
+- Summary table is helpful.
+
+**Needs improvement:**
+
+- Add validator/test files after they are read.
+- Mark `glazed/pkg/cmds/sources/update.go` as more important because it reveals the env-prefix normalization issue.
+- Avoid saying "no external docs needed" too strongly; source code was sufficient for this pass, but public docs may still matter for user-facing terminology.
+
+---
+
+## Final Recommendation
+
+Do not start coding the full original proposal. Start with a narrower implementation spike:
+
+1. Add `appName` and `envPrefix` to both spec structs.
+2. Add `MiddlewaresFromSpec(spec)` in `pkg/xgoja/app`.
+3. Wire `HostOptions.MiddlewaresFunc` through built-in commands.
+4. Add one env precedence test.
+5. Only then add config file support.
+
+This approach will prove the architecture without committing to too much YAML surface area. Once env support works end-to-end, config support will be much safer to add because the Host/middleware plumbing will already exist.
+
+The intern's work is a good foundation. The next step is to sharpen it into a smaller, stricter, more easily testable implementation plan.

--- a/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/analysis/02-review-of-intern-implementation.md
+++ b/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/analysis/02-review-of-intern-implementation.md
@@ -1,0 +1,665 @@
+---
+Title: Review of Intern Implementation
+Ticket: XGOJA-017
+Status: active
+Topics:
+    - xgoja
+    - glazed
+    - configuration
+    - middleware
+    - design
+DocType: analysis
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: cmd/xgoja/internal/buildspec/validate.go
+      Note: Config validation semantics reviewed and relaxed for local-only layers in commit e3f6986
+    - Path: cmd/xgoja/internal/generate/main.go
+      Note: Generator embedding bug reviewed; regression coverage added in commit e3f6986
+    - Path: examples/xgoja/11-config-env/README.md
+      Note: Runnable config/env example documentation updated for --config-file in commit e3f6986
+    - Path: pkg/xgoja/app/middlewares.go
+      Note: Runtime middleware and config-layer semantics reviewed and fixed in commit e3f6986
+    - Path: pkg/xgoja/app/middlewares_test.go
+      Note: Runtime config/env precedence and explicit-layer regression coverage in commit e3f6986
+ExternalSources: []
+Summary: Post-implementation technical review and coaching notes for the XGOJA-017 env/config feature work.
+LastUpdated: 2026-06-02T13:20:00-04:00
+WhatFor: Use this to review the implemented XGOJA-017 feature and coach the intern on implementation quality, testing, review discipline, and future improvements.
+WhenToUse: Before merging, before extending the feature to profiles/advanced middlewares, or when teaching another intern how to implement generated-binary features safely.
+---
+
+
+# Review of Intern Implementation
+
+## Executive Summary
+
+Little brother did good work. The implementation follows the revised plan: it keeps behavior in normal Go code instead of generated template snippets, separates `appName` from `envPrefix`, adds shell-safe env-prefix normalization, wires Glazed source middlewares through the xgoja Host, adds config-file loading with explicit precedence, and verifies the generated-binary path with a real example.
+
+The strongest part of the work is that the intern caught a critical generator bug during end-to-end testing: direct runtime tests passed, but generated binaries silently dropped `appName`, `envPrefix`, and `config` because `RenderEmbeddedSpec` builds a manual JSON payload. Finding and fixing that bug is exactly the kind of learning we want.
+
+The main weaknesses are around API precision, test coverage shape, and Git hygiene. The implementation still has a few semantic rough edges: `explicit` config files are accepted even when the `explicit` layer is not listed, `config.enabled` requires `appName` even for `cwd`/`explicit`-only configs, the user-facing docs do not yet fully document the `config` schema, and the commits became less clean after an amend folded Phase 2 code into a misleading docs commit.
+
+Overall: **solid implementation, good recovery from a real generated-code bug, but needs a follow-up cleanup pass before merge.**
+
+---
+
+## What Was Implemented
+
+The implementation adds:
+
+- Buildspec fields:
+  - `appName`
+  - `envPrefix`
+  - `config.enabled`
+  - `config.layers`
+  - `config.fileName`
+- Runtime spec fields mirroring those buildspec fields.
+- Runtime middleware construction in `pkg/xgoja/app/middlewares.go`.
+- Env-prefix derivation and validation.
+- Config-plan construction using Glazed's `pkg/config` plan API.
+- Middleware propagation through:
+  - built-in commands (`eval`, `run`, `repl`, `modules`)
+  - JS verb commands
+  - command-provider commands
+- Generator embedding fix in `cmd/xgoja/internal/generate/main.go`.
+- Tests for env/config parsing and precedence.
+- New example: `examples/xgoja/11-config-env/`.
+
+---
+
+## What You Did Well
+
+### 1. You accepted the review and narrowed the feature correctly
+
+The earlier review told you not to implement the entire original vision at once. You followed that advice:
+
+- Phase 1: `appName` and `envPrefix`
+- Phase 2: config files
+- Phase 3: profiles deferred
+- Phase 4: hardening and examples
+
+This is good engineering judgment. The original request mentioned "potentially glazed source middleware support," but "potentially" is not the same as "must implement now." You correctly deferred arbitrary `middlewares:` YAML and profile support.
+
+**Lesson:** Feature requests often contain a core need and several speculative extras. Implement the core, prove it, then revisit the extras.
+
+### 2. You kept behavior out of generated templates
+
+The best architectural choice was `pkg/xgoja/app/middlewares.go`:
+
+```go
+func MiddlewaresFromSpec(spec *Spec) cli.CobraMiddlewaresFunc
+```
+
+This keeps runtime parser policy in normal Go code rather than emitting complex Go closures from `main.go.tmpl`. That makes the feature easier to test, easier to read, and less fragile.
+
+Generated code should mostly connect pieces:
+
+```text
+generated main.go
+  -> decode embedded spec
+  -> NewRootCommand
+  -> Host
+  -> MiddlewaresFromSpec(spec)
+```
+
+The implementation follows this principle.
+
+### 3. You fixed the env-prefix shell-safety issue
+
+The previous plan copied Glazed's `strings.ToUpper(appName)` behavior too directly. The implementation improves on that with `DefaultEnvPrefix`:
+
+- `my-app` -> `MY_APP`
+- `my.app_name dev` -> `MY_APP_NAME_DEV`
+- `123-app` -> `APP_123_APP`
+
+That is better than producing shell-hostile prefixes like `MY-APP`.
+
+**This was exactly the kind of correction the review was asking for.**
+
+### 4. You preserved backward compatibility
+
+`MiddlewaresFromSpec` returns `cli.CobraCommandDefaultMiddlewares` when neither env nor config support is requested:
+
+```go
+if envPrefix == "" && !hasConfig {
+    return cli.CobraCommandDefaultMiddlewares
+}
+```
+
+That is important. Existing specs do not suddenly start reading environment variables or config files based only on `name`.
+
+### 5. You found the generator bug through realistic testing
+
+The most valuable implementation lesson came from testing the generated example. Unit tests passed because they constructed a runtime root directly with JSON. The generated binary failed because `RenderEmbeddedSpec` manually omitted new fields.
+
+You found the problem, explained it in the diary, and fixed it:
+
+```go
+AppName   string                `json:"appName,omitempty"`
+EnvPrefix string                `json:"envPrefix,omitempty"`
+Config    *buildspec.ConfigSpec `json:"config,omitempty"`
+```
+
+This is good debugging. Generated-code systems always need at least one end-to-end test that exercises:
+
+```text
+YAML -> buildspec -> RenderEmbeddedSpec -> generated binary -> runtime behavior
+```
+
+### 6. You added a useful example
+
+`examples/xgoja/11-config-env/` is a good teaching artifact. It demonstrates:
+
+- `appName`
+- `envPrefix`
+- `config.enabled`
+- CWD config file loading
+- env override
+- CLI flag override
+
+This example makes the feature much easier to understand than docs alone.
+
+---
+
+## What Was Weak or Needs Improvement
+
+### 1. The config layer semantics have a bug: `explicit` is not actually gated by `config.layers`
+
+`validateConfig` accepts `explicit` as a valid layer:
+
+```go
+var knownConfigLayers = map[string]bool{
+    "system":   true,
+    "xdg":      true,
+    "home":     true,
+    "git-root": true,
+    "cwd":      true,
+    "explicit": true,
+}
+```
+
+But `buildConfigPlan` ignores `explicit` in the layer loop and always adds the explicit config file if `--config-file` was provided:
+
+```go
+for _, layer := range config.Layers {
+    switch strings.TrimSpace(layer) {
+    case "system":
+        ...
+    case "cwd":
+        ...
+    }
+}
+
+if explicit != "" {
+    plan.Add(glazedconfig.ExplicitFile(explicit).Named("explicit-config").Kind("explicit-file"))
+}
+```
+
+That means this spec:
+
+```yaml
+config:
+  enabled: true
+  layers:
+    - cwd
+```
+
+still accepts `--config-file some.yaml` even though `explicit` is not in the layers list.
+
+This is a semantic mismatch. If `layers` is a policy list, then `explicit` should be honored only when listed. If explicit config should always be available, then `explicit` should not be listed as a layer.
+
+**Recommended fix:** add a helper:
+
+```go
+func configHasLayer(config *ConfigSpec, layer string) bool
+```
+
+Then only add the explicit source when both are true:
+
+```go
+if explicit != "" && configHasLayer(config, "explicit") {
+    plan.Add(glazedconfig.ExplicitFile(explicit).Named("explicit-config").Kind("explicit-file"))
+}
+```
+
+Also add tests:
+
+- `--config-file` works when `layers: [explicit]`.
+- `--config-file` does not load when `explicit` is omitted.
+
+### 2. `config.enabled` requiring `appName` is stricter than the implementation needs
+
+`validateConfig` currently requires `appName` whenever config is enabled:
+
+```go
+if strings.TrimSpace(spec.AppName) == "" {
+    report.AddError("config-app-name", "config", "config requires appName to be set")
+}
+```
+
+That is reasonable for app-scoped locations:
+
+- `system`
+- `xdg`
+- `home`
+
+But it is not technically needed for:
+
+- `cwd`
+- `git-root`
+- `explicit`
+
+A user might reasonably want:
+
+```yaml
+config:
+  enabled: true
+  layers:
+    - cwd
+    - explicit
+```
+
+with no app-level config discovery. The current validator rejects that.
+
+This may be acceptable if the product decision is: "config support always requires appName." But then the docs need to say so clearly. Otherwise, refine validation:
+
+```go
+if usesAppScopedConfigLayer(spec.Config.Layers) && strings.TrimSpace(spec.AppName) == "" {
+    report.AddError(...)
+}
+```
+
+**Coaching point:** validation rules should match the actual semantic dependency, not just the broad feature category.
+
+### 3. The user-facing buildspec docs are incomplete for config support
+
+The env-prefix docs were added to `cmd/xgoja/doc/06-buildspec-reference.md`, but the `config` schema is not fully documented there yet.
+
+The new example README is useful, but the buildspec reference should also include:
+
+```yaml
+config:
+  enabled: true
+  layers:
+    - cwd
+    - explicit
+  fileName: config.yaml
+```
+
+And explain:
+
+- Valid layers: `system`, `xdg`, `home`, `git-root`, `cwd`, `explicit`
+- What each layer resolves to
+- Which layers require `appName`
+- Config file format:
+
+```yaml
+section-slug:
+  field-name: value
+```
+
+- Flag name is `--config-file`, not `--config`
+- Precedence: defaults < config < env < args/flags
+
+**This is important:** the feature is now real public YAML surface. It needs reference documentation, not only an example.
+
+### 4. The implementation still lacks a generator regression test
+
+The `RenderEmbeddedSpec` bug was found manually through the example. That is good, but now it needs a permanent regression test.
+
+Add a test in `cmd/xgoja/internal/generate` that builds a `buildspec.Spec` with:
+
+```go
+AppName: "my-app"
+EnvPrefix: "MY_APP"
+Config: &buildspec.ConfigSpec{Enabled: true, Layers: []string{"cwd"}, FileName: "config.yaml"}
+```
+
+Then assert `RenderEmbeddedSpec` contains:
+
+```json
+"appName": "my-app"
+"envPrefix": "MY_APP"
+"config": {
+```
+
+Even better, unmarshal into `app.Spec` and assert fields structurally.
+
+This prevents future additions from repeating the same generated-spec omission bug.
+
+### 5. Tests use direct runtime specs more than generated specs
+
+The `pkg/xgoja/app/middlewares_test.go` tests are good for runtime behavior, but they do not test the full build pipeline. The new example caught the generator bug, but examples are not assertions unless wired into tests.
+
+Recommended next test levels:
+
+1. **Unit:** `DefaultEnvPrefix`, `buildConfigPlan`
+2. **Runtime:** `NewRootCommand` with JSON spec
+3. **Generator:** `RenderEmbeddedSpec` includes fields
+4. **End-to-end:** `xgoja build` for `examples/xgoja/11-config-env` and run binary
+
+You now have levels 1 and 2, plus manual level 4. Add level 3 at minimum.
+
+### 6. The commit history got messy
+
+This is a real process issue. Commit `2a465d1` is named:
+
+```text
+Docs: record XGOJA-017 phase 1 implementation
+```
+
+But its diff contains Phase 2 code changes:
+
+- `cmd/xgoja/internal/buildspec/spec.go`
+- `cmd/xgoja/internal/buildspec/validate.go`
+- `pkg/xgoja/app/middlewares.go`
+- `pkg/xgoja/app/middlewares_test.go`
+- runtime spec changes
+
+This happened because the failed Phase 2 commit was later amended into the previous docs commit. That makes review harder. A reviewer expects a docs commit to contain docs, not 500+ lines of feature code.
+
+**Recommended cleanup before merge:** interactive rebase the branch into clearer commits:
+
+1. `docs: add XGOJA-017 planning package`
+2. `xgoja: add generated binary env prefix support`
+3. `xgoja: add generated binary config file support`
+4. `xgoja: embed app runtime settings in generated specs`
+5. `xgoja: add config/env example`
+6. `docs: record implementation diary and changelog`
+
+**Coaching point:** commit messages are part of the review interface. If a commit says "Docs," it should not hide core implementation code.
+
+### 7. The `--config-file` naming should be called out explicitly
+
+The design and diary sometimes discuss `--config`, but Glazed's command settings field is `config-file`, so the flag is:
+
+```bash
+--config-file path/to/config.yaml
+```
+
+Not:
+
+```bash
+--config path/to/config.yaml
+```
+
+This matters because the initial manual test tried `--config` and failed. The docs should be explicit and consistent.
+
+### 8. The CWD-based tests could use a helper
+
+The tests are correct after the `errcheck` fix, but repeated `os.Chdir` patterns are noisy and global process state is easy to misuse.
+
+Consider a helper:
+
+```go
+func withWorkingDir(t *testing.T, dir string) {
+    t.Helper()
+    oldWd, err := os.Getwd()
+    require.NoError(t, err)
+    require.NoError(t, os.Chdir(dir))
+    t.Cleanup(func() { require.NoError(t, os.Chdir(oldWd)) })
+}
+```
+
+If this repository avoids testify, use `t.Fatalf` inside the helper. This makes future CWD tests safer and shorter.
+
+---
+
+## What You Should Have Known / Remembered
+
+### 1. Buildspec fields must flow through `RenderEmbeddedSpec`
+
+This is the biggest lesson.
+
+Adding a field to:
+
+- `cmd/xgoja/internal/buildspec/spec.go`
+- `pkg/xgoja/app/spec.go`
+
+is not enough.
+
+For xgoja generated binaries, a runtime-relevant field must flow through:
+
+```text
+xgoja.yaml
+  -> buildspec.Spec
+  -> RenderEmbeddedSpec payload
+  -> embeddedSpecJSON
+  -> app.Spec
+  -> MiddlewaresFromSpec
+```
+
+You initially missed the `RenderEmbeddedSpec payload` step. The example caught it. Next time, make this checklist explicit before coding.
+
+### 2. Public YAML semantics need tight docs and tests
+
+Now that `config.layers` exists, it has semantics. Users will infer that if a layer is omitted, it is disabled. If the implementation still accepts explicit files even when `explicit` is omitted, users will be surprised.
+
+When adding YAML fields, always ask:
+
+- What exact values are valid?
+- What are the defaults?
+- Which values are ignored?
+- Which values imply other required fields?
+- Is the behavior tested for both allowed and disallowed values?
+
+### 3. Examples are not just documentation; they are integration tests in disguise
+
+The new example found the generator bug. That means examples should become part of CI or at least a smoke script.
+
+For generated-code features, direct unit tests are not enough. You need at least one test that runs the generator and then runs the generated binary.
+
+### 4. Middleware ordering is subtle
+
+The implementation gets this right:
+
+```go
+FromCobra
+FromArgs
+FromEnv
+FromConfigPlanBuilder
+FromDefaults
+```
+
+Because each middleware calls `next` first, the effective order is:
+
+```text
+Defaults -> Config -> Env -> Args -> Cobra
+```
+
+This should be preserved carefully. A future refactor could easily break precedence.
+
+Add a comment near the middleware construction explaining the effective order. It is currently understandable to someone who knows Glazed, but not obvious to future contributors.
+
+### 5. Commit hygiene matters when teaching and reviewing
+
+The work is technically good, but the commit history is harder to review because code and docs got mixed. When working with an intern, the commit history is also a teaching artifact. Keep it clean.
+
+---
+
+## What You Should Have Looked At
+
+### 1. `cmd/xgoja/internal/generate/main.go` earlier
+
+This is the file that caused the bug. It should have been inspected as soon as new runtime spec fields were added.
+
+Question to ask next time:
+
+> "How does this field reach the generated binary?"
+
+### 2. Generator tests in `cmd/xgoja/internal/generate`
+
+You ran the tests, but the implementation should add a regression test there. Existing generator tests likely already show the style for assertions around rendered spec/main output.
+
+### 3. Glazed command settings docs/tests
+
+The flag is `--config-file`. The implementation correctly reads `CommandSettings.ConfigFile`, but the design language sometimes used `--config`. Before documenting public behavior, inspect the actual flag names.
+
+Useful files:
+
+- `glazed/pkg/cli/cli.go`
+- `glazed/pkg/cli/cobra_parser_config_test.go`
+
+### 4. Config-source tests in Glazed
+
+The xgoja implementation relies on Glazed's config plan behavior. Review these for subtle precedence and optional-source behavior:
+
+- `glazed/pkg/cmds/sources/config_files_test.go`
+- `glazed/pkg/cmds/sources/update_test.go`
+- `glazed/pkg/config/*_test.go` if present
+
+### 5. Existing xgoja generator examples
+
+The new feature is now another generated-runtime feature like assets/help/jsverbs. The existing examples and tests around embedded assets were good parallels for remembering `RenderEmbeddedSpec`.
+
+---
+
+## Recommended Follow-Up Fixes Before Merge
+
+### High Priority
+
+1. **Add generator regression test** for `RenderEmbeddedSpec` including `appName`, `envPrefix`, and `config`.
+2. **Fix or document `explicit` layer behavior**:
+   - Either gate explicit files on `layers: [explicit]`, or remove `explicit` from the layer list and make explicit files always available.
+3. **Update buildspec reference docs** with the config schema and `--config-file` flag name.
+4. **Clean up commit history** so code and docs commits are easy to review.
+
+### Medium Priority
+
+5. Add helper for temporary working directory in tests.
+6. Add comment in `MiddlewaresFromSpec` documenting effective precedence.
+7. Consider relaxing `appName` validation for `cwd`/`explicit`-only config layers, or document why appName is always required.
+
+### Low Priority
+
+8. Add an automated smoke script for `examples/xgoja/11-config-env`.
+9. Add docs for how provider-defined sections map to config files.
+10. Add a small table in the example README:
+
+| Source | Example | Result |
+|---|---|---|
+| config | `fixture.value: from-config-file` | `fixtureValue == "from-config-file"` |
+| env | `DEMO_FIXTURE_VALUE=from-env` | env wins |
+| flag | `--fixture-value from-flag` | flag wins |
+
+---
+
+## Review of Specific Files
+
+### `pkg/xgoja/app/middlewares.go`
+
+**Good:**
+
+- Centralizes runtime parser policy.
+- Preserves default behavior when no settings are configured.
+- Correctly orders config/env/CLI middlewares.
+- Uses normal Go code, not generated snippets.
+
+**Needs improvement:**
+
+- Add comment about effective precedence.
+- Clarify/gate explicit config layer behavior.
+- Consider splitting config plan construction into `config.go` if this file grows further.
+
+### `cmd/xgoja/internal/generate/main.go`
+
+**Good:**
+
+- Correct fix: include new runtime fields in the manual JSON payload.
+
+**Needs improvement:**
+
+- Add a regression test. This exact bug is likely to recur whenever future runtime fields are added.
+
+### `cmd/xgoja/internal/buildspec/validate.go`
+
+**Good:**
+
+- Adds explicit validation for env prefix and config layers.
+- Avoids silently accepting unknown config layer strings.
+
+**Needs improvement:**
+
+- AppName requirement may be too broad.
+- Explicit layer semantics need alignment with runtime behavior.
+
+### `pkg/xgoja/app/middlewares_test.go`
+
+**Good:**
+
+- Tests derived env prefix.
+- Tests explicit env prefix.
+- Tests historical no-env behavior.
+- Tests config/env/flag precedence.
+
+**Needs improvement:**
+
+- Uses direct JSON specs, so it does not catch generator omissions.
+- Repeated CWD setup should be factored into a helper.
+
+### `examples/xgoja/11-config-env/`
+
+**Good:**
+
+- Practical and easy to run.
+- Demonstrates the real user workflow.
+- Found the generator bug.
+
+**Needs improvement:**
+
+- Add note that the explicit Glazed flag is `--config-file`.
+- Consider adding a small smoke script or make target if examples are expected to be run regularly.
+
+---
+
+## Coaching Notes for Next Time
+
+### Always trace new fields across all layers
+
+For xgoja, use this checklist:
+
+```text
+YAML buildspec struct?
+Validation/defaulting?
+Runtime app spec struct?
+Embedded JSON payload?
+Generated main or runtime constructor?
+Runtime behavior helper?
+Unit tests?
+Generator tests?
+Generated-binary smoke test?
+Docs/example?
+```
+
+Do not stop after adding a field to two structs.
+
+### Test the generated artifact early
+
+Do not wait until Phase 4 to test a generated binary. For generated-code systems, an end-to-end generated artifact test should happen as soon as a runtime-relevant field is added.
+
+### Be precise with names
+
+`--config`, `--config-file`, `config.layers`, `explicit`, `appName`, `name`, `envPrefix` all have different meanings. When names are public, precision matters.
+
+### Keep commits reviewable
+
+A good commit answers:
+
+- What changed?
+- Why does this belong together?
+- How can I verify it?
+
+Avoid amending unrelated code into docs commits. If a commit attempt fails because of lint, fix the lint and retry the same commit, not `git commit --amend` against the previous unrelated commit.
+
+### Defer broad extension points until needed
+
+Deferring profiles and arbitrary middleware YAML was the right call. Broad extension points are hard to design because they define ordering, safety, and future compatibility. Add them only when a concrete user need makes the tradeoffs clear.
+
+---
+
+## Final Assessment
+
+This implementation is a strong first production pass. It adds the core env/config behavior requested by the ticket and verifies it with tests and a real generated binary. The most important follow-up is to make the generator regression test permanent and clarify config layer semantics.
+
+If the intern fixes the high-priority follow-ups above, this is mergeable work. More importantly, the intern learned the central lesson of this feature: in generated-binary systems, **runtime behavior must be tested through the generated artifact, not only through runtime unit tests**.

--- a/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/changelog.md
+++ b/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/changelog.md
@@ -40,3 +40,12 @@ Phase 1 MVP implemented: appName/envPrefix support for generated xgoja binaries,
 
 - /home/manuel/workspaces/2026-06-02/add-xgoja-env-app-name/go-go-goja/pkg/xgoja/app/middlewares.go — Runtime middleware policy
 
+
+## 2026-06-02
+
+Phase 2 implemented: config file support for generated xgoja binaries with layered discovery (system/xdg/home/git-root/cwd/explicit), config < env < CLI precedence, validation, and integration tests.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-02/add-xgoja-env-app-name/go-go-goja/pkg/xgoja/app/middlewares.go — Config plan builder and middleware ordering
+

--- a/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/changelog.md
+++ b/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/changelog.md
@@ -69,3 +69,13 @@ Implementation review follow-up: tightened explicit config-layer semantics, rela
 - /home/manuel/workspaces/2026-06-02/add-xgoja-env-app-name/go-go-goja/cmd/xgoja/internal/generate/generate_test.go — Generator embedded-spec regression added
 - /home/manuel/workspaces/2026-06-02/add-xgoja-env-app-name/go-go-goja/pkg/xgoja/app/middlewares.go — Runtime config-layer semantics fixed
 
+
+## 2026-06-02
+
+Documentation completion: added appName/envPrefix/config usage to the full xgoja user guide and YAML tutorial so users can discover the new features from built-in help (commit cb7ee3a).
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-02/add-xgoja-env-app-name/go-go-goja/cmd/xgoja/doc/02-user-guide.md — Full user-facing reference updated
+- /home/manuel/workspaces/2026-06-02/add-xgoja-env-app-name/go-go-goja/cmd/xgoja/doc/03-tutorial-using-xgoja-yaml.md — Guided tutorial updated
+

--- a/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/changelog.md
+++ b/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/changelog.md
@@ -1,0 +1,33 @@
+# Changelog
+
+## 2026-06-02
+
+- Initial workspace created
+
+
+## 2026-06-02
+
+Research and design: mapped xgoja architecture, Glazed middleware chain, and pinocchio reference patterns. Created comprehensive design doc with schema proposal, decision records, and phased implementation plan.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-02/add-xgoja-env-app-name/go-go-goja/cmd/xgoja/internal/buildspec/spec.go — Baseline for proposed schema extensions
+
+
+## 2026-06-02
+
+Created research logbook documenting all 34 resources consulted during design phase, with usefulness ratings, out-of-date assessments, and implementation priority rankings.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-02/add-xgoja-env-app-name/go-go-goja/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/reference/02-research-logbook.md — Research logbook with 34 resource entries
+
+
+## 2026-06-02
+
+Created review document for the intern research/design package, highlighting strengths, corrections, missing checks, and a narrower recommended MVP before implementation.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-02/add-xgoja-env-app-name/go-go-goja/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/analysis/01-review-of-intern-feature-plan-and-research-package.md — Intern-facing technical review and coaching notes
+

--- a/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/changelog.md
+++ b/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/changelog.md
@@ -58,3 +58,14 @@ Phase 4 complete: built all existing examples, added 11-config-env example, fixe
 
 - /home/manuel/workspaces/2026-06-02/add-xgoja-env-app-name/go-go-goja/cmd/xgoja/internal/generate/main.go — Fixed embedded spec JSON to include appName/envPrefix/config
 
+
+## 2026-06-02
+
+Implementation review follow-up: tightened explicit config-layer semantics, relaxed appName validation for local config layers, added generator regression coverage, expanded buildspec docs, and verified with focused/full tests (commit e3f6986).
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-02/add-xgoja-env-app-name/go-go-goja/cmd/xgoja/doc/06-buildspec-reference.md — Public config schema documented
+- /home/manuel/workspaces/2026-06-02/add-xgoja-env-app-name/go-go-goja/cmd/xgoja/internal/generate/generate_test.go — Generator embedded-spec regression added
+- /home/manuel/workspaces/2026-06-02/add-xgoja-env-app-name/go-go-goja/pkg/xgoja/app/middlewares.go — Runtime config-layer semantics fixed
+

--- a/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/changelog.md
+++ b/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/changelog.md
@@ -49,3 +49,12 @@ Phase 2 implemented: config file support for generated xgoja binaries with layer
 
 - /home/manuel/workspaces/2026-06-02/add-xgoja-env-app-name/go-go-goja/pkg/xgoja/app/middlewares.go — Config plan builder and middleware ordering
 
+
+## 2026-06-02
+
+Phase 4 complete: built all existing examples, added 11-config-env example, fixed RenderEmbeddedSpec generator bug, verified end-to-end config/env/CLI precedence in generated binaries.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-02/add-xgoja-env-app-name/go-go-goja/cmd/xgoja/internal/generate/main.go — Fixed embedded spec JSON to include appName/envPrefix/config
+

--- a/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/changelog.md
+++ b/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/changelog.md
@@ -31,3 +31,12 @@ Created review document for the intern research/design package, highlighting str
 
 - /home/manuel/workspaces/2026-06-02/add-xgoja-env-app-name/go-go-goja/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/analysis/01-review-of-intern-feature-plan-and-research-package.md — Intern-facing technical review and coaching notes
 
+
+## 2026-06-02
+
+Phase 1 MVP implemented: appName/envPrefix support for generated xgoja binaries, shell-safe prefix derivation, runtime middleware factory propagation, tests, and buildspec docs (commit f773542).
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-02/add-xgoja-env-app-name/go-go-goja/pkg/xgoja/app/middlewares.go — Runtime middleware policy
+

--- a/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/design-doc/01-env-prefix-app-name-glazed-source-middleware-support-for-xgoja-generated-binaries.md
+++ b/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/design-doc/01-env-prefix-app-name-glazed-source-middleware-support-for-xgoja-generated-binaries.md
@@ -1,0 +1,852 @@
+---
+Title: Env Prefix / App Name / Glazed Source Middleware Support for xgoja Generated Binaries
+Ticket: XGOJA-017
+Status: active
+Topics:
+    - xgoja
+    - glazed
+    - configuration
+    - middleware
+    - design
+DocType: design-doc
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: ../../../../../../../glazed/pkg/cli/cobra-parser.go
+      Note: Glazed parser config and built-in middleware path
+    - Path: ../../../../../../../pinocchio/pkg/cmds/cobra.go
+      Note: Reference custom MiddlewaresFunc implementation
+    - Path: cmd/xgoja/internal/buildspec/spec.go
+      Note: Current YAML spec struct; needs new fields for appName
+    - Path: cmd/xgoja/internal/generate/templates/main.go.tmpl
+      Note: Generated main template; must emit middleware wiring conditionally
+    - Path: pkg/xgoja/app/glazed.go
+      Note: Critical chokepoint; buildGlazedCobraCommand hardcodes default middlewares
+    - Path: pkg/xgoja/app/host.go
+      Note: Host construction and AttachDefaultCommands; must propagate middleware factory
+    - Path: pkg/xgoja/app/spec.go
+      Note: Runtime JSON spec struct; needs new fields
+ExternalSources: []
+Summary: ""
+LastUpdated: 0001-01-01T00:00:00Z
+WhatFor: ""
+WhenToUse: ""
+---
+
+
+
+
+
+
+
+
+# Env Prefix / App Name / Glazed Source Middleware Support for xgoja Generated Binaries
+
+## Executive Summary
+
+Today, every binary produced by `xgoja build` parses command-line flags and arguments using Glazed's default middleware chain (`CobraCommandDefaultMiddlewares`). That chain is minimal: it reads Cobra flags, positional arguments, and field defaults. It does **not** read environment variables, config files, or profiles. This means a generated binary cannot be configured via `MYAPP_API_KEY=secret` or `/etc/myapp/config.yaml`. The only way to inject values is through CLI flags at invocation time.
+
+This design document proposes extending `xgoja.yaml` so that a build spec can declare:
+
+1. **`appName`** — a stable application identity used for env-prefix generation, config-file discovery, and logging labels.
+2. **`envPrefix`** — an explicit environment-variable prefix (e.g. `MYAPP`). When set, every flag in every generated command becomes overridable via `MYAPP_<SECTION>_<FLAG>`.
+3. **`config`** — a declarative config-plan that tells the generated binary where to look for layered config files (system, XDG, home, git-root, CWD, explicit).
+4. **`profiles`** — optional profile settings that enable the generated binary to load named parameter sets from `profiles.yaml`.
+5. **`middlewares`** — an optional explicit list of Glazed source middlewares that the generated binary should wire into every command's parser chain.
+
+The goal is to make `xgoja` binaries behave like first-class Glazed applications (e.g. `pinocchio`, `glaze`) without forcing the user to write Go code. All wiring should be expressed in YAML and baked into the generated `main.go` at build time.
+
+---
+
+## Problem Statement and Scope
+
+### What is broken / missing today
+
+When you run `xgoja build -f xgoja.yaml`, the generator emits a `main.go` that creates commands through `app.NewRootCommand` or a target adapter. Each subcommand (`eval`, `run`, `repl`, `verbs`, provider commands) is converted to a Cobra command via `cli.BuildCobraCommand` with the following parser config:
+
+```go
+cli.WithParserConfig(cli.CobraParserConfig{
+    ShortHelpSections: []string{schema.DefaultSlug},
+    MiddlewaresFunc:   cli.CobraCommandDefaultMiddlewares,
+})
+```
+
+Source: `pkg/xgoja/app/glazed.go:12-16`
+
+`CobraCommandDefaultMiddlewares` is defined in `glazed/pkg/cli/cobra-parser.go:37-56` and returns only three middlewares:
+
+1. `cmd_sources.FromCobra(cmd, ...)` — reads `--flag value` from Cobra's parsed flags.
+2. `cmd_sources.FromArgs(args, ...)` — reads positional arguments.
+3. `cmd_sources.FromDefaults(...)` — fills in field definition defaults.
+
+There is **no** `FromEnv`, **no** `FromConfigPlanBuilder`, and **no** profile loading. If a provider module exposes a section `openai` with a field `api-key`, the user must pass `--openai-api-key` on every invocation. There is no mechanism for:
+
+- `XGOJA_OPENAI_API_KEY=sk-... ./dist/myapp eval '...'`
+- A project-local `config.yaml` that sets `openai.api-key`.
+- A user-wide `~/.config/myapp/config.yaml` that sets defaults.
+- A `profiles.yaml` with a `production` profile that overrides endpoint URLs.
+
+### Scope of this ticket
+
+This ticket is **design-only**; no code changes are being made yet. We will:
+
+1. Map exactly how Glazed applications (especially `pinocchio`) achieve env/config/profile support.
+2. Identify every file and data structure in xgoja that must change.
+3. Propose a backward-compatible `xgoja.yaml` schema extension.
+4. Specify how the Go template in `cmd/xgoja/internal/generate/templates/main.go.tmpl` must emit different code based on the new spec fields.
+5. Specify how `pkg/xgoja/app` must accept runtime middleware configuration.
+6. Provide a phased implementation plan, test strategy, and risk analysis.
+
+Out of scope: Vault integration, dynamic middleware registration at runtime (plugins loading their own sources), and changing the xgoja CLI itself (the `xgoja build` command only needs to pass new fields through; it does not need env/config support).
+
+---
+
+## Current-State Architecture
+
+To understand where the wires must go, we need to trace five subsystems: the build spec, the code generator, the generated binary's host layer, the command-wiring layer, and Glazed's middleware chain itself.
+
+### 1. The Build Spec (`buildspec.Spec`)
+
+File: `cmd/xgoja/internal/buildspec/spec.go`
+
+The YAML spec is unmarshaled into:
+
+```go
+type Spec struct {
+    Name             string                    `yaml:"name"`
+    Go               GoSpec                    `yaml:"go"`
+    Target           TargetSpec                `yaml:"target"`
+    Packages         []PackageSpec             `yaml:"packages"`
+    Runtimes         map[string]Runtime        `yaml:"runtimes"`
+    Commands         CommandsSpec              `yaml:"commands"`
+    CommandProviders []CommandProviderInstance `yaml:"commandProviders"`
+    JSVerbs          []JSVerbSourceSpec        `yaml:"jsverbs"`
+    Help             HelpSpec                  `yaml:"help"`
+    Assets           []AssetSourceSpec         `yaml:"assets"`
+    BaseDir          string                    `yaml:"-"`
+}
+```
+
+There is **no** field for app identity, env prefix, config layers, profiles, or middleware overrides. The spec is purely about "what Go packages to import" and "what runtime modules to expose."
+
+### 2. The Code Generator
+
+File: `cmd/xgoja/internal/generate/generate.go` and `templates.go`
+
+`WriteAll` produces a temporary workspace containing:
+
+- `go.mod` — derived from `GoSpec` and provider imports.
+- `main.go` — rendered from `templates/main.go.tmpl` via `mainTemplateDataFromSpec`.
+- `xgoja.gen.json` — the spec serialized as JSON and embedded as a string constant.
+- `xgoja_embed/...` — copied jsverb, help, and asset trees.
+
+The template `main.go.tmpl` (file: `cmd/xgoja/internal/generate/templates/main.go.tmpl`) has two primary branches based on `TargetKind`:
+
+- `xgoja` (default): calls `app.NewRootCommand(app.Options{...})`
+- `cobra`: calls `target.NewRootCommand()` then `host.AttachDefaultCommands(root)`
+- `adapter`: calls `target.Build(context.Background(), host)`
+
+In all three cases, the generated binary receives its operational configuration through `embeddedSpecJSON`. It does not receive any parser configuration.
+
+### 3. The Generated Host Layer
+
+File: `pkg/xgoja/app/host.go` and `root.go`
+
+`NewRootCommand` constructs a `Host` from the decoded `Spec` and attaches subcommands:
+
+```go
+func NewRootCommand(opts Options) (*cobra.Command, error) {
+    // ... decode spec ...
+    host := NewHostWithOptions(opts.Providers, spec, ...)
+    root := &cobra.Command{Use: spec.Name, Short: "Generated xgoja binary"}
+    host.AttachDefaultCommands(root)
+    return root, nil
+}
+```
+
+`AttachDefaultCommands` (file: `pkg/xgoja/app/host.go:35-57`) mounts `eval`, `run`, `repl`, `modules`, `verbs`, and command-provider commands. Every one of these commands is converted to Cobra via `buildGlazedCobraCommand` in `pkg/xgoja/app/glazed.go`.
+
+### 4. The Command-Wiring Layer
+
+File: `pkg/xgoja/app/glazed.go`
+
+```go
+func buildGlazedCobraCommand(command cmds.Command) (*cobra.Command, error) {
+    return cli.BuildCobraCommand(command,
+        cli.WithParserConfig(cli.CobraParserConfig{
+            ShortHelpSections: []string{schema.DefaultSlug},
+            MiddlewaresFunc:   cli.CobraCommandDefaultMiddlewares,
+        }),
+    )
+}
+```
+
+This is the **single chokepoint** where env/config/profile support must be injected. Today it is a package-internal function with no parameters. To support configurable middlewares, it must become parameterized or the `Host` must carry a middleware factory that it passes down to every command builder.
+
+### 5. Glazed's Middleware Chain
+
+File: `glazed/pkg/cli/cobra-parser.go`
+
+Glazed commands are parsed through a chain of `sources.Middleware` functions. The built-in chain (when `AppName` or `ConfigPlanBuilder` is set) looks like this:
+
+```go
+middlewares_ := []cmd_sources.Middleware{
+    cmd_sources.FromCobra(cmd, fields.WithSource("cobra")),
+    cmd_sources.FromArgs(args, fields.WithSource("arguments")),
+}
+
+if cfgCopy.AppName != "" {
+    envPrefix := strings.ToUpper(cfgCopy.AppName)
+    middlewares_ = append(middlewares_,
+        cmd_sources.FromEnv(envPrefix, fields.WithSource("env")),
+    )
+}
+
+if cfgCopy.ConfigPlanBuilder != nil {
+    middlewares_ = append(middlewares_,
+        cmd_sources.FromConfigPlanBuilder(
+            func(_ context.Context, _ *values.Values) (*glazedconfig.Plan, error) {
+                return cfgCopy.ConfigPlanBuilder(parsedCommandSections, cmd, args)
+            },
+            cmd_sources.WithParseOptions(fields.WithSource("config")),
+        ),
+    )
+}
+
+middlewares_ = append(middlewares_,
+    cmd_sources.FromDefaults(fields.WithSource(fields.SourceDefaults)),
+)
+```
+
+Source: `glazed/pkg/cli/cobra-parser.go:123-150`
+
+The **precedence order** is critical. Because `ExecuteWithSchema` reverses the middleware list before wrapping, the **last** middleware appended has the **highest** precedence. The actual evaluation order at runtime is:
+
+1. Defaults (lowest precedence)
+2. Config files
+3. Environment variables
+4. CLI arguments / Cobra flags (highest precedence)
+
+This means a flag `--openai-api-key` beats `MYAPP_OPENAI_API_KEY`, which beats a value in `config.yaml`, which beats the field's `Default` value.
+
+### 6. How Pinocchio Does It (Reference Implementation)
+
+File: `pinocchio/pkg/cmds/cobra.go`
+
+Pinocchio does not use the built-in `CobraParserConfig` env/config path. Instead, it supplies a **custom `MiddlewaresFunc`**:
+
+```go
+func GetPinocchioCommandMiddlewares(parsedCommandSections *values.Values, cmd *cobra.Command, args []string) ([]sources.Middleware, error) {
+    cfg := profilebootstrap.BootstrapConfig()
+    return []sources.Middleware{
+        sources.FromCobra(cmd, fields.WithSource("cobra")),
+        sources.FromArgs(args, fields.WithSource("arguments")),
+        sources.FromEnv(cfg.EnvPrefix, fields.WithSource("env")),
+        sources.FromConfigPlanBuilder(
+            func(_ context.Context, _ *values.Values) (*glazedconfig.Plan, error) {
+                return cfg.ConfigPlanBuilder(parsedCommandSections)
+            },
+            sources.WithConfigFileMapper(cfg.ConfigFileMapper),
+            sources.WithParseOptions(fields.WithSource("config")),
+        ),
+        sources.FromDefaults(fields.WithSource(fields.SourceDefaults)),
+    }, nil
+}
+```
+
+Pinocchio also wires profile loading as a **separate bootstrap layer** above the middleware chain (see `pinocchio/pkg/cmds/profilebootstrap/profile_selection.go`). Profile settings are parsed early, before command execution, and the effective profile influences which parameters are injected into the prompt engine. For xgoja, we can adopt a simpler model: profiles are just another source middleware that loads a `profiles.yaml` section map.
+
+---
+
+## Gap Analysis
+
+| Gap | Impact | Files to Touch |
+|---|---|---|
+| `buildspec.Spec` has no `appName`, `envPrefix`, `config`, `profiles`, or `middlewares` fields | User cannot declare env/config behavior in YAML | `cmd/xgoja/internal/buildspec/spec.go` |
+| `buildspec.Spec` JSON struct (`pkg/xgoja/app/spec.go`) mirrors the YAML struct but is also missing the new fields | Generated binary cannot decode the new fields from embedded JSON | `pkg/xgoja/app/spec.go` |
+| `main.go.tmpl` hardcodes `app.NewRootCommand` with no middleware configuration | Generated binary has no hook to inject `FromEnv` / `FromConfigPlanBuilder` | `cmd/xgoja/internal/generate/templates/main.go.tmpl` |
+| `mainTemplateDataFromSpec` does not populate middleware-related template variables | Template cannot conditionally emit middleware wiring | `cmd/xgoja/internal/generate/templates.go` |
+| `buildGlazedCobraCommand` is a zero-parameter helper that always uses `CobraCommandDefaultMiddlewares` | Every command in the generated binary lacks env/config parsing | `pkg/xgoja/app/glazed.go` |
+| `Host.AttachDefaultCommands` and `Host.AttachEval/AttachRun/AttachRepl` do not pass middleware configuration down to command builders | Even if `buildGlazedCobraCommand` gains a parameter, the Host must carry the factory | `pkg/xgoja/app/host.go` |
+| `Host` struct has no field for middleware factory or parser config | No place to store runtime parser policy | `pkg/xgoja/app/host.go` |
+| `NewRootCommand` and `NewHostWithOptions` do not accept middleware configuration | Entry points from generated `main.go` cannot inject policy | `pkg/xgoja/app/root.go`, `pkg/xgoja/app/host.go` |
+| `pkg/xgoja/app/framework.go` sets `logging.AddLoggingSectionToRootCommand(root, appName)` but `appName` is derived only from `spec.Name` | No explicit app name override; no env prefix derivation | `pkg/xgoja/app/framework.go` |
+| Validation (`doctor`) does not check new fields | Invalid configs could produce uncompilable or misbehaving binaries | `cmd/xgoja/internal/buildspec/validate.go` |
+
+---
+
+## Proposed Architecture and APIs
+
+### Overview
+
+We introduce a new top-level section in `xgoja.yaml` called `settings` (or we add fields directly to the spec root; see Decision Records). This section contains everything a generated binary needs to behave like a native Glazed application. The generator then:
+
+1. Embeds the settings into `xgoja.gen.json`.
+2. Emits a `main.go` that constructs a `Host` with a middleware factory derived from those settings.
+3. Emits code so that every command built by the Host uses that middleware factory instead of the hardcoded default.
+
+### New `xgoja.yaml` Schema (Proposed)
+
+```yaml
+name: my-app
+
+# NEW: Explicit application identity
+description: "My custom goja runtime"
+appName: my-app          # default: same as `name`
+envPrefix: MY_APP        # default: UPPER(appName)
+
+# NEW: Declarative config layers
+config:
+  enabled: true
+  layers:
+    - system
+    - xdg
+    - home
+    - git-root
+    - cwd
+  fileName: config.yaml   # discovered file name for system/xdg/home/git-root/cwd
+  explicitFlag: config    # if non-empty, adds --config flag to root command
+
+# NEW: Profile loading
+profiles:
+  enabled: true
+  file: profiles.yaml     # default; resolves via XDG if relative
+  appName: my-app         # default: same as top-level appName
+  defaultProfile: default
+
+# NEW: Explicit middleware list (advanced)
+middlewares:
+  - source: env
+    prefix: MY_APP        # optional override
+  - source: config
+    # uses the config plan defined above
+  - source: profiles
+    # uses the profiles defined above
+```
+
+**Backward compatibility:** If `config.enabled` is false or absent, and `middlewares` is absent, the generated binary behaves exactly as it does today. No breaking changes.
+
+### New `buildspec` Go Types
+
+File: `cmd/xgoja/internal/buildspec/spec.go`
+
+```go
+type Spec struct {
+    Name             string                    `yaml:"name"`
+    Description      string                    `yaml:"description,omitempty"`
+    AppName          string                    `yaml:"appName,omitempty"`
+    EnvPrefix        string                    `yaml:"envPrefix,omitempty"`
+    Config           *ConfigSpec               `yaml:"config,omitempty"`
+    Profiles         *ProfileSpec              `yaml:"profiles,omitempty"`
+    Middlewares      []MiddlewareSpec          `yaml:"middlewares,omitempty"`
+    Go               GoSpec                    `yaml:"go"`
+    Target           TargetSpec                `yaml:"target"`
+    Packages         []PackageSpec             `yaml:"packages"`
+    Runtimes         map[string]Runtime        `yaml:"runtimes"`
+    Commands         CommandsSpec              `yaml:"commands"`
+    CommandProviders []CommandProviderInstance `yaml:"commandProviders"`
+    JSVerbs          []JSVerbSourceSpec        `yaml:"jsverbs"`
+    Help             HelpSpec                  `yaml:"help"`
+    Assets           []AssetSourceSpec         `yaml:"assets"`
+    BaseDir          string                    `yaml:"-"`
+}
+
+type ConfigSpec struct {
+    Enabled      bool     `yaml:"enabled"`
+    Layers       []string `yaml:"layers,omitempty"`
+    FileName     string   `yaml:"fileName,omitempty"`
+    ExplicitFlag string   `yaml:"explicitFlag,omitempty"`
+}
+
+type ProfileSpec struct {
+    Enabled        bool   `yaml:"enabled"`
+    File           string `yaml:"file,omitempty"`
+    AppName        string `yaml:"appName,omitempty"`
+    DefaultProfile string `yaml:"defaultProfile,omitempty"`
+}
+
+type MiddlewareSpec struct {
+    Source string            `yaml:"source"`
+    Prefix string            `yaml:"prefix,omitempty"`
+    Config map[string]interface{} `yaml:"config,omitempty"`
+}
+```
+
+The JSON equivalent in `pkg/xgoja/app/spec.go` mirrors these fields so the embedded spec can be decoded at runtime.
+
+### Runtime Types in `pkg/xgoja/app`
+
+File: `pkg/xgoja/app/host.go`
+
+```go
+type Host struct {
+    Providers       *providerapi.Registry
+    Spec            *Spec
+    Factory         *RuntimeFactory
+    EmbeddedJSVerbs fs.FS
+    EmbeddedHelp    fs.FS
+    EmbeddedAssets  fs.FS
+    Services        HostServices
+    Out             io.Writer
+
+    // NEW: parser configuration propagated to every command
+    MiddlewaresFunc cli.CobraMiddlewaresFunc
+}
+
+type HostOptions struct {
+    EmbeddedJSVerbs fs.FS
+    EmbeddedHelp    fs.FS
+    EmbeddedAssets  fs.FS
+    Out             io.Writer
+
+    // NEW
+    MiddlewaresFunc cli.CobraMiddlewaresFunc
+}
+```
+
+If `MiddlewaresFunc` is nil, the Host falls back to `cli.CobraCommandDefaultMiddlewares` for backward compatibility.
+
+### Changes to `buildGlazedCobraCommand`
+
+File: `pkg/xgoja/app/glazed.go`
+
+```go
+func buildGlazedCobraCommandWithMiddlewares(command cmds.Command, middlewaresFunc cli.CobraMiddlewaresFunc) (*cobra.Command, error) {
+    if middlewaresFunc == nil {
+        middlewaresFunc = cli.CobraCommandDefaultMiddlewares
+    }
+    return cli.BuildCobraCommand(command,
+        cli.WithParserConfig(cli.CobraParserConfig{
+            ShortHelpSections: []string{schema.DefaultSlug},
+            MiddlewaresFunc:   middlewaresFunc,
+        }),
+    )
+}
+```
+
+All call sites inside `host.go` (`AttachEval`, `AttachRun`, `AttachRepl`, `AttachModules`, `AttachCommandProviders`) switch from `buildGlazedCobraCommand` to `buildGlazedCobraCommandWithMiddlewares(..., h.MiddlewaresFunc)`.
+
+### Generated `main.go` Changes
+
+The template must emit different construction code based on whether middlewares are configured. For the common case (`config.enabled: true`), the generator should produce a `ConfigPlanBuilder` closure and pass it to `app.NewRootCommand` inside a custom middleware function.
+
+**Pseudocode for the generator's template data additions:**
+
+```go
+type mainTemplateData struct {
+    // ... existing fields ...
+
+    // NEW
+    HasMiddlewares    bool
+    AppName           string
+    EnvPrefix         string
+    ConfigPlanBuilder string // Go source snippet for the closure
+}
+```
+
+**Pseudocode for template branch in `main.go.tmpl`:**
+
+```gotemplate
+{{- if .HasMiddlewares }}
+    middlewaresFunc := func(parsedCommandSections *values.Values, cmd *cobra.Command, args []string) ([]cmd_sources.Middleware, error) {
+        middlewares_ := []cmd_sources.Middleware{
+            cmd_sources.FromCobra(cmd, fields.WithSource("cobra")),
+            cmd_sources.FromArgs(args, fields.WithSource("arguments")),
+        }
+        {{- if .EnvPrefix }}
+        middlewares_ = append(middlewares_, cmd_sources.FromEnv("{{ .EnvPrefix }}", fields.WithSource("env")))
+        {{- end }}
+        {{- if .ConfigPlanBuilder }}
+        middlewares_ = append(middlewares_, cmd_sources.FromConfigPlanBuilder(
+            func(_ context.Context, _ *values.Values) (*glazedconfig.Plan, error) {
+                return {{ .ConfigPlanBuilder }}
+            },
+            cmd_sources.WithParseOptions(fields.WithSource("config")),
+        ))
+        {{- end }}
+        middlewares_ = append(middlewares_, cmd_sources.FromDefaults(fields.WithSource(fields.SourceDefaults)))
+        return middlewares_, nil
+    }
+{{- end }}
+```
+
+For the `xgoja` target kind, the generated `main` then becomes:
+
+```go
+root, err := app.NewRootCommand(app.Options{
+    Providers:       registry,
+    SpecJSON:        embeddedSpecJSON,
+    EmbeddedJSVerbs: embeddedJSVerbs,
+    EmbeddedHelp:    embeddedHelp,
+    EmbeddedAssets:  embeddedAssets,
+    MiddlewaresFunc: middlewaresFunc, // NEW
+})
+```
+
+For the `cobra` target kind, the `Host` construction gains the same field:
+
+```go
+host := app.NewHostWithOptions(registry, spec, app.HostOptions{
+    EmbeddedJSVerbs: embeddedJSVerbs,
+    EmbeddedHelp:    embeddedHelp,
+    EmbeddedAssets:  embeddedAssets,
+    MiddlewaresFunc: middlewaresFunc, // NEW
+})
+```
+
+### Config Plan Builder Generation
+
+The generator must turn the declarative `config` block into a Go closure that returns a `glazedconfig.Plan`. This is the most complex part of the template because it involves translating layer names into `glazedconfig.SourceSpec` function calls.
+
+**Layer mapping:**
+
+| Layer name | Generated call |
+|---|---|
+| `system` | `glazedconfig.SystemAppConfig(appName)` |
+| `xdg` | `glazedconfig.XDGAppConfig(appName)` |
+| `home` | `glazedconfig.HomeAppConfig(appName)` |
+| `git-root` | `glazedconfig.GitRootFile(fileName)` |
+| `cwd` | `glazedconfig.WorkingDirFile(fileName)` |
+| `explicit` | `glazedconfig.ExplicitFile(explicitPath)` (resolved from `--config` flag) |
+
+**Precedence order:** The generated plan must add layers in the order listed above (system lowest, explicit highest). The `glazedconfig.NewPlan` constructor should use `WithLayerOrder(...)` to ensure correct deduplication behavior.
+
+**Pseudocode for the generated closure:**
+
+```go
+func buildConfigPlan(parsed *values.Values, cmd *cobra.Command, args []string) (*glazedconfig.Plan, error) {
+    appName := "{{ .AppName }}"
+    fileName := "{{ .ConfigFileName }}"
+    plan := glazedconfig.NewPlan(
+        glazedconfig.WithLayerOrder(
+            glazedconfig.LayerSystem,
+            glazedconfig.LayerUser,
+            glazedconfig.LayerRepo,
+            glazedconfig.LayerCWD,
+            glazedconfig.LayerExplicit,
+        ),
+        glazedconfig.WithDedupePaths(),
+    )
+    {{- range .ConfigLayers }}
+    {{- if eq . "system" }}
+    plan.Add(glazedconfig.SystemAppConfig(appName).Named("system-app-config").Kind("app-config"))
+    {{- else if eq . "xdg" }}
+    plan.Add(glazedconfig.XDGAppConfig(appName).Named("xdg-app-config").Kind("app-config"))
+    {{- else if eq . "home" }}
+    plan.Add(glazedconfig.HomeAppConfig(appName).Named("home-app-config").Kind("app-config"))
+    {{- else if eq . "git-root" }}
+    plan.Add(glazedconfig.GitRootFile(fileName).Named("git-root-config").Kind("local-file"))
+    {{- else if eq . "cwd" }}
+    plan.Add(glazedconfig.WorkingDirFile(fileName).Named("cwd-config").Kind("local-file"))
+    {{- end }}
+    {{- end }}
+    // explicit layer is added only if the user passed --config
+    return plan, nil
+}
+```
+
+Note: The `explicit` layer requires reading a `--config` flag value. In the built-in Glazed parser path, `ConfigPlanBuilder` receives `parsedCommandSections`, `cmd`, and `args`. The generated closure can look up the flag from `cmd.Flags().Lookup("config")` or from the parsed command settings section. We will need to decide whether xgoja generates a `--config` flag on the root command or expects the user to use Glazed's built-in `--config` command setting. See Decision Records.
+
+### Profile Middleware Generation
+
+If `profiles.enabled: true`, the generator emits an additional middleware in the chain:
+
+```go
+middlewares_ = append(middlewares_,
+    sources.GatherFlagsFromCustomProfiles(
+        "{{ .DefaultProfile }}",
+        sources.WithProfileAppName("{{ .ProfileAppName }}"),
+        sources.WithProfileParseOptions(fields.WithSource("profiles")),
+    ),
+)
+```
+
+This loads `~/.config/<appName>/profiles.yaml` (or the explicit file if specified) and injects the selected profile's section maps into the parsed values. The profile name itself can come from a `--profile` flag or an env variable.
+
+---
+
+## Decision Records
+
+### Decision: Where to place the new fields in `xgoja.yaml`
+
+- **Context:** We could add `appName`, `envPrefix`, `config`, and `profiles` as top-level fields, or nest them under a `settings:` or `glazed:` block.
+- **Options considered:**
+  1. **Top-level** — Flat, easy to read, consistent with `name`, `target`, `packages`.
+  2. **`settings:` block** — Groups all runtime behavioral settings in one place.
+  3. **`glazed:` block** — Makes it obvious these are Glazed-specific features.
+- **Decision:** Use **top-level fields** for `appName`, `envPrefix`, `config`, `profiles`, and a separate `middlewares:` list for advanced overrides. This keeps the file readable and matches the flat style of existing fields (`help:`, `assets:`).
+- **Rationale:** xgoja is a Glazed-native tool; prefixing everything with `glazed:` is redundant. A `settings:` block adds nesting without adding clarity. Top-level fields are discoverable.
+- **Consequences:** The spec struct gains several new fields, but they are all optional and self-documenting.
+- **Status:** proposed
+
+### Decision: Should the generator emit a custom `MiddlewaresFunc` or use Glazed's built-in parser path?
+
+- **Context:** Glazed's `CobraParserConfig` has two ways to get env/config support: (a) set `AppName` and `ConfigPlanBuilder` and let the built-in parser path construct the middlewares, or (b) supply a custom `MiddlewaresFunc` that builds the chain manually.
+- **Options considered:**
+  1. **Built-in parser path** — Set `AppName` and `ConfigPlanBuilder` on `CobraParserConfig`. Less generated code; relies on Glazed's internal wiring.
+  2. **Custom `MiddlewaresFunc`** — The generator emits a Go function literal in `main.go` that returns the exact middleware slice. More explicit; easier to debug; allows profile middleware insertion.
+- **Decision:** Use **custom `MiddlewaresFunc`** for advanced configurations (profiles, explicit middleware list), and fall back to the **built-in path** for simple `appName` + `envPrefix` only.
+- **Rationale:** The built-in path does not support profile middlewares (`GatherFlagsFromCustomProfiles`) or arbitrary middleware ordering. A generated function literal is only ~20 lines of Go and is fully inspectable by the user when they run `--keep-work`. Explicit is better than implicit for generated code.
+- **Consequences:** The template becomes slightly more complex, but the generated binary's behavior is fully visible in `main.go`. We must ensure the generated function compiles against the exact Glazed version in `go.mod`.
+- **Status:** proposed
+
+### Decision: How should `--config` explicit file override work?
+
+- **Context:** Glazed commands already have a `--config` flag in the `CommandSettings` section (see `cli.CommandSettings`). However, `CobraParserConfig.ConfigPlanBuilder` receives `cmd` and `args`, so it can read that flag.
+- **Options considered:**
+  1. **Reuse Glazed's `--config`** — The `CommandSettings` section is parsed early; the `ConfigPlanBuilder` can extract `commandSettings.ConfigFile` and feed it into `glazedconfig.ExplicitFile(...)`.
+  2. **Generate a root-level `--config` flag** — Add a persistent flag directly to the generated root Cobra command. Simpler but duplicates Glazed's existing mechanism.
+- **Decision:** **Reuse Glazed's `--config`** through `CommandSettings.ConfigFile`. The generated `ConfigPlanBuilder` closure extracts the explicit config path from `parsedCommandSections` (which already contains `CommandSettings` after early parsing).
+- **Rationale:** No duplication, no flag collision, consistent with `pinocchio` and other Glazed apps.
+- **Consequences:** The generated closure needs to know how to decode `CommandSettings`. We can import `github.com/go-go-golems/glazed/pkg/cli` in generated code and call `parsed.DecodeSectionInto(cli.CommandSettingsSlug, &settings)`.
+- **Status:** proposed
+
+### Decision: Should `envPrefix` default to `UPPER(appName)` or remain empty?
+
+- **Context:** Glazed's built-in parser path does `envPrefix := strings.ToUpper(cfgCopy.AppName)`. This means setting `AppName: "my-app"` automatically enables `MY_APP_*` env vars. Some users may want env support disabled.
+- **Options considered:**
+  1. **Auto-enable from `appName`** — If `appName` is set, env is always on. Simple but removes control.
+  2. **Require explicit `envPrefix`** — Env support is opt-in. Safer but more verbose.
+  3. **Default from `appName`, allow empty override** — `envPrefix` defaults to `UPPER(appName)`; set to `""` to disable.
+- **Decision:** **Option 3** — `envPrefix` defaults to `UPPER(appName)` when `appName` is set; explicit `""` disables it.
+- **Rationale:** This matches Glazed's convention and user expectations. A user who bothers to set `appName` usually wants the full Glazed application behavior.
+- **Consequences:** We must document that `envPrefix: ""` is the escape hatch.
+- **Status:** proposed
+
+---
+
+## Pseudocode and Key Flows
+
+### Flow 1: Build-time path (xgoja build)
+
+```
+User writes xgoja.yaml with config.enabled: true
+       |
+       v
+xgoja build reads buildspec.Spec (new fields decoded)
+       |
+       v
+generate.WriteAll renders main.go.tmpl
+       |
+       +---> If config.enabled:
+       |         template emits ConfigPlanBuilder closure
+       |         template emits custom MiddlewaresFunc
+       |
+       +---> If profiles.enabled:
+       |         template emits GatherFlagsFromCustomProfiles middleware
+       |
+       v
+generated main.go contains full middleware wiring
+       |
+       v
+go build produces binary
+```
+
+### Flow 2: Runtime path (generated binary execution)
+
+```
+./dist/myapp eval 'require("hello").greet("world")' --openai-api-key sk-...
+       |
+       v
+Cobra parses --openai-api-key into its flag set
+       |
+       v
+cli.ParseCommandSettingsSection extracts --config, --profile, etc.
+       |
+       v
+Custom MiddlewaresFunc builds the chain:
+   1. FromDefaults          -> openai.api-key = "" (field default)
+   2. FromConfigPlanBuilder -> openai.api-key = "from config.yaml"
+   3. FromEnv(MY_APP_)      -> openai.api-key = "from env"
+   4. FromCobra             -> openai.api-key = "sk-..." (CLI wins)
+       |
+       v
+Parsed values decoded into command settings struct
+       |
+       v
+Command runs with effective configuration
+```
+
+### Flow 3: Config file discovery at runtime
+
+```
+ConfigPlanBuilder closure executes
+       |
+       v
+plan.Resolve(ctx) walks each layer:
+   LayerSystem:  /etc/my-app/config.yaml        (optional)
+   LayerUser:    ~/.config/my-app/config.yaml   (optional)
+   LayerUser:    ~/.my-app/config.yaml          (optional)
+   LayerRepo:    <git-root>/config.yaml         (optional)
+   LayerCWD:     ./config.yaml                  (optional)
+   LayerExplicit: --config path                 (if provided)
+       |
+       v
+Files returned in precedence order (low -> high)
+       |
+       v
+FromResolvedFiles middleware loads each file,
+merging section maps into parsed values
+```
+
+---
+
+## Phased Implementation Plan
+
+### Phase 1: Schema and validation (no generated code changes)
+
+**Goal:** Teach xgoja to read and validate the new YAML fields without changing the generator.
+
+1. Add new types to `cmd/xgoja/internal/buildspec/spec.go`.
+2. Add JSON mirror types to `pkg/xgoja/app/spec.go`.
+3. Add validation rules to `cmd/xgoja/internal/buildspec/validate.go`:
+   - `envPrefix` must be uppercase alphanumeric + underscore if provided.
+   - `config.layers` entries must be from the allowed set.
+   - `middlewares[].source` must be one of `env`, `config`, `profiles`, `vault` (future), `defaults`.
+4. Add test cases in `validate_test.go` and `load_test.go`.
+5. Update `cmd/xgoja/doc/06-buildspec-reference.md` with new fields.
+
+**Files:**
+- `cmd/xgoja/internal/buildspec/spec.go`
+- `pkg/xgoja/app/spec.go`
+- `cmd/xgoja/internal/buildspec/validate.go`
+- `cmd/xgoja/internal/buildspec/validate_test.go`
+- `cmd/xgoja/internal/buildspec/load_test.go`
+- `cmd/xgoja/doc/06-buildspec-reference.md`
+
+### Phase 2: Host and command wiring (no template changes)
+
+**Goal:** Make `pkg/xgoja/app` capable of accepting and using a custom middleware factory.
+
+1. Add `MiddlewaresFunc` to `Host` and `HostOptions`.
+2. Add `MiddlewaresFunc` to `app.Options`.
+3. Change `buildGlazedCobraCommand` to `buildGlazedCobraCommandWithMiddlewares`.
+4. Update every `Attach*` method in `host.go` to pass `h.MiddlewaresFunc`.
+5. Update `framework.go` to use `spec.AppName` if set, else `spec.Name`.
+6. Add unit tests in `root_test.go` and `host_test.go` (new file) that verify a custom middleware is invoked.
+
+**Files:**
+- `pkg/xgoja/app/host.go`
+- `pkg/xgoja/app/root.go`
+- `pkg/xgoja/app/glazed.go`
+- `pkg/xgoja/app/framework.go`
+- `pkg/xgoja/app/root_test.go`
+
+### Phase 3: Template and generator wiring
+
+**Goal:** Teach the generator to emit middleware-aware `main.go`.
+
+1. Extend `mainTemplateData` in `templates.go` with new boolean and string fields.
+2. Implement template helper functions (or pre-computed strings) for the `ConfigPlanBuilder` Go source snippet.
+3. Modify `main.go.tmpl` to emit the `middlewaresFunc` closure conditionally.
+4. Modify `main.go.tmpl` to pass `middlewaresFunc` into `app.NewRootCommand` or `app.NewHostWithOptions`.
+5. Add generator tests in `generate_test.go` that assert on rendered source code for various spec configurations.
+6. Add an end-to-end example under `examples/xgoja/` that demonstrates env + config + profiles.
+
+**Files:**
+- `cmd/xgoja/internal/generate/templates.go`
+- `cmd/xgoja/internal/generate/templates/main.go.tmpl`
+- `cmd/xgoja/internal/generate/generate_test.go`
+- `examples/xgoja/11-config-env-profiles/xgoja.yaml` (new)
+
+### Phase 4: Documentation and integration tests
+
+**Goal:** Ensure the feature is discoverable and works end-to-end.
+
+1. Write tutorial doc: `cmd/xgoja/doc/10-tutorial-config-env-profiles.md`.
+2. Add integration test script in `cmd/xgoja/scripts/` that:
+   - Builds an example binary with config enabled.
+   - Creates a `config.yaml` and verifies the binary reads it.
+   - Exports an env var and verifies it overrides the config file.
+   - Passes a CLI flag and verifies it overrides the env var.
+3. Update `README.md` with a "Configuration" section.
+
+**Files:**
+- `cmd/xgoja/doc/10-tutorial-config-env-profiles.md`
+- `cmd/xgoja/scripts/verify-config-env.sh`
+- `cmd/xgoja/README.md`
+
+---
+
+## Testing and Validation Strategy
+
+### Unit tests
+
+| Component | What to test |
+|---|---|
+| `buildspec` | Decode all new YAML shapes; reject invalid layers, bad prefixes, unknown middleware sources. |
+| `validate.go` | Ensure `doctor` catches missing `appName` when `config.enabled` is true. |
+| `pkg/xgoja/app` | Mock `CobraMiddlewaresFunc` and assert it is called during `AttachEval`. |
+| `generate` | Render template with new fields; verify emitted Go compiles (use `format.Source` as proxy). |
+
+### Integration tests
+
+1. **Env override:** Build binary with `envPrefix: TESTAPP`. Run `TESTAPP_EVAL_RUNTIME=foo ./dist/app eval '1'`. Assert the runtime profile is `foo`.
+2. **Config file override:** Create `config.yaml` with `eval: {runtime: bar}`. Run `./dist/app eval '1'`. Assert runtime is `bar`.
+3. **Precedence:** Set config to `bar`, env to `baz`, and CLI flag `--runtime qux`. Assert `qux` wins.
+4. **Profile loading:** Create `profiles.yaml` with `prod: {eval: {runtime: prod}}`. Run `./dist/app --profile prod eval '1'`. Assert runtime is `prod`.
+
+### Regression tests
+
+- Build every existing example in `examples/xgoja/` and confirm output is byte-identical to before (or at least functionally identical). The new fields are all optional; no existing spec should change behavior.
+
+---
+
+## Risks, Alternatives, and Open Questions
+
+### Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Template-generated Go code does not compile against future Glazed versions | Medium | High | Pin Glazed version in generated `go.mod`; add compile-time test in `generate_test.go` |
+| `ConfigPlanBuilder` closure in template becomes unwieldy | Medium | Medium | Extract a helper package `pkg/xgoja/appconfig` that provides `NewPlanFromSpec(*app.ConfigSpec) *glazedconfig.Plan`; template just calls that |
+| Profile middleware ordering conflicts with config middleware | Low | Medium | Document ordering; allow explicit `middlewares:` list for power users |
+| Existing `spec.Name` used as logging label changes if we introduce `appName` | Low | Low | Default `appName` to `spec.Name`; behavior is identical unless user overrides |
+
+### Alternatives
+
+1. **Runtime middleware registration (no generator changes):** Instead of generating middleware wiring, teach `pkg/xgoja/app` to build a middleware factory from the embedded JSON spec at runtime. This keeps the template small but requires more runtime code and makes the binary's behavior less visible.
+2. **Provider-supplied middlewares:** Allow each provider package to export a middleware factory function, similar to how they export `Register(registry)`. This is more flexible but overkill for the common case of "I just want env vars and a config file."
+
+### Open Questions
+
+1. Should `config.fileName` default to `config.yaml` or to `<appName>.yaml`?
+2. Should we support `config.includeLayers` / `config.excludeLayers` instead of an explicit `layers` list?
+3. How should the generated binary handle missing config files? Glazed's plan marks them `Optional: true`, so they are silently skipped. Is that acceptable, or should we add a `--strict-config` flag?
+4. Should `profiles` be a Glazed section (like `profile-settings` in Geppetto) or a source middleware? Geppetto uses both: a section for CLI flags (`--profile`, `--profile-registry`) and a middleware for loading the file. Do we need the section too?
+
+---
+
+## References
+
+### Key Files (xgoja)
+
+- `cmd/xgoja/internal/buildspec/spec.go` — YAML spec struct.
+- `cmd/xgoja/internal/buildspec/validate.go` — Validation logic.
+- `cmd/xgoja/internal/generate/templates.go` — Template data builder.
+- `cmd/xgoja/internal/generate/templates/main.go.tmpl` — Generated main template.
+- `pkg/xgoja/app/spec.go` — Runtime JSON spec struct.
+- `pkg/xgoja/app/host.go` — Host construction and command attachment.
+- `pkg/xgoja/app/root.go` — `NewRootCommand` and command definitions.
+- `pkg/xgoja/app/glazed.go` — `buildGlazedCobraCommand` chokepoint.
+- `pkg/xgoja/app/framework.go` — Root framework installation (logging, help).
+
+### Key Files (glazed)
+
+- `glazed/pkg/cli/cobra-parser.go` — `CobraParserConfig`, `CobraCommandDefaultMiddlewares`, built-in parser path.
+- `glazed/pkg/cmds/sources/middlewares.go` — `Middleware`, `Chain`, `ExecuteWithSchema`.
+- `glazed/pkg/cmds/sources/load-fields-from-config.go` — `FromConfigPlanBuilder`, `FromResolvedFiles`.
+- `glazed/pkg/cmds/sources/update.go` — `FromEnv`, `updateFromEnv`.
+- `glazed/pkg/cmds/sources/profiles.go` — `GatherFlagsFromCustomProfiles`, `WithProfileAppName`.
+- `glazed/pkg/config/plan_sources.go` — `SystemAppConfig`, `XDGAppConfig`, `HomeAppConfig`, `GitRootFile`, `WorkingDirFile`.
+
+### Key Files (pinocchio — reference implementation)
+
+- `pinocchio/pkg/cmds/cobra.go` — Custom `MiddlewaresFunc` wiring.
+- `pinocchio/pkg/cmds/profilebootstrap/profile_selection.go` — `AppBootstrapConfig`, `ConfigPlanBuilder`, profile registry resolution.
+
+### Documentation
+
+- `cmd/xgoja/doc/03-tutorial-using-xgoja-yaml.md` — Existing tutorial.
+- `cmd/xgoja/doc/06-buildspec-reference.md` — Existing buildspec reference.
+- Glazed example: `glazed/cmd/examples/middlewares-config-env/main.go` — Minimal demo of `AppName` + `ConfigPlanBuilder`.

--- a/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/index.md
+++ b/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/index.md
@@ -1,0 +1,60 @@
+---
+Title: Add env prefix / app name / glazed source middleware support to xgoja generated binaries
+Ticket: XGOJA-017
+Status: active
+Topics:
+    - xgoja
+    - glazed
+    - configuration
+    - middleware
+    - design
+DocType: index
+Intent: long-term
+Owners: []
+RelatedFiles: []
+ExternalSources: []
+Summary: ""
+LastUpdated: 2026-06-02T10:44:00.683920984-04:00
+WhatFor: ""
+WhenToUse: ""
+---
+
+# Add env prefix / app name / glazed source middleware support to xgoja generated binaries
+
+## Overview
+
+<!-- Provide a brief overview of the ticket, its goals, and current status -->
+
+## Key Links
+
+- **Related Files**: See frontmatter RelatedFiles field
+- **External Sources**: See frontmatter ExternalSources field
+
+## Status
+
+Current status: **active**
+
+## Topics
+
+- xgoja
+- glazed
+- configuration
+- middleware
+- design
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/reference/01-diary.md
+++ b/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/reference/01-diary.md
@@ -532,3 +532,72 @@ Equivalent CLI flag:
 ```
 
 Precedence: config.yaml < ENV_FIXTURE_* < --fixture-value
+
+---
+
+## Step 11: Fix Generator Spec Embedding and End-to-End Verification
+
+During Phase 4 example testing, I discovered a critical bug: `RenderEmbeddedSpec` in `cmd/xgoja/internal/generate/main.go` manually constructs the embedded JSON payload and was missing `AppName`, `EnvPrefix`, and `Config`. This means all generated binaries were silently dropping these fields. Unit tests passed because they bypass the generator and pass JSON specs directly to `NewRootCommand`.
+
+### Prompt Context
+
+**User prompt (verbatim):** "continue"
+
+**Assistant interpretation:** Continue working through the ticket phases.
+
+**Inferred user intent:** Complete the remaining phases (3 and 4) and verify everything works end-to-end.
+
+**Commit (generator fix):** 1e34b29 — "xgoja: fix generator to embed appName/envPrefix/config in spec JSON"
+
+### What I did
+
+- Built existing examples (`01-core-provider`, `05-command-provider`, `10-embedded-assets-fs`) with the rebuilt `xgoja` CLI — all passed.
+- Created new example `examples/xgoja/11-config-env/` with:
+  - `xgoja.yaml` demonstrating `appName`, `envPrefix`, and `config`
+  - `config.yaml` setting `fixture.value`
+  - `script.js` that reads `fixtureValue`
+  - `README.md` explaining precedence
+- Tested the new example binary:
+  - Config file only: `./dist/config-env-demo eval 'fixtureValue'` -> `from-config-file`
+  - Env override: `DEMO_FIXTURE_VALUE=from-env ./dist/config-env-demo eval 'fixtureValue'` -> `from-env`
+  - Flag override: `DEMO_FIXTURE_VALUE=from-env ./dist/config-env-demo eval --fixture-value from-flag 'fixtureValue'` -> `from-flag`
+- Discovered that the example binary wasn't reading config. Investigated and found `RenderEmbeddedSpec` was missing the new fields.
+- Fixed `RenderEmbeddedSpec` to include `AppName`, `EnvPrefix`, and `Config` in the embedded JSON payload.
+- Rebuilt `xgoja` CLI and regenerated the example binary.
+- Verified the fix works end-to-end.
+- Committed the fix with the new example.
+
+### What didn't work
+
+- The first generated binary for the new example silently ignored `config.yaml` because `RenderEmbeddedSpec` dropped the `Config` field. The embedded JSON only contained `name`, `target`, `packages`, `runtimes`, `commands`, etc.
+- The linter (`errcheck`) flagged `defer os.Chdir(oldWd)` in integration tests. Fixed by wrapping in an anonymous function.
+
+### What was tricky to build
+
+- Debugging why config files worked in unit tests but not in generated binaries. The gap was the generator's `RenderEmbeddedSpec` function, which I had not read during the initial research because it's a Go template helper that serializes the spec. This is a good lesson: when adding new spec fields, always trace them through the generator to the embedded JSON.
+- The `RenderEmbeddedSpec` function manually builds a JSON payload struct instead of marshaling the `buildspec.Spec` directly. This is intentional (it filters out build-time-only fields and transforms embedded paths), but it means new runtime-relevant fields must be explicitly added.
+
+### Code review instructions
+
+- Review `cmd/xgoja/internal/generate/main.go` for the `RenderEmbeddedSpec` payload struct changes.
+- Review `examples/xgoja/11-config-env/` for the new example.
+- Build and run the example to verify:
+  ```bash
+  xgoja build -f examples/xgoja/11-config-env/xgoja.yaml --xgoja-replace /path/to/go-go-goja
+  cd examples/xgoja/11-config-env
+  ../../dist/config-env-demo eval 'fixtureValue'
+  DEMO_FIXTURE_VALUE=override ../../dist/config-env-demo eval 'fixtureValue'
+  ```
+
+### Technical details
+
+The embedded spec JSON is produced by `RenderEmbeddedSpec`, not by direct JSON marshaling of `buildspec.Spec`. The payload struct must explicitly include new runtime-relevant fields. Build-time-only fields (like `Go`, `BaseDir`) are correctly omitted.
+
+The fix adds:
+```go
+AppName   string                `json:"appName,omitempty"`
+EnvPrefix string                `json:"envPrefix,omitempty"`
+Config    *buildspec.ConfigSpec `json:"config,omitempty"`
+```
+
+This ensures generated binaries receive the full runtime configuration.

--- a/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/reference/01-diary.md
+++ b/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/reference/01-diary.md
@@ -435,3 +435,100 @@ Environment variable:
 ```bash
 XGOJA_TEST_FIXTURE_VALUE=explicit-env ./dist/fixture eval 'fixtureValue'
 ```
+
+---
+
+## Step 10: Implement Config File Support (Phase 2)
+
+After completing Phase 1 (env prefix), the next task was to add declarative config-file loading so generated binaries can read layered configuration files (CWD, home, XDG, system, explicit) in addition to environment variables.
+
+### Prompt Context
+
+**User prompt (verbatim):** "continue"
+
+**Assistant interpretation:** Continue working through the ticket phases. Phase 2 is config-file support.
+
+**Inferred user intent:** The user wants steady progress through the implementation plan, with each phase tested and committed.
+
+**Commit (code):** 2a465d1 — "Docs: record XGOJA-017 phase 1 implementation" (amended to include Phase 2 code)
+
+Wait, actually the code commit hash changed due to amend. Let me check the actual hash.
+
+### What I did
+
+- Added `ConfigSpec` to both `cmd/xgoja/internal/buildspec/spec.go` and `pkg/xgoja/app/spec.go`:
+  - `Enabled bool`
+  - `Layers []string`
+  - `FileName string` (defaults to `config.yaml`)
+- Added config validation in `cmd/xgoja/internal/buildspec/validate.go`:
+  - Requires `appName` when config is enabled
+  - Validates each layer against a known set: system, xdg, home, git-root, cwd, explicit
+  - Requires at least one layer
+- Added config defaulting in `cmd/xgoja/internal/buildspec/load.go`:
+  - Sets `config.FileName` to `"config.yaml"` when empty and config is enabled
+- Extended `pkg/xgoja/app/middlewares.go`:
+  - `MiddlewaresFromSpec` now checks for both env prefix and config support
+  - Added `buildConfigPlan` helper that constructs a `glazedconfig.Plan` from the spec
+  - The plan reads the explicit `--config` flag from `CommandSettings` at runtime
+  - Config middleware is placed at lower precedence than env (config < env < CLI flags)
+- Added tests:
+  - Validation tests for config requiring appName, rejecting unknown layers, requiring layers
+  - Load test for config defaulting
+  - Integration test: generated binary reads `config.yaml` from CWD
+  - Integration test: env beats config
+  - Integration test: CLI flag beats env
+
+### What worked
+
+- `go test ./cmd/xgoja/internal/buildspec ./pkg/xgoja/app -count=1` passed.
+- `go test ./... -count=1` passed.
+- The pre-commit hook passed lint and tests.
+
+### What didn't work
+
+- `golangci-lint` flagged unchecked `os.Chdir` error return values in the new integration tests. Fixed by changing `defer os.Chdir(oldWd)` to a deferred anonymous function that checks the error.
+
+### What was tricky to build
+
+- Precedence ordering in the middleware chain. Config must be lower precedence than env, so `FromConfigPlanBuilder` must appear AFTER `FromEnv` in the returned middleware slice. Because `ExecuteWithSchema` reverses the slice before wrapping, the actual runtime order becomes: Defaults -> Config -> Env -> CLI flags. This matches the intended precedence.
+- The `buildConfigPlan` helper needs to read the explicit `--config` flag value from `CommandSettings`. This requires decoding the `command-settings` section from `parsedCommandSections`. The pattern is copied from Pinocchio's `pinocchioConfigPlanBuilder`.
+- The linter's `errcheck` caught the `defer os.Chdir` pattern that is common in tests but not lint-safe.
+
+### Code review instructions
+
+- Review `pkg/xgoja/app/middlewares.go` for the `buildConfigPlan` helper and middleware ordering.
+- Review `cmd/xgoja/internal/buildspec/validate.go` for config layer validation.
+- Validate with:
+  - `go test ./cmd/xgoja/internal/buildspec ./pkg/xgoja/app -count=1`
+  - `go test ./... -count=1`
+
+### Technical details
+
+Config file format for xgoja commands:
+
+```yaml
+# config.yaml
+section-slug:
+  field-name: value
+```
+
+Example for fixture provider:
+
+```yaml
+fixture:
+  value: from-config
+```
+
+Equivalent env var:
+
+```bash
+ENV_FIXTURE_FIXTURE_VALUE=from-env
+```
+
+Equivalent CLI flag:
+
+```bash
+./dist/app eval --fixture-value from-flag 'fixtureValue'
+```
+
+Precedence: config.yaml < ENV_FIXTURE_* < --fixture-value

--- a/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/reference/01-diary.md
+++ b/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/reference/01-diary.md
@@ -12,6 +12,10 @@ DocType: reference
 Intent: long-term
 Owners: []
 RelatedFiles:
+    - Path: cmd/xgoja/doc/02-user-guide.md
+      Note: Full xgoja user guide now documents appName/envPrefix/config user workflow (commit cb7ee3a)
+    - Path: cmd/xgoja/doc/03-tutorial-using-xgoja-yaml.md
+      Note: YAML tutorial now includes practical env/config step (commit cb7ee3a)
     - Path: cmd/xgoja/doc/06-buildspec-reference.md
       Note: |-
         Documents Phase 1 env-prefix MVP (commit f773542)
@@ -32,6 +36,7 @@ LastUpdated: 0001-01-01T00:00:00Z
 WhatFor: ""
 WhenToUse: ""
 ---
+
 
 
 

--- a/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/reference/01-diary.md
+++ b/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/reference/01-diary.md
@@ -13,19 +13,26 @@ Intent: long-term
 Owners: []
 RelatedFiles:
     - Path: cmd/xgoja/doc/06-buildspec-reference.md
-      Note: Documents Phase 1 env-prefix MVP (commit f773542)
+      Note: |-
+        Documents Phase 1 env-prefix MVP (commit f773542)
+        Step 12 documents buildspec reference expansion (commit e3f6986)
     - Path: cmd/xgoja/internal/buildspec/spec.go
       Note: Adds appName/envPrefix YAML fields (commit f773542)
+    - Path: cmd/xgoja/internal/generate/generate_test.go
+      Note: Step 12 documents embedded-spec regression coverage (commit e3f6986)
     - Path: pkg/xgoja/app/host.go
       Note: Propagates middleware factory through generated Host commands (commit f773542)
     - Path: pkg/xgoja/app/middlewares.go
-      Note: Phase 1 runtime middleware policy and env-prefix normalization (commit f773542)
+      Note: |-
+        Phase 1 runtime middleware policy and env-prefix normalization (commit f773542)
+        Step 12 documents explicit-layer semantics and precedence fix (commit e3f6986)
 ExternalSources: []
 Summary: ""
 LastUpdated: 0001-01-01T00:00:00Z
 WhatFor: ""
 WhenToUse: ""
 ---
+
 
 
 # Diary
@@ -601,3 +608,116 @@ Config    *buildspec.ConfigSpec `json:"config,omitempty"`
 ```
 
 This ensures generated binaries receive the full runtime configuration.
+
+---
+
+## Step 12: Address Implementation Review Follow-Ups Without Rewriting History
+
+After the implementation review identified the remaining high- and medium-priority risks, I applied the requested fixes directly on top of the branch rather than using an interactive rebase. The goal was to make the config semantics match the YAML schema, protect the generator against future runtime-field omissions, and document the public buildspec contract clearly enough for users and reviewers.
+
+This step tightened the `explicit` config layer, relaxed `appName` validation for local-only config discovery, added regression coverage for embedded runtime settings, documented the `config` schema and `--config-file` flag, and re-ran both focused and full validation.
+
+### Prompt Context
+
+**User prompt (verbatim):** (same as Step 11)
+
+**Assistant interpretation:** Continue from the compacted review-follow-up work and complete the high-/medium-priority implementation fixes, documentation updates, validation, and bookkeeping.
+
+**Inferred user intent:** The user wants the reviewed implementation made merge-ready without rewriting existing commits or performing an interactive rebase.
+
+**Commit (code):** e3f6986 — "xgoja: tighten config semantics and docs"
+
+### What I did
+
+- Updated `pkg/xgoja/app/middlewares.go` so `--config-file` is honored only when `explicit` appears in `config.layers`.
+- Added a comment documenting the Glazed middleware order and effective precedence: `defaults < config < env < args < cobra flags`.
+- Updated `cmd/xgoja/internal/buildspec/validate.go` so `appName` is required only for app-scoped layers: `system`, `xdg`, and `home`.
+- Added validation tests proving local layers (`cwd`, `git-root`, `explicit`) work without `appName`.
+- Added app middleware tests proving explicit config files are ignored without the `explicit` layer and loaded when the layer is present.
+- Factored repeated test working-directory changes into `chdirForTest`.
+- Added `TestRenderEmbeddedSpecIncludesRuntimeAppSettings` to prevent future generator regressions for `appName`, `envPrefix`, and `config`.
+- Expanded `cmd/xgoja/doc/06-buildspec-reference.md` with the `config` schema, supported layers, `--config-file` flag, precedence order, and `appName` requirements.
+- Updated `examples/xgoja/11-config-env/xgoja.yaml` to include the `explicit` layer and updated its README.
+
+### Why
+
+- The review correctly identified that the previous runtime honored `--config-file` even when the buildspec did not declare `explicit`, which made `config.layers` less truthful than intended.
+- Requiring `appName` for `cwd`/`git-root`/`explicit` was unnecessarily strict because those layers do not use app-scoped discovery paths.
+- The generator bug had already shown that runtime-relevant buildspec fields need direct regression coverage in `RenderEmbeddedSpec`.
+- Users need a public reference for the exact `config` shape and the correct Glazed flag name (`--config-file`, not `--config`).
+
+### What worked
+
+- Focused tests passed:
+  - `go test ./cmd/xgoja/internal/buildspec ./pkg/xgoja/app ./cmd/xgoja/internal/generate -count=1`
+- Generated example smoke passed:
+  - config file -> `from-config-file`
+  - env override -> `from-env`
+  - flag override -> `from-flag`
+  - explicit config file with `--config-file config.yaml` -> `from-config-file`
+- Full validation passed:
+  - `go test ./... -count=1`
+- The pre-commit hook also passed lint, `go generate ./...`, and `go test ./...` before creating commit `e3f6986`.
+
+### What didn't work
+
+- No implementation failures occurred in this step.
+- The pre-commit hook produced a Dagger warning while running `go generate ./...`:
+  - `A new release of dagger is available: v0.20.3 → v0.21.3`
+  This was informational and did not block the commit.
+
+### What I learned
+
+- The reviewed `explicit` behavior was subtle because the runtime previously appended `ExplicitFile` after iterating configured layers. Moving the explicit-file handling into the layer switch makes the YAML layer list the single source of truth.
+- `appName` validation needs to follow the actual config discovery API: app-scoped Glazed locations need an application name, but local file locations do not.
+- Generator regression tests should unmarshal the embedded JSON into the runtime `app.Spec`, not merely search for strings, when testing runtime contract preservation.
+
+### What was tricky to build
+
+- The trickiest part was preserving Glazed's middleware precedence while changing layer semantics. The returned middleware slice is ordered highest-to-lowest because Glazed middlewares call `next` before applying their own values, so comments and tests now make the effective precedence explicit.
+- The second subtlety was avoiding an overcorrection in validation: `config.enabled` does not universally imply an app-scoped config plan. The validator now checks only the layers that actually need `appName`.
+
+### What warrants a second pair of eyes
+
+- Review `buildConfigPlan` to confirm the chosen behavior is acceptable: `--config-file` is silently ignored unless `explicit` is enabled rather than rejected as an error.
+- Review the documentation wording around precedence and layer discovery paths for consistency with Glazed's current config source implementation.
+- Confirm whether future UX should warn when `--config-file` is supplied but the `explicit` layer is not configured.
+
+### What should be done in the future
+
+- Consider a runtime warning or validation path for ignored `--config-file` values when `explicit` is omitted.
+- Add broader generated-binary integration tests if xgoja gains a formal example smoke-test harness.
+- Keep profile/arbitrary middleware support deferred until there is a concrete use case and naming model.
+
+### Code review instructions
+
+- Start with `pkg/xgoja/app/middlewares.go`, especially `MiddlewaresFromSpec` and `buildConfigPlan`.
+- Review `cmd/xgoja/internal/buildspec/validate.go` for app-scoped-layer validation.
+- Review `cmd/xgoja/internal/generate/generate_test.go` for the embedded-spec regression test.
+- Review `pkg/xgoja/app/middlewares_test.go` for explicit-layer behavior and precedence coverage.
+- Validate with:
+  ```bash
+  go test ./cmd/xgoja/internal/buildspec ./pkg/xgoja/app ./cmd/xgoja/internal/generate -count=1
+  go test ./... -count=1
+  ```
+
+### Technical details
+
+The `explicit` layer fix moved explicit-file handling from an unconditional post-loop append:
+
+```go
+if explicit != "" {
+    plan.Add(glazedconfig.ExplicitFile(explicit))
+}
+```
+
+to a layer-gated switch branch:
+
+```go
+case "explicit":
+    if explicit != "" {
+        plan.Add(glazedconfig.ExplicitFile(explicit).Named("explicit-config").Kind("explicit-file"))
+    }
+```
+
+The validation fix uses `usesAppScopedConfigLayer(layers)` so `system`, `xdg`, and `home` require `appName`, while `cwd`, `git-root`, and `explicit` do not.

--- a/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/reference/01-diary.md
+++ b/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/reference/01-diary.md
@@ -1,0 +1,278 @@
+---
+Title: Diary
+Ticket: XGOJA-017
+Status: active
+Topics:
+    - xgoja
+    - glazed
+    - configuration
+    - middleware
+    - design
+DocType: reference
+Intent: long-term
+Owners: []
+RelatedFiles: []
+---
+
+# Diary
+
+## Goal
+
+Create a comprehensive design document and implementation guide for adding env-prefix / app-name / glazed source middleware support to xgoja generated binaries. The deliverable must be intern-ready: exhaustive, evidence-based, with pseudocode, API references, file references, and decision records. Store everything in a docmgr ticket and upload to reMarkable.
+
+---
+
+## Step 1: Ticket Creation and Initial Research
+
+The user asked for a design doc only (no code) covering how xgoja generated binaries can gain Glazed-style env/config/profile support by extending `xgoja.yaml`. I first needed to understand the current architecture of xgoja, how Glazed middleware chains work, and how a mature Glazed application (pinocchio) wires these features.
+
+### Prompt Context
+
+**User prompt (verbatim):** "Create a new docmgr ticket to add env prefix / app name / potentially glazed source middleware support to xgoja so that a user can specify more information about the generated binary and how it behaves straight from the xgoja.yaml. Create a detailed analysis / design / implementation guide that is for a new intern, explaining all the parts of the system needed to understand what it is, with prose paragraphs and bullet points and pseudocode and diagrams and api references and file references. It should be very clear and technical. Store in the ticket and then upload to remarkable. Study how glaze application do this by reading glazed documentation and maybe looking at some example applicaitons and pinocchio/ as an example of more complex repository / env / profile override file parsing. Don't write any code yet. keep a diary as you work."
+
+**Assistant interpretation:** Create a docmgr ticket, research xgoja + Glazed + pinocchio, produce a detailed design document suitable for an intern, and deliver it to reMarkable.
+
+**Inferred user intent:** The user wants a blueprint that an intern (or future self) can read to implement the feature without having to rediscover all the integration points between xgoja, Glazed, and generated Go code.
+
+### What I did
+
+- Explored the workspace: found `go-go-goja/` (xgoja lives under `cmd/xgoja/`), `glazed/`, `pinocchio/`, `geppetto/`.
+- Listed existing xgoja tickets to pick the next ID: `XGOJA-017`.
+- Created the docmgr ticket with topics `xgoja,glazed,configuration,middleware,design`.
+- Added two documents: a design-doc and a diary.
+
+### What worked
+
+- `docmgr ticket create-ticket` and `docmgr doc add` worked on the first try.
+- Ticket path: `go-go-goja/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/`
+
+### What was tricky to build
+
+Nothing tricky yet; this was pure bookkeeping.
+
+### What warrants a second pair of eyes
+
+- Confirm that `XGOJA-017` is indeed the next available ticket number (checked `ls` of `ttmp/2026/05/*` and `ttmp/2026/06/01`).
+
+### What should be done in the future
+
+- Begin reading source files to build evidence-backed architecture descriptions.
+
+---
+
+## Step 2: Deep Dive into xgoja Current State
+
+I needed to understand exactly how a generated binary is built today, from YAML spec to running Cobra commands.
+
+### What I did
+
+- Read `cmd/xgoja/internal/buildspec/spec.go` — the full YAML spec struct. Confirmed there are zero fields for app identity, env, config, or profiles.
+- Read `cmd/xgoja/cmd_build.go` — the `build` command loads the spec, calls `generate.WriteAll`, then `go build`. No env/config logic here; it's purely orchestration.
+- Read `cmd/xgoja/root.go` — the xgoja CLI itself uses Glazed but does not expose env/config features to the generated binary.
+- Read `cmd/xgoja/internal/generate/generate.go` and `templates.go` — understood how `main.go` is rendered from `mainTemplateDataFromSpec`.
+- Read `cmd/xgoja/internal/generate/templates/main.go.tmpl` — the actual generated main. Saw the three target branches (`xgoja`, `cobra`, `adapter`) and how `app.NewRootCommand` / `host.AttachDefaultCommands` are called.
+- Read `pkg/xgoja/app/host.go` — `Host.AttachDefaultCommands` mounts eval/run/repl/modules/verbs/provider commands.
+- Read `pkg/xgoja/app/root.go` — `NewRootCommand` decodes embedded JSON spec and creates the Host.
+- Read `pkg/xgoja/app/glazed.go` — found the critical chokepoint: `buildGlazedCobraCommand` hardcodes `MiddlewaresFunc: cli.CobraCommandDefaultMiddlewares`.
+- Read `pkg/xgoja/app/framework.go` — `installRootFramework` sets up logging and help. Derives `appName` from `spec.Name` only.
+- Read `pkg/xgoja/app/spec.go` — the JSON runtime spec. Mirrors the YAML struct but without new fields.
+- Read example `xgoja.yaml` files (`examples/xgoja/01-core-provider/`, `05-command-provider/`) to confirm current schema shape.
+
+### What worked
+
+- Traced the full path from `xgoja.yaml` -> `buildspec.Spec` -> `generate.WriteAll` -> `main.go.tmpl` -> `app.NewRootCommand` -> `buildGlazedCobraCommand`. The architecture is clean and has a single chokepoint (`glazed.go`), which makes the design straightforward.
+
+### What I learned
+
+- The generated binary's entire behavior is driven by `embeddedSpecJSON`. Any new feature that needs runtime awareness must add fields to `buildspec.Spec` (YAML), `pkg/xgoja/app/spec.go` (JSON), and potentially the template.
+- `buildGlazedCobraCommand` is private and parameterless. To make middlewares configurable, we either parameterize it or replace it with a Host method.
+
+### What was tricky to build
+
+- Understanding the template data flow required reading three files in sequence: `templates.go` (data struct), `generate.go` (orchestration), `main.go.tmpl` (rendering). The `HostConstruction` and `RootConstruction` strings are built in Go code and injected into the template, which is slightly unusual.
+
+### What warrants a second pair of eyes
+
+- Verify that `buildGlazedCobraCommand` is indeed called from **every** command attachment path in `host.go` (yes: `AttachEval`, `AttachRun`, `AttachRepl`, `AttachModules`, plus `buildVerbCommands` in `root.go`).
+
+---
+
+## Step 3: Study Glazed Middleware Chain
+
+To propose a design, I needed to understand exactly how Glazed's `CobraParserConfig` and middleware chain work, especially the precedence rules.
+
+### What I did
+
+- Read `glazed/pkg/cli/cobra-parser.go` — the full built-in parser path. Found the exact env/config wiring code (lines ~123-150). Confirmed that `AppName` drives `envPrefix` via `strings.ToUpper`.
+- Read `glazed/pkg/cmds/sources/middlewares.go` — `ExecuteWithSchema` reverses the middleware slice before wrapping. This means the **last** appended middleware has **highest** precedence. Critical for understanding why `FromCobra` must be appended after `FromEnv`.
+- Read `glazed/pkg/cmds/sources/load-fields-from-config.go` — `FromConfigPlanBuilder`, `FromResolvedFiles`, `ConfigFileMapper`.
+- Read `glazed/pkg/cmds/sources/update.go` — `FromEnv` implementation.
+- Read `glazed/pkg/cmds/sources/profiles.go` — `GatherFlagsFromCustomProfiles`, `WithProfileAppName`, `resolveProfileFilePath`.
+- Read `glazed/pkg/config/plan_sources.go` — `SystemAppConfig`, `XDGAppConfig`, `HomeAppConfig`, `GitRootFile`, `WorkingDirFile`, `ExplicitFile`.
+- Read `glazed/cmd/examples/middlewares-config-env/main.go` — a minimal working example of `AppName` + `ConfigPlanBuilder`.
+
+### What worked
+
+- The precedence model is now fully documented in the design doc:
+  1. Defaults (lowest)
+  2. Config files
+  3. Environment variables
+  4. Cobra flags (highest)
+- This matches exactly what users expect from 12-factor apps.
+
+### What I learned
+
+- `ConfigPlanBuilder` is a closure that receives `parsedCommandSections`, `cmd`, and `args`. This is how it can read the `--config` flag value from `CommandSettings`.
+- `GatherFlagsFromCustomProfiles` is a middleware, not a section. It loads a YAML file and injects profile values after config files but before env/flags (depending on where you place it in the chain). In pinocchio, profile resolution happens **outside** the middleware chain as a bootstrap step because profiles influence AI engine selection. For xgoja, we can treat profiles as a simpler source middleware unless we need profile-driven runtime selection.
+
+### What was tricky to build
+
+- Understanding the exact moment when `CommandSettings` is parsed. It happens in `ParseCommandSettingsSection` inside `CobraParser.Parse`, **before** the custom `middlewaresFunc` is invoked. This means a custom `ConfigPlanBuilder` can safely read `--config` from `parsedCommandSections` because it has already been parsed.
+
+---
+
+## Step 4: Study Pinocchio as Reference Implementation
+
+Pinocchio is the most complex Glazed application in the workspace and uses all the features we want: custom env prefix, config plan builder, profile bootstrap, and config file mapper.
+
+### What I did
+
+- Read `pinocchio/pkg/cmds/cobra.go` — `GetPinocchioCommandMiddlewares` builds the exact middleware chain we want to generate.
+- Read `pinocchio/pkg/cmds/profilebootstrap/profile_selection.go` — `pinocchioBootstrapConfig` returns `AppBootstrapConfig` with `AppName: "pinocchio"`, `EnvPrefix: "PINOCCHIO"`, `ConfigPlanBuilder`, and `ConfigFileMapper`.
+- Read `geppetto/pkg/cli/bootstrap/config.go` — `AppBootstrapConfig` struct definition and `Validate()` method. This is the blueprint for a "full" Glazed app bootstrap config.
+
+### What worked
+
+- Pinocchio's pattern is clean: a bootstrap config struct encapsulates app identity + env prefix + config plan + file mapper. The middleware function is a pure function of that config.
+- We can adopt a simplified version of this pattern for xgoja: instead of a runtime bootstrap config, we embed the equivalent information in `xgoja.yaml` and generate the Go code at build time.
+
+### What I learned
+
+- Pinocchio separates **profile settings** (which AI profile to use) from **command settings** (which config file to load). For xgoja, we probably don't need the full Geppetto profile registry machinery. A simple `profiles.yaml` loaded via `GatherFlagsFromCustomProfiles` is sufficient for most use cases.
+- `ConfigFileMapper` is important when the config file has a non-standard structure (e.g., pinocchio's config files have a `profile:` block that needs remapping to `profile-settings` section). For xgoja, we can default to the standard section map format and optionally expose a mapper if needed in the future.
+
+### What was tricky to build
+
+- Pinocchio's profile bootstrap is tightly coupled to Geppetto's AI engine profiles (`gepprofiles.Registry`, `EngineProfileSlug`). It took a few minutes to understand which parts were generic Glazed and which were Geppetto-specific. The generic parts are: `AppName`, `EnvPrefix`, `ConfigPlanBuilder`, `ConfigFileMapper`. The Geppetto-specific parts are: `NewProfileSection`, `BuildBaseSections`, profile registry resolution.
+
+---
+
+## Step 5: Draft Design Document
+
+Synthesized all research into a single comprehensive design doc.
+
+### What I did
+
+- Wrote the full design document at:
+  `go-go-goja/ttmp/2026/06/02/XGOJA-017--.../design-doc/01-env-prefix-app-name-glazed-source-middleware-support-for-xgoja-generated-binaries.md`
+- Sections included: Executive Summary, Problem Statement, Current-State Architecture (5 subsystems), Gap Analysis (table), Proposed Architecture and APIs (schema, types, pseudocode), 4 Decision Records, Key Flows (3 ASCII flow diagrams), Phased Implementation Plan (4 phases), Testing Strategy, Risks/Alternatives/Open Questions, References.
+
+### What worked
+
+- The document is ~39KB and covers every file that needs to change, with exact line references where possible.
+- Decision records make explicit choices that an intern might otherwise have to rediscover (e.g., top-level vs nested fields, custom MiddlewaresFunc vs built-in path).
+
+### What was tricky to build
+
+- Deciding how much Go code to include in the pseudocode sections. I aimed for "compilable pseudocode" — close enough to real Go that it could almost be copy-pasted, but still labeled as pseudocode so it doesn't get mistaken for the final implementation.
+- Balancing depth against readability. The doc is long, but an intern needs the full context because xgoja spans code generation, runtime host wiring, and Glazed middleware theory.
+
+### What warrants a second pair of eyes
+
+- The proposed `xgoja.yaml` schema extensions are based on inference from Glazed APIs. They should be reviewed by someone familiar with xgoja's user base to ensure the YAML shape feels natural.
+- The `ConfigPlanBuilder` template generation is the riskiest part. A pre-generated helper package (`pkg/xgoja/appconfig`) might be safer than emitting complex closures from templates.
+
+---
+
+## Step 6: Bookkeeping and Validation
+
+### What I did
+
+- Related key files to the design doc using `docmgr doc relate`.
+- Updated the changelog with a research entry.
+- Ran `docmgr doctor` to validate ticket hygiene.
+
+### Commands run
+
+```bash
+cd go-go-goja
+docmgr doc relate --doc "ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/design-doc/01-env-prefix-app-name-glazed-source-middleware-support-for-xgoja-generated-binaries.md" --file-note "/home/manuel/workspaces/2026-06-02/add-xgoja-env-app-name/go-go-goja/cmd/xgoja/internal/buildspec/spec.go:Current YAML spec struct; needs new fields"
+docmgr doc relate --doc "ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/design-doc/01-env-prefix-app-name-glazed-source-middleware-support-for-xgoja-generated-binaries.md" --file-note "/home/manuel/workspaces/2026-06-02/add-xgoja-env-app-name/go-go-goja/pkg/xgoja/app/spec.go:Runtime JSON spec struct; needs new fields"
+docmgr doc relate --doc "ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/design-doc/01-env-prefix-app-name-glazed-source-middleware-support-for-xgoja-generated-binaries.md" --file-note "/home/manuel/workspaces/2026-06-02/add-xgoja-env-app-name/go-go-goja/pkg/xgoja/app/glazed.go:Critical chokepoint; buildGlazedCobraCommand hardcodes default middlewares"
+docmgr doc relate --doc "ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/design-doc/01-env-prefix-app-name-glazed-source-middleware-support-for-xgoja-generated-binaries.md" --file-note "/home/manuel/workspaces/2026-06-02/add-xgoja-env-app-name/go-go-goja/cmd/xgoja/internal/generate/templates/main.go.tmpl:Generated main template; must emit middleware wiring conditionally"
+docmgr doc relate --doc "ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/design-doc/01-env-prefix-app-name-glazed-source-middleware-support-for-xgoja-generated-binaries.md" --file-note "/home/manuel/workspaces/2026-06-02/add-xgoja-env-app-name/go-go-goja/pkg/xgoja/app/host.go:Host construction and AttachDefaultCommands; must propagate middleware factory"
+docmgr doc relate --doc "ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/design-doc/01-env-prefix-app-name-glazed-source-middleware-support-for-xgoja-generated-binaries.md" --file-note "/home/manuel/workspaces/2026-06-02/add-xgoja-env-app-name/glazed/pkg/cli/cobra-parser.go:Glazed parser config and built-in middleware path"
+docmgr doc relate --doc "ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/design-doc/01-env-prefix-app-name-glazed-source-middleware-support-for-xgoja-generated-binaries.md" --file-note "/home/manuel/workspaces/2026-06-02/add-xgoja-env-app-name/pinocchio/pkg/cmds/cobra.go:Reference custom MiddlewaresFunc implementation"
+docmgr changelog update --ticket XGOJA-017 --entry "Research and design: mapped xgoja architecture, Glazed middleware chain, and pinocchio reference patterns. Created comprehensive design doc with schema proposal, decision records, and phased implementation plan." --file-note "/home/manuel/workspaces/2026-06-02/add-xgoja-env-app-name/go-go-goja/cmd/xgoja/internal/buildspec/spec.go:Baseline for proposed schema extensions"
+```
+
+### What worked
+
+- All `docmgr` commands succeeded.
+- `docmgr doctor --ticket XGOJA-017 --stale-after 30` passed with no warnings.
+
+---
+
+## Step 7: Upload to reMarkable
+
+### What I did
+
+- Verified remarquee status and cloud account.
+- Ran dry-run bundle upload.
+- Ran actual bundle upload.
+- Verified remote listing.
+
+### Commands run
+
+```bash
+remarquee status
+remarquee cloud account --non-interactive
+remarquee upload bundle --dry-run \
+  go-go-goja/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/design-doc/01-env-prefix-app-name-glazed-source-middleware-support-for-xgoja-generated-binaries.md \
+  go-go-goja/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/reference/01-diary.md \
+  --name "XGOJA-017 Design: Env Prefix / App Name / Glazed Middleware" \
+  --remote-dir "/ai/2026/06/02/XGOJA-017" \
+  --toc-depth 2
+
+remarquee upload bundle \
+  go-go-goja/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/design-doc/01-env-prefix-app-name-glazed-source-middleware-support-for-xgoja-generated-binaries.md \
+  go-go-goja/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/reference/01-diary.md \
+  --name "XGOJA-017 Design: Env Prefix / App Name / Glazed Middleware" \
+  --remote-dir "/ai/2026/06/02/XGOJA-017" \
+  --toc-depth 2
+
+remarquee cloud ls /ai/2026/06/02/XGOJA-017 --long --non-interactive
+```
+
+### What worked
+
+- Dry-run succeeded.
+- Upload succeeded.
+- Remote listing confirmed two documents in `/ai/2026/06/02/XGOJA-017`.
+
+---
+
+## Step 8: Final Handoff
+
+### Summary of deliverables
+
+1. **Ticket:** `XGOJA-017`
+2. **Path:** `go-go-goja/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/`
+3. **Design doc:** `design-doc/01-env-prefix-app-name-glazed-source-middleware-support-for-xgoja-generated-binaries.md` (~39KB)
+4. **Diary:** `reference/01-diary.md`
+5. **Validation:** `docmgr doctor --ticket XGOJA-017 --stale-after 30` passed cleanly.
+6. **reMarkable upload:** `/ai/2026/06/02/XGOJA-017` containing bundled PDF with ToC depth 2.
+
+### Unresolved risks / open questions
+
+- Should the generator emit a `ConfigPlanBuilder` closure directly, or should we create a helper package `pkg/xgoja/appconfig` to reduce template complexity?
+- Should `profiles` support be a simple middleware (as proposed) or a full Glazed section with `--profile` and `--profile-registry` flags (like Geppetto)?
+- Should `config.fileName` default to `config.yaml` or `<appName>.yaml`?
+
+### Code review instructions (for future implementation)
+
+- Start with `pkg/xgoja/app/glazed.go` — parameterize `buildGlazedCobraCommand`.
+- Then `pkg/xgoja/app/host.go` — add `MiddlewaresFunc` to `Host`/`HostOptions`.
+- Then `pkg/xgoja/app/spec.go` and `cmd/xgoja/internal/buildspec/spec.go` — add new fields.
+- Then `cmd/xgoja/internal/generate/templates.go` and `main.go.tmpl` — emit middleware wiring.
+- Validate by building `examples/xgoja/11-config-env-profiles` (to be created) and running the precedence integration test.

--- a/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/reference/01-diary.md
+++ b/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/reference/01-diary.md
@@ -11,8 +11,22 @@ Topics:
 DocType: reference
 Intent: long-term
 Owners: []
-RelatedFiles: []
+RelatedFiles:
+    - Path: cmd/xgoja/doc/06-buildspec-reference.md
+      Note: Documents Phase 1 env-prefix MVP (commit f773542)
+    - Path: cmd/xgoja/internal/buildspec/spec.go
+      Note: Adds appName/envPrefix YAML fields (commit f773542)
+    - Path: pkg/xgoja/app/host.go
+      Note: Propagates middleware factory through generated Host commands (commit f773542)
+    - Path: pkg/xgoja/app/middlewares.go
+      Note: Phase 1 runtime middleware policy and env-prefix normalization (commit f773542)
+ExternalSources: []
+Summary: ""
+LastUpdated: 0001-01-01T00:00:00Z
+WhatFor: ""
+WhenToUse: ""
 ---
+
 
 # Diary
 
@@ -276,3 +290,148 @@ remarquee cloud ls /ai/2026/06/02/XGOJA-017 --long --non-interactive
 - Then `pkg/xgoja/app/spec.go` and `cmd/xgoja/internal/buildspec/spec.go` — add new fields.
 - Then `cmd/xgoja/internal/generate/templates.go` and `main.go.tmpl` — emit middleware wiring.
 - Validate by building `examples/xgoja/11-config-env-profiles` (to be created) and running the precedence integration test.
+
+---
+
+## Step 9: Implement the Narrowed Env Prefix MVP
+
+The review asked for a smaller, safer first implementation rather than the full original config/profile/middleware surface. I converted the ticket tasks into explicit phases, committed the planning package, then implemented only Phase 1: `appName` / `envPrefix` support for generated xgoja binaries.
+
+The implementation keeps generated code boring: no template closure generation was needed. Instead, runtime helper code in `pkg/xgoja/app` derives a shell-safe env prefix from the embedded spec and supplies a Glazed `CobraMiddlewaresFunc` through the existing Host command-attachment path.
+
+### Prompt Context
+
+**User prompt (verbatim):** "back to little bro: update your plan according to the review. Add phases + tasks to the ticket tasks.md. Then work on them one by one, keeping a diary as you work. Commit at appropriate intervals."
+
+**Assistant interpretation:** Revise the ticket plan according to the review document, add actionable phased tasks, then start implementing them in sequence while keeping diary and commits current.
+
+**Inferred user intent:** The user wants the intern to learn from the critique, narrow scope before coding, and demonstrate disciplined implementation with tests, diary, and commits.
+
+**Commit (docs):** 9786267 — "Docs: add XGOJA-017 planning package"
+
+**Commit (code):** f773542 — "xgoja: add generated binary env prefix support"
+
+### What I did
+
+- Rewrote `tasks.md` into four phases:
+  - Phase 0: plan revision according to review.
+  - Phase 1: MVP app name / env prefix support.
+  - Phase 2: config-file support.
+  - Phase 3: profile / advanced middleware exploration.
+  - Phase 4: release hardening.
+- Committed the existing ticket docs and revised tasks as `9786267`.
+- Added `appName` and `envPrefix` to:
+  - `cmd/xgoja/internal/buildspec/spec.go`
+  - `pkg/xgoja/app/spec.go`
+- Trimmed those fields in `cmd/xgoja/internal/buildspec/load.go`.
+- Added explicit `envPrefix` validation in `cmd/xgoja/internal/buildspec/validate.go` using `[A-Z][A-Z0-9_]*` semantics.
+- Added `pkg/xgoja/app/middlewares.go` with:
+  - `MiddlewaresFromSpec`
+  - `EffectiveEnvPrefix`
+  - `DefaultEnvPrefix`
+- Propagated `cli.CobraMiddlewaresFunc` through:
+  - `Host`
+  - `HostOptions`
+  - `Options`
+  - built-in `eval`, `run`, `repl`, `modules`
+  - JS verb commands
+  - command-provider commands
+- Updated `pkg/xgoja/app/framework.go` so root framework identity prefers `spec.AppName`, then `spec.Name`, then `xgoja`.
+- Updated `cmd/xgoja/doc/06-buildspec-reference.md` with the MVP fields and env var examples.
+- Added focused tests:
+  - env prefix derivation from hyphenated app names
+  - explicit env prefix parsing
+  - derived env prefix parsing
+  - historical default behavior when neither field is set
+  - buildspec load and validation coverage
+
+### Why
+
+- The review correctly warned that the original plan was too broad for a first implementation.
+- The MVP proves the core architecture: runtime spec -> middleware helper -> Host propagation -> Glazed parser chain.
+- Keeping behavior in normal Go code avoids fragile generated template snippets.
+- Explicit `envPrefix` validation and derived-prefix normalization fix the review's shell-safety concern.
+
+### What worked
+
+- `go test ./cmd/xgoja/internal/buildspec ./pkg/xgoja/app -count=1` passed.
+- `go test ./... -count=1` passed.
+- The pre-commit hook ran `golangci-lint`, `go generate ./...`, and `go test ./...`; all completed successfully.
+- The code commit succeeded as `f773542`.
+
+### What didn't work
+
+- No code test failed during this step.
+- During the pre-commit hook's `go generate ./...`, Dagger emitted a trace line with `HTTP HEAD ... ERROR`, but the generation process continued and completed successfully. The hook summary reported both lint and tests as successful.
+
+### What I learned
+
+- The review's recommendation to avoid generated closures was practical: all Phase 1 behavior could live in `pkg/xgoja/app/middlewares.go`, and the existing generated `main.go` path still works because `NewHostWithOptions` derives the middleware factory from `spec` when no explicit function is passed.
+- Command providers need special care. If a provider supplies a `ParserConfig`, we should preserve it, but if its `MiddlewaresFunc` is nil we can still inject the xgoja middleware factory.
+- Existing specs must not suddenly read env vars based only on `name`. The implementation intentionally derives env vars from `appName`, not `name`, unless `envPrefix` is explicitly set.
+
+### What was tricky to build
+
+- The most important invariant was backward compatibility. It would have been easy to derive an env prefix from `spec.Name`, but that would make existing generated binaries start reading environment variables unexpectedly. The solution was to derive from `appName` only, or use explicit `envPrefix`.
+- JS verb and command-provider commands do not use exactly the same builder path as `eval` / `run` / `repl`. I had to thread the middleware factory into `newVerbsCommand` and into `AttachCommandProviders` separately.
+- Explicit provider parser configs need a merge rule. The implementation respects a provider's custom `MiddlewaresFunc` if present, but fills in xgoja's middleware factory when the provider parser config omits one.
+
+### What warrants a second pair of eyes
+
+- Review the `DefaultEnvPrefix` normalization policy. It currently uppercases letters, maps `-`, `_`, `.`, and spaces to underscores, collapses separators, trims underscores, and prefixes leading digits with `APP_`.
+- Review the command-provider parser config merge rule to confirm it is the right precedence between xgoja app-level behavior and provider-level customization.
+- Review whether explicit lowercase `envPrefix` should be rejected at buildspec validation, as it is now, or accepted and uppercased. Runtime currently uppercases explicit prefixes defensively.
+
+### What should be done in the future
+
+- Phase 2 should implement config-file support only after reading and extending the existing buildspec validator/load tests more deliberately.
+- Before adding profile support, resolve naming to avoid confusion with xgoja runtime profiles.
+- Add a generated-binary example after config support exists; Phase 1 docs are currently in the buildspec reference only.
+
+### Code review instructions
+
+- Start with `pkg/xgoja/app/middlewares.go`; it defines the new runtime parser policy and prefix normalization.
+- Then review `pkg/xgoja/app/host.go`, `root.go`, `glazed.go`, and `command_providers.go` to confirm the middleware factory reaches all command types.
+- Review `cmd/xgoja/internal/buildspec/validate.go` for explicit `envPrefix` validation.
+- Validate with:
+  - `go test ./cmd/xgoja/internal/buildspec ./pkg/xgoja/app -count=1`
+  - `go test ./... -count=1`
+
+### Technical details
+
+New env behavior examples:
+
+```yaml
+appName: env-fixture
+```
+
+Derives:
+
+```text
+ENV_FIXTURE
+```
+
+Provider section field:
+
+```go
+schema.NewSection("fixture", "Fixture settings", schema.WithPrefix("fixture-"), ...)
+fields.New("value", fields.TypeString, ...)
+```
+
+Environment variable:
+
+```bash
+ENV_FIXTURE_FIXTURE_VALUE=from-env ./dist/env-fixture eval 'fixtureValue'
+```
+
+Explicit prefix:
+
+```yaml
+envPrefix: XGOJA_TEST
+```
+
+Environment variable:
+
+```bash
+XGOJA_TEST_FIXTURE_VALUE=explicit-env ./dist/fixture eval 'fixtureValue'
+```

--- a/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/reference/02-research-logbook.md
+++ b/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/reference/02-research-logbook.md
@@ -1,0 +1,602 @@
+---
+Title: Research Logbook
+Ticket: XGOJA-017
+Status: active
+Topics:
+    - xgoja
+    - glazed
+    - configuration
+    - middleware
+    - design
+DocType: reference
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: cmd/xgoja/internal/buildspec/spec.go
+      Note: YAML spec struct; 34 resources catalogued in logbook
+ExternalSources: []
+Summary: ""
+LastUpdated: 0001-01-01T00:00:00Z
+WhatFor: ""
+WhenToUse: ""
+---
+
+
+# Research Logbook
+
+## Goal
+
+Keep a running record of every resource consulted during the XGOJA-017 research phase so that future readers (including the original researcher returning weeks later) can:
+
+- Quickly re-locate a source that proved useful.
+- Know which sources were dead-ends or misleading.
+- Spot stale documentation before trusting it.
+- Understand the chain of reasoning that led to each design decision.
+
+This logbook covers the research done on **2026-06-02** for the design of env-prefix / app-name / glazed source middleware support in xgoja generated binaries.
+
+---
+
+## How this logbook is organized
+
+Each entry follows this template:
+
+- **What I was researching** — the high-level question.
+- **What I was looking for in this document** — the specific answer.
+- **Why I chose it** — why this source was a promising place to look.
+- **How I found the resource** — grep / ls / prior knowledge / cross-reference.
+- **What I found useful** — concrete facts, APIs, line numbers.
+- **What I didn't find useful** — irrelevant or redundant content.
+- **What is out of date / wrong** — stale docs, misleading comments, dead code.
+- **What would need updating** — specific edits or follow-up work.
+
+---
+
+## xgoja Internal Resources
+
+### 1. `cmd/xgoja/internal/buildspec/spec.go`
+
+- **What I was researching:** What fields exist in `xgoja.yaml` today and where new fields would fit.
+- **What I was looking for:** The Go struct tags, field names, and any existing "settings" or "metadata" section.
+- **Why I chose it:** This is the canonical schema for the build spec. Any new YAML field must map to a field in `Spec`.
+- **How I found it:** `find go-go-goja/cmd/xgoja/internal/buildspec -name "*.go"` after locating the package from the build command.
+- **What I found useful:** The `Spec` struct is flat and well-organized: `Name`, `Go`, `Target`, `Packages`, `Runtimes`, `Commands`, `CommandProviders`, `JSVerbs`, `Help`, `Assets`. Each field has clear JSON/YAML tags. The absence of any `appName`, `envPrefix`, `config`, or `profiles` fields confirmed this is a green-field addition.
+- **What I didn't find useful:** Nothing here is irrelevant; every field is necessary for understanding the current shape.
+- **What is out of date / wrong:** Nothing observed.
+- **What would need updating:** This file is the **first implementation target** in Phase 1. Add `AppName`, `EnvPrefix`, `Config`, `Profiles`, `Middlewares` fields.
+
+### 2. `cmd/xgoja/cmd_build.go`
+
+- **What I was researching:** How the `xgoja build` CLI command orchestrates code generation.
+- **What I was looking for:** Whether the build command itself needs to change (e.g., new flags) or whether it simply passes the spec through.
+- **Why I chose it:** The build command is the entry point; understanding its control flow tells us whether we need CLI changes.
+- **How I found it:** Listed `cmd/xgoja/` directory.
+- **What I found useful:** The build command is thin: it calls `buildspec.LoadFile`, `generate.WriteAll`, `buildexec.GoModTidy`, and `buildexec.GoBuild`. It does not inspect the spec contents beyond `spec.Go.Tags` and `spec.Go.LDFlags`. This means **no CLI changes are required** for the new fields; the generator just needs to read them from the spec.
+- **What I didn't find useful:** The `defaultXGojaModuleVersion` function and `debug.ReadBuildInfo` logic are unrelated to this feature.
+- **What is out of date / wrong:** Nothing observed.
+- **What would need updating:** Likely nothing, unless we decide to add `--config` or `--profile` flags to `xgoja build` itself (not planned).
+
+### 3. `cmd/xgoja/root.go`
+
+- **What I was researching:** How the xgoja CLI itself is wired (not the generated binary).
+- **What I was looking for:** Whether xgoja's own CLI uses env/config middlewares, which would serve as a live example.
+- **Why I chose it:** If the xgoja tool already uses Glazed's env/config path, we can copy its pattern.
+- **How I found it:** Listed `cmd/xgoja/` directory.
+- **What I found useful:** The xgoja CLI uses `cli.BuildCobraCommand` with `CobraCommandDefaultMiddlewares`. It does **not** use `AppName` or `ConfigPlanBuilder`. This is expected because `xgoja build` is a build tool, not a long-running application that needs config files. However, it means there is **no internal example** of advanced middleware use within xgoja itself.
+- **What I didn't find useful:** The `helpSystem` and `logging` wiring are standard Glazed boilerplate.
+- **What is out of date / wrong:** Nothing observed.
+- **What would need updating:** Not applicable.
+
+### 4. `cmd/xgoja/internal/generate/templates/main.go.tmpl`
+
+- **What I was researching:** What code is emitted for the generated binary's `main.go`.
+- **What I was looking for:** Where `app.NewRootCommand` is called, how `Host` is constructed, and where middleware configuration would be injected.
+- **Why I chose it:** The template is the **code generation surface**. Any new feature that changes runtime behavior must emit different Go code here.
+- **How I found it:** `find cmd/xgoja/internal/generate -name "*.tmpl"`.
+- **What I found useful:**
+  - Three target branches: `adapter`, `cobra`, `xgoja` (default).
+  - For `xgoja`, it calls `app.NewRootCommand(app.Options{...})`.
+  - For `cobra`, it calls `app.NewHostWithOptions` then `host.AttachDefaultCommands(root)`.
+  - The `HostConstruction` and `RootConstruction` strings are pre-built in Go code and injected into the template.
+  - `embeddedSpecJSON` is embedded as a raw string constant.
+- **What I didn't find useful:** The `embed` directives and `decodeSpec` helper are standard and not relevant to middleware configuration.
+- **What is out of date / wrong:** Nothing observed.
+- **What would need updating:** This is the **primary template change** in Phase 3. Must conditionally emit a `middlewaresFunc` closure and pass it into `app.NewRootCommand` / `app.NewHostWithOptions`.
+
+### 5. `cmd/xgoja/internal/generate/generate.go`
+
+- **What I was researching:** How the generator assembles the build workspace.
+- **What I was looking for:** Where `main.go` is rendered and whether the generator needs new imports for generated code.
+- **Why I chose it:** To understand the full generation pipeline before proposing template changes.
+- **How I found it:** Same directory as `templates.go`.
+- **What I found useful:** `WriteAll` creates `go.mod`, `main.go`, `xgoja.gen.json`, and copies embedded assets. `main.go` is produced by `RenderMain(spec)`. The generator does not need to know about middlewares at this level; it just delegates to the template.
+- **What I didn't find useful:** The `copyEmbeddedJSVerbs`, `copyEmbeddedHelpSources`, and `copyEmbeddedAssets` helpers are unrelated.
+- **What is out of date / wrong:** Nothing observed.
+- **What would need updating:** If the template requires new imports (e.g., `glazed/pkg/config`), `RenderMain` or the template data builder must ensure those imports are present in `main.go.tmpl`.
+
+### 6. `cmd/xgoja/internal/generate/templates.go`
+
+- **What I was researching:** How template data is constructed from the spec.
+- **What I was looking for:** The `mainTemplateData` struct and `mainTemplateDataFromSpec` function to see where new fields would be added.
+- **Why I chose it:** The template is dumb; all logic lives in the Go code that builds `mainTemplateData`. Understanding this function is essential for proposing template changes.
+- **How I found it:** Same directory.
+- **What I found useful:**
+  - `mainTemplateData` contains `SpecJSON`, `HasEmbedded*`, `TargetKind`, `ProviderImports`, `HostConstruction`, `RootConstruction`.
+  - `mainTemplateDataFromSpec` computes `hasEmbedded`, `aliases`, `providers`, and pre-builds `HostConstruction` / `RootConstruction` strings.
+- **What I didn't find useful:** Nothing.
+- **What is out of date / wrong:** Nothing observed.
+- **What would need updating:** Add `HasMiddlewares`, `AppName`, `EnvPrefix`, `ConfigPlanBuilder` fields to `mainTemplateData`. Modify `mainTemplateDataFromSpec` to populate them from the spec.
+
+### 7. `cmd/xgoja/doc/03-tutorial-using-xgoja-yaml.md`
+
+- **What I was researching:** Current user-facing documentation for `xgoja.yaml`.
+- **What I was looking for:** The YAML schema as presented to users, common usage patterns, and any mention of env/config.
+- **Why I chose it:** User docs reveal the intended mental model. New features should feel natural in this context.
+- **How I found it:** `find cmd/xgoja/doc -name "*.md" | sort`.
+- **What I found useful:**
+  - Tutorial walks through `name`, `target`, `packages`, `runtimes`, `commands`, `jsverbs`, `assets`, `help`.
+  - The `modules` section uses `package`, `name`, `as`, `config` — shows that nested config objects are already idiomatic in xgoja.
+  - No mention of env, config files, or profiles. Confirms this is entirely new territory.
+- **What I didn't find useful:** The troubleshooting table at the end is helpful for users but not for design.
+- **What is out of date / wrong:** Nothing observed.
+- **What would need updating:** A new tutorial document (e.g., `10-tutorial-config-env-profiles.md`) should be added. This existing doc may need a cross-reference once the feature ships.
+
+### 8. `cmd/xgoja/doc/06-buildspec-reference.md`
+
+- **What I was researching:** The authoritative reference for all `xgoja.yaml` fields.
+- **What I was looking for:** Whether there are hidden or advanced fields not obvious from the Go struct.
+- **Why I chose it:** This is the user-facing spec reference. Any schema change must be documented here.
+- **How I found it:** Same directory listing.
+- **What I found useful:**
+  - Confirms the common shape: `name`, `go`, `target`, `packages`, `runtimes`, `commands`, `assets`, `help`.
+  - Mentions that `include` and `exclude` fields in `assets:` are "rejected until the generator enforces filtering." This shows the maintainers are cautious about adding schema fields without generator enforcement. We should follow the same pattern: add validation before adding behavior.
+- **What I didn't find useful:** The static HTTP serving example is a cool feature but not relevant to middlewares.
+- **What is out of date / wrong:** Nothing observed.
+- **What would need updating:** Add new top-level fields (`appName`, `envPrefix`, `config`, `profiles`, `middlewares`) with descriptions, defaults, and examples.
+
+### 9. `pkg/xgoja/app/host.go`
+
+- **What I was researching:** How the generated binary's runtime host is constructed and how commands are attached.
+- **What I was looking for:** The `Host` struct definition, `AttachDefaultCommands`, and the call sites for `buildGlazedCobraCommand`.
+- **Why I chose it:** The `Host` is the runtime coordinator. If middleware configuration is to be propagated to all commands, the `Host` must carry it.
+- **How I found it:** `find pkg/xgoja/app -name "*.go" | sort`.
+- **What I found useful:**
+  - `Host` struct contains `Providers`, `Spec`, `Factory`, `Embedded*`, `Services`, `Out`.
+  - `AttachDefaultCommands` is the central mount point: it calls `AttachEval`, `AttachRun`, `AttachRepl`, `AttachModules`, `AttachVerbs`, `AttachCommandProviders`.
+  - Every `Attach*` method calls `buildGlazedCobraCommand` (or `newVerbsCommand` for JS verbs, which does not use Glazed command building).
+- **What I didn't find useful:** `HostServices` and `AssetStore` are unrelated.
+- **What is out of date / wrong:** Nothing observed.
+- **What would need updating:** Add `MiddlewaresFunc` to `Host` and `HostOptions`. Update every `Attach*` method to pass `h.MiddlewaresFunc` to the command builder.
+
+### 10. `pkg/xgoja/app/root.go`
+
+- **What I was researching:** How `NewRootCommand` decodes the embedded spec and constructs the `Host`.
+- **What I was looking for:** The `Options` struct and whether it already has room for middleware configuration.
+- **Why I chose it:** `NewRootCommand` is called from generated `main.go`. It's the runtime entry point.
+- **How I found it:** Same directory.
+- **What I found useful:**
+  - `Options` struct: `Providers`, `SpecJSON`, `Out`, `EmbeddedJSVerbs`, `EmbeddedHelp`, `EmbeddedAssets`.
+  - `NewRootCommand` unmarshals JSON spec, creates `Host`, creates root `cobra.Command`, calls `host.AttachDefaultCommands`.
+  - `buildVerbCommands` (used by `newVerbsCommand`) also calls `cli.BuildCobraCommand` with a hardcoded `CobraCommandDefaultMiddlewares` for mounted verb subcommands.
+- **What I didn't find useful:** The `evalCommand`, `modulesCommand`, and verb scanning logic are implementation details not relevant to middleware wiring.
+- **What is out of date / wrong:** Nothing observed.
+- **What would need updating:** Add `MiddlewaresFunc` to `Options`. Pass it into `NewHostWithOptions` and into `buildVerbCommands`.
+
+### 11. `pkg/xgoja/app/spec.go`
+
+- **What I was researching:** The JSON runtime spec struct.
+- **What I was looking for:** Whether it already contains fields that are missing from the YAML spec (or vice versa) and how new fields would be added.
+- **Why I chose it:** The spec is embedded as JSON in the generated binary. New YAML fields must have JSON equivalents.
+- **How I found it:** Same directory.
+- **What I found useful:** The JSON struct mirrors the YAML struct but omits build-time-only fields (`Go`, `BaseDir`, `PackageSpec.Import`, etc.). It includes `Name`, `Target`, `Packages`, `Runtimes`, `Commands`, `CommandProviders`, `JSVerbs`, `Help`, `Assets`. The runtime spec does not need `Go` or `BaseDir`.
+- **What I didn't find useful:** Nothing.
+- **What is out of date / wrong:** Nothing observed.
+- **What would need updating:** Add `AppName`, `EnvPrefix`, `Config`, `Profiles`, `Middlewares` fields, keeping runtime-relevant fields only.
+
+### 12. `pkg/xgoja/app/glazed.go`
+
+- **What I was researching:** The exact chokepoint where Glazed commands are converted to Cobra commands.
+- **What I was looking for:** The `buildGlazedCobraCommand` function and whether it could be parameterized.
+- **Why I chose it:** This is the **single most important file** for middleware support. Every Glazed command in the generated binary passes through here.
+- **How I found it:** Same directory.
+- **What I found useful:**
+  - `buildGlazedCobraCommand` is a zero-parameter function that hardcodes:
+    ```go
+    cli.WithParserConfig(cli.CobraParserConfig{
+        ShortHelpSections: []string{schema.DefaultSlug},
+        MiddlewaresFunc:   cli.CobraCommandDefaultMiddlewares,
+    })
+    ```
+  - This confirms the feature gap: there is no mechanism to inject a custom middleware factory.
+- **What I didn't find useful:** `commandErrorStub` is a helper for error handling.
+- **What is out of date / wrong:** Nothing observed.
+- **What would need updating:** Replace `buildGlazedCobraCommand` with `buildGlazedCobraCommandWithMiddlewares(command cmds.Command, middlewaresFunc cli.CobraMiddlewaresFunc)`. Fall back to `CobraCommandDefaultMiddlewares` when nil.
+
+### 13. `pkg/xgoja/app/framework.go`
+
+- **What I was researching:** How the root command's framework (logging, help) is installed.
+- **What I was looking for:** Whether `appName` is already configurable and how it's derived.
+- **Why I chose it:** The framework sets up `logging.AddLoggingSectionToRootCommand(root, appName)`, which uses the app name for log configuration. If we add `appName` to the spec, this is where it would be consumed.
+- **How I found it:** Same directory.
+- **What I found useful:**
+  - `installRootFramework` derives `appName` from `spec.Name` if `spec != nil`.
+  - If we add `spec.AppName`, the logic should prefer it over `spec.Name`.
+- **What I didn't find useful:** Help source loading (`loadConfiguredHelpSources`) is detailed but not relevant to middlewares.
+- **What is out of date / wrong:** Nothing observed.
+- **What would need updating:** Change `appName := "xgoja"` fallback logic to:
+  ```go
+  appName := "xgoja"
+  if spec != nil {
+      if spec.AppName != "" {
+          appName = spec.AppName
+      } else if spec.Name != "" {
+          appName = spec.Name
+      }
+  }
+  ```
+
+### 14. `examples/xgoja/01-core-provider/xgoja.yaml`
+
+- **What I was researching:** A minimal real-world `xgoja.yaml` for reference.
+- **What I was looking for:** Common field patterns and where new fields would naturally fit.
+- **Why I chose it:** It's the simplest example; new features should not complicate this.
+- **How I found it:** `find examples/xgoja -name "xgoja.yaml" | head -10`.
+- **What I found useful:**
+  - Shows `name`, `target`, `packages`, `runtimes`, `commands` at top level.
+  - Confirms that adding `appName` and `envPrefix` at the same level feels natural.
+- **What I didn't find useful:** Nothing.
+- **What is out of date / wrong:** Nothing observed.
+- **What would need updating:** Not applicable (this is a stable example). A new example demonstrating env/config should be created separately.
+
+### 15. `examples/xgoja/05-command-provider/xgoja.yaml`
+
+- **What I was researching:** A more complex spec that uses `commandProviders`.
+- **What I was looking for:** How provider commands are mounted and whether they would also need middleware support.
+- **Why I chose it:** Command-provider commands are built from Go code, not JavaScript. They might have different middleware needs.
+- **How I found it:** Same directory listing.
+- **What I found useful:**
+  - `commandProviders` list references provider packages by ID.
+  - The actual command building for provider commands happens inside `AttachCommandProviders` in `host.go`, which also calls `buildGlazedCobraCommand`.
+  - This means **all command types** (eval, run, repl, provider commands, verb commands) pass through the same chokepoint. A single middleware factory change covers everything.
+- **What I didn't find useful:** Nothing.
+- **What is out of date / wrong:** Nothing observed.
+- **What would need updating:** Not applicable.
+
+---
+
+## Glazed Internal Resources
+
+### 16. `glazed/pkg/cli/cobra-parser.go`
+
+- **What I was researching:** How Glazed's Cobra parser builds middleware chains and how `AppName` / `ConfigPlanBuilder` are used.
+- **What I was looking for:** The exact code path that constructs `FromEnv` and `FromConfigPlanBuilder` middlewares, and the precedence order.
+- **Why I chose it:** This is the core Glazed file for CLI parsing. Understanding it is essential for designing the generated binary's behavior.
+- **How I found it:** `grep -r "AppName" glazed/pkg/cli/ --include="*.go"` led here.
+- **What I found useful:**
+  - `CobraParserConfig` struct contains `MiddlewaresFunc`, `ShortHelpSections`, `SkipCommandSettingsSection`, `EnableProfileSettingsSection`, `EnableCreateCommandSettingsSection`, `AppName`, `ConfigPlanBuilder`.
+  - Built-in parser path (lines ~123-150): if `cfgCopy.AppName != ""`, it appends `FromEnv(strings.ToUpper(cfgCopy.AppName), ...)`. If `cfgCopy.ConfigPlanBuilder != nil`, it appends `FromConfigPlanBuilder(...)`.
+  - `ParseCommandSettingsSection` is called **before** `middlewaresFunc`, so `--config` and `--profile` flags are already parsed when the config plan builder runs.
+  - `ExecuteWithSchema` reverses middlewares before wrapping, so the **last appended** middleware (Cobra flags) has **highest** precedence.
+- **What I didn't find useful:** The `ParseGlazedCommandSection` and `shouldValidateRequiredFields` logic are standard.
+- **What is out of date / wrong:** Nothing observed.
+- **What would need updating:** Not applicable (this is library code). The design doc references specific line ranges that may shift in future Glazed versions.
+
+### 17. `glazed/pkg/config/plan_sources.go`
+
+- **What I was researching:** What config discovery functions exist in Glazed and how they map to layer names.
+- **What I was looking for:** The exact function signatures for `SystemAppConfig`, `XDGAppConfig`, `HomeAppConfig`, `GitRootFile`, `WorkingDirFile`, `ExplicitFile`.
+- **Why I chose it:** The design proposes a declarative `config.layers` list in `xgoja.yaml`. Each layer name must map to a Glazed function.
+- **How I found it:** `grep -r "SystemAppConfig" glazed/ --include="*.go"`.
+- **What I found useful:**
+  - `SystemAppConfig(appName)` -> `/etc/<appName>/config.yaml`
+  - `XDGAppConfig(appName)` -> `$XDG_CONFIG_HOME/<appName>/config.yaml`
+  - `HomeAppConfig(appName)` -> `~/.<appName>/config.yaml`
+  - `GitRootFile(name)` -> `<git-root>/<name>`
+  - `WorkingDirFile(name)` -> `./<name>`
+  - `ExplicitFile(path)` -> exact path
+  - All are `Optional: true` except `ExplicitFile`.
+  - `LayerSystem`, `LayerUser`, `LayerRepo`, `LayerCWD`, `LayerExplicit` constants exist.
+- **What I didn't find useful:** `gitRoot` implementation detail (scrubbing Git env vars) is interesting but not relevant.
+- **What is out of date / wrong:** Nothing observed.
+- **What would need updating:** Not applicable.
+
+### 18. `glazed/pkg/cmds/sources/profiles.go`
+
+- **What I was researching:** How Glazed's profile loading middleware works.
+- **What I was looking for:** `GatherFlagsFromCustomProfiles`, `WithProfileAppName`, and the file resolution logic.
+- **Why I chose it:** The design proposes optional profile support via `profiles.enabled`.
+- **How I found it:** `grep -r "GatherFlagsFromCustomProfiles" glazed/ --include="*.go"`.
+- **What I found useful:**
+  - `GatherFlagsFromCustomProfiles(profileName, options...)` returns a `Middleware`.
+  - `WithProfileAppName(appName)` resolves to `~/.config/<appName>/profiles.yaml`.
+  - `WithProfileFile(path)` overrides the default location.
+  - The profile file format is:
+    ```yaml
+    profileName:
+      sectionSlug:
+        fieldName: value
+    ```
+  - Profile values are merged into parsed values with configurable precedence depending on where the middleware is placed in the chain.
+- **What I didn't find useful:** `loadProfileFromFile` and `resolveProfileFilePath` are implementation details.
+- **What is out of date / wrong:** Nothing observed.
+- **What would need updating:** Not applicable.
+
+### 19. `glazed/pkg/cmds/sources/middlewares.go`
+
+- **What I was researching:** The middleware execution model: how `Chain`, `Execute`, and `ExecuteWithSchema` work.
+- **What I was looking for:** The exact reversal behavior and how middlewares interact with schema cloning.
+- **Why I chose it:** Understanding precedence is critical for explaining why env beats config and flags beat env.
+- **How I found it:** `grep -r "ExecuteWithSchema" glazed/pkg/cmds/sources/ --include="*.go"`.
+- **What I found useful:**
+  - `ExecuteWithSchema` clones the schema, reverses the middleware slice, then wraps each middleware around the handler.
+  - The comment on lines ~44-56 is an excellent explanation of the reversal behavior:
+    > "Middlewares basically get executed in the reverse order they are provided... [f1, f2, f3] will be executed as f1(f2(f3(handler)))(schema_, parsedValues)."
+  - This means appending `FromDefaults`, then `FromConfigPlanBuilder`, then `FromEnv`, then `FromCobra` produces the expected precedence.
+- **What I didn't find useful:** The `Identity` helper is trivial.
+- **What is out of date / wrong:** Nothing observed.
+- **What would need updating:** Not applicable.
+
+### 20. `glazed/pkg/cmds/sources/load-fields-from-config.go`
+
+- **What I was researching:** How config files are loaded via a plan builder and how `ConfigFileMapper` works.
+- **What I was looking for:** `FromConfigPlanBuilder`, `FromResolvedFiles`, and the `ConfigPlanResolver` signature.
+- **Why I chose it:** The design proposes generating a `ConfigPlanBuilder` closure in the template.
+- **How I found it:** `grep -r "FromConfigPlanBuilder" glazed/pkg/cmds/sources/ --include="*.go"`.
+- **What I found useful:**
+  - `ConfigPlanResolver` signature: `func(ctx context.Context, parsedValues *values.Values) (*glazedconfig.Plan, error)`.
+  - `FromConfigPlanBuilder` calls `resolver(ctx, parsedValues)`, then `plan.Resolve(ctx)`, then `FromResolvedFiles(files, ...)`.
+  - `ConfigFileMapper` transforms raw config file structure into `map[sectionSlug]map[fieldName]value`.
+  - Default mapper expects standard section map format.
+- **What I didn't find useful:** `FromFile` and `FromFiles` (non-plan variants) are simpler but not what we need.
+- **What is out of date / wrong:** Nothing observed.
+- **What would need updating:** Not applicable.
+
+### 21. `glazed/pkg/cmds/sources/update.go`
+
+- **What I was researching:** How `FromEnv` works under the hood.
+- **What I was looking for:** The `updateFromEnv` function and how environment variable names are constructed.
+- **Why I chose it:** To confirm that `MYAPP_OPENAI_API_KEY` is the correct naming convention.
+- **How I found it:** `grep -n "func FromEnv" glazed/pkg/cmds/sources/*.go`.
+- **What I found useful:**
+  - `FromEnv(prefix, options...)` calls `updateFromEnv(schema_, parsedValues, prefix, options...)`.
+  - Env var names are derived from section prefix + field name, uppercased, with hyphens replaced by underscores.
+  - The prefix is prepended as-is (e.g., `MYAPP_` + `OPENAI_API_KEY`).
+- **What I didn't find useful:** `updateFromStringList` is for positional args, not env vars.
+- **What is out of date / wrong:** Nothing observed.
+- **What would need updating:** Not applicable.
+
+### 22. `glazed/pkg/cmds/sources/vault.go`
+
+- **What I was researching:** Whether Glazed has a standard pattern for sensitive config sources.
+- **What I was looking for:** How Vault integration works and whether it should be considered for xgoja.
+- **Why I chose it:** The user mentioned "potentially glazed source middleware support"; Vault is a Glazed source middleware.
+- **How I found it:** `grep -r "vault" glazed/pkg/cmds/sources/ --include="*.go"`.
+- **What I found useful:**
+  - `FromVaultSettings` is a middleware that reads sensitive fields from HashiCorp Vault.
+  - It only applies to fields marked `Type.IsSensitive()`.
+  - This is an advanced feature that could be added to xgoja later via the explicit `middlewares:` list.
+- **What I didn't find useful:** The full Vault client implementation (`apiVaultClient`, token resolution, KV v1/v2) is irrelevant for the current design.
+- **What is out of date / wrong:** Nothing observed.
+- **What would need updating:** Not applicable for this ticket, but the design doc mentions Vault as a future `middlewares[].source` option.
+
+### 23. `glazed/cmd/examples/middlewares-config-env/main.go`
+
+- **What I was researching:** A minimal, self-contained example of `AppName` + `ConfigPlanBuilder` in a Glazed application.
+- **What I was looking for:** The exact boilerplate needed to enable env and config support in a simple command.
+- **Why I chose it:** This is the simplest working example of the feature we want to add. It's the "hello world" of Glazed middleware configuration.
+- **How I found it:** `find glazed/cmd/examples -name "*.go" | xargs grep -l "ConfigPlanBuilder"`.
+- **What I found useful:**
+  - Demonstrates `cli.CobraParserConfig{AppName: "glazed-mw-demo", ConfigPlanBuilder: func(...) (*glazedconfig.Plan, error) { ... }}`.
+  - Shows the minimal config plan: `glazedconfig.NewPlan(glazedconfig.WithLayerOrder(glazedconfig.LayerExplicit)).Add(glazedconfig.ExplicitFile(...))`.
+  - Confirms that no custom `MiddlewaresFunc` is needed for simple cases; the built-in parser path handles `AppName` and `ConfigPlanBuilder` automatically.
+- **What I didn't find useful:** The `DemoCommand` itself (printing a row) is just a vehicle for the middleware demo.
+- **What is out of date / wrong:** Nothing observed.
+- **What would need updating:** Not applicable. This example is stable and should be referenced in the design doc's "References" section.
+
+---
+
+## Pinocchio Internal Resources
+
+### 24. `pinocchio/pkg/cmds/profilebootstrap/profile_selection.go`
+
+- **What I was researching:** How a mature Glazed application (Pinocchio) bootstraps its full configuration stack: app name, env prefix, config plan builder, config file mapper, and profile resolution.
+- **What I was looking for:** The `AppBootstrapConfig` struct and how it wires env, config, and profiles together.
+- **Why I chose it:** Pinocchio is the most complex Glazed app in the workspace. It uses every feature we want to add.
+- **How I found it:** `grep -r "BootstrapConfig" pinocchio/ --include="*.go"`.
+- **What I found useful:**
+  - `pinocchioBootstrapConfig()` returns `bootstrap.AppBootstrapConfig` with:
+    - `AppName: "pinocchio"`
+    - `EnvPrefix: "PINOCCHIO"`
+    - `ConfigFileMapper: configFileMapper`
+    - `ConfigPlanBuilder: pinocchioConfigPlanBuilder`
+    - `NewProfileSection` and `BuildBaseSections` (Geppetto-specific)
+  - `pinocchioConfigPlanBuilder` constructs a full layered plan:
+    - System app config (`/etc/pinocchio/config.yaml`)
+    - Home app config (`~/.pinocchio/config.yaml`)
+    - XDG app config (`~/.config/pinocchio/config.yaml`)
+    - Git root files (`configdoc.LocalOverrideFileName`)
+    - Working dir files
+    - Explicit file from `--config`
+  - `configFileMapper` remaps the `profile` block in config files to `profile-settings` section values.
+- **What I didn't find useful:**
+  - `ResolveCLIProfileRuntime` and `resolveConfigRuntime` are Geppetto-specific (AI engine profile resolution). They involve `gepprofiles.Registry`, `EngineProfileSlug`, and profile registry chains. These are overkill for xgoja.
+  - `normalizeProfileRegistryEntries` is a utility.
+- **What is out of date / wrong:** Nothing observed.
+- **What would need updating:** Not applicable. However, we should **not** copy Pinocchio's full profile bootstrap for xgoja. The design doc correctly proposes a simpler model: `GatherFlagsFromCustomProfiles` as a middleware.
+
+### 25. `pinocchio/pkg/cmds/cobra.go`
+
+- **What I was researching:** How Pinocchio's custom `MiddlewaresFunc` is wired into its commands.
+- **What I was looking for:** The exact middleware chain that Pinocchio uses.
+- **Why I chose it:** This is the reference implementation for a custom middleware chain in a Glazed app.
+- **How I found it:** `grep -r "GetPinocchioCommandMiddlewares" pinocchio/ --include="*.go"`.
+- **What I found useful:**
+  - `GetPinocchioCommandMiddlewares` builds the chain:
+    1. `FromCobra(cmd, ...)`
+    2. `FromArgs(args, ...)`
+    3. `FromEnv(cfg.EnvPrefix, ...)`
+    4. `FromConfigPlanBuilder(resolver, WithConfigFileMapper, WithParseOptions)`
+    5. `FromDefaults(...)`
+  - This is the **exact chain we want to generate** for xgoja binaries.
+  - `BuildCobraCommandWithGeppettoMiddlewares` wraps `cli.BuildCobraCommand` with `cli.WithParserConfig(config)`.
+- **What I didn't find useful:** Nothing.
+- **What is out of date / wrong:** Nothing observed.
+- **What would need updating:** Not applicable. This file should be referenced as the canonical example in implementation guides.
+
+---
+
+## Geppetto Internal Resources
+
+### 26. `geppetto/pkg/cli/bootstrap/config.go`
+
+- **What I was researching:** The `AppBootstrapConfig` struct definition to understand the contract Pinocchio implements.
+- **What I was looking for:** Required fields, validation rules, and the `ConfigPlanBuilder` type alias.
+- **Why I chose it:** Pinocchio's bootstrap config is an instance of this struct. Understanding the generic contract helps design xgoja's equivalent.
+- **How I found it:** `find geppetto/pkg/cli/bootstrap -name "*.go" | xargs grep -l "AppBootstrapConfig"`.
+- **What I found useful:**
+  - `AppBootstrapConfig` fields: `AppName`, `EnvPrefix`, `ConfigFileMapper`, `NewProfileSection`, `BuildBaseSections`, `ConfigPlanBuilder`.
+  - `Validate()` enforces that all fields are non-empty.
+  - `ConfigPlanBuilder` type: `func(parsed *values.Values) (*glazedconfig.Plan, error)`.
+- **What I didn't find useful:** `normalizedEnvPrefix()` is a trivial trim helper.
+- **What is out of date / wrong:** Nothing observed.
+- **What would need updating:** Not applicable. However, xgoja does not need the full `AppBootstrapConfig` abstraction at runtime. The design doc correctly proposes embedding equivalent information in `xgoja.yaml` and generating code.
+
+---
+
+## Skills / Process Resources
+
+### 27. `ticket-research-docmgr-remarkable/references/writing-style.md`
+
+- **What I was researching:** The expected structure and quality bar for design documents in this project.
+- **What I was looking for:** Section ordering, decision record format, evidence rules, and detail level.
+- **Why I chose it:** The user asked for a "detailed analysis / design / implementation guide that is for a new intern." This reference defines the project's writing standards.
+- **How I found it:** Read via the pinned `ticket-research-docmgr-remarkable` skill.
+- **What I found useful:**
+  - Recommended section order: Executive summary, Problem statement, Current-state analysis, Gap analysis, Proposed architecture, Decision records, Pseudocode, Implementation phases, Test strategy, Risks, References.
+  - Decision record format with Context, Options, Decision, Rationale, Consequences, Status.
+  - Evidence rules: anchor claims to files, use line references, distinguish observed from inferred.
+  - Clarity patterns: numbered lists, explicit naming ("Phase 1"), define terms before reuse.
+- **What I didn't find useful:** Nothing.
+- **What is out of date / wrong:** Nothing observed.
+- **What would need updating:** Not applicable.
+
+### 28. `ticket-research-docmgr-remarkable/references/deliverable-checklist.md`
+
+- **What I was researching:** The checklist of deliverables expected for a ticket research task.
+- **What I was looking for:** Validation steps (doctor, vocabulary, upload) and final handoff requirements.
+- **Why I chose it:** Ensures the output meets the project's quality gate.
+- **How I found it:** Same skill as above.
+- **What I found useful:**
+  - Ticket setup: design doc, diary, index/tasks/changelog.
+  - Bookkeeping: relate files, changelog, tasks.
+  - Validation: `docmgr doctor`, vocabulary warnings.
+  - reMarkable delivery: dry-run, real upload, remote listing.
+  - Final response must include ticket path, doc paths, validation status, upload destination.
+- **What I didn't find useful:** Nothing.
+- **What is out of date / wrong:** Nothing observed.
+- **What would need updating:** Not applicable.
+
+### 29. `diary/SKILL.md`
+
+- **What I was researching:** The expected format for diary entries.
+- **What I was looking for:** Section template, writing rules, and the working loop.
+- **Why I chose it:** The user explicitly asked to "keep a diary as you work."
+- **How I found it:** Pinned skill.
+- **What I found useful:**
+  - Strict step format: Goal, Prompt Context, What I did, Why, What worked, What didn't work, What I learned, What was tricky, What warrants review, Future work, Code review instructions, Technical details.
+  - Working loop: implement -> commit -> docmgr task check -> diary update -> relate files -> changelog update -> commit docs.
+  - Verbatim user prompt must be preserved the first time it appears.
+- **What I didn't find useful:** Nothing.
+- **What is out of date / wrong:** Nothing observed.
+- **What would need updating:** Not applicable.
+
+### 30. `docmgr/SKILL.md`
+
+- **What I was researching:** How to create tickets, add documents, relate files, and validate.
+- **What I was looking for:** Exact command syntax and conventions.
+- **Why I chose it:** Needed to set up the XGOJA-017 ticket workspace.
+- **How I found it:** Pinned skill.
+- **What I found useful:**
+  - `docmgr ticket create-ticket`, `docmgr doc add`, `docmgr doc relate`.
+  - `--file-note "path:reason"` format.
+  - Absolute paths preferred.
+  - `docmgr doctor --ticket --stale-after 30`.
+  - `docmgr vocab add` for unknown topics.
+- **What I didn't find useful:** Nothing.
+- **What is out of date / wrong:** Nothing observed.
+- **What would need updating:** Not applicable.
+
+---
+
+## External Resources
+
+### 31. Glazed external documentation (not consulted)
+
+- **What I was researching:** Whether there is official Glazed documentation beyond the source code.
+- **What I was looking for:** Public docs on middleware chains, config plans, or `CobraParserConfig`.
+- **Why I chose it:** The user mentioned "reading glazed documentation."
+- **How I found it:** Not searched. The workspace contains the full Glazed source code, and the relevant APIs are well-documented in Go doc comments.
+- **What I found useful:** N/A.
+- **What I didn't find useful:** N/A.
+- **What is out of date / wrong:** N/A.
+- **What would need updating:** If Glazed has public docs (e.g., on GitHub Pages or in a `docs/` directory), they should be checked for examples. However, the source code in this workspace is authoritative and up-to-date.
+
+### 32. reMarkable upload process (`remarquee` CLI)
+
+- **What I was researching:** How to upload the final document bundle.
+- **What I was looking for:** Bundle upload syntax, dry-run behavior, and remote directory conventions.
+- **Why I chose it:** The deliverable checklist requires reMarkable upload.
+- **How I found it:** Pinned `remarkable-upload` skill.
+- **What I found useful:**
+  - `remarquee upload bundle --dry-run <files> --name <name> --remote-dir <dir> --toc-depth 2`.
+  - Dry-run is mandatory before real upload.
+  - Remote directory convention: `/ai/YYYY/MM/DD/<TICKET-ID>`.
+  - Bundle name should not contain spaces (caused a pandoc failure; fixed by using `XGOJA-017-Design`).
+- **What I didn't find useful:** Nothing.
+- **What is out of date / wrong:** The skill does not mention the space-in-name pandoc failure. This is a runtime quirk of `remarquee`/`pandoc`.
+- **What would need updating:** The skill or `remarquee` docs could warn against spaces in bundle names.
+
+---
+
+## Summary of Findings
+
+| Category | Resources Read | Useful | Out of Date | Needs Updating |
+|---|---|---|---|---|
+| xgoja build spec | 2 (spec.go, cmd_build.go) | Yes | No | spec.go (Phase 1) |
+| xgoja CLI | 1 (root.go) | Limited | No | No |
+| xgoja generator | 3 (generate.go, templates.go, main.go.tmpl) | Yes | No | templates.go, main.go.tmpl (Phase 3) |
+| xgoja docs | 2 (tutorial, buildspec-ref) | Yes | No | Add new tutorial (Phase 4) |
+| xgoja runtime | 5 (host.go, root.go, spec.go, glazed.go, framework.go) | Yes | No | All five files (Phase 2) |
+| xgoja examples | 2 (01-core, 05-command) | Yes | No | Add new example (Phase 4) |
+| Glazed parser | 1 (cobra-parser.go) | Yes | No | No |
+| Glazed config | 1 (plan_sources.go) | Yes | No | No |
+| Glazed middlewares | 4 (middlewares.go, load-fields, update.go, profiles.go) | Yes | No | No |
+| Glazed vault | 1 (vault.go) | Partial | No | No |
+| Glazed examples | 1 (middlewares-config-env) | Yes | No | No |
+| Pinocchio | 2 (profile_selection.go, cobra.go) | Yes | No | No |
+| Geppetto | 1 (config.go) | Yes | No | No |
+| Process/skills | 4 (writing-style, checklist, diary, docmgr) | Yes | No | No |
+
+**Total resources read:** 30 internal files + 4 process skills = 34 resources.
+
+**Critical files for implementation (in dependency order):**
+1. `pkg/xgoja/app/spec.go` — add runtime fields.
+2. `cmd/xgoja/internal/buildspec/spec.go` — add YAML fields.
+3. `cmd/xgoja/internal/buildspec/validate.go` — add validation rules.
+4. `pkg/xgoja/app/glazed.go` — parameterize command builder.
+5. `pkg/xgoja/app/host.go` — propagate middleware factory.
+6. `pkg/xgoja/app/root.go` — pass middleware factory through Options.
+7. `pkg/xgoja/app/framework.go` — use `spec.AppName`.
+8. `cmd/xgoja/internal/generate/templates.go` — build template data.
+9. `cmd/xgoja/internal/generate/templates/main.go.tmpl` — emit middleware wiring.
+10. `cmd/xgoja/internal/generate/generate_test.go` — add template tests.
+
+---
+
+## Open Research Questions
+
+1. **Template complexity vs. helper package:** Should the generator emit a complex `ConfigPlanBuilder` closure, or should we create `pkg/xgoja/appconfig` to reduce template complexity? This was not resolved during research because it is an architectural tradeoff, not a factual question answerable by reading existing code.
+2. **Profile section vs. middleware:** Should profiles be a Glazed section (like Geppetto's `profile-settings`) or a source middleware? Geppetto uses both. Reading `geppetto/pkg/cli/bootstrap/config.go` showed the complexity of full section support. The simpler middleware approach is likely sufficient for xgoja.
+3. **Config file mapper necessity:** Does xgoja need a custom `ConfigFileMapper`? Pinocchio's mapper remaps the `profile` block. Xgoja's config files will likely use the standard section map format, so a mapper may be unnecessary in Phase 1.
+4. **Existing xgoja validation coverage:** How comprehensive is `validate_test.go`? Not read in detail. This should be checked before Phase 1 implementation to ensure new validation rules have adequate test coverage.
+5. **Glazed version pinning:** The generated `go.mod` pins a Glazed version. If we add new imports (e.g., `glazed/pkg/config`) to generated code, we must ensure the pinned version supports them. This is a build-time concern, not a research question.

--- a/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/tasks.md
+++ b/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/tasks.md
@@ -8,14 +8,14 @@
 
 ## Phase 1: MVP — app name and env prefix support
 
-- [ ] Add `appName` and `envPrefix` to the build-time xgoja YAML spec.
-- [ ] Add `appName` and `envPrefix` to the runtime embedded xgoja spec.
-- [ ] Add shell-safe env-prefix derivation and validation helpers.
-- [ ] Wire a Glazed middleware factory from the runtime spec instead of hardcoding `CobraCommandDefaultMiddlewares`.
-- [ ] Propagate the middleware factory through `HostOptions`, `Options`, built-in commands, JS verb commands, and command-provider commands.
-- [ ] Use `appName` for root logging/help framework identity, falling back to `name`.
-- [ ] Add focused tests for env-prefix derivation, env precedence, and existing default behavior.
-- [ ] Update xgoja buildspec docs with the MVP fields and examples.
+- [x] Add `appName` and `envPrefix` to the build-time xgoja YAML spec.
+- [x] Add `appName` and `envPrefix` to the runtime embedded xgoja spec.
+- [x] Add shell-safe env-prefix derivation and validation helpers.
+- [x] Wire a Glazed middleware factory from the runtime spec instead of hardcoding `CobraCommandDefaultMiddlewares`.
+- [x] Propagate the middleware factory through `HostOptions`, `Options`, built-in commands, JS verb commands, and command-provider commands.
+- [x] Use `appName` for root logging/help framework identity, falling back to `name`.
+- [x] Add focused tests for env-prefix derivation, env precedence, and existing default behavior.
+- [x] Update xgoja buildspec docs with the MVP fields and examples.
 
 ## Phase 2: Config-file support
 

--- a/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/tasks.md
+++ b/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/tasks.md
@@ -27,14 +27,17 @@
 
 ## Phase 3: Profiles and advanced source middleware exploration
 
-- [ ] Re-evaluate naming to avoid confusion with xgoja runtime profiles.
-- [ ] Decide whether profile support should be `glazedProfiles`, `parameterProfiles`, or deferred.
-- [ ] Inspect Glazed profile tests before proposing public YAML.
-- [ ] Do not add arbitrary `middlewares:` YAML until there is a concrete use case.
+- [x] Re-evaluate naming to avoid confusion with xgoja runtime profiles.
+- [x] Decide whether profile support should be `glazedProfiles`, `parameterProfiles`, or deferred.
+- [x] Inspect Glazed profile tests before proposing public YAML.
+- [x] Do not add arbitrary `middlewares:` YAML until there is a concrete use case.
+
+**Decision:** Profile support is deferred. Xgoja already uses the word "profile" for runtime profiles (`runtimes:`). Adding Glazed-style parameter profiles would create naming collisions. The current env + config support covers the 90% use case. If a user needs profiles, they can use Glazed's `--config` flag with multiple config files. Arbitrary `middlewares:` YAML is deferred until a concrete use case emerges.
 
 ## Phase 4: Review and release hardening
 
-- [ ] Build all existing `examples/xgoja/*` specs and confirm backward-compatible behavior.
-- [ ] Add a new minimal env/config example only after Phase 2.
-- [ ] Update the research logbook with validator/test files read during implementation.
-- [ ] Update diary and changelog after each completed phase.
+- [x] Build all existing `examples/xgoja/*` specs and confirm backward-compatible behavior.
+- [x] Add a new minimal env/config example after Phase 2.
+- [x] Update diary and changelog after each completed phase.
+- [x] Fix generator `RenderEmbeddedSpec` to include new fields in embedded JSON.
+- [x] Verify end-to-end precedence with actual generated binary.

--- a/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/tasks.md
+++ b/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/tasks.md
@@ -19,11 +19,11 @@
 
 ## Phase 2: Config-file support
 
-- [ ] Read existing buildspec load/validation tests before adding config schema.
-- [ ] Add `config` schema only after Phase 1 is passing.
-- [ ] Implement config plan construction in normal Go helper code, not template snippets.
-- [ ] Add concrete config examples showing section slug, CLI flag, env var, and resulting value.
-- [ ] Add integration tests for config < env < CLI precedence.
+- [x] Read existing buildspec load/validation tests before adding config schema.
+- [x] Add `config` schema only after Phase 1 is passing.
+- [x] Implement config plan construction in normal Go helper code, not template snippets.
+- [x] Add concrete config examples showing section slug, CLI flag, env var, and resulting value.
+- [x] Add integration tests for config < env < CLI precedence.
 
 ## Phase 3: Profiles and advanced source middleware exploration
 

--- a/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/tasks.md
+++ b/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/tasks.md
@@ -41,3 +41,12 @@
 - [x] Update diary and changelog after each completed phase.
 - [x] Fix generator `RenderEmbeddedSpec` to include new fields in embedded JSON.
 - [x] Verify end-to-end precedence with actual generated binary.
+
+## Phase 5: Implementation review follow-ups
+
+- [x] Add generator regression coverage for `RenderEmbeddedSpec` runtime fields.
+- [x] Make `--config-file` depend on the `explicit` config layer instead of always loading when supplied.
+- [x] Relax `appName` validation for local-only config layers (`cwd`, `git-root`, `explicit`).
+- [x] Document the full `config` schema, supported layers, precedence, and `--config-file` flag.
+- [x] Factor repeated test CWD setup into a helper.
+- [x] Re-run focused tests, generated example smoke, full test suite, and pre-commit validation.

--- a/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/tasks.md
+++ b/ttmp/2026/06/02/XGOJA-017--add-env-prefix-app-name-glazed-source-middleware-support-to-xgoja-generated-binaries/tasks.md
@@ -1,0 +1,40 @@
+# Tasks
+
+## Phase 0: Revise plan according to review
+
+- [x] Add a narrowed implementation plan to `tasks.md` that separates MVP env support from config/profile follow-ups.
+- [x] Treat `appName` and `envPrefix` as different concepts: app identity vs shell-safe env namespace.
+- [x] Prefer runtime helper functions over generated Go closure snippets for behavior.
+
+## Phase 1: MVP — app name and env prefix support
+
+- [ ] Add `appName` and `envPrefix` to the build-time xgoja YAML spec.
+- [ ] Add `appName` and `envPrefix` to the runtime embedded xgoja spec.
+- [ ] Add shell-safe env-prefix derivation and validation helpers.
+- [ ] Wire a Glazed middleware factory from the runtime spec instead of hardcoding `CobraCommandDefaultMiddlewares`.
+- [ ] Propagate the middleware factory through `HostOptions`, `Options`, built-in commands, JS verb commands, and command-provider commands.
+- [ ] Use `appName` for root logging/help framework identity, falling back to `name`.
+- [ ] Add focused tests for env-prefix derivation, env precedence, and existing default behavior.
+- [ ] Update xgoja buildspec docs with the MVP fields and examples.
+
+## Phase 2: Config-file support
+
+- [ ] Read existing buildspec load/validation tests before adding config schema.
+- [ ] Add `config` schema only after Phase 1 is passing.
+- [ ] Implement config plan construction in normal Go helper code, not template snippets.
+- [ ] Add concrete config examples showing section slug, CLI flag, env var, and resulting value.
+- [ ] Add integration tests for config < env < CLI precedence.
+
+## Phase 3: Profiles and advanced source middleware exploration
+
+- [ ] Re-evaluate naming to avoid confusion with xgoja runtime profiles.
+- [ ] Decide whether profile support should be `glazedProfiles`, `parameterProfiles`, or deferred.
+- [ ] Inspect Glazed profile tests before proposing public YAML.
+- [ ] Do not add arbitrary `middlewares:` YAML until there is a concrete use case.
+
+## Phase 4: Review and release hardening
+
+- [ ] Build all existing `examples/xgoja/*` specs and confirm backward-compatible behavior.
+- [ ] Add a new minimal env/config example only after Phase 2.
+- [ ] Update the research logbook with validator/test files read during implementation.
+- [ ] Update diary and changelog after each completed phase.

--- a/ttmp/vocabulary.yaml
+++ b/ttmp/vocabulary.yaml
@@ -125,6 +125,12 @@ topics:
       description: Intent-encoded YAML document format that separates semantic content from typographic presentation
     - slug: information-design
       description: Design discipline focused on making complex information clear, accessible, and easy to navigate
+    - slug: design
+      description: Design documents, architecture, and system design
+    - slug: configuration
+      description: Configuration management, config files, environment variables, and settings
+    - slug: middleware
+      description: Middleware chains, source middlewares, and parser middlewares
 docTypes:
     - slug: index
       description: Ticket index documents


### PR DESCRIPTION
This change introduces support for configuring generated `xgoja` binaries via
environment variables and YAML configuration files, integrating with the Glazed
CLI framework.

### Key Changes

- **New `xgoja.yaml` Settings:**
  - `appName`: An application identity used for config file discovery (e.g.,
    `~/.config/<appName>`).
  - `envPrefix`: A shell-safe prefix for environment variables. If omitted, one
    is derived from `appName`.
  - `config`: An object to enable and configure config file loading, specifying
    layers (`cwd`, `xdg`, `home`, etc.) and the filename.

- **Conditional Middleware:**
  - The generated binary now includes a conditional Glazed middleware chain.
  - If `envPrefix` or `config` are defined in the build spec, middleware for
    environment and config file sources is enabled.
  - If these settings are absent, the binary maintains its historical behavior,
    only parsing CLI flags and arguments, ensuring full backward compatibility.

- **Configuration Precedence:**
  - The standard Glazed precedence is followed:
    `Defaults < Config Files < Environment Variables < CLI Flags & Arguments`

- **Implementation Details:**
  - The build spec (`xgoja.yaml`) is extended with validation for the new
    settings.
  - The generator embeds these settings into the binary's runtime spec.
  - At runtime, the application host constructs the appropriate middleware
    stack based on the embedded spec.

A new example (`examples/xgoja/11-config-env`) and updated documentation are
included to demonstrate the new functionality.