### PR TITLE
Docs: Add documentation for built-in Goja modules

### DIFF
--- a/pkg/doc/20-db-module.md
+++ b/pkg/doc/20-db-module.md
@@ -1,0 +1,105 @@
+---
+Title: Database Module
+Slug: db-module
+Short: Run SQL queries from JavaScript against sqlite3 or any Go database/sql driver
+Topics:
+- database
+- modules
+- goja
+- javascript
+Commands:
+- goja-repl
+IsTopLevel: true
+IsTemplate: false
+ShowPerDefault: true
+SectionType: GeneralTopic
+---
+
+The `database` (and `db`) modules expose a minimal SQL helper surface for Goja runtimes. They wrap Go's `database/sql` connection pool so JavaScript handlers can query and execute statements without leaving the event-driven flow.
+
+## Go setup
+
+The database module is part of the default registry, so it is available automatically when you build an engine with the default modules:
+
+```go
+factory, err := engine.NewBuilder().Build()
+```
+
+For production uses, pre-configure the database connection from Go so the runtime does not need to call `configure()`:
+
+```go
+db, _ := sql.Open("sqlite3", ":memory:")
+module := databasemod.New(
+    databasemod.WithPreconfiguredDB(db),
+    databasemod.WithCloseFn(db.Close),
+    databasemod.WithName("database"),
+)
+factory, err := engine.NewBuilder().WithModules(module).Build()
+```
+
+When you pre-configure the module, `configure()` is disabled and calling it throws.
+
+## JavaScript usage
+
+```javascript
+const db = require("database");
+
+db.configure("sqlite3", ":memory:");
+
+db.exec(`
+  CREATE TABLE users (
+    id INTEGER PRIMARY KEY,
+    name TEXT
+  )
+`);
+
+db.exec("INSERT INTO users (name) VALUES (?)", "Ada");
+
+const rows = db.query("SELECT * FROM users WHERE name = ?", "Ada");
+for (const row of rows) {
+  console.log(row.id, row.name);
+}
+```
+
+## Module API
+
+### `configure(driverName, dataSourceName)`
+
+Opens a new `database/sql` connection using the named driver and DSN. Only available when the module was not pre-configured from Go. Throws when called on a pre-configured module.
+
+### `query(sql, ...args)`
+
+Executes a `SELECT`-style statement and returns an array of plain objects, one per row. Column names become object keys. `args` are passed as positional query parameters.
+
+If `args` contains a single array, that array is flattened and used as positional parameters. This makes it convenient to spread an existing list.
+
+### `exec(sql, ...args)`
+
+Executes an `INSERT`, `UPDATE`, `DELETE`, or DDL statement and returns a result summary:
+
+```javascript
+{
+  success: true,
+  rowsAffected: 1,
+  lastInsertId: 3
+}
+```
+
+If the statement fails, the function returns an object with `success: false` and `error: "message"`.
+
+### `close()`
+
+Closes the underlying connection if the module owns it. Safe to call multiple times. Silently does nothing when there is no owned connection.
+
+## Module aliases
+
+Both `require("database")` and `require("db")` resolve to the same module instance.
+
+## Troubleshooting
+
+| Problem | Cause | Solution |
+|---|---|---|
+| "database not configured" error | No `configure()` call and no pre-configured DB | Call `configure()` before queries, or pre-configure the module in Go |
+| "preconfigured and does not allow configure" error | Go side used `WithPreconfiguredDB` | Remove the `configure()` call from JavaScript |
+| Driver import missing at runtime | The Go binary was not linked against the driver | Add the driver import to your Go main package (for example, `_ "github.com/mattn/go-sqlite3"`) |
+| Query parameters do not match | Wrong number of `?` placeholders | Ensure placeholder count equals the number of bound arguments |

--- a/pkg/doc/20-db-module.md
+++ b/pkg/doc/20-db-module.md
@@ -53,7 +53,11 @@ db.exec(`
   )
 `);
 
