### PR TITLE
feat(xgoja): Allow mounting jsverbs on the root command

### DIFF
--- a/cmd/xgoja/doc/02-user-guide.md
+++ b/cmd/xgoja/doc/02-user-guide.md
@@ -79,7 +79,7 @@ commands:
 
 `go` controls the generated module. `go.version` defaults to `1.26`, and `go.module` defaults to `example.com/generated/<name>`.
 
-`target` controls the generated binary shape and output path.
+`target` controls the generated binary shape and output path. `target.output` is resolved by `xgoja build` from the shell's current working directory, unless it is absolute or overridden with `xgoja build --output`. It is not resolved relative to the spec file and it is not written inside the temporary generated module.
 
 `packages` selects Go provider packages that will be imported by generated source.
 
@@ -87,7 +87,7 @@ commands:
 
 `commands` enables generated command families and points them at runtime profiles.
 
-`jsverbs` configures JavaScript verb sources that are mounted under the generated jsverbs command.
+`jsverbs` configures JavaScript verb sources. By default, discovered verbs are mounted under the generated jsverbs command. The command name defaults to `verbs` when `commands.jsverbs.enabled: true`; set `commands.jsverbs.name` to rename that container command. Set `commands.jsverbs.mount: root` when discovered verb packages should be registered directly under the generated binary root instead.
 
 `assets` configures local file trees copied into and embedded by the generated binary.
 
@@ -222,7 +222,9 @@ commands:
     name: verbs
 ```
 
-`runtime` must reference an existing runtime profile when the command is enabled. `name` controls the command name exposed by the generated binary.
+`runtime` must reference an existing runtime profile when the command is enabled. `name` controls the command name exposed by the generated binary. If a built-in command name is omitted, xgoja applies defaults: `eval`, `run`, `repl`, and `verbs` for `commands.jsverbs`.
+
+`commands.jsverbs.mount` controls where discovered JavaScript verb commands are attached. Omit it for the default container command (`./app verbs ...`). Set it to `root`, `/`, or `.` to attach discovered verb packages directly under the binary root (`./app tools greet ...`). Root mounting is convenient for self-contained helper binaries, but it increases the chance of command-name collisions with built-in commands such as `help`, `eval`, `run`, `repl`, and `modules`.
 
 The `eval` command spec controls one-shot JavaScript string evaluation. When enabled, `commands.eval.name` is the command name exposed by the generated binary and `commands.eval.runtime` selects the runtime profile used by that command.
 
@@ -429,7 +431,7 @@ jsverbs:
     embed: false
 ```
 
-The files must exist at runtime.
+The files must exist at runtime. For runtime filesystem sources, `path` is stored in the generated spec as written and is interpreted by the generated binary at startup. Use an absolute path when the binary may be launched from a different working directory.
 
 ### Embedded local source
 
@@ -442,9 +444,9 @@ jsverbs:
     embed: true
 ```
 
-At build time, xgoja copies the directory into the generated workspace under `xgoja_embed/jsverbs/<id>/`. Generated source embeds it with `go:embed`, and the runtime scans the embedded filesystem.
+At build time, xgoja copies the directory into the generated workspace under `xgoja_embed/jsverbs/<id>/`. Generated source embeds it with `go:embed`, rewrites the embedded spec to point at that generated root, and the runtime scans the embedded filesystem.
 
-The original `path` must exist when `xgoja build` runs. It does not need to exist when the generated binary runs.
+The original `path` is resolved relative to the directory containing the `xgoja.yaml` file, not relative to the shell's current working directory. It must exist when `xgoja build` runs. It does not need to exist when the generated binary runs.
 
 ### Provider-shipped source
 
@@ -470,7 +472,9 @@ func Register(registry *providerapi.Registry) error {
 }
 ```
 
-Provider-shipped sources are selected by package ID and source name.
+Provider-shipped sources are selected by package ID and source name. The provider source's `Root` is interpreted inside the provider's registered `fs.FS`.
+
+By default, discovered JavaScript verb commands are added below the configured `commands.jsverbs.name` command. A verb package can still define nested command paths with `__package__({ name, parents })`, but those paths are nested inside the jsverbs container command. When `commands.jsverbs.mount: root` is set, the same package/parent path is attached directly to the generated root command instead.
 
 ## Validation
 
