### PR TITLE
feat(xgoja): Add http 'serve' command provider for jsverbs

### DIFF
--- a/cmd/xgoja/doc/01-overview.md
+++ b/cmd/xgoja/doc/01-overview.md
@@ -88,6 +88,8 @@ A pure xgoja generated binary currently provides these command families:
 - `modules` lists provider modules registered in the binary.
 - the configured `jsverbs` command mounts JavaScript functions as Glazed/Cobra commands when enabled.
 
+Provider packages can also contribute command families. For example, the HTTP provider can mount `serve` commands that run JavaScript verbs as long-lived Express site setup functions.
+
 Existing applications can also use xgoja in target modes that attach these generated commands to a Cobra root or delegate integration to an adapter package.
 
 ## When to use xgoja
@@ -101,3 +103,4 @@ Do not use `xgoja` as a dynamic Go plugin loader. The reliable extension boundar
 - `buildspec` for the YAML reference.
 - `tutorial` for an end-to-end build flow.
 - `tutorial-static-assets-http-server` for embedding and serving bundled static web assets.
+- `tutorial-http-serve-jsverbs` for serving Express routes registered by generated JavaScript verbs.

--- a/cmd/xgoja/doc/02-user-guide.md
+++ b/cmd/xgoja/doc/02-user-guide.md
@@ -401,6 +401,8 @@ Long-running scripts, such as Express-style HTTP servers, can use the generated 
 
 See `examples/xgoja/10-embedded-assets-fs` and `xgoja help tutorial-static-assets-http-server` for a static-site example that passes `require("fs:assets")` directly to `require("express").app().staticFromAssetsModule("/static", assets, "/app/public")`, so embedded assets are served without a host staging directory.
 
+Generated binaries can also expose HTTP setup functions as JavaScript verbs by enabling the HTTP provider's `serve` command provider. In that mode, `./dist/my-app serve sites demo --http-listen 127.0.0.1:8787` invokes the selected verb once, then keeps the runtime alive for request handling. See `examples/xgoja/13-http-serve-jsverbs` and `xgoja help tutorial-http-serve-jsverbs`.
+
 ## JavaScript verb sources
 
 `jsverbs` supports three distinct source modes.

--- a/cmd/xgoja/doc/06-buildspec-reference.md
+++ b/cmd/xgoja/doc/06-buildspec-reference.md
@@ -136,6 +136,21 @@ app.staticFromAssetsModule("/static", assets, "/app/public")
 
 Use `run --keep-alive` for server setup scripts so the runtime stays alive after route registration. See `examples/xgoja/10-embedded-assets-fs` and `xgoja help tutorial-static-assets-http-server`.
 
+To expose HTTP setup functions as generated JavaScript verb commands, add the HTTP provider's `serve` command provider and configure jsverb sources:
+
+```yaml
+command_providers:
+  - id: http-serve
+    package: go-go-goja-http
+    name: serve
+    mount: serve
+jsverbs:
+  - id: local
+    path: verbs
+```
+
+The resulting generated command shape is `./dist/app serve <package> <verb> --http-listen 127.0.0.1:8787`. The selected verb registers Express routes and the provider-backed command keeps the runtime alive. See `examples/xgoja/13-http-serve-jsverbs` and `xgoja help tutorial-http-serve-jsverbs`.
+
 Generated binaries can opt into Glazed-style environment variable parsing with `appName` or `envPrefix`:
 
 ```yaml

--- a/cmd/xgoja/doc/12-tutorial-http-serve-jsverbs.md
+++ b/cmd/xgoja/doc/12-tutorial-http-serve-jsverbs.md
@@ -1,0 +1,150 @@
+---
+Title: "Tutorial: HTTP serve commands for JavaScript verbs"
+Slug: tutorial-http-serve-jsverbs
+Short: "Build a generated xgoja binary whose provider-backed serve command runs JavaScript verbs as HTTP site setup functions."
+Topics:
+- xgoja
+- tutorial
+- jsverbs
+- http
+- express
+Commands:
+- xgoja build
+- xgoja doctor
+- xgoja list-modules
+Flags:
+- --http-listen
+IsTopLevel: true
+IsTemplate: false
+ShowPerDefault: true
+SectionType: Tutorial
+---
+
+This tutorial builds a generated xgoja binary that exposes HTTP site setup functions as JavaScript verbs.
+
+The generated command shape is:
+
+```bash
+./dist/http-serve-jsverbs serve sites demo --http-listen 127.0.0.1:8787
+```
+
+The `serve` command is contributed by the `go-go-goja-http` provider. It scans the configured `jsverbs:` sources, creates commands from the discovered verb metadata, invokes the selected verb once, and keeps the runtime alive until Ctrl-C or SIGTERM. The selected verb should register routes through `require("express")`.
+
+This is different from the built-in `verbs` command. `verbs sites demo` runs the JavaScript function as a short-lived CLI command and closes the runtime after the function returns. `serve sites demo` treats the function as HTTP setup code and keeps the runtime alive for request handling.
+
+## 1. Create the JavaScript verb
+
+Create `verbs/sites.js`:
+
+```js
+__package__({ name: "sites" })
+__verb__("demo", { name: "demo", output: "text", short: "Serve demo site" })
+function demo() {
+  const express = require("express")
+  const app = express.app()
+
+  app.get("/", (_req, res) => res.send("hello from an xgoja jsverb site"))
+  app.get("/healthz", (_req, res) => res.json({ ok: true, site: "demo" }))
+}
+```
+
+The function registers routes and then returns. It does not need to block. The provider-backed `serve` command owns the blocking lifecycle.
+
+## 2. Write xgoja.yaml
+
+Enable the HTTP provider package, select the `express` module in the top-level module list, configure the `serve` command provider, and point `jsverbs:` at the verb directory:
+
+```yaml
+name: http-serve-jsverbs
+target:
+  kind: xgoja
+  output: dist/http-serve-jsverbs
+packages:
+  - id: go-go-goja-http
+    import: github.com/go-go-golems/go-go-goja/pkg/xgoja/providers/http
+    register: Register
+modules:
+  - package: go-go-goja-http
+    name: express
+    as: express
+commands:
+  jsverbs:
+    enabled: true
+    name: verbs
+command_providers:
+  - id: http-serve
+    package: go-go-goja-http
+    name: serve
+    mount: serve
+jsverbs:
+  - id: local
+    path: verbs
+```
+
+The single top-level `modules:` list is the module set used by generated commands and provider commands. There is no separate runtime profile selection for this mode.
+
+## 3. Validate, build, and run
+
+Validate and inspect the module set:
+
+```bash
+xgoja doctor -f xgoja.yaml
+xgoja list-modules -f xgoja.yaml
+```
+
+Build:
+
+```bash
+xgoja build -f xgoja.yaml --keep-work
+```
+
+Run the HTTP setup verb:
+
+```bash
+./dist/http-serve-jsverbs serve sites demo --http-listen 127.0.0.1:8787
+```
+
+Open:
+
+```text
+http://127.0.0.1:8787/
+http://127.0.0.1:8787/healthz
+```
+
+Stop the server with Ctrl-C.
+
+## 4. Compare the three HTTP execution modes
+
+| Mode | Command shape | Runtime lifetime | Use when |
+| --- | --- | --- | --- |
+| Short-lived verb | `./dist/app verbs sites demo` | Closes after the verb returns | The verb is a normal CLI command. |
+| Script server | `./dist/app run scripts/server.js --http-listen ... --keep-alive` | Kept alive by the built-in `run` command | The server setup is a script file. |
+| Verb server | `./dist/app serve sites demo --http-listen ...` | Kept alive by the HTTP provider's `serve` command | The server setup should be discoverable as a generated jsverb command. |
+
+Use `run --keep-alive` for standalone setup scripts. Use provider-backed `serve` when the route setup should be part of the generated verb command tree.
+
+## 5. Runnable repository example
+
+The repository contains a complete smoke-tested version at:
+
+```text
+examples/xgoja/13-http-serve-jsverbs
+```
+
+Run it with:
+
+```bash
+make -C examples/xgoja/13-http-serve-jsverbs smoke
+```
+
+That target builds the generated binary, starts `serve sites demo` on a test port, fetches the HTML and health endpoints with `curl`, and stops the process.
+
+## Troubleshooting
+
+| Problem | What to check |
+| --- | --- |
+| `Cannot find module 'express'` | Add `go-go-goja-http` to `packages:` and select `name: express` in `modules:`. |
+| No `serve` command exists | Add a `command_providers:` entry with `package: go-go-goja-http`, `name: serve`, and `mount: serve`. |
+| No `serve sites demo` command exists | Confirm the `jsverbs:` path points at the directory containing `sites.js` and that the file scans correctly. |
+| Server exits immediately when using `verbs` | Use `serve sites demo`; the built-in `verbs` command is intentionally short-lived. |
+| Address is already in use | Change `--http-listen` or stop the process currently bound to that address. The HTTP provider reports listen failures during startup. |

--- a/cmd/xgoja/internal/generate/generate_test.go
+++ b/cmd/xgoja/internal/generate/generate_test.go
@@ -1,13 +1,18 @@
 package generate
 
 import (
+	"context"
 	"encoding/json"
+	"io"
+	"net"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-go-golems/go-go-goja/cmd/xgoja/internal/buildspec"
 	"github.com/go-go-golems/go-go-goja/pkg/xgoja/app"
@@ -468,6 +473,73 @@ function embeddedGreet(name) {
 	}
 }
 
+func TestGeneratedProgramServesHTTPVerb(t *testing.T) {
+	baseDir := t.TempDir()
+	verbsDir := filepath.Join(baseDir, "verbs")
+	if err := os.MkdirAll(verbsDir, 0o755); err != nil {
+		t.Fatalf("mkdir verbs: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(verbsDir, "sites.js"), []byte(`
+__package__({ name: "sites" })
+__verb__("demo", { name: "demo", output: "text", short: "Serve demo" })
+function demo() {
+  const express = require("express")
+  const app = express.app()
+  app.get("/healthz", (_req, res) => res.json({ ok: true, source: "jsverb" }))
+}
+`), 0o644); err != nil {
+		t.Fatalf("write verb: %v", err)
+	}
+	buildSpec := &buildspec.BuildSpec{
+		Name:    "http-serve-verb",
+		Go:      buildspec.GoSpec{Version: "1.26", Module: "example.com/generated/http-serve-verb"},
+		Target:  buildspec.TargetSpec{Kind: "xgoja", Output: "dist/http-serve-verb"},
+		BaseDir: baseDir,
+		Packages: []buildspec.PackageSpec{{
+			ID:       "go-go-goja-http",
+			Import:   "github.com/go-go-golems/go-go-goja/pkg/xgoja/providers/http",
+			Register: "Register",
+		}},
+		Modules: []buildspec.ModuleInstanceSpec{{Package: "go-go-goja-http", Name: "express", As: "express"}},
+		Commands: buildspec.CommandsSpec{
+			JSVerbs: buildspec.CommandSpec{Enabled: true, Name: "verbs"},
+		},
+		CommandProviders: []buildspec.CommandProviderInstanceSpec{{
+			ID:      "http-serve",
+			Package: "go-go-goja-http",
+			Name:    "serve",
+			Mount:   "serve",
+		}},
+		JSVerbs: []buildspec.JSVerbSourceSpec{{ID: "local", Path: verbsDir}},
+	}
+	addr := freeTCPAddr(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cmd, dir := startGeneratedCommand(t, ctx, buildSpec, "serve", "sites", "demo", "--http-listen", addr)
+	url := "http://" + addr + "/healthz"
+	var body string
+	for i := 0; i < 80; i++ {
+		resp, err := http.Get(url)
+		if err == nil {
+			data, readErr := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			if readErr == nil && resp.StatusCode == http.StatusOK {
+				body = string(data)
+				break
+			}
+		}
+		if cmd.ProcessState != nil && cmd.ProcessState.Exited() {
+			t.Fatalf("generated serve command exited early")
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if !strings.Contains(body, `"ok":true`) || !strings.Contains(body, `"source":"jsverb"`) {
+		t.Fatalf("unexpected health response from %s in %s: %q", url, dir, body)
+	}
+	cancel()
+	_ = cmd.Wait()
+}
+
 func TestGeneratedProgramReadsEmbeddedAssetsThroughFSAliases(t *testing.T) {
 	baseDir := t.TempDir()
 	assetDir := filepath.Join(baseDir, "assets", "config")
@@ -609,6 +681,48 @@ func runGeneratedCommand(t *testing.T, buildSpec *buildspec.BuildSpec, args ...s
 	t.Helper()
 	dir, _ := runGeneratedCommandWithOutput(t, buildSpec, args...)
 	return dir
+}
+
+func startGeneratedCommand(t *testing.T, ctx context.Context, buildSpec *buildspec.BuildSpec, args ...string) (*exec.Cmd, string) {
+	t.Helper()
+	repoRoot, err := filepath.Abs("../../../..")
+	if err != nil {
+		t.Fatalf("repo root: %v", err)
+	}
+	dir := t.TempDir()
+	if err := WriteAll(dir, buildSpec, Options{XGojaModuleVersion: "v0.0.0", XGojaReplace: repoRoot}); err != nil {
+		t.Fatalf("write generated program: %v", err)
+	}
+	cmd := exec.Command("go", "mod", "tidy")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("go mod tidy: %v\n%s", err, out)
+	}
+	binPath := filepath.Join(dir, "generated-test")
+	cmd = exec.Command("go", "build", "-o", binPath, ".")
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GOWORK=off")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("go build generated program: %v\n%s", err, out)
+	}
+	cmd = exec.CommandContext(ctx, binPath, args...)
+	cmd.Dir = dir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start generated command: %v", err)
+	}
+	return cmd, dir
+}
+
+func freeTCPAddr(t *testing.T) string {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen free tcp addr: %v", err)
+	}
+	defer func() { _ = listener.Close() }()
+	return listener.Addr().String()
 }
 
 func runGeneratedCommandWithOutput(t *testing.T, buildSpec *buildspec.BuildSpec, args ...string) (string, []byte) {

--- a/examples/xgoja/13-http-serve-jsverbs/Makefile
+++ b/examples/xgoja/13-http-serve-jsverbs/Makefile
@@ -1,0 +1,36 @@
+.DEFAULT_GOAL := smoke
+
+REPO_ROOT := $(abspath ../../..)
+BIN := $(CURDIR)/dist/http-serve-jsverbs
+XGOJA := cd $(REPO_ROOT) && GOWORK=off go run ./cmd/xgoja
+HTTP_ADDR := 127.0.0.1:18788
+
+.PHONY: smoke doctor build serve-smoke clean
+
+smoke: doctor build serve-smoke
+
+doctor:
+	$(XGOJA) doctor -f $(CURDIR)/xgoja.yaml
+
+build:
+	$(XGOJA) build -f $(CURDIR)/xgoja.yaml --output $(BIN) --xgoja-replace $(REPO_ROOT) --keep-work
+
+serve-smoke: build
+	@set -eu; \
+	log=$$(mktemp); \
+	$(BIN) serve sites demo --http-listen $(HTTP_ADDR) >$$log 2>&1 & \
+	pid=$$!; \
+	trap 'kill $$pid >/dev/null 2>&1 || true; wait $$pid >/dev/null 2>&1 || true; rm -f $$log' EXIT; \
+	for i in $$(seq 1 80); do \
+		if curl -fsS http://$(HTTP_ADDR)/healthz >/tmp/xgoja-http-serve-health.json 2>/dev/null; then break; fi; \
+		if ! kill -0 $$pid >/dev/null 2>&1; then cat $$log; exit 1; fi; \
+		sleep 0.1; \
+	done; \
+	grep -q '"ok":true' /tmp/xgoja-http-serve-health.json; \
+	grep -q '"site":"demo"' /tmp/xgoja-http-serve-health.json; \
+	curl -fsS http://$(HTTP_ADDR)/ | grep -q 'hello from an xgoja jsverb site'; \
+	kill $$pid >/dev/null 2>&1 || true; \
+	wait $$pid >/dev/null 2>&1 || true
+
+clean:
+	rm -rf $(CURDIR)/dist

--- a/examples/xgoja/13-http-serve-jsverbs/README.md
+++ b/examples/xgoja/13-http-serve-jsverbs/README.md
@@ -1,0 +1,40 @@
+# xgoja HTTP serve jsverbs example
+
+This example builds a generated xgoja binary that exposes a provider-backed
+`serve` command from `go-go-goja-http`. The command mirrors configured
+JavaScript verbs, invokes the selected verb once to register Express routes, and
+keeps the runtime alive until the process is stopped.
+
+The site setup verb lives in `verbs/sites.js`:
+
+```js
+__package__({ name: "sites" })
+__verb__("demo", { name: "demo", output: "text" })
+function demo() {
+  const express = require("express")
+  const app = express.app()
+  app.get("/", (_req, res) => res.send("hello from an xgoja jsverb site"))
+  app.get("/healthz", (_req, res) => res.json({ ok: true, site: "demo" }))
+}
+```
+
+Run the smoke test:
+
+```bash
+make -C examples/xgoja/13-http-serve-jsverbs smoke
+```
+
+Manual run:
+
+```bash
+make -C examples/xgoja/13-http-serve-jsverbs build
+./examples/xgoja/13-http-serve-jsverbs/dist/http-serve-jsverbs \
+  serve sites demo --http-listen 127.0.0.1:8787
+```
+
+Then open:
+
+- <http://127.0.0.1:8787/>
+- <http://127.0.0.1:8787/healthz>
+
+Stop the server with Ctrl-C.

--- a/examples/xgoja/13-http-serve-jsverbs/verbs/sites.js
+++ b/examples/xgoja/13-http-serve-jsverbs/verbs/sites.js
@@ -1,0 +1,15 @@
+__package__({ name: "sites", short: "HTTP site setup verbs" })
+
+__verb__("demo", {
+  name: "demo",
+  output: "text",
+  short: "Serve a tiny Express-backed demo site",
+  tags: ["http", "site"]
+})
+function demo() {
+  const express = require("express")
+  const app = express.app()
+
+  app.get("/", (_req, res) => res.send("hello from an xgoja jsverb site"))
+  app.get("/healthz", (_req, res) => res.json({ ok: true, site: "demo" }))
+}

--- a/examples/xgoja/13-http-serve-jsverbs/xgoja.yaml
+++ b/examples/xgoja/13-http-serve-jsverbs/xgoja.yaml
@@ -1,0 +1,29 @@
+name: http-serve-jsverbs
+target:
+  kind: xgoja
+  output: dist/http-serve-jsverbs
+packages:
+  - id: go-go-goja-http
+    import: github.com/go-go-golems/go-go-goja/pkg/xgoja/providers/http
+modules:
+  - package: go-go-goja-http
+    name: express
+commands:
+  jsverbs:
+    enabled: true
+    name: verbs
+  eval:
+    enabled: false
+  run:
+    enabled: false
+  repl:
+    enabled: false
+commandProviders:
+  - id: http-serve
+    package: go-go-goja-http
+    name: serve
+    mount: serve
+jsverbs:
+  - id: local-sites
+    path: ./verbs
+    embed: true

--- a/examples/xgoja/README.md
+++ b/examples/xgoja/README.md
@@ -18,6 +18,7 @@ Each example directory has its own `README.md`, `Makefile`, and `xgoja.yaml`. St
 10. `10-embedded-assets-fs/` — local files are embedded into the generated binary and read through `require("fs:assets")`, while host writes use `require("fs:host")`.
 11. `11-config-env/` — generated binaries read Glazed config files and environment variables according to `appName`, `envPrefix`, and `config` settings.
 12. `12-geppetto-host-services/` — generated Geppetto jsverbs use profile flags, a SQLite turn store, contributed Go tools, contributed Go middleware, and a JSONL event sink.
+13. `13-http-serve-jsverbs/` — the HTTP provider contributes a `serve` command that keeps a jsverb-registered Express site alive.
 
 The Discord bot xgoja example lives in the sibling `discord-bot` repository because it demonstrates inserting xgoja into an existing host-owned runner rather than a standalone generated binary.
 
@@ -34,7 +35,8 @@ for dir in \
   07-embedded-jsverbs \
   08-provider-shipped-jsverbs \
   09-provider-shipped-help-docs \
-  10-embedded-assets-fs; do
+  10-embedded-assets-fs \
+  13-http-serve-jsverbs; do
   make -C examples/xgoja/$dir smoke
 done
 ```