-db.exec("INSERT INTO users (name) VALUES (?)", "Ada");
+try {
+  db.exec("INSERT INTO users (name) VALUES (?)", "Ada");
+} catch (e) {
+  console.error("insert failed:", e);
+}
 
 const rows = db.query("SELECT * FROM users WHERE name = ?", "Ada");
 for (const row of rows) {
@@ -75,7 +79,7 @@ If `args` contains a single array, that array is flattened and used as positiona
 
 ### `exec(sql, ...args)`
 
-Executes an `INSERT`, `UPDATE`, `DELETE`, or DDL statement and returns a result summary:
+Executes an `INSERT`, `UPDATE`, `DELETE`, or DDL statement and returns a result summary on success:
 
 ```javascript
 {
@@ -85,7 +89,7 @@ Executes an `INSERT`, `UPDATE`, `DELETE`, or DDL statement and returns a result 
 }
 ```
 
-If the statement fails, the function returns an object with `success: false` and `error: "message"`.
+If the statement fails, `exec` **throws an exception** with the error message. The underlying Go function returns both a result object and a non-nil error, and Goja raises the error as a JavaScript exception. Use `try/catch` to handle failed SQL executions.
 
 ### `close()`
 

--- a/pkg/doc/21-crypto-module.md
+++ b/pkg/doc/21-crypto-module.md
@@ -1,0 +1,77 @@
+---
+Title: Crypto Module
+Slug: crypto-module
+Short: Generate UUIDs, random bytes, and SHA/MD5 hashes from JavaScript
+Topics:
+- crypto
+- modules
+- goja
+- javascript
+Commands:
+- goja-repl
+IsTopLevel: true
+IsTemplate: false
+ShowPerDefault: true
+SectionType: GeneralTopic
+---
+
+The `crypto` module provides basic cryptographic helpers for Goja runtimes. It exposes UUID generation, random byte generation, and Node-style `createHash` digest objects.
+
+The module is aliased as both `crypto` and `node:crypto`. It is intentionally a lightweight subset, not a full Node.js crypto polyfill.
+
+## JavaScript usage
+
+```javascript
+const crypto = require("crypto");
+
+const id = crypto.randomUUID();
+// e.g. "550e8400-e29b-41d4-a716-446655440000"
+
+const buf = crypto.randomBytes(16);
+// Buffer with 16 random bytes
+
+const hash = crypto.createHash("sha256")
+  .update("hello")
+  .digest("hex");
+// "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+```
+
+## Module API
+
+### `randomUUID()`
+
+Generates a version-4 UUID string.
+
+### `randomBytes(size)`
+
+Generates a `Buffer` containing `size` cryptographically secure random bytes. Throws a type error when `size` is negative.
+
+### `createHash(algorithm)`
+
+Creates a hash object for the named algorithm. Supported algorithms:
+
+- `sha256`
+- `sha512`
+- `sha1`
+- `md5`
+
+Returns a Go-backed object with two methods:
+
+- `update(data)` — appends data to the hash state and returns the same object for chaining.
+- `digest(encoding?)` — finalizes the hash and returns the digest.
+  - Without an encoding, returns a `Buffer`.
+  - With `"hex"`, returns a hex string.
+  - With `"base64"`, returns a Base64 string.
+  - Any other encoding throws a type error.
+
+## Security notes
+
+This module exists primarily for Node.js compatibility and convenience helpers such as request signatures and content hashing. SHA-1 and MD5 are provided because callers may need to match existing third-party interfaces. For new designs requiring collision resistance, prefer `sha256`.
+
+## Troubleshooting
+
+| Problem | Cause | Solution |
+|---|---|---|
+| "unsupported hash algorithm" error | Algorithm name is not in the supported list | Use `sha256`, `sha512`, `sha1`, or `md5` |
+| "randomBytes size must be >= 0" error | Negative size passed | Pass a non-negative integer size |
+| Data is not a string or Buffer inside `update()` | The runtime `buffer` module decodes the value automatically | Ensure the `buffer` module is available in the runtime |

--- a/pkg/doc/22-events-module.md
+++ b/pkg/doc/22-events-module.md
@@ -1,0 +1,99 @@
+---
+Title: Events Module
+Slug: events-module
+Short: Node-style EventEmitter backed by Go-native dispatch
+Topics:
+- events
+- modules
+- goja
+- javascript
+Commands:
+- goja-repl
+IsTopLevel: true
+IsTemplate: false
+ShowPerDefault: true
+SectionType: GeneralTopic
+---
+
+The `events` module exports a Go-native `EventEmitter` constructor that mirrors a subset of the Node.js `events.EventEmitter` API. It is aliased as both `events` and `node:events`.
+
+This implementation is not goroutine-safe outside the owning goja runtime goroutine. All listener registration, emission, and removal happen synchronously on that goroutine through the runtime owner.
+
+## JavaScript usage
+
+```javascript
+const EventEmitter = require("events");
+
+const emitter = new EventEmitter();
+
+emitter.on("data", (chunk) => {
+  console.log("received:", chunk);
+});
+
+emitter.once("end", () => {
+  console.log("stream ended");
+});
+
+emitter.emit("data", "hello");
+emitter.emit("end");
+```
+
+## Constructor
+
+### `new EventEmitter()`
+
+Creates a new emitter instance backed by a Go-native dispatch table.
+
+## Instance methods
+
+### `on(name, listener)` / `addListener(name, listener)`
+
+Registers a listener function for `name`. Both methods are aliases.
+
+### `once(name, listener)`
+
+Registers a listener that fires exactly once and is automatically removed before invocation.
+
+### `off(name, listener)` / `removeListener(name, listener)`
+
+Removes the first listener that strictly matches the provided function reference.
+
+### `removeAllListeners(name?)`
+
+Without arguments, removes every listener on the emitter. With `name`, removes only listeners for that event.
+
+### `emit(name, ...args)`
+
+Invokes all listeners for `name` in registration order. Returns `true` if at least one listener was called, `false` otherwise.
+
+Emitting the `"error"` event with no listeners causes a thrown error rather than a silent return.
+
+### `listeners(name)`
+
+Returns an array of listener functions. For `once` listeners, returns the wrapper rather than the original function unless the emitter unwraps them internally.
+
+### `rawListeners(name)`
+
+Returns the raw listener array including wrapper objects for `once` registrations.
+
+### `listenerCount(name)`
+
+Returns the number of registered listeners for `name`.
+
+### `eventNames()`
+
+Returns an array of string event names that currently have one or more listener. Symbol names are omitted from this list.
+
+## Properties
+
+### `EventEmitter.default`
+
+Points to the constructor itself, matching Node.js conventions.
+
+## Troubleshooting
+
+| Problem | Cause | Solution |
+|---|---|---|
+| Emitter does not fire callbacks as expected | The call is being made from a goroutine other than the runtime owner | Use `runtimeServices.PostWithCustomContext` or equivalent to dispatch back onto the owner |
+| "listener must be a function" error | A non-function value was passed to `on` / `once` / `addListener` | Pass a function reference |
+| "unhandled error event" thrown | `emit("error", ...)` with no error listeners | Attach an `"error"` handler or wrap calls in a guard |

--- a/pkg/doc/23-exec-module.md
+++ b/pkg/doc/23-exec-module.md
@@ -1,0 +1,49 @@
+---
+Title: Exec Module
+Slug: exec-module
+Short: Run external host commands from JavaScript
+Topics:
+- exec
+- modules
+- goja
+- javascript
+Commands:
+- goja-repl
+IsTopLevel: true
+IsTemplate: false
+ShowPerDefault: true
+SectionType: GeneralTopic
+---
+
+The `exec` module wraps `os/exec` so JavaScript runtimes can run external host processes. It is simple by design: one function, command plus arguments, returning the combined standard output and standard error as a string.
+
+## JavaScript usage
+
+```javascript
+const exec = require("exec");
+
+const output = exec.run("echo", ["hello", "world"]);
+console.log(output);
+// "hello world\n"
+```
+
+## Module API
+
+### `run(cmd, args)`
+
+Runs `cmd` with `args` on the host operating system and returns the combined stdout and stderr as a single string. If the command exits with a non-zero status or cannot be started, the function throws an error.
+
+- `cmd` — executable name or absolute path.
+- `args` — array of string arguments passed to the executable.
+
+## Security notes
+
+This module exists to let trusted scripts call local tools, compilers, or system utilities. Because it executes arbitrary host commands, it should only be enabled in runtimes you trust. In untrusted environments, disable the `exec` module through engine middleware.
+
+## Troubleshooting
+
+| Problem | Cause | Solution |
+|---|---|---|
+| "executable file not found in $PATH" error | The command name is not on the host PATH | Use the absolute path to the executable |
+| Command exits with an error | The process returned a non-zero exit code | Check the command arguments and environment before calling |
+| Empty output despite command success | The command wrote everything to stderr | Rethrow or log errors to see stderr content |

--- a/pkg/doc/24-fs-module.md
+++ b/pkg/doc/24-fs-module.md
@@ -1,0 +1,137 @@
+---
+Title: File System Module
+Slug: fs-module
+Short: Promise-based and synchronous file system helpers for Goja runtimes
+Topics:
+- fs
+- modules
+- goja
+- javascript
+Commands:
+- goja-repl
+IsTopLevel: true
+IsTemplate: false
+ShowPerDefault: true
+SectionType: GeneralTopic
+---
+
+The `fs` module provides Node-style file system access for Goja runtimes. It is aliased as both `fs` and `node:fs`. The module exports both asynchronous promise-based functions and synchronous blocking variants.
+
+Async operations run on background goroutines and resolve through the runtime owner, so they do not freeze the JavaScript event loop. Sync operations block the runtime goroutine and should be used sparingly.
+
+## JavaScript usage
+
+```javascript
+const fs = require("fs");
+
+await fs.mkdir("/tmp/demo", { recursive: true });
+await fs.writeFile("/tmp/demo/hello.txt", "hello world");
+const text = await fs.readFile("/tmp/demo/hello.txt", "utf8");
+console.log(text);
+
+const exists = await fs.exists("/tmp/demo/hello.txt");
+
+const entries = await fs.readdir("/tmp/demo");
+
+const stats = await fs.stat("/tmp/demo/hello.txt");
+console.log(stats.size, stats.isFile);
+```
+
+## Async API
+
+All async functions return Promises.
+
+### `readFile(path, encoding?)`
+
+Reads the entire file. Without an encoding, resolves to a `Buffer`. With `"utf8"`, resolves to a string.
+
+### `writeFile(path, data, options?)`
+
+Writes `data` to `path`, overwriting if necessary. `data` can be a string, `Buffer`, `Uint8Array`, or `DataView`. `options` may include:
+- `encoding` — string encoding when `data` is a string.
+- `mode` — numeric file permission mode (default `0o644`).
+
+### `appendFile(path, data, options?)`
+
+Appends `data` to `path`. Accepts the same data types and options as `writeFile`.
+
+### `exists(path)`
+
+Resolves to `true` if the path exists, `false` otherwise.
+
+### `mkdir(path, options?)`
+
+Creates a directory. `options` may include:
+- `recursive` — create parent directories as needed (default `false`).
+- `mode` — permission mode (default `0o755`).
+
+### `readdir(path)`
+
+Resolves to an array of entry names in the directory.
+
+### `stat(path)`
+
+Resolves to a `FileStats` object:
+- `name` — base name of the file.
+- `size` — size in bytes.
+- `mode` — file mode bits.
+- `modTime` — modification time as an ISO8601 string.
+- `isDir` — `true` if the entry is a directory.
+- `isFile` — `true` if the entry is a regular file.
+
+### `unlink(path)`
+
+Deletes a file.
+
+### `rename(oldPath, newPath)`
+
+Renames or moves a file or directory.
+
+### `copyFile(src, dst)`
+
+Copies a file from `src` to `dst`.
+
+### `rm(path, options?)`
+
+Removes a file or directory. `options` may include:
+- `recursive` — remove directories and their contents (default `false`).
+- `force` — do not throw when the path does not exist (default `false`).
+
+## Sync API
+
+Each async function has a synchronous counterpart:
+
+- `readFileSync(path, encoding?)` — returns string or Buffer.
+- `writeFileSync(path, data, options?)`
+- `appendFileSync(path, data, options?)`
+- `existsSync(path)` — returns boolean.
+- `mkdirSync(path, options?)`
+- `readdirSync(path)` — returns `string[]`.
+- `statSync(path)` — returns `FileStats`.
+- `unlinkSync(path)`
+- `renameSync(oldPath, newPath)`
+- `copyFileSync(src, dst)`
+- `rmSync(path, options?)`
+
+## Read-only backends
+
+For embedded assets, you can create a read-only `fs` module from a Go `embed.FS` or any `fs.FS`. This is useful for serving static files or asset bundles:
+
+```go
+assetsMod := fs.New(
+    fs.WithName("fs:assets"),
+    fs.WithBackend(fs.NewReadOnlyFSBackend(
+        fs.FSMount{FS: embedFS, Root: "app/public", Mount: "/"},
+    )),
+)
+```
+
+Read-only modules reject writes and return `EROFS` errors.
+
+## Troubleshooting
+
+| Problem | Cause | Solution |
+|---|---|---|
+| "fs module requires runtime services" panic | The module is used in a runtime without owner services | Build the engine with an owner-based runtime factory |
+| File not found inside embedded FS | Wrong mount root or virtual path | Use `cleanVirtualPath` logic and mount with matching prefixes |
+| Promises never resolve | Background goroutine blocked or runtime closed | Ensure the runtime context is alive and the owner event loop is running |

--- a/pkg/doc/25-os-module.md
+++ b/pkg/doc/25-os-module.md
@@ -1,0 +1,79 @@
+---
+Title: OS Module
+Slug: os-module
+Short: Inspect host operating system properties from JavaScript
+Topics:
+- os
+- modules
+- goja
+- javascript
+Commands:
+- goja-repl
+IsTopLevel: true
+IsTemplate: false
+ShowPerDefault: true
+SectionType: GeneralTopic
+---
+
+The `os` module exposes basic host operating system introspection helpers. It is aliased as both `os` and `node:os`. The module is read-only and safe to use in any runtime context.
+
+## JavaScript usage
+
+```javascript
+const os = require("os");
+
+console.log(os.platform());   // "linux", "darwin", "windows"...
+console.log(os.arch());       // "amd64", "arm64"...
+console.log(os.homedir());    // "/home/user"
+console.log(os.tmpdir());     // "/tmp"
+console.log(os.hostname());   // "my-machine"
+console.log(os.EOL);          // "\n" or "\r\n"
+
+const cpus = os.cpus();
+console.log(cpus.length);     // number of logical CPUs
+```
+
+## Module API
+
+### `homedir()`
+
+Returns the current user's home directory path.
+
+### `tmpdir()`
+
+Returns the default temporary directory path.
+
+### `platform()`
+
+Returns the Go operating system name (`runtime.GOOS`), such as `linux`, `darwin`, or `windows`.
+
+### `arch()`
+
+Returns the Go architecture name (`runtime.GOARCH`), such as `amd64` or `arm64`.
+
+### `hostname()`
+
+Returns the host name reported by the operating system.
+
+### `release()`
+
+Returns the same value as `platform()`. Provided for Node.js compatibility.
+
+### `type()`
+
+Returns the same value as `platform()`. Provided for Node.js compatibility.
+
+### `cpus()`
+
+Returns an array of CPU objects. The current implementation returns lightweight stubs with `model`, `speed`, and `times` fields so that generic Node.js code does not fail.
+
+### `os.EOL`
+
+A string constant: `\n` on Unix-like systems and `\r\n` on Windows.
+
+## Troubleshooting
+
+| Problem | Cause | Solution |
+|---|---|---|
+| `cpus()` array is empty | Zero logical processors reported by Go runtime | This is extremely unlikely; check the Go runtime environment |
+| `hostname()` returns an error | OS call fails | Verify process permissions for reading the host name |

--- a/pkg/doc/26-path-module.md
+++ b/pkg/doc/26-path-module.md
@@ -1,0 +1,89 @@
+---
+Title: Path Module
+Slug: path-module
+Short: Cross-platform filepath manipulation helpers
+Topics:
+- path
+- modules
+- goja
+- javascript
+Commands:
+- goja-repl
+IsTopLevel: true
+IsTemplate: false
+ShowPerDefault: true
+SectionType: GeneralTopic
+---
+
+The `path` module wraps Go's `path/filepath` package for host-platform path manipulation. It is aliased as both `path` and `node:path`. The separator and behavior match the operating system on which the runtime runs.
+
+## JavaScript usage
+
+```javascript
+const path = require("path");
+
+const full = path.join("/tmp", "demo", "file.txt");
+// "/tmp/demo/file.txt"
+
+const dir = path.dirname("/tmp/demo/file.txt");
+// "/tmp/demo"
+
+const base = path.basename("/tmp/demo/file.txt");
+// "file.txt"
+
+const ext = path.extname("/tmp/demo/file.txt");
+// ".txt"
+
+const abs = path.isAbsolute("/tmp/demo");
+// true
+
+const rel = path.relative("/tmp/demo", "/tmp/demo/output");
+// "output"
+
+const resolved = path.resolve("demo", ".."); // resolves against cwd
+```
+
+## Module API
+
+### `join(...parts)`
+
+Joins path elements into a single path using the OS-specific separator. Cleans up `..` and `.` segments.
+
+### `resolve(...parts)`
+
+Joins path elements and converts the result to an absolute path relative to the current working directory.
+
+### `dirname(path)`
+
+Returns the directory portion of `path`, excluding the final separator and file name.
+
+### `basename(path)`
+
+Returns the last element of `path`.
+
+### `extname(path)`
+
+Returns the file extension, including the leading dot. Returns an empty string when there is no extension.
+
+### `isAbsolute(path)`
+
+Returns `true` if `path` is absolute on the current platform.
+
+### `relative(from, to)`
+
+Returns the shortest relative path from `from` to `to`.
+
+### `path.separator`
+
+`string` — the OS path separator (`/` on Unix, `\` on Windows).
+
+### `path.delimiter`
+
+`string` — the OS path list delimiter (`:` on Unix, `;` on Windows).
+
+## Troubleshooting
+
+| Problem | Cause | Solution |
+|---|---|---|
+| Paths contain backslashes on Linux | The script assumes Windows separators | Use `path.join` instead of manual string concatenation |
+| `resolve()` returns unexpected root | No arguments provided | Call with explicit starting paths, or accept that it resolves against the process cwd |

--- a/pkg/doc/27-time-module.md
+++ b/pkg/doc/27-time-module.md
@@ -1,0 +1,54 @@
+---
+Title: Time Module
+Slug: time-module
+Short: Monotonic timing helpers for JavaScript-side performance measurements
+Topics:
+- time
+- modules
+- goja
+- javascript
+Commands:
+- goja-repl
+IsTopLevel: true
+IsTemplate: false
+ShowPerDefault: true
+SectionType: GeneralTopic
+---
+
+The `time` module provides lightweight monotonic clock helpers. It is not a wall-clock date library; it is designed for benchmarking and measuring elapsed intervals inside a Goja runtime.
+
+The counter starts when the module is first loaded into a runtime, so `now()` values are relative to that point.
+
+## JavaScript usage
+
+```javascript
+const time = require("time");
+
+const start = time.now();
+for (let i = 0; i < 100000; i++) {
+  Math.sqrt(i);
+}
+const elapsed = time.since(start);
+console.log(`took ${elapsed} ms`);
+```
+
+## Module API
+
+### `now()`
+
+Returns the number of milliseconds elapsed since the module was initialized in the current runtime. The value is a monotonic float and never decreases.
+
+### `since(startMs)`
+
+Given a previous value returned by `now()`, returns the delta in milliseconds. Equivalent to `now() - startMs` but expressed as a helper.
+
+## Design notes
+
+`time` uses Go's `time.Since` over a baseline recorded at module load time. This avoids the overhead and non-monotonic behavior of wall-clock date APIs. If you need calendar dates, format strings, or time zones, use JavaScript's built-in `Date` object instead.
+
+## Troubleshooting
+
+| Problem | Cause | Solution |
+|---|---|---|
+| Negative `since()` result | The `startMs` argument came from a different runtime instance | Capture `now()` inside the same runtime before measuring |
+| Very small `now()` values | The module was loaded seconds ago | This is expected; values are relative to module initialization |

--- a/pkg/doc/28-timer-module.md
+++ b/pkg/doc/28-timer-module.md
@@ -1,0 +1,53 @@
+---
+Title: Timer Module
+Slug: timer-module
+Short: Promise-based sleep and delay helpers
+Topics:
+- timer
+- modules
+- goja
+- javascript
+Commands:
+- goja-repl
+IsTopLevel: true
+IsTemplate: false
+ShowPerDefault: true
+SectionType: GeneralTopic
+---
+
+The `timer` module exposes a single Promise-based helper: `sleep`. It lets JavaScript code pause asynchronously without blocking the runtime owner goroutine.
+
+The module requires a runtime with owner services because the backing goroutine dispatches resolution back onto the goja runtime through the owner event loop.
+
+## JavaScript usage
+
+```javascript
+const timer = require("timer");
+
+async function delayedHello() {
+  await timer.sleep(500);
+  console.log("hello after 500 ms");
+}
+
+delayedHello();
+```
+
+## Module API
+
+### `sleep(ms)`
+
+Returns a Promise that resolves after `ms` milliseconds. The timer is canceled if either the owner call context or the runtime lifetime context ends before the delay completes.
+
+If `ms` is negative, the Promise rejects with an error string.
+
+## Design notes
+
+`sleep` is a thin wrapper around Go's `time.Timer` that sends its resolve call through the runtime owner's dispatch queue. This means the JavaScript Promise resolves on the correct goroutine and does not race with concurrent runtime access.
+
+## Troubleshooting
+
+| Problem | Cause | Solution |
+|---|---|---|
+| "timer module requires runtime services" panic | The runtime was built without owner-based services | Use a factory created with `engine.NewBuilder().Build()` rather than a bare `goja.New()` |
+| Promise never resolves after a long delay | The owner call context was canceled or timed out | Increase the context deadline on the owner call, or move the sleep to a longer-lived context |
+| Negative duration rejected | `ms < 0` | Pass a non-negative integer for the sleep duration |

--- a/pkg/xgoja/app/assets_test.go
+++ b/pkg/xgoja/app/assets_test.go
@@ -34,6 +34,37 @@ func TestAssetStoreResolveAsset(t *testing.T) {
 	}
 }
 
+func TestRuntimeFactoryPassesRuntimeOwnerToModules(t *testing.T) {
+	spec := &Spec{
+		Runtimes: map[string]Runtime{
+			"main": {Modules: []ModuleInstance{{Package: "fixture", Name: "owner-check", As: "owner-check"}}},
+		},
+	}
+	seen := false
+	registry := providerapi.NewRegistry()
+	if err := registry.Package("fixture", providerapi.Module{
+		Name: "owner-check",
+		New: func(ctx providerapi.ModuleContext) (require.ModuleLoader, error) {
+			if ctx.RuntimeOwner == nil {
+				t.Fatalf("expected module context runtime owner")
+			}
+			seen = true
+			return func(vm *goja.Runtime, module *goja.Object) {}, nil
+		},
+	}); err != nil {
+		t.Fatalf("register provider: %v", err)
+	}
+
+	rt, err := NewRuntimeFactory(registry, spec).NewRuntime(context.Background(), "main")
+	if err != nil {
+		t.Fatalf("new runtime: %v", err)
+	}
+	defer func() { _ = rt.Close(context.Background()) }()
+	if !seen {
+		t.Fatal("module factory did not observe runtime owner")
+	}
+}
+
 func TestRuntimeFactoryPassesHostServicesToModules(t *testing.T) {
 	assetFS := fstest.MapFS{
 		"xgoja_embed/assets/app/config.json": &fstest.MapFile{Data: []byte(`{"ok":true}`)},

--- a/pkg/xgoja/app/factory.go
+++ b/pkg/xgoja/app/factory.go
@@ -37,11 +37,12 @@ func (s providerRuntimeModuleSpec) RegisterRuntimeModule(ctx *engine.RuntimeModu
 		return fmt.Errorf("marshal config for %s.%s: %w", s.instance.Package, s.instance.Name, err)
 	}
 	loader, err := s.module.New(providerapi.ModuleContext{
-		Context: ctx.Context,
-		Name:    s.instance.Name,
-		As:      s.instance.Alias(),
-		Config:  config,
-		Host:    s.services,
+		Context:      ctx.Context,
+		Name:         s.instance.Name,
+		As:           s.instance.Alias(),
+		Config:       config,
+		Host:         s.services,
+		RuntimeOwner: ctx.Owner,
 	})
 	if err != nil {
 		return fmt.Errorf("create module %s.%s: %w", s.instance.Package, s.instance.Name, err)

--- a/pkg/xgoja/providerapi/module.go
+++ b/pkg/xgoja/providerapi/module.go
@@ -6,16 +6,18 @@ import (
 	"io/fs"
 
 	"github.com/dop251/goja_nodejs/require"
+	"github.com/go-go-golems/go-go-goja/pkg/runtimeowner"
 )
 
 type ModuleFactory func(ModuleContext) (require.ModuleLoader, error)
 
 type ModuleContext struct {
-	Context context.Context
-	Name    string
-	As      string
-	Config  json.RawMessage
-	Host    HostServices
+	Context      context.Context
+	Name         string
+	As           string
+	Config       json.RawMessage
+	Host         HostServices
+	RuntimeOwner runtimeowner.RuntimeOwner
 }
 
 type AssetResolver interface {


### PR DESCRIPTION
This change introduces comprehensive documentation for several core Goja modules,
making them easier for developers to discover and use.

New documentation has been added for the following modules:
- `db` / `database`
- `crypto`
- `events`
- `exec`
- `fs`
- `os`
- `path`
- `time`
- `timer`

Each document provides details on:
- Go-side setup and configuration.
- JavaScript API and usage examples.
- Common troubleshooting steps.

The new documentation files are embedded into the binary, and tests have been
updated to ensure they are correctly included.