@@ -480,7 +484,7 @@ Run validation before building:
 xgoja doctor -f xgoja.yaml
 ```
 
-The validator checks supported target kinds, package uniqueness, known runtime package IDs, duplicate runtime aliases, enabled command runtime references, command provider package/runtime references, jsverb source IDs, help source IDs, asset source IDs, provider help source package references, and local paths for embedded sources.
+The validator checks supported target kinds, package uniqueness, known runtime package IDs, duplicate runtime aliases, enabled command runtime references, command provider package/runtime references, jsverb source IDs, help source IDs, asset source IDs, provider help source package references, and local paths for embedded sources. Local `replace`, embedded `jsverbs.path`, embedded `help.sources[].path`, and embedded `assets[].path` entries are checked relative to the spec file directory. Runtime filesystem jsverb paths are also checked relative to the spec file for validation, but the generated binary stores the path as written; use absolute paths for runtime filesystem sources when launch directories vary.
 
 ## Troubleshooting
 

--- a/cmd/xgoja/doc/03-tutorial-using-xgoja-yaml.md
+++ b/cmd/xgoja/doc/03-tutorial-using-xgoja-yaml.md
@@ -223,7 +223,7 @@ Build again and run:
 ./dist/fixture verbs tools greet --name intern
 ```
 
-This mode scans `./verbs` from disk when the generated binary starts.
+This mode scans `./verbs` from disk when the generated binary starts. Runtime filesystem paths are stored as written in the generated spec, so prefer an absolute path when the binary may be launched from a different directory. The validator still checks the path relative to the `xgoja.yaml` file during `xgoja doctor` and `xgoja build`.
 
 ## 8. Embed local jsverbs into the generated binary
 
@@ -242,7 +242,21 @@ Build again:
 xgoja build -f xgoja.yaml --keep-work
 ```
 
-xgoja copies `./verbs` into the generated workspace and generated `main.go` embeds it with `go:embed`. The final binary no longer needs the original `./verbs` directory at runtime.
+xgoja resolves `./verbs` relative to the `xgoja.yaml` file, copies it into the generated workspace, rewrites the embedded spec path to `xgoja_embed/jsverbs/<id>`, and generated `main.go` embeds it with `go:embed`. The final binary no longer needs the original `./verbs` directory at runtime.
+
+Embedded and runtime filesystem verbs are mounted below the configured jsverbs command by default. The default command is `verbs`, so the example is `./dist/fixture verbs tools greet --name intern`.
+
+For a self-contained helper binary, you can mount discovered JavaScript verb packages directly under the generated root command:
+
+```yaml
+commands:
+  jsverbs:
+    enabled: true
+    runtime: main
+    mount: root
+```
+
+With that option, the same verb becomes `./dist/fixture tools greet --name intern`. Use root mounting when the JavaScript verbs are the primary user-facing command surface. Keep the default `verbs` container when you want to avoid collisions with built-in commands.
 
 ## 9. Embed assets and read them through fs aliases
 
@@ -399,8 +413,9 @@ If the generated build fails, the generated source usually shows whether the pro
 | `require("fs")` fails after adding `fs:assets` | `as: fs:assets` registers only `fs:assets`; use that name or add a separate `as: fs` entry. |
 | embedded asset write fails with `EROFS` | Embedded assets are read-only; use a separate host alias such as `fs:host` for writes. |
 | jsverb command is missing | Confirm `commands.jsverbs.enabled: true` and that the source scans without diagnostics. |
-| embedded jsverb missing | Build with `--keep-work` and inspect `xgoja_embed/jsverbs/<id>/`. |
+| embedded jsverb missing | Build with `--keep-work` and inspect `xgoja_embed/jsverbs/<id>/`; remember the source `path` was resolved relative to the spec file directory. |
 | provider source missing | Confirm the provider registers `VerbSource{Name, FS, Root}` and the spec uses the same package ID and source name. |
+| want jsverbs at root | Set `commands.jsverbs.mount: root`; use a Go `commandProviders` entry instead when commands need non-JavaScript behavior or custom Go services. |
 
 ## See also
 

--- a/cmd/xgoja/doc/06-buildspec-reference.md
+++ b/cmd/xgoja/doc/06-buildspec-reference.md
@@ -65,7 +65,15 @@ help:
       source: runtime-api
 ```
 
-Use embedded local docs for project-specific tutorials. The local directory is copied into `xgoja_embed/help/<id>/` during generation and does not need to exist when the generated binary runs. For a runnable provider-shipped help example, see `examples/xgoja/09-provider-shipped-help-docs`.
+Use embedded local docs for project-specific tutorials. The local directory is resolved relative to the `xgoja.yaml` file, copied into `xgoja_embed/help/<id>/` during generation, and does not need to exist when the generated binary runs. For a runnable provider-shipped help example, see `examples/xgoja/09-provider-shipped-help-docs`.
+
+Path resolution rules to remember:
+
+- `packages[].replace`, embedded `jsverbs[].path`, embedded `help.sources[].path`, and embedded `assets[].path` are resolved relative to the directory containing the `xgoja.yaml` file.
+- Runtime filesystem `jsverbs[].path` is checked relative to the spec directory during validation, but is stored as written in the generated binary; use an absolute path if runtime launch directories vary.
+- `target.output` is resolved by `xgoja build` from the shell's current working directory, unless it is absolute or overridden with `--output`.
+- `commands.jsverbs.name` defaults to `verbs`. JavaScript verbs are mounted below that command by default.
+- Set `commands.jsverbs.mount: root` (also accepts `/` or `.`) to mount discovered JavaScript verb packages directly under the generated root command.
 
 Use embedded assets for templates, static data, static web files, and default configuration that JavaScript should read from the final binary:
 