--- a/pkg/xgoja/app/command_providers.go
+++ b/pkg/xgoja/app/command_providers.go
@@ -74,6 +74,7 @@ func (h *Host) newCommandSet(instance CommandProviderInstanceSpec, provider prov
 		Providers:       h.Providers,
 		RuntimeFactory:  h.Factory,
 		SelectedModules: selected,
+		JSVerbs:         newJSVerbSourceSet(h.Providers, h.EmbeddedJSVerbs, h.RuntimeSpec.JSVerbs),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create command set %s.%s: %w", instance.Package, instance.Name, err)

--- a/pkg/xgoja/app/command_providers_test.go
+++ b/pkg/xgoja/app/command_providers_test.go
@@ -2,6 +2,8 @@ package app
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/go-go-golems/glazed/pkg/cmds"
@@ -80,6 +82,55 @@ func TestHostAttachCommandProvidersPassesSelectedModules(t *testing.T) {
 	if err := root.ExecuteContext(context.Background()); err != nil {
 		t.Fatalf("execute command provider command: %v", err)
 	}
+}
+
+func TestHostAttachCommandProvidersProvidesJSVerbSources(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "tools.js"), []byte(`
+__package__({ name: "tools" });
+__verb__("hello", { name: "hello", short: "Hello", output: "text" });
+function hello() { return "hello"; }
+`), 0o644); err != nil {
+		t.Fatalf("write jsverb: %v", err)
+	}
+	registry := providerapi.NewProviderRegistry()
+	if err := registry.Package("fixture",
+		providerapi.CommandSetProvider{
+			Name: "tools",
+			NewCommandSet: func(ctx providerapi.CommandSetContext) (*providerapi.CommandSet, error) {
+				if ctx.JSVerbs == nil {
+					t.Fatal("expected jsverb source set")
+				}
+				sources := ctx.JSVerbs.ListJSVerbSources()
+				if len(sources) != 1 || sources[0].ID != "local" {
+					t.Fatalf("sources = %#v", sources)
+				}
+				registries, err := ctx.JSVerbs.ScanAllJSVerbSources()
+				if err != nil {
+					t.Fatalf("scan all jsverb sources: %v", err)
+				}
+				if len(registries) != 1 || len(registries[0].Verbs()) != 1 {
+					t.Fatalf("registries = %#v", registries)
+				}
+				return &providerapi.CommandSet{Commands: []cmds.Command{&fixtureBareCommand{
+					CommandDescription: cmds.NewCommandDescription("ping", cmds.WithShort("Ping")),
+					run:                func(context.Context, *values.Values) error { return nil },
+				}}}, nil
+			},
+		},
+	); err != nil {
+		t.Fatalf("register provider: %v", err)
+	}
+	runtimeSpec := &RuntimeSpec{
+		JSVerbs: []JSVerbSourceSpec{{ID: "local", Path: dir}},
+		CommandProviders: []CommandProviderInstanceSpec{{
+			ID:      "fixture-tools",
+			Package: "fixture",
+			Name:    "tools",
+		}},
+	}
+	root := &cobra.Command{Use: "test"}
+	NewHost(registry, runtimeSpec).AttachDefaultCommands(root)
 }
 
 func TestHostAttachCommandProvidersMountsGlazedCommand(t *testing.T) {

--- a/pkg/xgoja/app/jsverb_sources.go
+++ b/pkg/xgoja/app/jsverb_sources.go
@@ -1,0 +1,76 @@
+package app
+
+import (
+	"fmt"
+	"io/fs"
+	"strings"
+
+	"github.com/go-go-golems/go-go-goja/pkg/jsverbs"
+	"github.com/go-go-golems/go-go-goja/pkg/xgoja/providerapi"
+)
+
+type jsVerbSourceSet struct {
+	providers       *providerapi.ProviderRegistry
+	embeddedJSVerbs fs.FS
+	sources         []JSVerbSourceSpec
+}
+
+func newJSVerbSourceSet(providers *providerapi.ProviderRegistry, embeddedJSVerbs fs.FS, sources []JSVerbSourceSpec) *jsVerbSourceSet {
+	return &jsVerbSourceSet{
+		providers:       providers,
+		embeddedJSVerbs: embeddedJSVerbs,
+		sources:         append([]JSVerbSourceSpec(nil), sources...),
+	}
+}
+
+func (s *jsVerbSourceSet) ListJSVerbSources() []providerapi.JSVerbSourceDescriptor {
+	if s == nil || len(s.sources) == 0 {
+		return nil
+	}
+	out := make([]providerapi.JSVerbSourceDescriptor, 0, len(s.sources))
+	for _, source := range s.sources {
+		out = append(out, providerapi.JSVerbSourceDescriptor{
+			ID:      source.ID,
+			Path:    source.Path,
+			Embed:   source.Embed,
+			Package: source.Package,
+			Source:  source.Source,
+		})
+	}
+	return out
+}
+
+func (s *jsVerbSourceSet) ScanJSVerbSource(id string) (*jsverbs.Registry, error) {
+	if s == nil {
+		return nil, fmt.Errorf("jsverb source set is nil")
+	}
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return nil, fmt.Errorf("jsverb source id is required")
+	}
+	for _, source := range s.sources {
+		if source.ID != id {
+			continue
+		}
+		return scanVerbSource(s.providers, s.embeddedJSVerbs, source)
+	}
+	return nil, fmt.Errorf("unknown jsverb source %q", id)
+}
+
+func (s *jsVerbSourceSet) ScanAllJSVerbSources() ([]*jsverbs.Registry, error) {
+	if s == nil || len(s.sources) == 0 {
+		return nil, nil
+	}
+	registries := make([]*jsverbs.Registry, 0, len(s.sources))
+	for _, source := range s.sources {
+		registry, err := scanVerbSource(s.providers, s.embeddedJSVerbs, source)
+		if err != nil {
+			return nil, err
+		}
+		if registry == nil {
+			continue
+		}
+		registries = append(registries, registry)
+	}
+	return registries, nil
+}

--- a/pkg/xgoja/providerapi/commands.go
+++ b/pkg/xgoja/providerapi/commands.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-go-golems/glazed/pkg/cmds"
 	"github.com/go-go-golems/glazed/pkg/cmds/values"
 	"github.com/go-go-golems/go-go-goja/pkg/engine"
+	"github.com/go-go-golems/go-go-goja/pkg/jsverbs"
 )
 
 // RuntimeFactory creates xgoja runtimes from the generated binary's single
@@ -20,6 +21,25 @@ import (
 type RuntimeFactory interface {
 	NewRuntime(ctx context.Context, opts ...require.Option) (*engine.Runtime, error)
 	NewRuntimeFromSections(ctx context.Context, vals *values.Values, opts ...require.Option) (*engine.Runtime, error)
+}
+
+// JSVerbSourceDescriptor describes one configured JavaScript verb source in the
+// generated binary's runtime spec.
+type JSVerbSourceDescriptor struct {
+	ID      string
+	Path    string
+	Embed   bool
+	Package string
+	Source  string
+}
+
+// JSVerbSourceSet lets command providers discover and scan the JavaScript verb
+// sources configured for the generated binary. Providers should use this instead
+// of reimplementing local, embedded, and provider-shipped source resolution.
+type JSVerbSourceSet interface {
+	ListJSVerbSources() []JSVerbSourceDescriptor
+	ScanJSVerbSource(id string) (*jsverbs.Registry, error)
+	ScanAllJSVerbSources() ([]*jsverbs.Registry, error)
 }
 
 // CommandSetContext is passed to command set providers when generated xgoja
@@ -34,6 +54,7 @@ type CommandSetContext struct {
 	Providers       *ProviderRegistry
 	RuntimeFactory  RuntimeFactory
 	SelectedModules []ModuleDescriptor
+	JSVerbs         JSVerbSourceSet
 }
 
 // CommandSetProvider registers a package-owned command factory.

--- a/pkg/xgoja/providers/http/http.go
+++ b/pkg/xgoja/providers/http/http.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	stdhttp "net/http"
 	"strings"
 	"sync"
@@ -147,10 +148,14 @@ func (c *capability) start(vm *goja.Runtime, entry *runtimeEntry) error {
 	if entry.server != nil {
 		return nil
 	}
+	listener, err := net.Listen("tcp", cfg.Listen)
+	if err != nil {
+		return fmt.Errorf("listen on %s: %w", cfg.Listen, err)
+	}
 	server := &stdhttp.Server{Addr: cfg.Listen, Handler: entry.host, ReadHeaderTimeout: 5 * time.Second}
 	entry.server = server
 	go func() {
-		if err := server.ListenAndServe(); err != nil && !errors.Is(err, stdhttp.ErrServerClosed) {
+		if err := server.Serve(listener); err != nil && !errors.Is(err, stdhttp.ErrServerClosed) {
 			fmt.Printf("xgoja http server failed on %s: %v\n", cfg.Listen, err)
 		}
 	}()

--- a/pkg/xgoja/providers/http/http.go
+++ b/pkg/xgoja/providers/http/http.go
@@ -33,6 +33,14 @@ func Register(registry *providerapi.ProviderRegistry) error {
 			},
 		},
 		providerapi.WithPackageCapability(capability),
+		providerapi.CommandSetProvider{
+			Name:         "serve",
+			DefaultMount: "serve",
+			Description:  "Serve JavaScript verb-backed HTTP sites",
+			NewCommandSet: func(ctx providerapi.CommandSetContext) (*providerapi.CommandSet, error) {
+				return newServeCommandSet(ctx)
+			},
+		},
 	)
 }
 