--- a/cmd/xgoja/internal/buildspec/validate.go
+++ b/cmd/xgoja/internal/buildspec/validate.go
@@ -232,6 +232,20 @@ func validateCommands(report *Report, spec *Spec) {
 	validateCommandRuntime(report, "commands.run", spec.Commands.Run, spec.Runtimes)
 	validateCommandRuntime(report, "commands.repl", spec.Commands.Repl, spec.Runtimes)
 	validateCommandRuntime(report, "commands.jsverbs", spec.Commands.JSVerbs, spec.Runtimes)
+	validateJSVerbCommandMount(report, spec.Commands.JSVerbs)
+}
+
+func validateJSVerbCommandMount(report *Report, command CommandSpec) {
+	mount := strings.TrimSpace(command.Mount)
+	if mount == "" {
+		return
+	}
+	switch strings.ToLower(mount) {
+	case "root", "/", ".":
+		report.AddOK("command-mount", "commands.jsverbs.mount", "root")
+	default:
+		report.AddError("command-mount", "commands.jsverbs.mount", fmt.Sprintf("unsupported jsverbs mount %q; supported values are root, /, and .", mount))
+	}
 }
 
 func validateCommandRuntime(report *Report, path string, command CommandSpec, runtimes map[string]Runtime) {

--- a/cmd/xgoja/internal/buildspec/validate_test.go
+++ b/cmd/xgoja/internal/buildspec/validate_test.go
@@ -169,6 +169,30 @@ func validSpec() *Spec {
 	}
 }
 