--- a/pkg/xgoja/providers/http/http_test.go
+++ b/pkg/xgoja/providers/http/http_test.go
@@ -19,6 +19,9 @@ func TestRegister(t *testing.T) {
 	if _, ok := registry.ResolveModule(PackageID, "express"); !ok {
 		t.Fatal("expected express module")
 	}
+	if _, ok := registry.ResolveCommandSetProvider(PackageID, "serve"); !ok {
+		t.Fatal("expected serve command provider")
+	}
 	caps, ok := registry.ResolvePackageCapabilities(PackageID)
 	if !ok || len(caps) != 1 {
 		t.Fatalf("capabilities = %#v ok=%v", caps, ok)

--- a/pkg/xgoja/providers/http/http_test.go
+++ b/pkg/xgoja/providers/http/http_test.go
@@ -2,6 +2,8 @@ package http
 
 import (
 	"context"
+	"net"
+	"strings"
 	"testing"
 
 	"github.com/dop251/goja"
@@ -90,6 +92,29 @@ func TestCapabilityAllowsExplicitHTTPDisable(t *testing.T) {
 	defer entry.mu.Unlock()
 	if entry.settings.Enabled || entry.settings.Listen != "127.0.0.1:9999" {
 		t.Fatalf("settings = %#v", entry.settings)
+	}
+}
+
+func TestCapabilityStartReportsPortConflictsSynchronously(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve listen address: %v", err)
+	}
+	defer func() { _ = listener.Close() }()
+
+	capability := newHTTPCapability()
+	vm := goja.New()
+	entry := capability.entry(vm)
+	entry.mu.Lock()
+	entry.settings = settings{Enabled: true, Listen: listener.Addr().String()}
+	entry.mu.Unlock()
+
+	err = capability.start(vm, entry)
+	if err == nil {
+		t.Fatal("expected port conflict error")
+	}
+	if !strings.Contains(err.Error(), "listen on ") {
+		t.Fatalf("expected listen error, got %v", err)
 	}
 }
 

--- a/pkg/xgoja/providers/http/serve.go
+++ b/pkg/xgoja/providers/http/serve.go
@@ -1,0 +1,132 @@
+package http
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/dop251/goja_nodejs/require"
+	"github.com/go-go-golems/glazed/pkg/cmds"
+	"github.com/go-go-golems/glazed/pkg/cmds/schema"
+	"github.com/go-go-golems/glazed/pkg/cmds/values"
+	"github.com/go-go-golems/go-go-goja/pkg/engine"
+	"github.com/go-go-golems/go-go-goja/pkg/jsverbs"
+	"github.com/go-go-golems/go-go-goja/pkg/xgoja/providerapi"
+	"github.com/go-go-golems/go-go-goja/pkg/xgoja/providerutil"
+)
+
+func newServeCommandSet(ctx providerapi.CommandSetContext) (*providerapi.CommandSet, error) {
+	if ctx.JSVerbs == nil {
+		return nil, fmt.Errorf("http serve command requires configured jsverb sources")
+	}
+	if ctx.RuntimeFactory == nil {
+		return nil, fmt.Errorf("http serve command requires runtime factory")
+	}
+
+	sections, err := providerutil.CollectGlazedConfigSections(ctx.SelectedModules, providerapi.SectionRequest{
+		CommandProviderID: ctx.Name,
+	}, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	registries, err := ctx.JSVerbs.ScanAllJSVerbSources()
+	if err != nil {
+		return nil, err
+	}
+	commands := make([]cmds.Command, 0)
+	for _, registry := range registries {
+		if registry == nil {
+			continue
+		}
+		for _, verb := range registry.Verbs() {
+			verb := verb
+			registry := registry
+			cmd, err := registry.CommandForVerbWithInvoker(verb, func(runCtx context.Context, _ *jsverbs.Registry, verb *jsverbs.VerbSpec, parsedValues *values.Values) (interface{}, error) {
+				return serveVerb(runCtx, ctx, registry, verb, parsedValues)
+			})
+			if err != nil {
+				return nil, err
+			}
+			if len(sections) > 0 {
+				if err := addSectionsToServeCommand(cmd.Description(), sections, "http serve runtime"); err != nil {
+					return nil, err
+				}
+			}
+			commands = append(commands, cmd)
+		}
+	}
+	return &providerapi.CommandSet{Commands: commands}, nil
+}
+
+func serveVerb(ctx context.Context, commandCtx providerapi.CommandSetContext, registry *jsverbs.Registry, verb *jsverbs.VerbSpec, parsedValues *values.Values) (interface{}, error) {
+	if registry == nil {
+		return nil, fmt.Errorf("jsverb registry is nil")
+	}
+	if verb == nil {
+		return nil, fmt.Errorf("jsverb is nil")
+	}
+	rt, err := commandCtx.RuntimeFactory.NewRuntimeFromSections(ctx, parsedValues, require.WithLoader(registry.RequireLoader()))
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rt.Close(context.Background()) }()
+
+	if len(commandCtx.SelectedModules) > 0 {
+		if err := providerutil.InitRuntimeFromSections(ctx, parsedValues, runtimeHandle{rt: rt}, commandCtx.SelectedModules); err != nil {
+			return nil, err
+		}
+	}
+	if _, err := registry.InvokeInRuntime(ctx, rt, verb, parsedValues); err != nil {
+		return nil, err
+	}
+
+	fmt.Fprintln(os.Stderr, "xgoja http serve: runtime is alive; press Ctrl-C to stop")
+	return nil, waitForServeShutdown(ctx)
+}
+
+func waitForServeShutdown(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	signalCtx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	<-signalCtx.Done()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func addSectionsToServeCommand(desc *cmds.CommandDescription, sections []schema.Section, source string) error {
+	if desc == nil {
+		return fmt.Errorf("command description is nil")
+	}
+	seen := map[string]string{}
+	if desc.Schema != nil {
+		desc.Schema.ForEach(func(slug string, _ schema.Section) {
+			seen[slug] = "command schema"
+		})
+	}
+	collected := []schema.Section{}
+	if err := providerutil.AppendUniqueSections(&collected, seen, sections, source); err != nil {
+		return err
+	}
+	desc.SetSections(collected...)
+	return nil
+}
+
+type runtimeHandle struct {
+	rt *engine.Runtime
+}
+
+func (h runtimeHandle) EngineRuntime() *engine.Runtime { return h.rt }
+
+func (h runtimeHandle) Close(ctx context.Context) error {
+	if h.rt == nil {
+		return nil
+	}
+	return h.rt.Close(ctx)
+}

--- a/pkg/xgoja/providers/http/serve_test.go
+++ b/pkg/xgoja/providers/http/serve_test.go
@@ -1,0 +1,109 @@
+package http
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dop251/goja_nodejs/require"
+	"github.com/go-go-golems/glazed/pkg/cmds/values"
+	"github.com/go-go-golems/go-go-goja/pkg/engine"
+	"github.com/go-go-golems/go-go-goja/pkg/jsverbs"
+	"github.com/go-go-golems/go-go-goja/pkg/xgoja/providerapi"
+)
+
+func TestNewServeCommandSetRequiresJSVerbSources(t *testing.T) {
+	_, ok := providerapi.NewProviderRegistry().ResolveCommandSetProvider(PackageID, "serve")
+	if ok {
+		t.Fatal("empty registry unexpectedly resolved serve provider")
+	}
+	_, err := newServeCommandSet(providerapi.CommandSetContext{RuntimeFactory: fakeRuntimeFactory{}})
+	if err == nil {
+		t.Fatal("expected missing jsverb source error")
+	}
+}
+
+func TestNewServeCommandSetBuildsVerbCommandsWithHTTPSection(t *testing.T) {
+	registry := scanServeTestRegistry(t)
+	capability := newHTTPCapability()
+	set, err := newServeCommandSet(providerapi.CommandSetContext{
+		Name:           "serve",
+		RuntimeFactory: fakeRuntimeFactory{},
+		SelectedModules: []providerapi.ModuleDescriptor{{
+			PackageID:           PackageID,
+			ModuleID:            "express",
+			As:                  "express",
+			PackageCapabilities: []providerapi.PackageCapability{capability},
+		}},
+		JSVerbs: fakeJSVerbSourceSet{registries: []*jsverbs.Registry{registry}},
+	})
+	if err != nil {
+		t.Fatalf("new serve command set: %v", err)
+	}
+	if len(set.Commands) != 1 {
+		t.Fatalf("commands = %d, want 1", len(set.Commands))
+	}
+	desc := set.Commands[0].Description()
+	if desc.Name != "demo" {
+		t.Fatalf("command name = %q, want demo", desc.Name)
+	}
+	if desc.Parents[0] != "sites" {
+		t.Fatalf("parents = %#v, want sites", desc.Parents)
+	}
+	if _, ok := desc.Schema.Get("http"); !ok {
+		t.Fatalf("expected http section on serve command; schema=%#v", desc.Schema)
+	}
+}
+
+func scanServeTestRegistry(t *testing.T) *jsverbs.Registry {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sites.js")
+	source := `
+__package__({ name: "sites" });
+__verb__("demo", { name: "demo", short: "Serve demo", output: "text" });
+function demo() {}
+`
+	if err := os.WriteFile(path, []byte(source), 0o644); err != nil {
+		t.Fatalf("write verb: %v", err)
+	}
+	registry, err := jsverbs.ScanDir(dir)
+	if err != nil {
+		t.Fatalf("scan dir: %v", err)
+	}
+	return registry
+}
+
+type fakeRuntimeFactory struct{}
+
+func (fakeRuntimeFactory) NewRuntime(context.Context, ...require.Option) (*engine.Runtime, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (fakeRuntimeFactory) NewRuntimeFromSections(context.Context, *values.Values, ...require.Option) (*engine.Runtime, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+type fakeJSVerbSourceSet struct {
+	registries []*jsverbs.Registry
+}
+
+func (s fakeJSVerbSourceSet) ListJSVerbSources() []providerapi.JSVerbSourceDescriptor {
+	return []providerapi.JSVerbSourceDescriptor{{ID: "fake"}}
+}
+
+func (s fakeJSVerbSourceSet) ScanJSVerbSource(id string) (*jsverbs.Registry, error) {
+	if id != "fake" {
+		return nil, fmt.Errorf("unknown fake source %q", id)
+	}
+	if len(s.registries) == 0 {
+		return nil, nil
+	}
+	return s.registries[0], nil
+}
+
+func (s fakeJSVerbSourceSet) ScanAllJSVerbSources() ([]*jsverbs.Registry, error) {
+	return s.registries, nil
+}

--- a/ttmp/2026/06/04/GOJA-064--http-serve-support-for-xgoja-generated-verbs/changelog.md
+++ b/ttmp/2026/06/04/GOJA-064--http-serve-support-for-xgoja-generated-verbs/changelog.md
@@ -55,3 +55,14 @@ Implemented first GOJA-064 code slice: command-provider jsverb source access plu
 - /home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/pkg/xgoja/providerapi/commands.go — Added JSVerbSourceSet API
 - /home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/pkg/xgoja/providers/http/serve.go — Implemented HTTP serve command provider
 
+
+## 2026-06-04
+
+Added generated-binary HTTP serve jsverb smoke test and examples/xgoja/13-http-serve-jsverbs runnable example.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/cmd/xgoja/internal/generate/generate_test.go — Generated serve command smoke coverage
+- /home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/examples/xgoja/13-http-serve-jsverbs/verbs/sites.js — New example setup verb
+- /home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/examples/xgoja/13-http-serve-jsverbs/xgoja.yaml — New example buildspec
+

--- a/ttmp/2026/06/04/GOJA-064--http-serve-support-for-xgoja-generated-verbs/changelog.md
+++ b/ttmp/2026/06/04/GOJA-064--http-serve-support-for-xgoja-generated-verbs/changelog.md
@@ -24,3 +24,34 @@ Validated GOJA-064 with docmgr doctor, resolved missing topic vocabulary, upload
 - /home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/ttmp/2026/06/04/GOJA-064--http-serve-support-for-xgoja-generated-verbs/design-doc/01-http-serve-support-for-xgoja-generated-verbs.md — Included in uploaded bundle
 - /home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/ttmp/2026/06/04/GOJA-064--http-serve-support-for-xgoja-generated-verbs/reference/01-diary.md — Included in uploaded bundle and updated with delivery evidence
 
+
+## 2026-06-04
+
+Added GOJA-064 research logbook covering consulted source files, docs, examples, external goja-site resources, stale paths, and update needs; uploaded updated bundle including the logbook to reMarkable.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/ttmp/2026/06/04/GOJA-064--http-serve-support-for-xgoja-generated-verbs/reference/01-diary.md — Updated with logbook creation and upload step
+- /home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/ttmp/2026/06/04/GOJA-064--http-serve-support-for-xgoja-generated-verbs/reference/02-research-logbook.md — New resource usefulness and freshness logbook
+
+
+## 2026-06-04
+
+Updated GOJA-064 serve design for the simplified single-runtime xgoja.yaml schema: top-level modules list, no command runtime fields, no commandProviders runtimeProfile in recommended examples.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/ttmp/2026/06/04/GOJA-064--http-serve-support-for-xgoja-generated-verbs/design-doc/01-http-serve-support-for-xgoja-generated-verbs.md — Plan updated for single-runtime xgoja schema
+- /home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/ttmp/2026/06/04/GOJA-064--http-serve-support-for-xgoja-generated-verbs/reference/01-diary.md — Recorded schema simplification update
+
+
+## 2026-06-04
+
+Implemented first GOJA-064 code slice: command-provider jsverb source access plus go-go-goja-http serve command provider with long-lived runtime invocation.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/pkg/xgoja/app/jsverb_sources.go — Centralized jsverb source scanning for command providers
+- /home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/pkg/xgoja/providerapi/commands.go — Added JSVerbSourceSet API
+- /home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/pkg/xgoja/providers/http/serve.go — Implemented HTTP serve command provider
+

--- a/ttmp/2026/06/04/GOJA-064--http-serve-support-for-xgoja-generated-verbs/changelog.md
+++ b/ttmp/2026/06/04/GOJA-064--http-serve-support-for-xgoja-generated-verbs/changelog.md
@@ -66,3 +66,13 @@ Added generated-binary HTTP serve jsverb smoke test and examples/xgoja/13-http-s
 - /home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/examples/xgoja/13-http-serve-jsverbs/verbs/sites.js — New example setup verb
 - /home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/examples/xgoja/13-http-serve-jsverbs/xgoja.yaml — New example buildspec
 
+
+## 2026-06-04
+
+Step 9: hardened HTTP serve startup errors with synchronous net.Listen binding and added xgoja help documentation for HTTP serve jsverbs (commit 9af57aabb02a554c746b2ea29c14503bed9373f3)
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/cmd/xgoja/doc/12-tutorial-http-serve-jsverbs.md — New tutorial
+- /home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/pkg/xgoja/providers/http/http.go — Synchronous bind before serving
+

--- a/ttmp/2026/06/04/GOJA-064--http-serve-support-for-xgoja-generated-verbs/design-doc/01-http-serve-support-for-xgoja-generated-verbs.md
+++ b/ttmp/2026/06/04/GOJA-064--http-serve-support-for-xgoja-generated-verbs/design-doc/01-http-serve-support-for-xgoja-generated-verbs.md
@@ -13,6 +13,12 @@ Owners: []
 RelatedFiles:
     - Path: ../../../../../../../../../../code/wesen/2026-05-03--goja-hosting-site/pkg/app/server.go
       Note: External reference for single-site goja runtime plus HTTP server lifecycle
+    - Path: cmd/xgoja/internal/generate/generate_test.go
+      Note: Generated-binary HTTP serve verb smoke test
+    - Path: examples/xgoja/13-http-serve-jsverbs/verbs/sites.js
+      Note: Example JavaScript site setup verb
+    - Path: examples/xgoja/13-http-serve-jsverbs/xgoja.yaml
+      Note: Runnable xgoja buildspec for HTTP serve jsverbs example
     - Path: modules/express/express.go
       Note: JavaScript express.app API and route/static registration surface
     - Path: pkg/xgoja/app/command_providers.go
@@ -41,6 +47,7 @@ LastUpdated: 2026-06-04T22:43:00-04:00
 WhatFor: Use when implementing or reviewing first-class HTTP serve support for generated xgoja verb commands.
 WhenToUse: Before changing pkg/xgoja, pkg/jsverbs, modules/express, pkg/gojahttp, or the go-go-goja HTTP provider.
 ---
+
 
 
 

--- a/ttmp/2026/06/04/GOJA-064--http-serve-support-for-xgoja-generated-verbs/design-doc/01-http-serve-support-for-xgoja-generated-verbs.md
+++ b/ttmp/2026/06/04/GOJA-064--http-serve-support-for-xgoja-generated-verbs/design-doc/01-http-serve-support-for-xgoja-generated-verbs.md
@@ -16,15 +16,25 @@ RelatedFiles:
     - Path: modules/express/express.go
       Note: JavaScript express.app API and route/static registration surface
     - Path: pkg/xgoja/app/command_providers.go
-      Note: Provider command set mounting and CommandSetContext construction
+      Note: |-
+        Provider command set mounting and CommandSetContext construction
+        Passes jsverb source set into command provider context
+    - Path: pkg/xgoja/app/jsverb_sources.go
+      Note: New app-side jsverb source scanner exposed to command providers
     - Path: pkg/xgoja/app/root.go
       Note: Existing generated root and jsverbs command construction that currently closes runtimes after invocation
     - Path: pkg/xgoja/app/run.go
       Note: Existing keep-alive runtime lifecycle to model for serve
     - Path: pkg/xgoja/providerapi/commands.go
-      Note: Command provider API that needs jsverb source access for HTTP serve
+      Note: |-
+        Command provider API that needs jsverb source access for HTTP serve
+        Added JSVerbSourceSet to CommandSetContext for serve provider implementation
     - Path: pkg/xgoja/providers/http/http.go
-      Note: HTTP provider express module
+      Note: |-
+        HTTP provider express module
+        Registers serve command provider with HTTP package
+    - Path: pkg/xgoja/providers/http/serve.go
+      Note: New HTTP serve command provider implementation
 ExternalSources: []
 Summary: Design and implementation guide for serving HTTP sites from xgoja-generated JavaScript verbs using the express/gojahttp provider stack.
 LastUpdated: 2026-06-04T22:43:00-04:00
@@ -33,11 +43,12 @@ WhenToUse: Before changing pkg/xgoja, pkg/jsverbs, modules/express, pkg/gojahttp
 ---
 
 
+
 # HTTP Serve Support for xgoja Generated Verbs
 
 ## Executive summary
 
-Generated xgoja binaries already have most of the building blocks needed to serve HTTP sites from JavaScript: runtime profiles, provider modules, JavaScript verb scanning, an Express-style module, a `gojahttp.Host`, and a `run --keep-alive` command. The missing product shape is a first-class generated command that treats a JavaScript verb as a **site setup function**: build one long-lived runtime, invoke the selected verb once so it registers Express routes, keep the runtime and HTTP server alive, and shut everything down on Ctrl-C/SIGTERM.
+Generated xgoja binaries already have most of the building blocks needed to serve HTTP sites from JavaScript: a single generated runtime module list, provider modules, JavaScript verb scanning, an Express-style module, a `gojahttp.Host`, and a `run --keep-alive` command. The missing product shape is a first-class generated command that treats a JavaScript verb as a **site setup function**: build one long-lived runtime, invoke the selected verb once so it registers Express routes, keep the runtime and HTTP server alive, and shut everything down on Ctrl-C/SIGTERM.
 
 The recommended design is a provider-backed `serve` command set supplied by `pkg/xgoja/providers/http`. Generated applications opt into it through `commandProviders`, and the command provider dynamically mirrors configured JavaScript verbs under a `serve` command tree:
 
@@ -45,11 +56,21 @@ The recommended design is a provider-backed `serve` command set supplied by `pkg
 ./my-app serve <package-path> <verb-name> [verb flags] --http-listen 127.0.0.1:8787
 ```
 
-This keeps HTTP-specific command behavior close to the HTTP provider while reusing the same xgoja runtime-profile and jsverbs machinery as ordinary generated verb commands. It also avoids the most tempting but weaker design, `express.serve()` alone, which would make JavaScript block manually and would not give generated binaries a discoverable CLI command shape.
+This keeps HTTP-specific command behavior close to the HTTP provider while reusing the same xgoja single-runtime and jsverbs machinery as ordinary generated verb commands. It also avoids the most tempting but weaker design, `express.serve()` alone, which would make JavaScript block manually and would not give generated binaries a discoverable CLI command shape.
+
+### Update: single-runtime xgoja.yaml simplification
+
+This plan now assumes the newer xgoja schema where `xgoja.yaml` has one top-level `modules:` list and no `runtimes:` map. That simplifies the HTTP serve design substantially:
+
+- `serve` no longer has to choose or validate a runtime profile.
+- `commandProviders[].runtimeProfile` should not be used in examples or new implementation work.
+- `RuntimeFactory.NewRuntimeFromSections(ctx, vals, ...)` can create the one configured runtime directly.
+- Module sections such as `--http-listen` are collected from the single configured module list.
+- Future multi-site serving still means multiple **runtime instances**, but not multiple YAML runtime profiles. Each site instance should use the same generated module set unless a later schema introduces per-site module overrides.
 
 For a new intern, the short version is:
 
-1. `xgoja.yaml` describes provider packages, runtime profiles, generated commands, JavaScript verb sources, and command providers.
+1. `xgoja.yaml` describes provider packages, one generated runtime's module list, generated commands, JavaScript verb sources, and command providers.
 2. xgoja generates a normal Go binary that embeds a normalized `app.RuntimeSpec`.
 3. At startup, the generated root command builds an `app.Host`, attaches built-in commands, and attaches provider-owned command sets.
 4. The existing `verbs` command scans JavaScript files and creates one Cobra/Glazed command per `__verb__` declaration.
@@ -79,7 +100,7 @@ where `sites kanban` is an ordinary discovered JavaScript verb whose body regist
 This design covers:
 
 - serving one JavaScript verb-backed site from one generated xgoja process;
-- integrating with configured xgoja runtime profiles and module sections;
+- integrating with the configured xgoja runtime module list and module sections;
 - preserving existing `run`, `eval`, `repl`, and `verbs` behavior;
 - making `go-go-goja-http` provide an opt-in `serve` command provider;
 - preparing an explicit path for future multi-site serving, similar to `goja-site serve-multi`.
@@ -90,7 +111,7 @@ The first implementation should not try to become the full `goja-site` applicati
 
 - database policy management from `goja-site`;
 - production observability and tracing wrappers from `goja-site`;
-- automatic virtual-host dispatch across many runtimes;
+- automatic virtual-host dispatch across many separately-created site runtimes;
 - hot reload;
 - untrusted JavaScript sandboxing.
 
@@ -116,9 +137,9 @@ xgoja.yaml
 
 ### Buildspec and runtime spec command-provider schema
 
-At build time, `cmd/xgoja/internal/buildspec/build_spec.go` defines the declarative YAML schema. `BuildSpec.CommandProviders` selects provider-owned command sets, and `CommandProviderInstanceSpec` carries `id`, `package`, `name`, `mount`, `runtimeProfile`, optional module filtering, static config, and a `lazy` flag (`cmd/xgoja/internal/buildspec/build_spec.go:16-29`, `cmd/xgoja/internal/buildspec/build_spec.go:109-120`). At runtime, the generated binary uses the reduced `app.RuntimeSpec`, which keeps the same command-provider fields (`pkg/xgoja/app/runtime_spec.go:84-96`).
+At build time, `cmd/xgoja/internal/buildspec/build_spec.go` defines the declarative YAML schema. The current simplified schema has a top-level `modules:` list instead of a `runtimes:` map, and `CommandProviderInstanceSpec` carries `id`, `package`, `name`, `mount`, optional module filtering, static config, and a `lazy` flag (`cmd/xgoja/internal/buildspec/build_spec.go:16-29`, `cmd/xgoja/internal/buildspec/build_spec.go:100-109`). At runtime, the generated binary uses the reduced `app.RuntimeSpec`, which keeps the same single-runtime `modules` and command-provider fields (`pkg/xgoja/app/runtime_spec.go:15-27`, `pkg/xgoja/app/runtime_spec.go:76-87`).
 
-Validation currently checks that command-provider IDs are present and unique, package IDs exist, provider names are present, and optional `runtimeProfile` values point at existing runtime profiles (`cmd/xgoja/internal/buildspec/validate.go:267-296`). That means an HTTP serve command provider can be introduced without inventing a new top-level command schema, as long as users opt in:
+Validation now rejects/flags legacy command-provider `runtimeProfile` fields and validates command-provider IDs, package IDs, and provider names against the single-runtime buildspec. That means an HTTP serve command provider can be introduced without inventing a new top-level command schema, as long as users opt in:
 
 ```yaml
 commandProviders:
@@ -126,12 +147,11 @@ commandProviders:
     package: go-go-goja-http
     name: serve
     mount: serve
-    runtimeProfile: main
 ```
 
 ### How provider command sets are attached
 
-`pkg/xgoja/app/command_providers.go` resolves each configured provider by `(package, name)`, applies the configured mount, creates a `providerapi.CommandSetContext`, and adds returned Glazed commands to Cobra (`pkg/xgoja/app/command_providers.go:19-56`). The context already includes the runtime profile, static provider config, selected runtime modules, provider registry, and an xgoja `RuntimeFactory` (`pkg/xgoja/app/command_providers.go:59-86`; `pkg/xgoja/providerapi/commands.go:24-37`).
+`pkg/xgoja/app/command_providers.go` resolves each configured provider by `(package, name)`, applies the configured mount, creates a `providerapi.CommandSetContext`, and adds returned Glazed commands to Cobra (`pkg/xgoja/app/command_providers.go:19-56`). The context still includes a compatibility `RuntimeProfile` value (`main`), static provider config, selected runtime modules, provider registry, and an xgoja `RuntimeFactory` (`pkg/xgoja/app/command_providers.go:59-86`; `pkg/xgoja/providerapi/commands.go:24-37`).
 
 The context is almost sufficient for HTTP serve support. The missing piece is access to configured JavaScript verb sources. Built-in jsverbs support can scan `runtimeSpec.JSVerbs`, but provider command sets currently cannot.
 
@@ -139,7 +159,7 @@ The context is almost sufficient for HTTP serve support. The missing piece is ac
 
 Built-in `verbs` support lives in `pkg/xgoja/app/root.go`. It does three things:
 
-1. Determine the runtime profile for `commands.jsverbs`.
+1. Use the single generated runtime module list for `commands.jsverbs`.
 2. Scan configured JavaScript verb sources.
 3. For every discovered `VerbSpec`, build a Glazed command whose invoker creates a fresh runtime, invokes the verb, then closes the runtime.
 
@@ -189,10 +209,10 @@ The external example at `/home/manuel/code/wesen/2026-05-03--goja-hosting-site` 
 
 ### What already works
 
-- Runtime profiles can select the `go-go-goja-http.express` module.
+- The top-level `modules:` list can select the `go-go-goja-http.express` module.
 - The HTTP provider exposes `--http-listen` as a module section.
 - `run --keep-alive` can serve scripts that register Express routes.
-- `commands.jsverbs` can turn `__verb__` declarations into generated commands.
+- `commands.jsverbs` can turn `__verb__` declarations into generated commands without choosing among runtime profiles.
 - Provider command sets can mount package-owned Glazed commands.
 
 ### What is missing
@@ -236,32 +256,28 @@ packages:
   - id: go-go-goja-http
     import: github.com/go-go-golems/go-go-goja/pkg/xgoja/providers/http
 
-runtimes:
-  main:
-    modules:
-      - package: go-go-goja-host
-        name: fs
-        as: fs:assets
-        config:
-          embedded:
-            allow: true
-            mounts:
-              - asset: app-assets
-                mount: /app
-      - package: go-go-goja-http
-        name: express
+modules:
+  - package: go-go-goja-host
+    name: fs
+    as: fs:assets
+    config:
+      embedded:
+        allow: true
+        mounts:
+          - asset: app-assets
+            mount: /app
+  - package: go-go-goja-http
+    name: express
 
 commands:
   jsverbs:
     enabled: true
-    runtime: main
 
 commandProviders:
   - id: http-serve
     package: go-go-goja-http
     name: serve
     mount: serve
-    runtimeProfile: main
 ```
 
 The generated command tree becomes:
@@ -284,7 +300,7 @@ Cobra/Glazed parses:
 
 HTTP serve command invoker:
   1. scan configured jsverb source(s)
-  2. create runtime from runtime profile with registry.RequireLoader()
+  2. create the generated runtime with registry.RequireLoader()
   3. initialize selected module runtime capabilities from parsed Glazed values
   4. invoke selected verb once
   5. verb calls require("express") and registers routes
@@ -295,7 +311,7 @@ HTTP serve command invoker:
 
 ### Required provider API extension
 
-The HTTP provider command set needs a supported way to discover the same JavaScript verb sources that built-in `commands.jsverbs` uses. Add a small jsverb source accessor to `providerapi.CommandSetContext`.
+The HTTP provider command set needs a supported way to discover the same JavaScript verb sources that built-in `commands.jsverbs` uses. It no longer needs to choose a runtime profile; it should use the one generated runtime configuration. Add a small jsverb source accessor to `providerapi.CommandSetContext`.
 
 Proposed API sketch:
 
@@ -321,7 +337,7 @@ type CommandSetContext struct {
     PackageID       string
     Name            string
     Mount           string
-    RuntimeProfile  string
+    RuntimeProfile  string // compatibility value, normally "main" in the single-runtime schema
     Config          json.RawMessage
     Host            HostServices
     Providers       *ProviderRegistry
@@ -369,7 +385,7 @@ func newServeCommandSet(ctx providerapi.CommandSetContext, capability *capabilit
         ctx.SelectedModules,
         providerapi.SectionRequest{
             CommandProviderID: ctx.Name,
-            RuntimeProfile:    ctx.RuntimeProfile,
+            RuntimeProfile:    "main",
         },
         nil,
     )
@@ -395,7 +411,7 @@ The lifetime-aware invoker is the crucial behavior change:
 
 ```go
 func serveVerb(ctx context.Context, c providerapi.CommandSetContext, registry *jsverbs.Registry, verb *jsverbs.VerbSpec, vals *values.Values) (any, error) {
-    rt, err := c.RuntimeFactory.NewRuntimeFromSections(ctx, c.RuntimeProfile, vals, require.WithLoader(registry.RequireLoader()))
+    rt, err := c.RuntimeFactory.NewRuntimeFromSections(ctx, vals, require.WithLoader(registry.RequireLoader()))
     if err != nil { return nil, err }
     defer func() { _ = rt.Close(context.Background()) }()
 
@@ -482,7 +498,7 @@ Do not build multi-site first. The single-site command will surface most integra
 
 ### Decision: Provide `serve` as an HTTP provider command set
 
-- **Context:** The command is HTTP-specific but must participate in xgoja runtime profiles, module sections, and JavaScript verb discovery.
+- **Context:** The command is HTTP-specific but must participate in xgoja's single runtime module list, module sections, and JavaScript verb discovery.
 - **Options considered:** Add `express.serve()` only; add a new built-in `commands.serve`; add an HTTP provider `CommandSetProvider`.
 - **Decision:** Add an opt-in `CommandSetProvider{Name: "serve"}` to `go-go-goja-http` and extend command-provider context with jsverb source access.
 - **Rationale:** Provider command sets already exist for package-owned commands. The HTTP provider owns `--http-listen`, server lifetime, and Express host behavior. Keeping `serve` in the provider avoids growing xgoja core with HTTP-only command semantics.
@@ -730,7 +746,7 @@ GOWORK=off go test ./cmd/xgoja/internal/buildspec ./cmd/xgoja/internal/generate 
 - **Bind errors:** Current async server start can hide port conflicts. Serve commands should make bind failures synchronous.
 - **Duplicate HTTP sections:** Serve commands will combine verb-owned sections and module sections. Section slugs must remain unique.
 - **Source loader consistency:** The same registry loader must be used to invoke the setup verb, otherwise relative `require(...)` calls can fail.
-- **Multi-site port conflicts:** Current auto-start mode cannot run many site runtimes on one address. Manual server ownership is required before `serve-multi`.
+- **Multi-site port conflicts:** The single xgoja.yaml runtime schema does not prevent a serve command from creating multiple runtime instances, but current auto-start mode cannot run many site runtimes on one address. Manual server ownership is required before `serve-multi`.
 - **Security:** This system runs trusted JavaScript. Do not describe it as a safe multi-tenant sandbox.
 
 ## Alternatives considered
@@ -790,17 +806,19 @@ Handlers receive `(req, res)`. They may return a string, return a UI DSL value, 
 ### Proposed buildspec fragment
 
 ```yaml
+modules:
+  - package: go-go-goja-http
+    name: express
+
 commands:
   jsverbs:
     enabled: true
-    runtime: main
 
 commandProviders:
   - id: http-serve
     package: go-go-goja-http
     name: serve
     mount: serve
-    runtimeProfile: main
 ```
 
 ### Proposed provider registration fragment

--- a/ttmp/2026/06/04/GOJA-064--http-serve-support-for-xgoja-generated-verbs/reference/01-diary.md
+++ b/ttmp/2026/06/04/GOJA-064--http-serve-support-for-xgoja-generated-verbs/reference/01-diary.md
@@ -486,7 +486,7 @@ The implementation follows the simplified single-runtime schema. The serve invok
 
 **Inferred user intent:** The user wants the proposed single-runtime HTTP serve command-provider design implemented, with tickets committed at appropriate intervals and diary updates maintained.
 
-**Commit (code):** pending — this diary step was written immediately before the first implementation commit.
+**Commit (code):** 3994c9df90ad3f21d9cd4f3ddcd6c384c11c6cb9 — "GOJA-064: add HTTP serve command provider"
 
 ### What I did
 - Added `providerapi.JSVerbSourceDescriptor` and `providerapi.JSVerbSourceSet`.
@@ -551,3 +551,73 @@ The implementation follows the simplified single-runtime schema. The serve invok
   - `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/pkg/xgoja/providers/http/serve.go`
   - `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/pkg/xgoja/providers/http/http_test.go`
   - `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/pkg/xgoja/providers/http/serve_test.go`.
+
+## Step 8: Add generated-binary smoke coverage and a runnable example
+
+I added the second implementation slice for GOJA-064: a generated-binary smoke test and a new numbered xgoja example. The test proves that generated source can import the HTTP provider, mount the provider-owned `serve` command, scan a configured jsverb source, run `serve sites demo --http-listen ...`, and answer HTTP requests from an Express route registered by the JavaScript verb.
+
+I also added `examples/xgoja/13-http-serve-jsverbs`, which gives future users and maintainers a concrete Makefile-driven example of the new command-provider flow.
+
+### Prompt Context
+
+**User prompt (verbatim):** (see Step 7)
+
+**Assistant interpretation:** Continue implementation beyond the provider code into validation and examples.
+
+**Inferred user intent:** The user wants a complete, reviewable implementation with proof that the generated xgoja path works.
+
+**Commit (code):** pending — this diary step was written before the second implementation commit.
+
+### What I did
+- Added `TestGeneratedProgramServesHTTPVerb` in `cmd/xgoja/internal/generate/generate_test.go`.
+- Added helpers to build and start a generated binary for long-running command tests.
+- Created `examples/xgoja/13-http-serve-jsverbs` with:
+  - `xgoja.yaml`
+  - `verbs/sites.js`
+  - `Makefile`
+  - `README.md`
+- Updated `examples/xgoja/README.md` to list the new example and include it in the bulk smoke loop.
+- Ran targeted generated and example validation.
+
+### Why
+- Package tests prove the command provider can be constructed, but generated xgoja features also need generated-source coverage.
+- The example makes the feature discoverable and gives contributors a copy/paste command path.
+
+### What worked
+- `GOWORK=off go test ./cmd/xgoja/internal/generate -run GeneratedProgramServesHTTPVerb -count=1` passed.
+- `make -C examples/xgoja/13-http-serve-jsverbs smoke` passed.
+- A combined targeted test command passed:
+  - `GOWORK=off go test ./pkg/xgoja/app ./pkg/xgoja/providers/http ./cmd/xgoja/internal/generate -run 'GeneratedProgramServesHTTPVerb|TestHostAttachCommandProvidersProvidesJSVerbSources|TestNewServeCommandSet|TestRegister' -count=1`
+
+### What didn't work
+- The first generated smoke test used `go run . serve ...` for the long-running process. Canceling the `go run` context did not cleanly terminate all test I/O and failed with:
+  - `*** Test I/O incomplete 1m0s after exiting.`
+  - `exec: WaitDelay expired before I/O complete`
+- I fixed this by changing the helper to `go build -o generated-test .` and executing the generated binary directly, so context cancellation targets the server process itself.
+
+### What I learned
+- Long-running generated-command tests should run a built binary, not `go run`, to avoid orphaned child process and I/O behavior.
+- The new example can use only the HTTP provider; no host or asset provider is required for a minimal route smoke.
+
+### What was tricky to build
+- The test had to wait for readiness without assuming instant startup. I used a temporary TCP address and retried `GET /healthz` until the server responded or the generated command exited early.
+- Because the serve command is intentionally long-running, the test must explicitly cancel the context and wait for the process.
+
+### What warrants a second pair of eyes
+- The generated test currently checks one JSON route. A reviewer should decide whether to also test `HEAD`, static mounts, or promise-returning setup verbs in this ticket or a follow-up.
+- The example's Makefile uses a fixed high port. If this collides in CI, switch to a dynamic port helper script.
+
+### What should be done in the future
+- Add a static-asset variant once `serve` and `fs:assets` are both exercised together in an example.
+- Consider adding `serve` help docs in `cmd/xgoja/doc` or provider-shipped HTTP docs.
+
+### Code review instructions
+- Start with `cmd/xgoja/internal/generate/generate_test.go::TestGeneratedProgramServesHTTPVerb` to see the generated path proof.
+- Then run `make -C examples/xgoja/13-http-serve-jsverbs smoke` for the example path.
+
+### Technical details
+- Validation commands:
+  - `GOWORK=off go test ./cmd/xgoja/internal/generate -run GeneratedProgramServesHTTPVerb -count=1`
+  - `GOWORK=off go test ./pkg/xgoja/app ./pkg/xgoja/providers/http ./cmd/xgoja/internal/generate -run 'GeneratedProgramServesHTTPVerb|TestHostAttachCommandProvidersProvidesJSVerbSources|TestNewServeCommandSet|TestRegister' -count=1`
+  - `make -C examples/xgoja/13-http-serve-jsverbs smoke`
+- New example path: `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/examples/xgoja/13-http-serve-jsverbs`.

--- a/ttmp/2026/06/04/GOJA-064--http-serve-support-for-xgoja-generated-verbs/reference/01-diary.md
+++ b/ttmp/2026/06/04/GOJA-064--http-serve-support-for-xgoja-generated-verbs/reference/01-diary.md
@@ -334,3 +334,220 @@ This step completed the requested delivery loop: the design and diary are stored
   - `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/ttmp/2026/06/04/GOJA-064--http-serve-support-for-xgoja-generated-verbs/reference/01-diary.md`
   - `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/ttmp/2026/06/04/GOJA-064--http-serve-support-for-xgoja-generated-verbs/tasks.md`
   - `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/ttmp/2026/06/04/GOJA-064--http-serve-support-for-xgoja-generated-verbs/changelog.md`.
+
+## Step 5: Add a research logbook for resource freshness and usefulness
+
+I added a dedicated research logbook document to GOJA-064 so future implementers can see which code files, examples, docs, and external goja-site resources informed the design. The logbook records why each resource was chosen, how it was found, what was useful, what was not useful, which paths were stale or missing, and what should be updated after implementation.
+
+This step turns the implicit reading trail from the design and diary into an explicit maintenance aid. It should reduce rediscovery work when GOJA-064 moves from research into implementation.
+
+### Prompt Context
+
+**User prompt (verbatim):** "Create a research logbook document in the ticket that allows us to keep track of which resources    
+ are useful / out of date / need updating .                                                          
+                                                                                                     
+ For all the documents and external resources you read, list:                                        
+                                                                                                     
+ - what you were researching                                                                         
+ - what you were looking for in this document in particular                                          
+ - why you chose it
+ - how you found the resource itself
+ - what you found useful in the document                                                             
+ - what you didn't find useful                                                                       
+ - what is out of date / what was wrong                                                              
+ - what would need updating.                                                                         
+                                                                                                     
+ Store in ticket and upload to remarkable."
+
+**Assistant interpretation:** Create a new ticket document that indexes all resources consulted during GOJA-064 research and evaluates their usefulness, staleness, and update needs; then upload the updated ticket package to reMarkable.
+
+**Inferred user intent:** The user wants the research trail to become a durable resource-quality log, not only a design narrative.
+
+**Commit (code):** N/A — documentation/research only; no code behavior changed.
+
+### What I did
+- Added `reference/02-research-logbook.md` with `docmgr doc add`.
+- Added a new task: `Create research logbook and upload updated bundle to reMarkable`.
+- Wrote the logbook covering xgoja app files, provider API files, jsverbs files, Express/gojahttp files, xgoja examples/docs, goja-site external resources, missing/stale attempted paths, process references, and ticket resources.
+- Related the logbook to key code and external reference files using `docmgr doc relate`.
+
+### Why
+- The design document explains the recommended architecture, but it does not provide a per-resource freshness/usefulness ledger.
+- The user specifically asked to track useful, out-of-date, and update-needed resources.
+
+### What worked
+- The new logbook document was created at `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/ttmp/2026/06/04/GOJA-064--http-serve-support-for-xgoja-generated-verbs/reference/02-research-logbook.md`.
+- The logbook captures both useful resources and wrong/missing paths encountered during the original investigation.
+- File relations were added for six key resources that shaped the logbook.
+
+### What didn't work
+- The reMarkable upload emitted a warning before succeeding:
+  - Output: `WARNING: 2026/06/04 19:42:26 apictx.go:259: remote tree has changed, refresh the file tree`
+  - Output: `OK: uploaded GOJA-064 HTTP Serve Support for xgoja Generated Verbs.pdf -> /ai/2026/06/04/GOJA-064`
+- The warning did not block delivery; the upload completed and the remote listing showed the bundle.
+
+### What I learned
+- The research trail benefits from separating source-code resources, external goja-site resources, process references, and ticket-local resources.
+- Missing paths are worth logging because they prevent future researchers from repeating incorrect assumptions.
+
+### What was tricky to build
+- The main challenge was scope. The user asked for all documents and external resources read, but the original investigation also read many source files. I included source files as resources because they materially shaped the design, while still separating process references from technical references.
+
+### What warrants a second pair of eyes
+- The logbook should be reviewed for whether any resource should be marked more strongly as stale versus merely incomplete for GOJA-064.
+- The goja-site developer guide staleness note should be checked by someone familiar with that repository's current documentation expectations.
+
+### What should be done in the future
+- Update the logbook after GOJA-064 implementation lands, especially for docs/examples that become stale once `serve <verb>` exists.
+- Add generated example and test resources to the logbook during implementation.
+
+### Code review instructions
+- Start with `reference/02-research-logbook.md` and confirm each entry has the requested eight fields.
+- Validate with `docmgr doctor --ticket GOJA-064 --stale-after 30`.
+- Confirm upload with `remarquee cloud ls /ai/2026/06/04/GOJA-064 --long --non-interactive`.
+
+### Technical details
+- Logbook path: `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/ttmp/2026/06/04/GOJA-064--http-serve-support-for-xgoja-generated-verbs/reference/02-research-logbook.md`.
+- `docmgr doctor --ticket GOJA-064 --stale-after 30` passed after adding the logbook.
+- Dry-run upload included design doc, diary, research logbook, tasks, and changelog.
+- reMarkable destination: `/ai/2026/06/04/GOJA-064`.
+
+## Step 6: Update the plan for the single-runtime xgoja.yaml schema
+
+I updated the design to account for the newer simplified xgoja schema where `xgoja.yaml` no longer supports a `runtimes:` map. The plan now assumes one top-level `modules:` list, no `commands.*.runtime` fields in examples, and no `commandProviders[].runtimeProfile` in new implementation guidance.
+
+This simplification makes the HTTP serve command-provider design cleaner. The `serve` provider no longer has to choose among runtime profiles; it can create the one configured runtime, add the jsverb source loader, initialize module sections such as `--http-listen`, invoke the site setup verb, and wait for shutdown.
+
+### Prompt Context
+
+**User prompt (verbatim):** "We did remove support for multiple runtimes int he xgoja.yaml file, which will simplify things I'm sure. Update your plan."
+
+**Assistant interpretation:** Revise the GOJA-064 design so it no longer assumes xgoja buildspecs contain multiple named runtime profiles.
+
+**Inferred user intent:** The user wants the implementation guide to match the current xgoja schema and take advantage of the simplification.
+
+**Commit (code):** N/A — documentation/research only; no code behavior changed.
+
+### What I did
+- Inspected the current simplified schema in:
+  - `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/cmd/xgoja/internal/buildspec/build_spec.go`
+  - `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/pkg/xgoja/app/runtime_spec.go`
+  - `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/pkg/xgoja/app/factory.go`
+  - `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/pkg/xgoja/app/module_sections.go`
+  - `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/pkg/xgoja/app/command_providers.go`
+- Updated the design document's executive summary, schema explanation, gap analysis, YAML examples, pseudocode, decision records, risks, and buildspec quick sheet.
+- Removed `runtimes: main`, `commands.jsverbs.runtime: main`, and `commandProviders[].runtimeProfile: main` from recommended examples.
+- Updated pseudocode to use `RuntimeFactory.NewRuntimeFromSections(ctx, vals, ...)` instead of passing a profile string.
+
+### Why
+- The previous design was correct for the older multi-runtime schema but now overcomplicated the implementation plan.
+- The serve command provider should follow the current code shape: one generated runtime module list and compatibility `RuntimeProfile: "main"` only where existing provider capability APIs still carry that field.
+
+### What worked
+- The design became simpler: no per-command runtime selection, no runtime-profile validation in the serve command, and fewer YAML fields for users.
+- The current code already has `RuntimeFactory.NewRuntimeFromSections(ctx, vals, opts...)`, which is the exact shape the serve invoker should use.
+
+### What didn't work
+- N/A. This was a documentation update; no command failed during the update.
+
+### What I learned
+- The codebase has already moved toward single-runtime semantics while retaining some compatibility naming, such as `defaultRuntimeProfile = "main"` and `CommandSetContext.RuntimeProfile`.
+- Future multi-site serving should be described as multiple runtime **instances**, not multiple YAML runtime profiles.
+
+### What was tricky to build
+- The tricky part was preserving references to compatibility fields without reintroducing old schema guidance. The plan now says not to use `runtimeProfile` in examples or new implementation work, while acknowledging that some internal capability APIs still receive `RuntimeProfile: "main"`.
+
+### What warrants a second pair of eyes
+- Review whether `CommandSetContext.RuntimeProfile` should remain visible to new command providers, or whether a later cleanup should deprecate it after all multi-runtime tests/docs are removed.
+- Review older xgoja tests and docs that still mention runtime profiles; they may be stale after the schema simplification.
+
+### What should be done in the future
+- Update the research logbook to mark older runtime-profile resources as stale if implementation work confirms they are no longer valid.
+- During implementation, remove or update remaining tests/docs that still expect `runtimes:` in xgoja.yaml.
+
+### Code review instructions
+- In the design doc, search for `runtimes:`, `runtime: main`, and `runtimeProfile:`; none should appear in recommended YAML snippets.
+- Validate docs with `docmgr doctor --ticket GOJA-064 --stale-after 30`.
+
+### Technical details
+- Updated design doc: `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/ttmp/2026/06/04/GOJA-064--http-serve-support-for-xgoja-generated-verbs/design-doc/01-http-serve-support-for-xgoja-generated-verbs.md`.
+
+## Step 7: Implement command-provider jsverb source access and HTTP serve commands
+
+I implemented the first code slice of GOJA-064: command providers can now access configured JavaScript verb sources, and the first-party HTTP provider registers a `serve` command provider that mirrors discovered jsverbs with a long-lived runtime lifecycle. This turns the design from a proposal into a concrete provider extension path for generated binaries.
+
+The implementation follows the simplified single-runtime schema. The serve invoker creates the one configured runtime through `RuntimeFactory.NewRuntimeFromSections(ctx, vals, require.WithLoader(...))`, initializes selected module capabilities such as the HTTP section, invokes the selected setup verb once, and then waits for Ctrl-C/SIGTERM or context cancellation before closing the runtime.
+
+### Prompt Context
+
+**User prompt (verbatim):** "go ahead."
+
+**Assistant interpretation:** Proceed from the updated GOJA-064 plan into implementation.
+
+**Inferred user intent:** The user wants the proposed single-runtime HTTP serve command-provider design implemented, with tickets committed at appropriate intervals and diary updates maintained.
+
+**Commit (code):** pending — this diary step was written immediately before the first implementation commit.
+
+### What I did
+- Added `providerapi.JSVerbSourceDescriptor` and `providerapi.JSVerbSourceSet`.
+- Added `CommandSetContext.JSVerbs` so provider command sets can discover and scan configured jsverb sources.
+- Added `pkg/xgoja/app/jsverb_sources.go` to centralize app-side jsverb source scanning for local, embedded, and provider-shipped sources.
+- Updated `pkg/xgoja/app/command_providers.go` to pass the jsverb source set into provider contexts.
+- Added `pkg/xgoja/providers/http/serve.go` implementing the HTTP `serve` command provider command set and long-lived serve invoker.
+- Updated `pkg/xgoja/providers/http/http.go` to register `CommandSetProvider{Name: "serve"}`.
+- Added tests for command-provider jsverb source access and HTTP serve command generation.
+- Ran `gofmt` and package tests.
+
+### Why
+- Built-in jsverbs could scan configured sources, but command providers could not. The HTTP provider needs that capability to create a `serve` command tree from the same verbs.
+- Ordinary jsverb commands close the runtime after invocation; HTTP setup verbs need the runtime kept alive for request handling.
+
+### What worked
+- `GOWORK=off go test ./pkg/xgoja/app ./pkg/xgoja/providers/http -count=1` passed.
+- The single-runtime API shape matched current code: `RuntimeFactory.NewRuntimeFromSections(ctx, vals, opts...)` did not require profile plumbing.
+- Existing jsverbs command wrappers could be reused with a custom invoker.
+
+### What didn't work
+- The first version of the test JavaScript used an invalid `__verb__` declaration with the function inline:
+  - `__verb__("demo", { short: "Serve demo" }, function demo() {});`
+- The scanner failed with:
+  - `sites.js: __verb__ requires a function name and object metadata`
+- I fixed the tests to match existing examples:
+  - `__verb__("demo", { name: "demo", short: "Serve demo", output: "text" });`
+  - `function demo() {}`
+
+### What I learned
+- jsverbs metadata declarations name functions; they do not accept an inline function argument in the current scanner.
+- The HTTP serve command can be built with very little new command machinery once command providers can see jsverb sources.
+
+### What was tricky to build
+- The main edge was section composition. The serve provider must append HTTP/module sections to command descriptions already produced by jsverbs without clobbering verb-owned sections. I mirrored the existing unique-section logic with `providerutil.AppendUniqueSections`.
+- Another edge was runtime initialization. Creating the runtime is not enough; module capabilities must be initialized from parsed values before invoking the setup verb, otherwise HTTP settings such as `--http-listen` would not be applied.
+
+### What warrants a second pair of eyes
+- `providerapi` now imports `pkg/jsverbs` for the source-scanning interface. Review whether that coupling is acceptable or whether the interface should be moved to a smaller shared package.
+- The HTTP provider still starts the listener asynchronously when `require("express")` runs. Bind failures are not made synchronous in this first slice.
+- `serve` currently mirrors all configured verbs. Filtering by tag such as `http`/`site` remains a possible follow-up.
+
+### What should be done in the future
+- Add a generated-binary smoke test that builds an xgoja app, runs `serve <verb> --http-listen ...`, and probes HTTP endpoints.
+- Add an example under `examples/xgoja/13-http-serve-jsverbs`.
+- Improve HTTP provider listener startup so bind errors are surfaced synchronously for server commands.
+
+### Code review instructions
+- Start with `pkg/xgoja/providerapi/commands.go` for the API addition.
+- Then read `pkg/xgoja/app/jsverb_sources.go` and `pkg/xgoja/app/command_providers.go` to see how generated apps supply sources.
+- Then read `pkg/xgoja/providers/http/serve.go` for the serve lifecycle.
+- Validate with `GOWORK=off go test ./pkg/xgoja/app ./pkg/xgoja/providers/http -count=1`.
+
+### Technical details
+- Validation command: `GOWORK=off go test ./pkg/xgoja/app ./pkg/xgoja/providers/http -count=1`.
+- Modified implementation files:
+  - `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/pkg/xgoja/providerapi/commands.go`
+  - `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/pkg/xgoja/app/jsverb_sources.go`
+  - `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/pkg/xgoja/app/command_providers.go`
+  - `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/pkg/xgoja/app/command_providers_test.go`
+  - `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/pkg/xgoja/providers/http/http.go`
+  - `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/pkg/xgoja/providers/http/serve.go`
+  - `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/pkg/xgoja/providers/http/http_test.go`
+  - `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/pkg/xgoja/providers/http/serve_test.go`.

--- a/ttmp/2026/06/04/GOJA-064--http-serve-support-for-xgoja-generated-verbs/reference/01-diary.md
+++ b/ttmp/2026/06/04/GOJA-064--http-serve-support-for-xgoja-generated-verbs/reference/01-diary.md
@@ -13,6 +13,12 @@ Owners: []
 RelatedFiles:
     - Path: ../../../../../../../../../../code/wesen/2026-05-03--goja-hosting-site/pkg/app/multi_server.go
       Note: External reference that shaped future multi-site serve discussion
+    - Path: cmd/xgoja/doc/12-tutorial-http-serve-jsverbs.md
+      Note: Embedded xgoja help tutorial for provider-backed HTTP serve jsverbs (commit 9af57aabb02a554c746b2ea29c14503bed9373f3)
+    - Path: pkg/xgoja/providers/http/http.go
+      Note: Synchronous HTTP listener binding for GOJA-064 serve hardening (commit 9af57aabb02a554c746b2ea29c14503bed9373f3)
+    - Path: pkg/xgoja/providers/http/http_test.go
+      Note: Regression coverage for synchronous port conflict errors (commit 9af57aabb02a554c746b2ea29c14503bed9373f3)
     - Path: ttmp/2026/06/04/GOJA-064--http-serve-support-for-xgoja-generated-verbs/design-doc/01-http-serve-support-for-xgoja-generated-verbs.md
       Note: Primary GOJA-064 design produced during this investigation
 ExternalSources: []
@@ -21,6 +27,7 @@ LastUpdated: 2026-06-04T22:43:00-04:00
 WhatFor: Use to resume or review the GOJA-064 investigation.
 WhenToUse: Read before implementing HTTP serve support for xgoja generated verbs.
 ---
+
 
 
 # Diary
@@ -621,3 +628,93 @@ I also added `examples/xgoja/13-http-serve-jsverbs`, which gives future users an
   - `GOWORK=off go test ./pkg/xgoja/app ./pkg/xgoja/providers/http ./cmd/xgoja/internal/generate -run 'GeneratedProgramServesHTTPVerb|TestHostAttachCommandProvidersProvidesJSVerbSources|TestNewServeCommandSet|TestRegister' -count=1`
   - `make -C examples/xgoja/13-http-serve-jsverbs smoke`
 - New example path: `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/examples/xgoja/13-http-serve-jsverbs`.
+
+## Step 9: Harden HTTP serve startup and add generated-command help docs
+
+I continued the GOJA-064 follow-up work by addressing two of the remaining hardening/documentation tasks. The HTTP provider now binds its TCP listener synchronously before starting the background server goroutine, which turns address conflicts into immediate command startup errors instead of delayed background log messages.
+
+I also added an embedded xgoja help tutorial for provider-backed HTTP serving of JavaScript verbs and cross-linked it from the overview, user guide, and buildspec reference. The help docs now distinguish short-lived `verbs`, script-based `run --keep-alive`, and provider-backed `serve` commands.
+
+### Prompt Context
+
+**User prompt (verbatim):** "ok, continue with the other tasks."
+
+**Assistant interpretation:** Continue the GOJA-064 follow-up list after the Obsidian report, especially hardening startup behavior and adding xgoja help/docs.
+
+**Inferred user intent:** The user wants the remaining implementation-quality tasks completed rather than stopping at the initial feature and external report.
+
+**Commit (code):** 9af57aabb02a554c746b2ea29c14503bed9373f3 — "GOJA-064: harden HTTP serve startup docs"
+
+### What I did
+- Changed `pkg/xgoja/providers/http/http.go` so `capability.start` calls `net.Listen("tcp", cfg.Listen)` synchronously and then serves with `server.Serve(listener)` in the goroutine.
+- Added `TestCapabilityStartReportsPortConflictsSynchronously` in `pkg/xgoja/providers/http/http_test.go`.
+- Added `cmd/xgoja/doc/12-tutorial-http-serve-jsverbs.md`.
+- Linked the new tutorial from:
+  - `cmd/xgoja/doc/01-overview.md`
+  - `cmd/xgoja/doc/02-user-guide.md`
+  - `cmd/xgoja/doc/06-buildspec-reference.md`
+- Checked task 7, added task 8, then checked task 8 after the code/docs commit.
+- Ran focused validation and the example smoke target.
+- Committed the hardening and help docs in commit `9af57aabb02a554c746b2ea29c14503bed9373f3`.
+
+### Why
+- Binding before starting the goroutine makes listen-address errors deterministic and visible at command startup.
+- The new help page gives generated-binary users a first-party explanation of when to use `serve` versus `verbs` versus `run --keep-alive`.
+- The task list needed to reflect that the generated-binary smoke/example task had already been completed and that the new follow-up task was completed in this step.
+
+### What worked
+- Focused package test passed:
+  - `GOWORK=off go test ./pkg/xgoja/providers/http -count=1`
+- Combined validation passed before commit:
+  - `GOWORK=off go test ./pkg/xgoja/app ./pkg/xgoja/providers/http -count=1`
+  - `GOWORK=off go test ./cmd/xgoja/internal/generate -run GeneratedProgramServesHTTPVerb -count=1`
+  - `make -C examples/xgoja/13-http-serve-jsverbs smoke`
+- The commit pre-commit hook eventually passed full lint and full tests:
+  - `golangci-lint run -v`: `0 issues.`
+  - `go test ./...`: all packages passed.
+
+### What didn't work
+- The first commit attempt failed in the pre-commit lint hook because the new test used an unchecked deferred close:
+  - File: `pkg/xgoja/providers/http/http_test.go:103:22`
+  - Error: `Error return value of listener.Close is not checked (errcheck)`
+  - Problematic code: `defer listener.Close()`
+- I fixed it by changing the defer to:
+  - `defer func() { _ = listener.Close() }()`
+- The pre-commit hook also runs `go generate ./...`, which starts a Dagger session and prints a release notice:
+  - `A new release of dagger is available: v0.20.3 → v0.21.4`
+  - This was informational and did not block the final commit.
+
+### What I learned
+- The HTTP provider startup path can report bind failures synchronously without changing the Express JavaScript authoring model.
+- The generated help system embeds all Markdown files in `cmd/xgoja/doc`, so adding the tutorial only required a new Markdown file with Glazed help frontmatter plus cross-links.
+- Pre-commit catches lint failures that focused package tests do not, especially `errcheck` issues in test cleanup paths.
+
+### What was tricky to build
+- The startup hardening needed to preserve the existing runtime-owned shutdown behavior. The solution was to bind the listener synchronously, store the `http.Server` as before, and let `server.Shutdown(ctx)` close the listener through the server during runtime cleanup.
+- The documentation needed to avoid implying that `serve` replaces `run --keep-alive`. The final wording separates the three modes by command shape and runtime lifetime.
+
+### What warrants a second pair of eyes
+- Review whether `fmt.Printf` in the background `server.Serve` error path should move to stderr or a structured logger.
+- Review whether future readiness reporting should print the bound address after successful `net.Listen`, especially if support for `:0` or inherited listeners is added.
+
+### What should be done in the future
+- Decide whether provider-backed `serve` should filter verbs by tags such as `http`, `site`, or `serve` instead of mirroring every configured verb.
+- Revisit the `providerapi` to `jsverbs` dependency if additional providers need narrower jsverb command descriptors rather than full registries.
+
+### Code review instructions
+- Start with `pkg/xgoja/providers/http/http.go`, especially `capability.start`.
+- Review `pkg/xgoja/providers/http/http_test.go` for the synchronous port-conflict regression test.
+- Review `cmd/xgoja/doc/12-tutorial-http-serve-jsverbs.md` and the cross-links in the overview/user-guide/buildspec docs.
+- Validate with:
+  - `GOWORK=off go test ./pkg/xgoja/app ./pkg/xgoja/providers/http -count=1`
+  - `GOWORK=off go test ./cmd/xgoja/internal/generate -run GeneratedProgramServesHTTPVerb -count=1`
+  - `make -C examples/xgoja/13-http-serve-jsverbs smoke`
+
+### Technical details
+- New synchronous bind code path:
+  - `listener, err := net.Listen("tcp", cfg.Listen)`
+  - `server.Serve(listener)`
+- New help slug:
+  - `tutorial-http-serve-jsverbs`
+- Related commit:
+  - `9af57aabb02a554c746b2ea29c14503bed9373f3`

--- a/ttmp/2026/06/04/GOJA-064--http-serve-support-for-xgoja-generated-verbs/reference/01-diary.md
+++ b/ttmp/2026/06/04/GOJA-064--http-serve-support-for-xgoja-generated-verbs/reference/01-diary.md
@@ -566,7 +566,7 @@ I also added `examples/xgoja/13-http-serve-jsverbs`, which gives future users an
 
 **Inferred user intent:** The user wants a complete, reviewable implementation with proof that the generated xgoja path works.
 
-**Commit (code):** pending — this diary step was written before the second implementation commit.
+**Commit (code):** ba318da5278936824e7cfa5ee30f354ec095b58f — "GOJA-064: add generated HTTP serve smoke"
 
 ### What I did
 - Added `TestGeneratedProgramServesHTTPVerb` in `cmd/xgoja/internal/generate/generate_test.go`.

--- a/ttmp/2026/06/04/GOJA-064--http-serve-support-for-xgoja-generated-verbs/reference/02-research-logbook.md
+++ b/ttmp/2026/06/04/GOJA-064--http-serve-support-for-xgoja-generated-verbs/reference/02-research-logbook.md
@@ -1,0 +1,574 @@
+---
+Title: Research Logbook
+Ticket: GOJA-064
+Status: active
+Topics:
+    - goja
+    - xgoja
+    - http
+    - verbs
+DocType: reference
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: ../../../../../../../../../../code/wesen/2026-05-03--goja-hosting-site/pkg/app/multi_server.go
+      Note: External goja-site multi-site reference evaluated in the logbook
+    - Path: ../../../../../../../../../../code/wesen/2026-05-03--goja-hosting-site/pkg/app/server.go
+      Note: External goja-site single-site reference evaluated in the logbook
+    - Path: modules/express/express.go
+      Note: Express module API evaluated in the logbook
+    - Path: pkg/xgoja/app/command_providers.go
+      Note: Command provider mounting and context construction evaluated in the logbook
+    - Path: pkg/xgoja/app/root.go
+      Note: Key xgoja jsverbs command flow evaluated in the logbook
+    - Path: pkg/xgoja/providers/http/http.go
+      Note: HTTP provider lifecycle and serve command provider target evaluated in the logbook
+ExternalSources: []
+Summary: Logbook of resources consulted for GOJA-064, with usefulness, stale areas, and update needs.
+LastUpdated: 2026-06-04T23:37:00-04:00
+WhatFor: Use to track which GOJA-064 research resources were useful, stale, wrong, or need follow-up updates.
+WhenToUse: Read before continuing implementation or documentation work on xgoja HTTP serve support.
+---
+
+
+# Research Logbook
+
+## Goal
+
+This logbook records the resources consulted while researching GOJA-064: HTTP serve support for xgoja generated JavaScript verbs. It is meant to help future implementers understand which files and documents were useful, which were stale or incomplete, and what should be updated as the implementation proceeds.
+
+## Context
+
+The investigation focused on one question: how should generated xgoja binaries serve HTTP sites defined as JavaScript verbs that use the `express` package? The main candidate design is an HTTP provider command provider, rather than only a JavaScript-level `express.serve()` method.
+
+Resource status terms used below:
+
+- **Useful:** The resource directly informed the design or implementation guide.
+- **Partially useful:** The resource provided context but not a complete answer.
+- **Not useful / missing:** The resource path did not exist or did not contain the expected content.
+- **Needs update:** The resource should be revised after the GOJA-064 implementation lands.
+
+## Quick index
+
+| Resource | Status | Main value |
+| --- | --- | --- |
+| `pkg/xgoja/app/root.go` | Useful | Existing generated root and jsverbs command flow. |
+| `pkg/xgoja/app/run.go` | Useful | Keep-alive lifecycle model for long-running HTTP setup. |
+| `pkg/xgoja/app/command_providers.go` | Useful | Provider-owned command mounting. |
+| `pkg/xgoja/providerapi/commands.go` | Useful | Command provider API gap. |
+| `pkg/xgoja/providers/http/http.go` | Useful | HTTP provider, express module registration, server lifecycle. |
+| `modules/express/express.go` | Useful | JavaScript Express API surface. |
+| `pkg/gojahttp/host.go` | Useful | HTTP request dispatch into Goja handlers. |
+| `pkg/jsverbs/runtime.go` | Useful | Verb invocation in existing runtimes. |
+| `examples/xgoja/10-embedded-assets-fs/*` | Useful | Existing generated HTTP/static-assets smoke pattern. |
+| `cmd/xgoja/doc/09-tutorial-static-assets-http-server.md` | Useful, needs update later | Current documented `run --keep-alive` path. |
+| `goja-site/pkg/app/server.go` | Useful | External reference for single-site runtime/server ownership. |
+| `goja-site/pkg/app/multi_server.go` | Useful | External reference for future multi-site dispatch. |
+| Missing `pkg/app/modules.go` | Missing | Search assumption was wrong; module wiring lives elsewhere. |
+| Missing `scripts/server.js` | Missing | Example script was named differently. |
+
+## Detailed resource entries
+
+### `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/pkg/xgoja/app/root.go`
+
+- **What I was researching:** How generated xgoja roots attach commands and how JavaScript verbs become generated CLI commands.
+- **What I was looking for in this document:** The implementation of `commands.jsverbs`, especially where runtimes are created, invoked, and closed.
+- **Why I chose it:** Search results showed `newVerbsCommand`, `buildVerbCommands`, `scanVerbSource`, and `NewRootCommand` in this file.
+- **How I found the resource:** `rg -n "CommandProvider|Provider|jsverbs|__verb__|NewLazyCommand" pkg/xgoja cmd/xgoja examples/xgoja pkg/jsverbs pkg/jsverbscli modules/express pkg/gojahttp pkg/engine -S`.
+- **What I found useful:** `NewRootCommand` decodes the runtime spec and delegates command attachment. `buildVerbCommands` scans configured verb sources and builds one Glazed command per discovered verb. The current invoker creates a runtime with `factory.NewRuntimeFromSections`, invokes the verb, and defers `rt.Close(...)`.
+- **What I didn't find useful:** It is intentionally oriented toward short-lived CLI verbs, so it does not provide a long-lived serve model by itself.
+- **What is out of date / what was wrong:** Nothing appears wrong. It is current for ordinary jsverb command execution, but insufficient for HTTP serving.
+- **What would need updating:** If command providers get reusable jsverb source access, some scanning logic should be factored so `root.go` and the HTTP serve command do not duplicate source resolution.
+
+### `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/pkg/xgoja/app/host.go`
+
+- **What I was researching:** How xgoja generated commands are attached to the Cobra root.
+- **What I was looking for in this document:** The attachment order of built-in commands and provider command sets.
+- **Why I chose it:** `root.go` constructs an `app.Host`; this file defines the host object and its `AttachDefaultCommands` method.
+- **How I found the resource:** Followed `NewHostWithOptions(...)` from `pkg/xgoja/app/root.go`.
+- **What I found useful:** `AttachDefaultCommands` installs `eval`, `run`, `repl`, `modules`, optionally `verbs`, and then provider command sets. This proves an HTTP provider can add a `serve` command without a new generated root mode.
+- **What I didn't find useful:** It does not contain provider-specific command behavior.
+- **What is out of date / what was wrong:** No obvious stale content.
+- **What would need updating:** Probably no direct update unless the new serve feature needs a different command attachment order or root-level collision handling.
+
+### `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/pkg/xgoja/app/run.go`
+
+- **What I was researching:** Existing long-lived runtime behavior in generated xgoja commands.
+- **What I was looking for in this document:** Signal handling, runtime creation, module initialization, script execution, and `--keep-alive` semantics.
+- **Why I chose it:** The existing static-assets HTTP tutorial says long-running Express servers can use `run --keep-alive`.
+- **How I found the resource:** Search results and direct read of xgoja app command files.
+- **What I found useful:** `runScriptFileWithInitializers` creates a runtime, runs a script as a module, and waits for Ctrl-C/SIGTERM when `keepAlive` is true. This is the model for serving a jsverb-backed site.
+- **What I didn't find useful:** It starts from a script file path, not from a scanned jsverb registry.
+- **What is out of date / what was wrong:** Nothing wrong. It is the correct script-file workaround today.
+- **What would need updating:** Documentation should cross-reference the new `serve` command once GOJA-064 is implemented, while keeping `run --keep-alive` documented for script setup files.
+
+### `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/pkg/xgoja/app/command_providers.go`
+
+- **What I was researching:** Whether the Express/HTTP provider can register a command provider that exposes `serve`.
+- **What I was looking for in this document:** Command provider lookup, context construction, mount behavior, selected module filtering, and Glazed/Cobra attachment.
+- **Why I chose it:** The user specifically asked whether the Express Goja module can register a command provider.
+- **How I found the resource:** `rg` search for `CommandSetProvider` and `commandProviders`.
+- **What I found useful:** `AttachCommandProviders` resolves configured providers and mounts returned commands. `newCommandSet` passes runtime profile, config, providers, runtime factory, and selected modules into `providerapi.CommandSetContext`.
+- **What I didn't find useful:** The context currently lacks jsverb source access, which is the main missing feature for a provider-supplied `serve` command that mirrors configured verbs.
+- **What is out of date / what was wrong:** No stale behavior; the API is just not yet broad enough for this use case.
+- **What would need updating:** Add jsverb source accessor(s) to the command-provider context or another supported package-level API, then test provider command sets can scan configured sources.
+
+### `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/pkg/xgoja/app/factory.go`
+
+- **What I was researching:** How command providers create runtimes from selected xgoja runtime profiles.
+- **What I was looking for in this document:** `RuntimeFactory.NewRuntimeFromSections`, module registration, host service contributions, and config merging.
+- **Why I chose it:** A `serve` command provider must create the same kind of runtime as built-in commands.
+- **How I found the resource:** Followed `RuntimeFactory` from `CommandSetContext` and `root.go`.
+- **What I found useful:** It resolves selected modules, gathers host services, applies provider config sections, registers module loaders, and creates an `engine.Runtime` with startup/lifetime contexts.
+- **What I didn't find useful:** It does not manage post-start command lifetime or HTTP server ownership directly.
+- **What is out of date / what was wrong:** No obvious stale content.
+- **What would need updating:** Probably no direct update unless HTTP serving requires richer host service exposure from runtime creation.
+
+### `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/pkg/xgoja/app/module_sections.go`
+
+- **What I was researching:** How provider module sections are collected and runtime initializers are called.
+- **What I was looking for in this document:** Reusable helpers for appending HTTP provider sections to the proposed `serve` commands.
+- **Why I chose it:** Serve commands need the same `--http-listen` section as `run` and `verbs`.
+- **How I found the resource:** Followed calls to `sectionsForRuntimeProfile` and `initRuntimeFromSections`.
+- **What I found useful:** `sectionsForRuntimeProfile` collects `GlazedConfigSectionCapability` sections, and `initRuntimeFromSections` runs runtime initializers such as the HTTP capability.
+- **What I didn't find useful:** The helpers are on the app-side runtime factory and not automatically available to external provider code.
+- **What is out of date / what was wrong:** No obvious stale content.
+- **What would need updating:** If HTTP serve lives in a provider package, add exported provider utility or context access so provider command sets can collect the same sections without copying internals.
+
+### `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/pkg/xgoja/providerapi/commands.go`
+
+- **What I was researching:** The stable provider-facing API for custom command sets.
+- **What I was looking for in this document:** What a command provider receives and whether it can access runtime profiles, modules, and JavaScript verb sources.
+- **Why I chose it:** This is the API the HTTP provider would implement for a `serve` command.
+- **How I found the resource:** Search results for `CommandSetProvider`.
+- **What I found useful:** `CommandSetContext` already includes runtime profile, static config, host services, providers, runtime factory, and selected modules.
+- **What I didn't find useful:** It does not expose configured jsverb sources or scanning helpers.
+- **What is out of date / what was wrong:** Not wrong; incomplete for GOJA-064's desired provider-driven verb serve command.
+- **What would need updating:** Add a jsverb source access abstraction. Decide whether this API should directly mention `pkg/jsverbs` or expose a narrower provider-safe interface.
+
+### `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/pkg/xgoja/providerapi/module.go`
+
+- **What I was researching:** What module setup context gives native modules at runtime.
+- **What I was looking for in this document:** Host services, runtime owner, config, and closer registration available to modules such as `express`.
+- **Why I chose it:** HTTP serving crosses provider module setup, runtime owner access, and runtime-scoped cleanup.
+- **How I found the resource:** Followed provider module registration from `factory.go` and `providers/http/http.go`.
+- **What I found useful:** `ModuleSetupContext` includes `RuntimeOwner` and `AddCloser`, which are important for runtime-safe HTTP request dispatch and server shutdown.
+- **What I didn't find useful:** It is module setup API, not command provider API.
+- **What is out of date / what was wrong:** No obvious stale content.
+- **What would need updating:** No required update for v1 unless the HTTP provider chooses to expose route hosts as host services for manual server ownership.
+
+### `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/pkg/xgoja/providerapi/capabilities.go`
+
+- **What I was researching:** Provider capabilities that expose config sections and runtime initialization hooks.
+- **What I was looking for in this document:** Interfaces used by the HTTP provider to add `--http-listen` and initialize per-runtime server settings.
+- **Why I chose it:** The proposed serve command must reuse existing HTTP module sections and runtime initializer behavior.
+- **How I found the resource:** Followed `WithPackageCapability` and `InitRuntimeFromSections` from the HTTP provider and app module sections.
+- **What I found useful:** `GlazedConfigSectionCapability`, `RuntimeInitializerCapability`, and `HostServiceContributionCapability` define the extension points needed for HTTP configuration and future server ownership.
+- **What I didn't find useful:** It does not directly help command providers scan jsverbs.
+- **What is out of date / what was wrong:** No obvious stale content.
+- **What would need updating:** If future multi-site serving uses manual server ownership, add or document a provider-defined host service contract for HTTP route hosts.
+
+### `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/pkg/xgoja/providerapi/provider_registry.go`
+
+- **What I was researching:** How provider packages register modules, capabilities, command sets, help, and verb sources.
+- **What I was looking for in this document:** Whether command set providers are registered per package and resolved later by generated apps.
+- **Why I chose it:** The first attempted path `providerapi/registry.go` was wrong; this is the actual registry file.
+- **How I found the resource:** Listed `pkg/xgoja/providerapi` files after the failed read and opened `provider_registry.go`.
+- **What I found useful:** `ProviderRegistry.Package` collects entries; `ResolveCommandSetProvider` and `ResolveVerbSource` are existing lookup methods relevant to GOJA-064.
+- **What I didn't find useful:** It does not describe higher-level semantics; it is just the registry implementation.
+- **What is out of date / what was wrong:** The path I initially guessed, `registry.go`, was wrong. The implementation itself is current.
+- **What would need updating:** Probably no update unless adding convenience lookup methods for jsverb source contexts.
+
+### `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/pkg/jsverbs/runtime.go`
+
+- **What I was researching:** How a scanned JavaScript verb is invoked inside a Goja runtime.
+- **What I was looking for in this document:** Whether `InvokeInRuntime` can be reused by a long-lived serve command.
+- **Why I chose it:** A provider `serve` command should reuse existing verb binding and invocation logic instead of inventing a new route setup function API.
+- **How I found the resource:** Search results for `InvokeInRuntime`, `RequireLoader`, and `__verb__`.
+- **What I found useful:** `RequireLoader` exposes the scanned-source loader, and `InvokeInRuntime` invokes a verb inside a caller-owned runtime without closing it. This is exactly the primitive the serve command needs.
+- **What I didn't find useful:** Default `Registry.invoke` creates and closes its own runtime, so the serve command must avoid that path.
+- **What is out of date / what was wrong:** The promise waiting comment says polling is a simple v1 prototype. That caveat remains important for HTTP setup verbs that return promises.
+- **What would need updating:** If serve needs better readiness semantics for async setup verbs, promise handling may need stronger event-loop integration later.
+
+### `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/pkg/jsverbs/model.go`
+
+- **What I was researching:** The metadata model for discovered JavaScript verbs.
+- **What I was looking for in this document:** Fields such as tags, parents, fields, sections, and full command path.
+- **Why I chose it:** The design considered whether `serve` should expose all verbs or filter by tags such as `http` and `site`.
+- **How I found the resource:** Followed `VerbSpec` from `jsverbs/runtime.go` and command generation.
+- **What I found useful:** `VerbSpec` includes `Tags`, `Parents`, `Fields`, `UseSections`, and `FullPath`, so a future command provider can filter or mirror command paths without changing the verb declaration format.
+- **What I didn't find useful:** It does not decide policy; it only exposes metadata.
+- **What is out of date / what was wrong:** No obvious stale content.
+- **What would need updating:** If the implementation chooses tag filtering, docs should specify the recommended tags and tests should cover filtering.
+
+### `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/modules/express/express.go`
+
+- **What I was researching:** What the JavaScript `express` module currently exposes and whether `express.serve()` already exists.
+- **What I was looking for in this document:** Route registration methods, static serving helpers, runtime owner wiring, and server/listen APIs.
+- **Why I chose it:** The user explicitly mentioned the Express package and asked whether one solution is just an `express serve()` method.
+- **How I found the resource:** Search results for `modules/express` and `express.app`.
+- **What I found useful:** The module exposes `app()`, route methods, `static`, and `staticFromAssetsModule`. It registers Goja callbacks with a `gojahttp.Host` and uses runtimebridge ownership when possible.
+- **What I didn't find useful:** There is no explicit `serve()` or `listen()` JavaScript method today.
+- **What is out of date / what was wrong:** Nothing wrong. The API is route-registration only.
+- **What would need updating:** After GOJA-064, TypeScript docs and module docs may need to explain the preferred generated `serve` command. Add `express.listen()` only if a separate script convenience is still desired.
+
+### `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/modules/express/typescript.go`
+
+- **What I was researching:** Whether the TypeScript declaration surface reflects current Express APIs.
+- **What I was looking for in this document:** Express module declaration shape and whether serve/listen exists.
+- **Why I chose it:** Search results pointed to it while inspecting the Express module.
+- **How I found the resource:** `rg -n "express" modules/express`.
+- **What I found useful:** It confirms the documented module surface is `app`, route methods, and static helpers.
+- **What I didn't find useful:** It was not central to command-provider design.
+- **What is out of date / what was wrong:** It will become out of date if any JavaScript-level `express.serve()` or `listen()` method is added later.
+- **What would need updating:** Update declarations only if the JavaScript Express API changes. A pure generated command provider may not require this file to change.
+
+### `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/modules/express/express_integration_test.go`
+
+- **What I was researching:** Existing integration coverage for Express/gojahttp behavior.
+- **What I was looking for in this document:** Tests for route registration, static embedded assets, body handling, async handlers, and HEAD fallback.
+- **Why I chose it:** It validates the behavior a serve command would depend on.
+- **How I found the resource:** `rg --files modules/express` and search output for Express tests.
+- **What I found useful:** The file is a good model for package-level HTTP tests, especially static asset and async handler behavior.
+- **What I didn't find useful:** It does not exercise generated xgoja command providers or long-lived generated verb commands.
+- **What is out of date / what was wrong:** No obvious stale content.
+- **What would need updating:** Add or complement tests for the new generated `serve` command in xgoja provider/generate tests, not necessarily only here.
+
+### `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/pkg/gojahttp/host.go`
+
+- **What I was researching:** How registered Express routes handle real HTTP requests.
+- **What I was looking for in this document:** Runtime owner calls, request/response DTO creation, promise handling, static mount precedence, and error handling.
+- **Why I chose it:** Serve support must keep a runtime alive so `gojahttp.Host` can call route callbacks safely.
+- **How I found the resource:** Followed `gojahttp.Host` from `modules/express` and the HTTP provider.
+- **What I found useful:** `ServeHTTP` calls route handlers through `h.owner.Call(...)`, proving runtime ownership is central and the runtime must not be closed after setup.
+- **What I didn't find useful:** It does not own listener lifecycle; it is an `http.Handler`.
+- **What is out of date / what was wrong:** No obvious stale content. Promise handling is polling-based, which is noted elsewhere as a v1 approach.
+- **What would need updating:** If manual server ownership or multi-site mode is added, this file may remain unchanged; outer dispatch can wrap multiple `gojahttp.Host` values.
+
+### `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/pkg/xgoja/providers/http/http.go`
+
+- **What I was researching:** Current xgoja HTTP provider behavior and whether it is the right place for `serve`.
+- **What I was looking for in this document:** Provider registration, HTTP config flags, runtime initialization, Express loader wiring, server start, and shutdown.
+- **Why I chose it:** This provider owns the generated `express` module and HTTP server lifecycle.
+- **How I found the resource:** `rg -n "go-go-goja-http|express|http" pkg/xgoja/providers modules/express -S`.
+- **What I found useful:** The provider already exposes `--http-listen`, stores runtime-specific settings, starts `net/http.Server`, and registers cleanup with the runtime.
+- **What I didn't find useful:** It does not yet register a command provider. Server startup is asynchronous and prints bind failures, which is not ideal for a CLI `serve` command.
+- **What is out of date / what was wrong:** The behavior is current, but the async `ListenAndServe` start path is too weak for robust serve-command startup because port conflicts may surface only in a goroutine.
+- **What would need updating:** Register `CommandSetProvider{Name: "serve"}`. Consider changing startup to bind synchronously with `net.Listen` before serving. Later add manual server ownership mode for multi-site.
+
+### `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/pkg/xgoja/providers/http/http_test.go`
+
+- **What I was researching:** Current tests for HTTP provider registration and config behavior.
+- **What I was looking for in this document:** What existing behavior is tested and where new tests should be added.
+- **Why I chose it:** The proposed command provider will live in the same package.
+- **How I found the resource:** Listed `pkg/xgoja/providers/http` files after reading `http.go`.
+- **What I found useful:** Tests already verify registration, config section prefix, nil runtime handling, default enablement when values are present, and explicit disable.
+- **What I didn't find useful:** No command provider tests exist yet.
+- **What is out of date / what was wrong:** Not out of date, but incomplete for GOJA-064.
+- **What would need updating:** Add tests that `Register` exposes both `express` and `serve`, that the serve command set mirrors jsverb commands, and that runtime lifetime persists until cancellation.
+
+### `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/cmd/xgoja/internal/buildspec/build_spec.go`
+
+- **What I was researching:** The YAML schema for generated xgoja binaries.
+- **What I was looking for in this document:** Whether command providers are already configurable in `xgoja.yaml`.
+- **Why I chose it:** The design needed a concrete buildspec fragment for users.
+- **How I found the resource:** Search for `type BuildSpec` after an attempted read of a non-existent `spec.go`.
+- **What I found useful:** `BuildSpec` already has `CommandProviders`, and `CommandProviderInstanceSpec` includes all fields needed to opt into an HTTP `serve` command provider.
+- **What I didn't find useful:** The schema does not describe behavior; it only carries data.
+- **What is out of date / what was wrong:** I initially guessed `cmd/xgoja/internal/buildspec/spec.go`; the actual file is `build_spec.go`.
+- **What would need updating:** If the implementation adds provider-specific `config` fields for filtering serve verbs, document them in user docs rather than changing this generic schema.
+
+### `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/cmd/xgoja/internal/buildspec/validate.go`
+
+- **What I was researching:** Whether a proposed `commandProviders` fragment would pass validation.
+- **What I was looking for in this document:** Validation rules for provider IDs, packages, names, runtime profiles, and jsverb command mounts.
+- **Why I chose it:** The design includes a YAML snippet for `commandProviders: go-go-goja-http.serve`.
+- **How I found the resource:** Search results for `validateCommandProviders` and `commands.jsverbs.mount`.
+- **What I found useful:** Existing validation already supports command providers and checks runtime profile references.
+- **What I didn't find useful:** It cannot validate whether a provider actually registers a named command set until runtime/generated command construction.
+- **What is out of date / what was wrong:** No obvious stale content.
+- **What would need updating:** Optional: add static validation if xgoja doctor gains provider introspection for provider command set names.
+
+### `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/examples/xgoja/10-embedded-assets-fs/xgoja.yaml`
+
+- **What I was researching:** A concrete generated xgoja app that uses HTTP and embedded assets.
+- **What I was looking for in this document:** How users configure host `fs`, HTTP `express`, embedded assets, and generated commands.
+- **Why I chose it:** The static-assets tutorial and search results indicated this was the canonical existing HTTP xgoja example.
+- **How I found the resource:** Search results for `staticFromAssetsModule`, `--http-listen`, and docs references to `examples/xgoja/10-embedded-assets-fs`.
+- **What I found useful:** It shows the provider package IDs and runtime module config needed for `require("fs:assets")` and `require("express")`.
+- **What I didn't find useful:** It does not use jsverbs or command providers.
+- **What is out of date / what was wrong:** Not out of date. It is just script-oriented rather than verb-oriented.
+- **What would need updating:** Add a sibling example for GOJA-064, probably `examples/xgoja/13-http-serve-jsverbs`, rather than changing this one heavily.
+
+### `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/examples/xgoja/10-embedded-assets-fs/scripts/serve-static-assets.js`
+
+- **What I was researching:** Existing JavaScript setup script style for Express serving in generated xgoja.
+- **What I was looking for in this document:** How a script registers routes and static assets using `express.app()`.
+- **Why I chose it:** It is the live example behind `make serve-smoke` for embedded static assets.
+- **How I found the resource:** After the guessed `scripts/server.js` path failed, listed the example directory and found `serve-static-assets.js`.
+- **What I found useful:** It is a minimal route-registration script that can be converted almost directly into a site setup verb.
+- **What I didn't find useful:** It is a script, not a `__verb__` file, so it does not demonstrate generated verb command metadata.
+- **What is out of date / what was wrong:** The resource is current. The guessed filename `server.js` was wrong.
+- **What would need updating:** A new verb-based example should reuse this pattern and wrap it in `__verb__("static", ...)`.
+
+### `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/examples/xgoja/10-embedded-assets-fs/README.md`
+
+- **What I was researching:** How the repository currently explains generated HTTP serving with embedded assets.
+- **What I was looking for in this document:** User-facing explanation and smoke-test commands.
+- **Why I chose it:** The example is likely what users would find before a new serve-verb example exists.
+- **How I found the resource:** Directory listing of `examples/xgoja/10-embedded-assets-fs`.
+- **What I found useful:** The README explains `run scripts/serve-static-assets.js --http-listen ... --keep-alive` and why the generated runtime must stay alive.
+- **What I didn't find useful:** It does not mention jsverbs or command providers.
+- **What is out of date / what was wrong:** It is current for script serving. It will become incomplete once generated verb serving exists.
+- **What would need updating:** Add a "See also" link to the new jsverb serve example after implementation.
+
+### `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/examples/xgoja/10-embedded-assets-fs/Makefile`
+
+- **What I was researching:** How generated HTTP examples are smoke tested.
+- **What I was looking for in this document:** Build, run, and serve smoke command patterns.
+- **Why I chose it:** The proposed implementation guide needed a generated example smoke-test recipe.
+- **How I found the resource:** Directory listing of the embedded-assets example.
+- **What I found useful:** `serve-smoke` starts the generated binary in the background, probes with `curl`, checks responses, and cleans up with traps.
+- **What I didn't find useful:** It tests `run --keep-alive`, not a generated `serve` command.
+- **What is out of date / what was wrong:** Current for its example.
+- **What would need updating:** Copy the test pattern into the new GOJA-064 example and adapt the command from `run ... --keep-alive` to `serve ...`.
+
+### `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/cmd/xgoja/doc/09-tutorial-static-assets-http-server.md`
+
+- **What I was researching:** Current official documentation for generated xgoja HTTP serving.
+- **What I was looking for in this document:** The public recommended way to serve static assets and configure `--http-listen`.
+- **Why I chose it:** Search results showed this tutorial directly discusses generated binaries serving HTTP through Express.
+- **How I found the resource:** `rg -n "Long-running scripts|static asset|http server|--keep-alive" cmd/xgoja/doc examples/xgoja`.
+- **What I found useful:** It clearly explains embedded assets, `fs:assets`, `express.app()`, `staticFromAssetsModule`, `--http-listen`, and why `--keep-alive` matters.
+- **What I didn't find useful:** It only covers script-file serving, not jsverb-backed serving.
+- **What is out of date / what was wrong:** Current today. It will be incomplete after GOJA-064 implementation because it will not mention the generated `serve` command.
+- **What would need updating:** Add a section comparing `run --keep-alive` for setup scripts with `serve <verb>` for generated verb-backed sites. Link to the new example.
+
+### `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/examples/xgoja/05-command-provider/README.md`
+
+- **What I was researching:** Existing provider-shipped command set example.
+- **What I was looking for in this document:** How command providers are explained to users and how generated commands are mounted.
+- **Why I chose it:** The proposed design uses `CommandSetProvider`.
+- **How I found the resource:** Search output from `examples/xgoja/README.md` and `commandProviders` references.
+- **What I found useful:** It confirms the generated command tree model for provider-owned commands and provides a concise example of mounted commands.
+- **What I didn't find useful:** The example is not HTTP-related and does not scan jsverbs.
+- **What is out of date / what was wrong:** Current for generic command provider behavior.
+- **What would need updating:** Add a cross-reference from any future HTTP serve example back to generic command-provider docs if helpful.
+
+### `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/examples/xgoja/05-command-provider/xgoja.yaml`
+
+- **What I was researching:** Concrete YAML syntax for command provider mounting.
+- **What I was looking for in this document:** `commandProviders` shape, including `id`, `package`, `name`, `mount`, and `runtimeProfile`.
+- **Why I chose it:** The design doc needed an accurate YAML fragment.
+- **How I found the resource:** Read alongside the command-provider example README.
+- **What I found useful:** It provides a minimal working pattern for mounting a provider command set.
+- **What I didn't find useful:** It does not include jsverbs or HTTP modules.
+- **What is out of date / what was wrong:** No obvious stale content.
+- **What would need updating:** No update required; the future HTTP serve example should follow this pattern.
+
+### `/home/manuel/code/wesen/2026-05-03--goja-hosting-site/cmd/goja-site/serve.go`
+
+- **What I was researching:** External reference for a real `serve` command that hosts JavaScript Express-style sites.
+- **What I was looking for in this document:** CLI flags, signal handling, server construction, diagnostics setup, and run lifecycle.
+- **Why I chose it:** The user specifically asked to inspect `/home/manuel/code/wesen/2026-05-03--goja-hosting-site`.
+- **How I found the resource:** User-provided path plus `rg -n "express|serve|verb|CommandProvider|require\(|goja"` in that repository.
+- **What I found useful:** `serve` creates a signal context, starts diagnostics, constructs `app.NewServer`, defers cleanup, prints status, and calls `srv.Run(ctx)`.
+- **What I didn't find useful:** It is a standalone app command, not an xgoja provider command provider.
+- **What is out of date / what was wrong:** No obvious stale content for goja-site.
+- **What would need updating:** No direct update required. It remains an external reference model.
+
+### `/home/manuel/code/wesen/2026-05-03--goja-hosting-site/pkg/app/server.go`
+
+- **What I was researching:** How goja-site creates a runtime, loads scripts, and serves routes through Express.
+- **What I was looking for in this document:** Single-site ownership of database, runtime, route host, and HTTP server.
+- **Why I chose it:** It is the closest working implementation of the desired server shape.
+- **How I found the resource:** Followed `app.NewServer` from `cmd/goja-site/serve.go`.
+- **What I found useful:** It creates `gojahttp.Host`, registers `express`, creates one runtime, sets the host runtime, loads scripts, serves through `net/http.Server`, and closes runtime/database/server together.
+- **What I didn't find useful:** It loads sorted script files rather than invoking jsverbs.
+- **What is out of date / what was wrong:** No obvious stale content.
+- **What would need updating:** No direct update. The xgoja implementation should borrow the lifecycle, not the app-specific database and observability layers.
+
+### `/home/manuel/code/wesen/2026-05-03--goja-hosting-site/pkg/app/scripts.go`
+
+- **What I was researching:** How goja-site finds and orders JavaScript setup files.
+- **What I was looking for in this document:** Script discovery semantics and startup determinism.
+- **Why I chose it:** The user mentioned how goja-site loads and serves verbs/scripts using Express.
+- **How I found the resource:** Followed `LoadScripts` from `pkg/app/server.go`.
+- **What I found useful:** It walks configured directories, deduplicates paths, sorts `.js` files, and fails if no scripts are found.
+- **What I didn't find useful:** It is not directly applicable to jsverb source scanning because xgoja already has `jsverbs.ScanDir`/`ScanFS`.
+- **What is out of date / what was wrong:** No obvious stale content.
+- **What would need updating:** No direct update. It reinforces that startup resources should fail fast if missing.
+
+### `/home/manuel/code/wesen/2026-05-03--goja-hosting-site/pkg/app/multi_server.go`
+
+- **What I was researching:** Future multi-site serve architecture.
+- **What I was looking for in this document:** How one outer HTTP listener dispatches to many isolated site runtimes.
+- **Why I chose it:** The user asked whether a serve verb could serve different sites, and the external repo has a multi-site server.
+- **How I found the resource:** Search results and direct read of goja-site app files.
+- **What I found useful:** `MultiServer` creates one `Server` per site and dispatches by normalized Host header. This is the right future model for `serve-multi`.
+- **What I didn't find useful:** It assumes each site is a goja-site `Server` with database config, not a generic xgoja runtime/verb pair.
+- **What is out of date / what was wrong:** No obvious stale content.
+- **What would need updating:** No direct update. The future xgoja multi-site implementation should adapt the pattern after HTTP provider server ownership is explicit.
+
+### `/home/manuel/code/wesen/2026-05-03--goja-hosting-site/examples/kanban/scripts/app.js`
+
+- **What I was researching:** A real site script using `require("express")`.
+- **What I was looking for in this document:** How JavaScript code registers routes, static assets, UI DSL rendering, and application behavior.
+- **Why I chose it:** Search results showed it as a representative goja-site example using Express.
+- **How I found the resource:** `rg -n "const express = require\(\"express\"\)|app = express.app"` in the goja-site repository.
+- **What I found useful:** It shows idiomatic site setup: require modules, create `app`, mount static assets, migrate/seed state, and define routes later in the file.
+- **What I didn't find useful:** It is long and app-specific; most business logic is not relevant to generic xgoja serving.
+- **What is out of date / what was wrong:** No obvious stale content.
+- **What would need updating:** No direct update. A future xgoja example should be much smaller.
+
+### `/home/manuel/code/wesen/2026-05-03--goja-hosting-site/pkg/doc/developer-guide/developer-guide.md`
+
+- **What I was researching:** High-level explanation of goja-site internals.
+- **What I was looking for in this document:** Architecture narrative that could inform the intern-facing GOJA-064 design style.
+- **Why I chose it:** It appeared in goja-site repository search results as a developer-facing architecture guide.
+- **How I found the resource:** `rg --files` and direct read of the goja-site doc path.
+- **What I found useful:** It explains the CLI-to-runtime-to-route-host flow and names the boundaries a new contributor should understand.
+- **What I didn't find useful:** It contains some package names that differ from current upstream go-go-goja package layout and is goja-site-specific.
+- **What is out of date / what was wrong:** The guide references `pkg/web` in places, while this GOJA-064 investigation focused on upstream `pkg/gojahttp` and `modules/express`. That difference is expected because goja-site has its own historical docs and app structure.
+- **What would need updating:** If goja-site is maintained as a current reference, update package references to match the active code organization and add notes distinguishing goja-site app code from upstream go-go-goja modules.
+
+### `/home/manuel/code/wesen/2026-05-03--goja-hosting-site/pkg/app/modules.go`
+
+- **What I was researching:** Expected module wiring file in goja-site.
+- **What I was looking for in this document:** Central module registration for Express, UI DSL, database, and other site modules.
+- **Why I chose it:** I inferred the path while looking for app module wiring.
+- **How I found the resource:** Attempted direct read after inspecting `pkg/app` files.
+- **What I found useful:** Nothing; the file does not exist.
+- **What I didn't find useful:** The path was wrong.
+- **What is out of date / what was wrong:** My assumption was wrong. Module wiring is in `pkg/app/server.go` and database-specific helper files.
+- **What would need updating:** No repository update needed. Future researchers should not look for this path.
+
+### `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/examples/xgoja/10-embedded-assets-fs/scripts/server.js`
+
+- **What I was researching:** Expected static HTTP setup script in the xgoja embedded-assets example.
+- **What I was looking for in this document:** Minimal Express setup script.
+- **Why I chose it:** The tutorial uses the generic name `scripts/server.js`; I tried that path in the concrete example.
+- **How I found the resource:** Attempted direct read based on tutorial naming.
+- **What I found useful:** Nothing; the file does not exist.
+- **What I didn't find useful:** The example's actual file is `scripts/serve-static-assets.js`.
+- **What is out of date / what was wrong:** The mismatch is between tutorial prose and example filename, not necessarily a broken example.
+- **What would need updating:** Consider aligning tutorial and example names, or explicitly mention that the repository example uses `serve-static-assets.js`.
+
+### `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/cmd/xgoja/internal/buildspec/spec.go`
+
+- **What I was researching:** Expected buildspec type definitions.
+- **What I was looking for in this document:** `BuildSpec` and command-provider schema.
+- **Why I chose it:** I guessed a common filename.
+- **How I found the resource:** Attempted direct read, then searched for `type BuildSpec`.
+- **What I found useful:** Nothing from this path; it does not exist.
+- **What I didn't find useful:** The filename was wrong.
+- **What is out of date / what was wrong:** The actual file is `cmd/xgoja/internal/buildspec/build_spec.go`.
+- **What would need updating:** No repository update needed. This is a research-path correction.
+
+## Process references consulted
+
+These were not product/source references, but they shaped the deliverable workflow.
+
+### `/home/manuel/.pi/agent/skills/ticket-research-docmgr-remarkable/references/writing-style.md`
+
+- **What I was researching:** Required style for the design deliverable.
+- **What I was looking for in this document:** Structure, evidence rules, decision record format, and detail level.
+- **Why I chose it:** The active ticket-research skill instructs loading this reference before writing.
+- **How I found the resource:** It is referenced by the pinned `ticket-research-docmgr-remarkable` skill.
+- **What I found useful:** It set the design doc structure and emphasized evidence-backed claims.
+- **What I didn't find useful:** It is generic process guidance, not GOJA-specific technical content.
+- **What is out of date / what was wrong:** No issue observed.
+- **What would need updating:** N/A for GOJA-064.
+
+### `/home/manuel/.pi/agent/skills/ticket-research-docmgr-remarkable/references/deliverable-checklist.md`
+
+- **What I was researching:** Required completion steps for ticket delivery and reMarkable upload.
+- **What I was looking for in this document:** Validation and upload checklist.
+- **Why I chose it:** The active ticket-research skill instructs loading this reference before delivery.
+- **How I found the resource:** It is referenced by the pinned `ticket-research-docmgr-remarkable` skill.
+- **What I found useful:** It reminded me to run `docmgr doctor`, perform a dry-run upload, upload the bundle, and verify the remote listing.
+- **What I didn't find useful:** It is not technical architecture content.
+- **What is out of date / what was wrong:** No issue observed.
+- **What would need updating:** N/A for GOJA-064.
+
+## Ticket resources consulted
+
+### `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/ttmp/2026/06/04/GOJA-064--http-serve-support-for-xgoja-generated-verbs/design-doc/01-http-serve-support-for-xgoja-generated-verbs.md`
+
+- **What I was researching:** The already-written GOJA-064 design package before creating this logbook.
+- **What I was looking for in this document:** The resource list and claims to turn into a separate research logbook.
+- **Why I chose it:** The user asked for a research logbook after the design doc had already been written.
+- **How I found the resource:** `docmgr doc list --ticket GOJA-064` and direct ticket path.
+- **What I found useful:** It contained the file reference map, architecture findings, and decisions that identify the resources used.
+- **What I didn't find useful:** It was not structured as a resource-by-resource logbook.
+- **What is out of date / what was wrong:** No known issue.
+- **What would need updating:** If implementation decisions change, update both the design doc and this logbook.
+
+### `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/ttmp/2026/06/04/GOJA-064--http-serve-support-for-xgoja-generated-verbs/reference/01-diary.md`
+
+- **What I was researching:** The chronological investigation record.
+- **What I was looking for in this document:** Commands run, failures encountered, and resources inspected.
+- **Why I chose it:** The diary captured details not all repeated in the design doc.
+- **How I found the resource:** `docmgr doc list --ticket GOJA-064` and direct ticket path.
+- **What I found useful:** It recorded failed reads, vocabulary validation issues, upload retries, and the investigation sequence.
+- **What I didn't find useful:** It is chronological rather than resource-indexed.
+- **What is out of date / what was wrong:** No known issue.
+- **What would need updating:** Add future implementation steps if the ticket continues beyond research.
+
+### `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/ttmp/2026/06/04/GOJA-064--http-serve-support-for-xgoja-generated-verbs/tasks.md`
+
+- **What I was researching:** Ticket task completion state.
+- **What I was looking for in this document:** Whether the original research/design/upload tasks were complete and whether to add a logbook task.
+- **Why I chose it:** The user asked for an additional deliverable in the same ticket.
+- **How I found the resource:** `docmgr task list --ticket GOJA-064` and direct read.
+- **What I found useful:** It showed prior tasks were checked and allowed tracking the new logbook/upload task.
+- **What I didn't find useful:** It does not contain technical architecture content.
+- **What is out of date / what was wrong:** No issue observed.
+- **What would need updating:** Check the new logbook task after this document is validated and uploaded.
+
+### `/home/manuel/workspaces/2026-06-03/goja-runtime-flags/go-go-goja/ttmp/2026/06/04/GOJA-064--http-serve-support-for-xgoja-generated-verbs/changelog.md`
+
+- **What I was researching:** Ticket history and delivery evidence.
+- **What I was looking for in this document:** Existing entries to keep the logbook addition consistent with prior bookkeeping.
+- **Why I chose it:** The logbook addition should be reflected in changelog updates.
+- **How I found the resource:** Direct ticket path and docmgr workflow.
+- **What I found useful:** It recorded initial ticket creation, design completion, validation, and upload.
+- **What I didn't find useful:** It does not provide detailed resource evaluation.
+- **What is out of date / what was wrong:** No issue observed.
+- **What would need updating:** Add a changelog entry for this research logbook and reMarkable re-upload.
+
+## Resources that need follow-up updates after implementation
+
+1. **`cmd/xgoja/doc/09-tutorial-static-assets-http-server.md`**
+   - Add `serve <verb>` as the preferred verb-backed site path.
+   - Keep `run --keep-alive` for script-backed setup files.
+
+2. **`examples/xgoja/10-embedded-assets-fs/README.md`**
+   - Add a link to the new jsverb serve example after it exists.
+
+3. **New example `examples/xgoja/13-http-serve-jsverbs`**
+   - Add a minimal generated app with embedded assets, a `sites static` verb, and a `serve-smoke` target.
+
+4. **`pkg/xgoja/providers/http/http_test.go`**
+   - Add command-provider registration and serve-command behavior tests.
+
+5. **`pkg/xgoja/app` command-provider tests**
+   - Add tests for exposing configured jsverb sources to command providers.
+
+6. **`modules/express/typescript.go`**
+   - Update only if the JavaScript API itself gains `listen()` or `serve()`.
+
+7. **goja-site developer guide**
+   - Optional: refresh package references if goja-site docs are intended to remain a current upstream architecture reference.
+
+## Suggested use during implementation
+
+Before implementing GOJA-064, read this logbook in this order:
+
+1. `pkg/xgoja/app/root.go`, `run.go`, and `command_providers.go` entries.
+2. `providerapi/commands.go` and `providerapi/capabilities.go` entries.
+3. `pkg/xgoja/providers/http/http.go` and `modules/express/express.go` entries.
+4. `examples/xgoja/10-embedded-assets-fs` entries.
+5. goja-site `server.go` and `multi_server.go` entries.
+
+This sequence explains the current generated command path, the missing API seam, the HTTP provider lifecycle, and the future multi-site direction.

--- a/ttmp/2026/06/04/GOJA-064--http-serve-support-for-xgoja-generated-verbs/tasks.md
+++ b/ttmp/2026/06/04/GOJA-064--http-serve-support-for-xgoja-generated-verbs/tasks.md
@@ -9,4 +9,4 @@
 - [x] Create research logbook and upload updated bundle to reMarkable
 - [x] Implement single-runtime HTTP serve command provider and jsverb source access for command providers
 - [x] Add generated-binary smoke test and runnable xgoja HTTP serve jsverbs example
-- [ ] Harden HTTP serve startup errors and add xgoja help documentation
+- [x] Harden HTTP serve startup errors and add xgoja help documentation

--- a/ttmp/2026/06/04/GOJA-064--http-serve-support-for-xgoja-generated-verbs/tasks.md
+++ b/ttmp/2026/06/04/GOJA-064--http-serve-support-for-xgoja-generated-verbs/tasks.md
@@ -6,3 +6,5 @@
 - [x] Study express module and external hosting site example
 - [x] Design serve support API and implementation plan
 - [x] Validate ticket documentation and upload bundle to reMarkable
+- [x] Create research logbook and upload updated bundle to reMarkable
+- [ ] Implement single-runtime HTTP serve command provider and jsverb source access for command providers

--- a/ttmp/2026/06/04/GOJA-064--http-serve-support-for-xgoja-generated-verbs/tasks.md
+++ b/ttmp/2026/06/04/GOJA-064--http-serve-support-for-xgoja-generated-verbs/tasks.md
@@ -7,4 +7,5 @@
 - [x] Design serve support API and implementation plan
 - [x] Validate ticket documentation and upload bundle to reMarkable
 - [x] Create research logbook and upload updated bundle to reMarkable
-- [ ] Implement single-runtime HTTP serve command provider and jsverb source access for command providers
+- [x] Implement single-runtime HTTP serve command provider and jsverb source access for command providers
+- [ ] Add generated-binary smoke test and runnable xgoja HTTP serve jsverbs example

--- a/ttmp/2026/06/04/GOJA-064--http-serve-support-for-xgoja-generated-verbs/tasks.md
+++ b/ttmp/2026/06/04/GOJA-064--http-serve-support-for-xgoja-generated-verbs/tasks.md
@@ -8,4 +8,5 @@
 - [x] Validate ticket documentation and upload bundle to reMarkable
 - [x] Create research logbook and upload updated bundle to reMarkable
 - [x] Implement single-runtime HTTP serve command provider and jsverb source access for command providers
-- [ ] Add generated-binary smoke test and runnable xgoja HTTP serve jsverbs example
+- [x] Add generated-binary smoke test and runnable xgoja HTTP serve jsverbs example
+- [ ] Harden HTTP serve startup errors and add xgoja help documentation

--- a/ttmp/vocabulary.yaml
+++ b/ttmp/vocabulary.yaml
@@ -119,6 +119,8 @@ topics:
       description: HTTP servers, routing, and web serving
     - slug: verbs
       description: JavaScript verb command definitions and generated verb commands
+    - slug: application-integration
+      description: Integrating generated/runtime code into existing applications
 docTypes:
     - slug: index
       description: Index document for a ticket


### PR DESCRIPTION
This change introduces a new `serve` command provider within the HTTP provider
package. It enables JavaScript verbs, which are typically short-lived, to be
run as long-lived HTTP servers.

This provides an alternative to `run --keep-alive` for running `express`-style
applications, with the benefit of making server setup scripts discoverable as
first-class CLI commands within the generated application's command tree.

**Key Changes:**

*   **New `http-serve` Command Provider:** A new command provider, `serve`, is
    added to the `http` provider. When enabled in `xgoja.yaml`, it scans the
    configured `jsverbs` sources.
*   **Generated `serve` Command:** The provider creates a `serve` command in the
    generated binary. This command has subcommands that mirror the package and
    verb structure of the discovered `jsverbs`.
*   **Long-Lived Execution:** When a command like `./app serve sites demo` is
    executed, the corresponding JavaScript verb is run once to register HTTP
    routes. The provider then keeps the Go runtime alive to handle incoming
    requests, unlike the standard `verbs` command which exits immediately.
*   **New Example and Documentation:** A complete example, a new tutorial, and
    updates to the user guide have been added to demonstrate and document this
    new functionality.