+func TestValidateJSVerbCommandMountAcceptsRootAliases(t *testing.T) {
+	for _, mount := range []string{"root", "/", "."} {
+		spec := validSpec()
+		spec.Commands.JSVerbs = CommandSpec{Enabled: true, Runtime: "main", Mount: mount}
+
+		report := Validate(spec)
+		if report.HasErrors() {
+			t.Fatalf("mount %q: expected no validation errors, got %#v", mount, report.Checks)
+		}
+		assertCheck(t, report, StatusOK, "command-mount", "commands.jsverbs.mount")
+	}
+}
+
+func TestValidateJSVerbCommandMountRejectsUnknownValue(t *testing.T) {
+	spec := validSpec()
+	spec.Commands.JSVerbs = CommandSpec{Enabled: true, Runtime: "main", Mount: "top-level"}
+
+	report := Validate(spec)
+	if !report.HasErrors() {
+		t.Fatalf("expected validation errors, got %#v", report.Checks)
+	}
+	assertCheck(t, report, StatusError, "command-mount", "commands.jsverbs.mount")
+}
+
 func assertCheck(t *testing.T, report *Report, status Status, name string, path string) {
 	t.Helper()
 	for _, check := range report.Checks {

--- a/pkg/xgoja/app/host.go
+++ b/pkg/xgoja/app/host.go
@@ -128,7 +128,22 @@ func (h *Host) AttachModules(root *cobra.Command) {
 }
 
 func (h *Host) AttachVerbs(root *cobra.Command) {
-	if root == nil || h == nil {
+	if root == nil || h == nil || h.Spec == nil {
+		return
+	}
+	if commandMount(h.Spec.Commands.JSVerbs) == "root" {
+		cmds, err := buildVerbCommands(h.Providers, h.Factory, h.Spec, h.EmbeddedJSVerbs)
+		if err != nil {
+			root.AddCommand(commandErrorStub(commandName(h.Spec.Commands.JSVerbs, "verbs"), "Run configured JavaScript verb commands", err))
+			return
+		}
+		middlewaresFunc := h.MiddlewaresFunc
+		if middlewaresFunc == nil {
+			middlewaresFunc = cli.CobraCommandDefaultMiddlewares
+		}
+		if err := cli.AddCommandsToRootCommand(root, cmds, nil, cli.WithParserConfig(cli.CobraParserConfig{MiddlewaresFunc: middlewaresFunc})); err != nil {
+			root.AddCommand(commandErrorStub(commandName(h.Spec.Commands.JSVerbs, "verbs"), "Run configured JavaScript verb commands", err))
+		}
 		return
 	}
 	root.AddCommand(newVerbsCommand(h.Providers, h.Factory, h.Spec, h.EmbeddedJSVerbs, h.MiddlewaresFunc))

--- a/pkg/xgoja/app/root.go
+++ b/pkg/xgoja/app/root.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/fs"
 	"sort"
+	"strings"
 
 	"github.com/dop251/goja"
 	"github.com/dop251/goja_nodejs/require"
@@ -332,4 +333,13 @@ func commandName(command CommandSpec, fallback string) string {
 		return command.Name
 	}
 	return fallback
+}
+
+func commandMount(command CommandSpec) string {
+	switch strings.ToLower(strings.TrimSpace(command.Mount)) {
+	case "root", "/", ".":
+		return "root"
+	default:
+		return ""
+	}
 }

--- a/pkg/xgoja/app/root_test.go
+++ b/pkg/xgoja/app/root_test.go
@@ -462,6 +462,46 @@ function embeddedGreet(name) {
 	}
 }
 
+func TestGeneratedRootMountsEmbeddedJSVerbsAtRoot(t *testing.T) {
+	registry := providerapi.NewRegistry()
+	if err := testprovider.Register(registry); err != nil {
+		t.Fatalf("register provider: %v", err)
+	}
+	embedded := fstest.MapFS{
+		"xgoja_embed/jsverbs/local/tools.js": &fstest.MapFile{Data: []byte(`
+__package__({ name: "tools" })
+__verb__("embeddedGreet", {
+  name: "embedded-greet",
+  output: "text",
+  fields: {
+    name: { type: "string", required: true }
+  }
+})
+function embeddedGreet(name) {
+  const hello = require("hello")
+  return hello.greet(name)
+}
+`)},
+	}
+	specJSON := `{
+  "name": "fixture",
+  "target": {"kind": "xgoja", "output": "dist/fixture"},
+  "packages": [{"id": "fixture"}],
+  "runtimes": {"repl": {"modules": [{"package": "fixture", "name": "hello", "as": "hello"}]}},
+  "commands": {"eval": {"enabled": true, "runtime": "repl", "name": "eval"}, "jsverbs": {"enabled": true, "runtime": "repl", "name": "verbs", "mount": "root"}},
+  "jsverbs": [{"id": "local", "path": "xgoja_embed/jsverbs/local", "embed": true}]
+}`
+	out := &bytes.Buffer{}
+	root, err := NewRootCommand(Options{Providers: registry, SpecJSON: specJSON, Out: out, EmbeddedJSVerbs: embedded})
+	if err != nil {
+		t.Fatalf("new root: %v", err)
+	}
+	root.SetArgs([]string{"tools", "embedded-greet", "--name", "intern"})
+	if err := root.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("execute root-mounted embedded verb: %v", err)
+	}
+}
+
 func TestGeneratedRootMountsFilesystemJSVerbs(t *testing.T) {
 	registry := providerapi.NewRegistry()
 	if err := testprovider.Register(registry); err != nil {

--- a/ttmp/2026/06/02/XGOJA-JSVERBS-ROOT-001--xgoja-root-mounted-javascript-verbs/README.md
+++ b/ttmp/2026/06/02/XGOJA-JSVERBS-ROOT-001--xgoja-root-mounted-javascript-verbs/README.md
@@ -1,0 +1,21 @@
+# xgoja root-mounted JavaScript verbs
+
+This is the document workspace for ticket XGOJA-JSVERBS-ROOT-001.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr doc add --ticket XGOJA-JSVERBS-ROOT-001 --doc-type design-doc --title "My Design"`
+- Import sources: `docmgr import file --ticket XGOJA-JSVERBS-ROOT-001 --file /path/to/doc.md`
+- Update metadata: `docmgr meta update --ticket XGOJA-JSVERBS-ROOT-001 --field Status --value review`

--- a/ttmp/2026/06/02/XGOJA-JSVERBS-ROOT-001--xgoja-root-mounted-javascript-verbs/changelog.md
+++ b/ttmp/2026/06/02/XGOJA-JSVERBS-ROOT-001--xgoja-root-mounted-javascript-verbs/changelog.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## 2026-06-02
+
+- Initial workspace created
+
+
+## 2026-06-02
+
+Implemented root-mounted jsverbs option design and code path
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-02/goja-text/go-go-goja/cmd/xgoja/internal/buildspec/validate.go — Mount validation
+- /home/manuel/workspaces/2026-06-02/goja-text/go-go-goja/pkg/xgoja/app/host.go — Root attachment behavior
+

--- a/ttmp/2026/06/02/XGOJA-JSVERBS-ROOT-001--xgoja-root-mounted-javascript-verbs/design-doc/01-root-mounted-javascript-verbs-design-and-implementation-guide.md
+++ b/ttmp/2026/06/02/XGOJA-JSVERBS-ROOT-001--xgoja-root-mounted-javascript-verbs/design-doc/01-root-mounted-javascript-verbs-design-and-implementation-guide.md
@@ -1,0 +1,210 @@
+---
+Title: Root-mounted JavaScript verbs design and implementation guide
+Ticket: XGOJA-JSVERBS-ROOT-001
+Status: active
+Topics:
+    - xgoja
+    - jsverbs
+    - cli
+    - buildspec
+DocType: design-doc
+Intent: Design and implementation guide for mounting xgoja JavaScript verbs directly under the generated root command
+Owners: []
+RelatedFiles:
+    - Path: cmd/xgoja/doc/02-user-guide.md
+      Note: User-facing root-mount documentation
+    - Path: cmd/xgoja/internal/buildspec/validate.go
+      Note: Validation for commands.jsverbs.mount
+    - Path: pkg/xgoja/app/host.go
+      Note: Attaches jsverbs either under the default container command or directly under root
+    - Path: pkg/xgoja/app/root.go
+      Note: Shared jsverbs command construction and mount normalization
+    - Path: pkg/xgoja/app/root_test.go
+      Note: Runtime coverage for root-mounted embedded jsverbs
+ExternalSources: []
+Summary: ""
+LastUpdated: 0001-01-01T00:00:00Z
+WhatFor: ""
+WhenToUse: ""
+---
+
+
+# Root-mounted JavaScript verbs design and implementation guide
+
+## Executive summary
+
+xgoja already supports JavaScript verbs through a generated container command, usually `verbs`. A generated binary can expose commands such as `myapp verbs tools greet`. That shape is safe because it isolates all JavaScript-defined commands below one namespace, but it is not ideal for a self-contained helper binary whose primary command surface is made of JavaScript verbs.
+
+This ticket adds a small buildspec option:
+
+```yaml
+commands:
+  jsverbs:
+    enabled: true
+    runtime: main
+    mount: root
+```
+
+When `mount: root` is set, xgoja scans the configured JavaScript verb sources exactly as before, but mounts the discovered verb packages directly under the generated root command. A command that previously ran as `myapp verbs tools greet` can then run as `myapp tools greet`.
+
+## Problem statement
+
+The default jsverbs behavior is intentionally conservative. It creates a single Cobra command for JavaScript verbs and mounts all scanned verb commands under it. This avoids root command collisions with built-in generated commands such as `help`, `eval`, `run`, `repl`, and `modules`.
+
+Some binaries, however, are designed to be verb-first. In those binaries the `verbs` prefix is noise. A `goja-text` binary that bundles useful Markdown, sanitize, and extract verbs should feel like a normal CLI:
+
+```bash
+goja-text markdown toc README.md
+goja-text sanitize json broken.json
+goja-text extract validate response.md
+```
+
+rather than:
+
+```bash
+goja-text verbs markdown toc README.md
+goja-text verbs sanitize json broken.json
+goja-text verbs extract validate response.md
+```
+
+The missing capability is not a new JavaScript verb scanner or runtime. It is a mount location option for the commands that already exist.
+
+## Current architecture
+
+The generated xgoja root command is assembled by `pkg/xgoja/app.Host.AttachDefaultCommands`. Built-in commands are attached in sequence:
+
+```text
+AttachDefaultCommands(root):
+    install root framework/help/logging
+    attach eval if enabled
+    attach run if enabled
+    attach repl if enabled
+    attach modules
+    attach jsverbs if enabled
+    attach command providers
+```
+
+The existing jsverbs path calls `AttachVerbs`, which adds `newVerbsCommand(...)` as one child of the root command. `newVerbsCommand` builds all verb commands, then mounts them below that container command using Glazed/Cobra command wiring.
+
+```mermaid
+flowchart TD
+  Root[generated root command]
+  Verbs[verbs command]
+  Sources[jsverbs sources]
+  Scan[scanVerbSource]
+  Build[buildVerbCommands]
+  Packages[verb package commands]
+
+  Root --> Verbs
+  Sources --> Scan
+  Scan --> Build
+  Build --> Packages
+  Packages --> Verbs
+```
+
+The new option keeps `scanVerbSource` and `buildVerbCommands` unchanged. It only changes the final attachment point.
+
+## Proposed solution
+
+Add semantics to the existing `CommandSpec.Mount` field for `commands.jsverbs`:
+
+| Value | Meaning |
+| --- | --- |
+| omitted / empty | Keep current behavior: mount verbs under `commands.jsverbs.name`, defaulting to `verbs`. |
+| `root` | Mount discovered JavaScript verb package commands directly under the generated root command. |
+| `/` | Alias for `root`. |
+| `.` | Alias for `root`. |
+
+The aliases make YAML ergonomics simple while keeping the documented value `root` clear.
+
+Implementation shape:
+
+```text
+AttachVerbs(root):
+    if commands.jsverbs.mount normalizes to root:
+        commands = buildVerbCommands(...)
+        AddCommandsToRootCommand(root, commands)
+        return
+
+    root.AddCommand(newVerbsCommand(...))
+```
+
+Validation shape:
+
+```text
+validateCommands(spec):
+    validate command runtimes as before
+    if commands.jsverbs.mount is non-empty:
+        accept root, /, .
+        reject anything else
+```
+
+## Design decisions
+
+### Decision 1: Reuse `commands.jsverbs.mount`
+
+`CommandSpec` already has a `Mount` field. Using it avoids adding another buildspec shape and aligns jsverbs with the command-provider vocabulary. The field was not previously used by built-in jsverbs, so this is an additive behavior.
+
+### Decision 2: Keep container mode as the default
+
+Root mounting increases the chance of command collisions. A JavaScript package named `help`, `eval`, `run`, `repl`, or `modules` would be confusing and may fail during command registration. The default remains the conservative `verbs` container.
+
+### Decision 3: Do not change scanning or invocation
+
+The scanner, runtime factory, module-section initialization, and JavaScript invocation path stay the same. This reduces risk: root-mounted verbs receive the same runtime profile, module initializers, provider config sections, and relative `require()` behavior as container-mounted verbs.
+
+### Decision 4: Validate typos
+
+A misspelled mount value such as `top-level` should fail `xgoja doctor` instead of silently falling back to container mode. The validator accepts only `root`, `/`, and `.` for now.
+
+## Implementation plan
+
+1. Add a `commandMount` helper in `pkg/xgoja/app/root.go` that normalizes `root`, `/`, and `.`.
+2. Update `Host.AttachVerbs` in `pkg/xgoja/app/host.go`:
+   - root mount: call `buildVerbCommands` and add the resulting commands to the generated root command.
+   - default mount: preserve `newVerbsCommand` behavior.
+3. Add validation in `cmd/xgoja/internal/buildspec/validate.go` for `commands.jsverbs.mount`.
+4. Add tests:
+   - root-mounted embedded jsverbs execute without the `verbs` prefix.
+   - `commands.jsverbs.mount` accepts root aliases.
+   - unknown mount values fail validation.
+5. Update xgoja docs:
+   - user guide
+   - tutorial
+   - buildspec reference
+6. Use the option in `goja-text/cmd/goja-text/xgoja.yaml` so `goja-text markdown toc ...` works directly.
+
+## Risks and constraints
+
+- Root mounting can collide with built-in command names or command-provider mounts. The option is explicit so callers choose that risk.
+- Root mounting does not make JavaScript verbs equivalent to Go command providers. Go command providers are still the right choice for commands that need custom Go services, long-lived state, or non-JavaScript behavior.
+- The `sources` helper command remains available only in the default container mode. Root-mounted binaries can inspect configured sources through buildspec/docs, but there is no root-level `sources` command added by this feature.
+
+## Validation strategy
+
+Run targeted tests in `go-go-goja`:
+
+```bash
+go test ./cmd/xgoja ./cmd/xgoja/internal/buildspec ./pkg/xgoja/app -count=1
+```
+
+Then validate the downstream `goja-text` binary:
+
+```bash
+cd /home/manuel/workspaces/2026-06-02/goja-text/goja-text
+make build-xgoja
+./dist/goja-text markdown toc examples/markdown/sample.md --output json
+./dist/goja-text sanitize json examples/json/broken.json --output json
+./dist/goja-text extract validate examples/text/structured-data-sample.md --output json
+```
+
+## File references
+
+- `/home/manuel/workspaces/2026-06-02/goja-text/go-go-goja/pkg/xgoja/app/host.go`
+- `/home/manuel/workspaces/2026-06-02/goja-text/go-go-goja/pkg/xgoja/app/root.go`
+- `/home/manuel/workspaces/2026-06-02/goja-text/go-go-goja/pkg/xgoja/app/root_test.go`
+- `/home/manuel/workspaces/2026-06-02/goja-text/go-go-goja/cmd/xgoja/internal/buildspec/validate.go`
+- `/home/manuel/workspaces/2026-06-02/goja-text/go-go-goja/cmd/xgoja/internal/buildspec/validate_test.go`
+- `/home/manuel/workspaces/2026-06-02/goja-text/go-go-goja/cmd/xgoja/doc/02-user-guide.md`
+- `/home/manuel/workspaces/2026-06-02/goja-text/go-go-goja/cmd/xgoja/doc/03-tutorial-using-xgoja-yaml.md`
+- `/home/manuel/workspaces/2026-06-02/goja-text/go-go-goja/cmd/xgoja/doc/06-buildspec-reference.md`

--- a/ttmp/2026/06/02/XGOJA-JSVERBS-ROOT-001--xgoja-root-mounted-javascript-verbs/index.md
+++ b/ttmp/2026/06/02/XGOJA-JSVERBS-ROOT-001--xgoja-root-mounted-javascript-verbs/index.md
@@ -1,0 +1,58 @@
+---
+Title: xgoja root-mounted JavaScript verbs
+Ticket: XGOJA-JSVERBS-ROOT-001
+Status: active
+Topics:
+    - xgoja
+    - jsverbs
+    - cli
+    - buildspec
+DocType: index
+Intent: long-term
+Owners: []
+RelatedFiles: []
+ExternalSources: []
+Summary: ""
+LastUpdated: 2026-06-02T14:35:12.455471678-04:00
+WhatFor: ""
+WhenToUse: ""
+---
+
+# xgoja root-mounted JavaScript verbs
+
+## Overview
+
+<!-- Provide a brief overview of the ticket, its goals, and current status -->
+
+## Key Links
+
+- **Related Files**: See frontmatter RelatedFiles field
+- **External Sources**: See frontmatter ExternalSources field
+
+## Status
+
+Current status: **active**
+
+## Topics
+
+- xgoja
+- jsverbs
+- cli
+- buildspec
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/2026/06/02/XGOJA-JSVERBS-ROOT-001--xgoja-root-mounted-javascript-verbs/reference/01-implementation-diary.md
+++ b/ttmp/2026/06/02/XGOJA-JSVERBS-ROOT-001--xgoja-root-mounted-javascript-verbs/reference/01-implementation-diary.md
@@ -1,0 +1,113 @@
+---
+Title: Implementation diary
+Ticket: XGOJA-JSVERBS-ROOT-001
+Status: active
+Topics:
+  - xgoja
+  - jsverbs
+  - cli
+  - buildspec
+DocType: reference
+Intent: Chronological implementation diary for root-mounted xgoja JavaScript verbs
+---
+
+# Diary
+
+## Goal
+
+Capture the design and implementation process for adding an xgoja buildspec option that mounts JavaScript verb packages directly under the generated root command.
+
+## Step 1: Add root-mounted jsverbs support
+
+The implementation adds an explicit root-mount option for xgoja JavaScript verbs. The default behavior stays unchanged: verbs are still mounted below the configured jsverbs command, usually `verbs`. When a buildspec sets `commands.jsverbs.mount: root`, xgoja scans and builds the same JavaScript verb commands but attaches them directly to the generated root command.
+
+This is useful for self-contained helper binaries where the JavaScript verbs are the primary command surface. A binary can expose `goja-text markdown toc ...` instead of `goja-text verbs markdown toc ...` while still using the same jsverbs scanner, runtime profile, module initialization, and invocation machinery.
+
+### Prompt Context
+
+**User prompt (verbatim):** "ok, create a docmgr ticket in ./go-go-goja/ttmp (with docmgr --root ...) to add said option to register jsverbs to the root verb directly, and implement it, and use it in your example, that way we have a nice self contained helpful binary"
+
+**Assistant interpretation:** Create a docmgr ticket under the go-go-goja `ttmp` root, implement a root-mounted jsverbs option in xgoja, and then use it in the goja-text generated binary spec.
+
+**Inferred user intent:** Make xgoja capable of producing binaries whose JavaScript verbs feel like first-class CLI commands, without an extra `verbs` prefix.
+
+**Commit (code):** pending — implementation not committed yet.
+
+### What I did
+
+- Created ticket `XGOJA-JSVERBS-ROOT-001` under `/home/manuel/workspaces/2026-06-02/goja-text/go-go-goja/ttmp` using `docmgr --root ./ttmp`.
+- Wrote the design guide at `design-doc/01-root-mounted-javascript-verbs-design-and-implementation-guide.md`.
+- Updated `pkg/xgoja/app/host.go` so `AttachVerbs` checks `commands.jsverbs.mount`.
+- Added `commandMount` in `pkg/xgoja/app/root.go`, accepting `root`, `/`, and `.` as root-mount aliases.
+- Added buildspec validation in `cmd/xgoja/internal/buildspec/validate.go` for `commands.jsverbs.mount`.
+- Added tests in:
+  - `pkg/xgoja/app/root_test.go`
+  - `cmd/xgoja/internal/buildspec/validate_test.go`
+- Updated xgoja docs:
+  - `cmd/xgoja/doc/02-user-guide.md`
+  - `cmd/xgoja/doc/03-tutorial-using-xgoja-yaml.md`
+  - `cmd/xgoja/doc/06-buildspec-reference.md`
+- Ran targeted tests successfully:
+  - `go test ./cmd/xgoja ./cmd/xgoja/internal/buildspec ./pkg/xgoja/app -count=1`
+
+### Why
+
+The default `verbs` container is safe, but it is not ideal for binaries where bundled JavaScript commands are the main user-facing feature. Root mounting is an explicit opt-in that improves ergonomics without changing the default behavior or the scanner/runtime implementation.
+
+### What worked
+
+- The root mount can reuse existing `buildVerbCommands`; no changes were needed in the JS scanner or invocation path.
+- Root-mounted embedded verbs execute correctly in the new runtime test.
+- Buildspec validation catches unsupported mount strings.
+- The docs now explain both the default container mode and root-mounted mode.
+
+### What didn't work
+
+- My first docmgr command used `docmgr --root .`, which created a misplaced ticket workspace under `go-go-goja/2026/...`. I corrected this by creating the ticket with `docmgr --root ./ttmp` and removing the misplaced workspace.
+
+### What I learned
+
+- `CommandSpec.Mount` already existed, so this feature could be implemented as semantics for the existing field rather than a new buildspec key.
+- The root-mount behavior belongs in `Host.AttachVerbs`, not in the scanner. The scanner should continue producing Glazed command descriptions independent of where they are attached.
+
+### What was tricky to build
+
+- The sharp edge is command collision. Root-mounted JavaScript packages can collide with built-in commands such as `help`, `eval`, `run`, `repl`, and `modules`. The feature therefore remains explicit and the docs recommend default container mode when collision avoidance matters.
+
+### What warrants a second pair of eyes
+
+- Whether root-mounted jsverbs should also expose a root-level `sources` helper command or whether omitting it is the right tradeoff.
+- Whether additional reserved-name validation should warn when a root-mounted verb package collides with built-in commands.
+
+### What should be done in the future
+
+- Use `commands.jsverbs.mount: root` in `goja-text/cmd/goja-text/xgoja.yaml` and validate the resulting self-contained binary.
+- Consider command-collision diagnostics if root mounting becomes common.
+
+### Code review instructions
+
+- Start with `pkg/xgoja/app/host.go`, especially `AttachVerbs`.
+- Review `pkg/xgoja/app/root.go` for `commandMount`.
+- Review tests in `pkg/xgoja/app/root_test.go` and `cmd/xgoja/internal/buildspec/validate_test.go`.
+- Validate with:
+  - `go test ./cmd/xgoja ./cmd/xgoja/internal/buildspec ./pkg/xgoja/app -count=1`
+
+### Technical details
+
+Buildspec usage:
+
+```yaml
+commands:
+  jsverbs:
+    enabled: true
+    runtime: main
+    mount: root
+```
+
+Accepted aliases:
+
+```yaml
+mount: root
+mount: /
+mount: .
+```

--- a/ttmp/2026/06/02/XGOJA-JSVERBS-ROOT-001--xgoja-root-mounted-javascript-verbs/tasks.md
+++ b/ttmp/2026/06/02/XGOJA-JSVERBS-ROOT-001--xgoja-root-mounted-javascript-verbs/tasks.md
@@ -1,0 +1,21 @@
+---
+Ticket: XGOJA-JSVERBS-ROOT-001
+Title: Tasks
+Status: active
+Topics:
+  - xgoja
+  - jsverbs
+  - cli
+  - buildspec
+DocType: tasks
+---
+
+# Tasks
+
+- [x] Create ticket workspace and design documentation under `go-go-goja/ttmp`.
+- [x] Implement `commands.jsverbs.mount: root` in xgoja app command attachment.
+- [x] Add buildspec validation for supported jsverbs mount values.
+- [x] Add runtime test coverage for root-mounted embedded jsverbs.
+- [x] Update xgoja help docs for root mounting, path resolution, and command defaults.
+- [x] Use root-mounted jsverbs in `goja-text/cmd/goja-text/xgoja.yaml`.
+- [x] Validate xgoja targeted tests and goja-text generated binary smoke tests.


### PR DESCRIPTION
This change introduces a new configuration option, `commands.jsverbs.mount`, in
the `xgoja.yaml` build spec. This allows JavaScript-defined "verb" commands to
be attached directly to the generated application's root command, rather than
being nested under the default `verbs` subcommand.

Key changes:

- **New Build Spec Option**: Added `commands.jsverbs.mount` to the build spec.
  Setting its value to `root`, `/`, or `.` enables mounting verbs at the root
  level.
- **Conditional Mounting Logic**: The application host now inspects the `mount`
  setting. If set to `root`, it attaches the discovered verb packages directly
  to the root `cobra.Command`. Otherwise, it preserves the existing behavior of
  grouping them under a container command.
- **Validation**: Implemented a validation check to ensure that `mount` contains
  a supported value.
- **Testing**: Added new unit and integration tests to verify that verbs are
  correctly mounted at the root when the new option is used.
- **Documentation**: Updated the user guide, tutorial, and reference documents
  to explain the new feature, its use cases, and potential command name
  collisions.