### PR TITLE
feat(xgoja): Support build environment variables and kebab-case jsverb flags

### DIFF
--- a/cmd/xgoja/cmd_build.go
+++ b/cmd/xgoja/cmd_build.go
@@ -131,7 +131,7 @@ func (c *buildCommand) Run(ctx context.Context, vals *values.Values) error {
 	if err := os.MkdirAll(filepath.Dir(outputPath), 0o755); err != nil {
 		return fmt.Errorf("create output directory: %w", err)
 	}
-	if _, err := buildexec.GoBuild(ctx, workDir, outputPath, buildSpec.Go.Tags, buildSpec.Go.LDFlags); err != nil {
+	if _, err := buildexec.GoBuild(ctx, workDir, outputPath, buildSpec.Go.Tags, buildSpec.Go.LDFlags, buildSpec.Go.Env); err != nil {
 		return err
 	}
 	_, err = fmt.Fprintf(c.out, "xgoja build ok: %s\n", outputPath)

--- a/cmd/xgoja/doc/02-user-guide.md
+++ b/cmd/xgoja/doc/02-user-guide.md
@@ -61,6 +61,8 @@ commands:
     name: verbs
 ```
 
+`go.env` can pass build-time environment variables to `go build`. Use it for CGO-heavy builds that need linker environment in addition to `go.tags` and `go.ldflags`; for example, Bleve vector-search binaries can set `CGO_LDFLAGS` for FAISS. See `xgoja help buildspec-reference` for a complete example.
+
 ## Top-level fields
 
 `name` is the generated application name. It defaults to `xgoja-app`.

--- a/cmd/xgoja/doc/06-buildspec-reference.md
+++ b/cmd/xgoja/doc/06-buildspec-reference.md
@@ -97,6 +97,19 @@ modules:
 
 Then JavaScript can use `require("fs:assets")` for read-only embedded files and `require("fs:host")` for explicitly allowed host filesystem access.
 
+Use `go.env` when `go build` needs additional environment variables. This is primarily for CGO-enabled packages whose linker flags are too specific to bake into `ldflags`. For example, a Bleve vector-search binary that links FAISS can declare both build tags and CGO linker flags:
+
+```yaml
+go:
+  tags:
+    - vectors
+  ldflags:
+    - -r
+    - /usr/local/lib
+  env:
+    CGO_LDFLAGS: "-L/usr/local/lib -lfaiss_c -lfaiss -lstdc++ -lm"
+```
+
 Use `go.imports` when generated code must compile an additional Go package even though the generated source does not reference a Go identifier from it. The most common case is a SQL driver package that registers itself through `init()` and is later selected by the database module's runtime `driverName` config:
 
 ```yaml

--- a/cmd/xgoja/internal/buildexec/buildexec.go
+++ b/cmd/xgoja/internal/buildexec/buildexec.go
@@ -3,7 +3,9 @@ package buildexec
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
+	"sort"
 )
 
 type Result struct {
@@ -12,10 +14,10 @@ type Result struct {
 }
 
 func GoModTidy(ctx context.Context, dir string) (Result, error) {
-	return run(ctx, dir, "go", "mod", "tidy")
+	return run(ctx, dir, nil, "go", "mod", "tidy")
 }
 
-func GoBuild(ctx context.Context, dir string, output string, tags []string, ldflags []string) (Result, error) {
+func GoBuild(ctx context.Context, dir string, output string, tags []string, ldflags []string, env map[string]string) (Result, error) {
 	args := []string{"build", "-o", output}
 	if len(tags) > 0 {
 		args = append(args, "-tags", joinSpace(tags))
@@ -24,18 +26,42 @@ func GoBuild(ctx context.Context, dir string, output string, tags []string, ldfl
 		args = append(args, "-ldflags", joinSpace(ldflags))
 	}
 	args = append(args, ".")
-	return run(ctx, dir, "go", args...)
+	return run(ctx, dir, env, "go", args...)
 }
 
-func run(ctx context.Context, dir string, name string, args ...string) (Result, error) {
+func run(ctx context.Context, dir string, env map[string]string, name string, args ...string) (Result, error) {
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Dir = dir
+	if len(env) > 0 {
+		cmd.Env = append(os.Environ(), sortedEnv(env)...)
+	}
 	out, err := cmd.CombinedOutput()
-	result := Result{Command: name + " " + joinSpace(args), Output: string(out)}
+	result := Result{Command: commandString(env, name, args), Output: string(out)}
 	if err != nil {
 		return result, fmt.Errorf("%s failed: %w\n%s", result.Command, err, result.Output)
 	}
 	return result, nil
+}
+
+func commandString(env map[string]string, name string, args []string) string {
+	cmd := name + " " + joinSpace(args)
+	if len(env) == 0 {
+		return cmd
+	}
+	return joinSpace(sortedEnv(env)) + " " + cmd
+}
+
+func sortedEnv(env map[string]string) []string {
+	keys := make([]string, 0, len(env))
+	for key := range env {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	out := make([]string, 0, len(keys))
+	for _, key := range keys {
+		out = append(out, key+"="+env[key])
+	}
+	return out
 }
 
 func joinSpace(items []string) string {

--- a/cmd/xgoja/internal/buildexec/buildexec_test.go
+++ b/cmd/xgoja/internal/buildexec/buildexec_test.go
@@ -1,0 +1,20 @@
+package buildexec
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestSortedEnvAndCommandString(t *testing.T) {
+	env := map[string]string{"CGO_LDFLAGS": "-L/usr/local/lib -lfaiss", "A": "b"}
+	got := sortedEnv(env)
+	want := []string{"A=b", "CGO_LDFLAGS=-L/usr/local/lib -lfaiss"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("sortedEnv = %#v, want %#v", got, want)
+	}
+	cmd := commandString(env, "go", []string{"build", "."})
+	if !strings.HasPrefix(cmd, "A=b CGO_LDFLAGS=-L/usr/local/lib -lfaiss go build .") {
+		t.Fatalf("commandString = %q", cmd)
+	}
+}

--- a/cmd/xgoja/internal/buildspec/build_spec.go
+++ b/cmd/xgoja/internal/buildspec/build_spec.go
@@ -37,11 +37,12 @@ type ConfigFileSpec struct {
 }
 
 type GoSpec struct {
-	Version string         `yaml:"version" json:"version"`
-	Module  string         `yaml:"module" json:"module"`
-	Tags    []string       `yaml:"tags" json:"tags,omitempty"`
-	LDFlags []string       `yaml:"ldflags" json:"ldflags,omitempty"`
-	Imports []GoImportSpec `yaml:"imports" json:"imports,omitempty"`
+	Version string            `yaml:"version" json:"version"`
+	Module  string            `yaml:"module" json:"module"`
+	Tags    []string          `yaml:"tags" json:"tags,omitempty"`
+	LDFlags []string          `yaml:"ldflags" json:"ldflags,omitempty"`
+	Env     map[string]string `yaml:"env" json:"env,omitempty"`
+	Imports []GoImportSpec    `yaml:"imports" json:"imports,omitempty"`
 }
 
 // GoImportSpec describes an extra Go import that should be emitted into

--- a/pkg/doc/11-jsverbs-example-reference.md
+++ b/pkg/doc/11-jsverbs-example-reference.md
@@ -178,13 +178,13 @@ These keys are intentionally close to Glazed concepts. The subsystem is not inve
 
 ## Field naming
 
-Top-level JavaScript parameter fields are exposed on the CLI using kebab-case. This keeps command lines idiomatic while preserving JavaScript parameter names at invocation time:
+JavaScript parameter and field names are exposed on the CLI using kebab-case. This keeps command lines idiomatic while preserving JavaScript parameter names and bound-section object keys at invocation time:
 
 - `profilePath` becomes `--profile-path`, but the function still receives the `profilePath` argument.
 - `foo_bar` becomes `--foo-bar`, but the function still receives the `foo_bar` argument.
 - Already-kebab names such as `profile-path` remain `--profile-path`.
 
-Section fields currently preserve their declared field names because bound section objects are passed to JavaScript as objects. Renaming those fields at the CLI boundary would otherwise also change object keys such as `filters.localOnly`.
+Section fields follow the same CLI naming rule without changing JavaScript object keys. A field declared as `localOnly` inside a `filters` section is exposed as `--local-only`, but JavaScript still reads `filters.localOnly`. Internally, jsverbs remaps parsed CLI/Glazed field names back to the declared JavaScript names before invoking the function.
 
 ## Field type mapping
 

--- a/pkg/doc/11-jsverbs-example-reference.md
+++ b/pkg/doc/11-jsverbs-example-reference.md
@@ -176,6 +176,16 @@ Supported field metadata keys:
 
 These keys are intentionally close to Glazed concepts. The subsystem is not inventing a separate CLI schema language; it is translating a small JavaScript-friendly metadata format into existing Glazed schema structures.
 
+## Field naming
+
+Top-level JavaScript parameter fields are exposed on the CLI using kebab-case. This keeps command lines idiomatic while preserving JavaScript parameter names at invocation time:
+
+- `profilePath` becomes `--profile-path`, but the function still receives the `profilePath` argument.
+- `foo_bar` becomes `--foo-bar`, but the function still receives the `foo_bar` argument.
+- Already-kebab names such as `profile-path` remain `--profile-path`.
+
+Section fields currently preserve their declared field names because bound section objects are passed to JavaScript as objects. Renaming those fields at the CLI boundary would otherwise also change object keys such as `filters.localOnly`.
+
 ## Field type mapping
 
 Supported field types currently map to Glazed like this:

--- a/pkg/jsverbs/binding.go
+++ b/pkg/jsverbs/binding.go
@@ -30,11 +30,18 @@ type ExtraFieldBinding struct {
 	SectionSlug string
 }
 
+type FieldNameBinding struct {
+	SectionSlug string
+	JSName      string
+	CLIName     string
+}
+
 type VerbBindingPlan struct {
 	Verb               *VerbSpec
 	Parameters         []ParameterBinding
 	ExtraFields        []ExtraFieldBinding
 	ReferencedSections []string
+	FieldNames         []FieldNameBinding
 }
 
 func buildVerbBindingPlan(r *Registry, verb *VerbSpec) (*VerbBindingPlan, error) {
@@ -85,6 +92,9 @@ func buildVerbBindingPlan(r *Registry, verb *VerbSpec) (*VerbBindingPlan, error)
 			return nil, err
 		}
 		plan.Parameters = append(plan.Parameters, binding)
+		if binding.Mode == BindingModePositional {
+			plan.addFieldNameBinding(binding.SectionSlug, binding.Field.Name)
+		}
 	}
 
 	extraFieldNames := make([]string, 0, len(verb.Fields))
@@ -116,6 +126,7 @@ func buildVerbBindingPlan(r *Registry, verb *VerbSpec) (*VerbBindingPlan, error)
 			Field:       fieldSpec,
 			SectionSlug: sectionSlug,
 		})
+		plan.addFieldNameBinding(sectionSlug, fieldSpec.Name)
 	}
 
 	for slug := range referencedSections {
@@ -156,7 +167,45 @@ func buildVerbBindingPlan(r *Registry, verb *VerbSpec) (*VerbBindingPlan, error)
 		appendSection(slug)
 	}
 
+	for _, slug := range plan.ReferencedSections {
+		section, ok := r.ResolveSection(verb, slug)
+		if !ok || section == nil {
+			continue
+		}
+		fieldNames := make([]string, 0, len(section.Fields))
+		for name := range section.Fields {
+			fieldNames = append(fieldNames, name)
+		}
+		sort.Strings(fieldNames)
+		for _, name := range fieldNames {
+			field := section.Fields[name]
+			if field == nil {
+				continue
+			}
+			plan.addFieldNameBinding(slug, field.Name)
+		}
+	}
+
 	return plan, nil
+}
+
+func (p *VerbBindingPlan) addFieldNameBinding(sectionSlug string, jsName string) {
+	if p == nil {
+		return
+	}
+	jsName = strings.TrimSpace(jsName)
+	if jsName == "" {
+		return
+	}
+	sectionSlug = cleanCommandWord(sectionSlug)
+	if sectionSlug == "" {
+		sectionSlug = schema.DefaultSlug
+	}
+	p.FieldNames = append(p.FieldNames, FieldNameBinding{
+		SectionSlug: sectionSlug,
+		JSName:      jsName,
+		CLIName:     cliFieldName(jsName),
+	})
 }
 
 func resolveParameterBinding(verb *VerbSpec, param ParameterSpec, fieldSpec *FieldSpec) (ParameterBinding, error) {

--- a/pkg/jsverbs/command.go
+++ b/pkg/jsverbs/command.go
@@ -157,7 +157,7 @@ func (r *Registry) buildDescription(verb *VerbSpec) (*cmds.CommandDescription, e
 		}
 		sort.Strings(fieldNames)
 		for _, name := range fieldNames {
-			field, err := buildFieldDefinition(spec.Fields[name])
+			field, err := buildFieldDefinition(spec.Fields[name], false)
 			if err != nil {
 				return nil, fmt.Errorf("%s section %s field %s: %w", verb.SourceRef(), slug, name, err)
 			}
@@ -170,7 +170,7 @@ func (r *Registry) buildDescription(verb *VerbSpec) (*cmds.CommandDescription, e
 		if err != nil {
 			return err
 		}
-		field, err := buildFieldDefinition(fieldSpec)
+		field, err := buildFieldDefinition(fieldSpec, true)
 		if err != nil {
 			return err
 		}
@@ -227,11 +227,14 @@ func inferFieldFromParam(param ParameterSpec) *FieldSpec {
 	return field
 }
 
-func buildFieldDefinition(spec *FieldSpec) (*fields.Definition, error) {
+func buildFieldDefinition(spec *FieldSpec, normalizeName bool) (*fields.Definition, error) {
 	if spec == nil {
 		return nil, fmt.Errorf("field spec is nil")
 	}
 	name := strings.TrimSpace(spec.Name)
+	if normalizeName {
+		name = cliFieldName(name)
+	}
 	if name == "" {
 		return nil, fmt.Errorf("field name is empty")
 	}
@@ -263,6 +266,10 @@ func buildFieldDefinition(spec *FieldSpec) (*fields.Definition, error) {
 		options = append(options, fields.WithDefault(value))
 	}
 	return fields.New(name, fieldType, options...), nil
+}
+
+func cliFieldName(name string) string {
+	return cleanCommandWord(name)
 }
 
 func glazedFieldType(spec *FieldSpec) (fields.Type, error) {

--- a/pkg/jsverbs/command.go
+++ b/pkg/jsverbs/command.go
@@ -157,7 +157,7 @@ func (r *Registry) buildDescription(verb *VerbSpec) (*cmds.CommandDescription, e
 		}
 		sort.Strings(fieldNames)
 		for _, name := range fieldNames {
-			field, err := buildFieldDefinition(spec.Fields[name], false)
+			field, err := buildFieldDefinition(spec.Fields[name], true)
 			if err != nil {
 				return nil, fmt.Errorf("%s section %s field %s: %w", verb.SourceRef(), slug, name, err)
 			}
@@ -170,8 +170,7 @@ func (r *Registry) buildDescription(verb *VerbSpec) (*cmds.CommandDescription, e
 		if err != nil {
 			return err
 		}
-		normalizeName := sectionSlug == schema.DefaultSlug
-		field, err := buildFieldDefinition(fieldSpec, normalizeName)
+		field, err := buildFieldDefinition(fieldSpec, true)
 		if err != nil {
 			return err
 		}

--- a/pkg/jsverbs/command.go
+++ b/pkg/jsverbs/command.go
@@ -170,7 +170,8 @@ func (r *Registry) buildDescription(verb *VerbSpec) (*cmds.CommandDescription, e
 		if err != nil {
 			return err
 		}
-		field, err := buildFieldDefinition(fieldSpec, true)
+		normalizeName := sectionSlug == schema.DefaultSlug
+		field, err := buildFieldDefinition(fieldSpec, normalizeName)
 		if err != nil {
 			return err
 		}

--- a/pkg/jsverbs/jsverbs_test.go
+++ b/pkg/jsverbs/jsverbs_test.go
@@ -516,6 +516,46 @@ func TestCommandDescriptionForVerb(t *testing.T) {
 	require.NotNil(t, desc.Schema)
 }
 
+func TestTopLevelFieldNamesUseKebabCaseCLI(t *testing.T) {
+	registry, err := ScanSource("naming.js", `
+function show(profilePath, foo_bar) {
+  return [{ profilePath, foo_bar }];
+}
+
+__verb__("show", {
+  fields: {
+    profilePath: { help: "Profile path" },
+    foo_bar: { help: "Foo bar" }
+  }
+});
+`)
+	require.NoError(t, err)
+	verb, ok := registry.Verb("naming show")
+	require.True(t, ok)
+	desc, err := registry.CommandDescriptionForVerb(verb)
+	require.NoError(t, err)
+	flags := desc.GetDefaultFlags()
+	require.NotNil(t, flags)
+	_, ok = flags.Get("profile-path")
+	require.True(t, ok, "camelCase field should be exposed as kebab-case CLI flag")
+	_, ok = flags.Get("foo-bar")
+	require.True(t, ok, "snake_case field should be exposed as kebab-case CLI flag")
+	_, ok = flags.Get("profilePath")
+	require.False(t, ok, "camelCase field should not be exposed literally")
+	_, ok = flags.Get("foo_bar")
+	require.False(t, ok, "snake_case field should not be exposed literally")
+
+	commandMap := mustCommandMap(t, registry)
+	rows := runCommand(t, commandMap["naming show"], map[string]map[string]interface{}{
+		"default": {
+			"profile-path": "profiles.yaml",
+			"foo-bar":      "snake",
+		},
+	})
+	require.Equal(t, "profiles.yaml", rows[0]["profilePath"])
+	require.Equal(t, "snake", rows[0]["foo_bar"])
+}
+
 func TestCommandForVerbWithInvokerUsesCustomInvoker(t *testing.T) {
 	registry := mustRegistry(t)
 	verb, ok := registry.Verb("basics greet")

--- a/pkg/jsverbs/jsverbs_test.go
+++ b/pkg/jsverbs/jsverbs_test.go
@@ -556,6 +556,38 @@ __verb__("show", {
 	require.Equal(t, "snake", rows[0]["foo_bar"])
 }
 
+func TestBoundSectionFieldNamesPreserveJavaScriptObjectKeys(t *testing.T) {
+	registry, err := ScanSource("section_keys.js", `
+__section__("filters", {
+  title: "Filters"
+});
+
+function summarize(filters) {
+  return [{
+    local: filters.localOnly,
+    hasKebabKey: Object.prototype.hasOwnProperty.call(filters, "local-only")
+  }];
+}
+
+__verb__("summarize", {
+  fields: {
+    filters: { bind: "filters" },
+    localOnly: { section: "filters", help: "Local-only section field" }
+  }
+});
+`)
+	require.NoError(t, err)
+
+	commandMap := mustCommandMap(t, registry)
+	rows := runCommand(t, commandMap["section-keys summarize"], map[string]map[string]interface{}{
+		"filters": {
+			"localOnly": "from-section",
+		},
+	})
+	require.Equal(t, "from-section", rows[0]["local"])
+	require.Equal(t, false, rows[0]["hasKebabKey"])
+}
+
 func TestCommandForVerbWithInvokerUsesCustomInvoker(t *testing.T) {
 	registry := mustRegistry(t)
 	verb, ok := registry.Verb("basics greet")

--- a/pkg/jsverbs/jsverbs_test.go
+++ b/pkg/jsverbs/jsverbs_test.go
@@ -456,7 +456,7 @@ __verb__("summarize", {
 	commandMap := mustCommandMap(t, registry)
 	rows := runCommand(t, commandMap["local summarize"], map[string]map[string]interface{}{
 		"filters": {
-			"localOnly": "from-local",
+			"local-only": "from-local",
 		},
 	})
 	require.Equal(t, "from-local", rows[0]["local"])
@@ -578,14 +578,119 @@ __verb__("summarize", {
 `)
 	require.NoError(t, err)
 
+	verb, ok := registry.Verb("section-keys summarize")
+	require.True(t, ok)
+	desc, err := registry.CommandDescriptionForVerb(verb)
+	require.NoError(t, err)
+	section, ok := desc.GetSection("filters")
+	require.True(t, ok)
+	fields := section.GetDefinitions()
+	_, ok = fields.Get("local-only")
+	require.True(t, ok, "section field should be exposed as kebab-case CLI/config key")
+	_, ok = fields.Get("localOnly")
+	require.False(t, ok, "section field should not be exposed literally at the CLI boundary")
+
 	commandMap := mustCommandMap(t, registry)
 	rows := runCommand(t, commandMap["section-keys summarize"], map[string]map[string]interface{}{
 		"filters": {
-			"localOnly": "from-section",
+			"local-only": "from-section",
 		},
 	})
 	require.Equal(t, "from-section", rows[0]["local"])
 	require.Equal(t, false, rows[0]["hasKebabKey"])
+}
+
+func TestSharedSectionFieldNamesUseKebabCaseCLIAndCamelCaseObjectKeys(t *testing.T) {
+	registry, err := ScanSource("shared_section_keys.js", `
+function summarize(filters) {
+  return [{
+    max: filters.maxResults,
+    hasKebabKey: Object.prototype.hasOwnProperty.call(filters, "max-results")
+  }];
+}
+
+__verb__("summarize", {
+  fields: {
+    filters: { bind: "filters" }
+  }
+});
+`)
+	require.NoError(t, err)
+	require.NoError(t, registry.AddSharedSection(&SectionSpec{
+		Slug:  "filters",
+		Title: "Filters",
+		Fields: map[string]*FieldSpec{
+			"maxResults": {Type: "int"},
+		},
+	}))
+
+	verb, ok := registry.Verb("shared-section-keys summarize")
+	require.True(t, ok)
+	desc, err := registry.CommandDescriptionForVerb(verb)
+	require.NoError(t, err)
+	section, ok := desc.GetSection("filters")
+	require.True(t, ok)
+	fields := section.GetDefinitions()
+	_, ok = fields.Get("max-results")
+	require.True(t, ok)
+	_, ok = fields.Get("maxResults")
+	require.False(t, ok)
+
+	commandMap := mustCommandMap(t, registry)
+	rows := runCommand(t, commandMap["shared-section-keys summarize"], map[string]map[string]interface{}{
+		"filters": {
+			"max-results": 10,
+		},
+	})
+	require.EqualValues(t, 10, rows[0]["max"])
+	require.Equal(t, false, rows[0]["hasKebabKey"])
+}
+
+func TestBindAllAndContextUseJavaScriptFieldNames(t *testing.T) {
+	registry, err := ScanSource("all_context_keys.js", `
+__section__("filters", {
+  fields: {
+    maxResults: { type: "int" }
+  }
+});
+
+function inspect(allValues, meta) {
+  return [{
+    defaultProfile: allValues.profilePath,
+    defaultHasKebabKey: Object.prototype.hasOwnProperty.call(allValues, "profile-path"),
+    filterMax: allValues.maxResults,
+    filterHasKebabKey: Object.prototype.hasOwnProperty.call(allValues, "max-results"),
+    contextMax: meta.sections.filters.maxResults,
+    rawContextMax: meta.rawValues.filters["max-results"]
+  }];
+}
+
+__verb__("inspect", {
+  sections: ["filters"],
+  fields: {
+    allValues: { bind: "all" },
+    meta: { bind: "context" },
+    profilePath: { help: "Profile path" }
+  }
+});
+`)
+	require.NoError(t, err)
+
+	commandMap := mustCommandMap(t, registry)
+	rows := runCommand(t, commandMap["all-context-keys inspect"], map[string]map[string]interface{}{
+		"default": {
+			"profile-path": "profiles.yaml",
+		},
+		"filters": {
+			"max-results": 42,
+		},
+	})
+	require.Equal(t, "profiles.yaml", rows[0]["defaultProfile"])
+	require.Equal(t, false, rows[0]["defaultHasKebabKey"])
+	require.EqualValues(t, 42, rows[0]["filterMax"])
+	require.Equal(t, false, rows[0]["filterHasKebabKey"])
+	require.EqualValues(t, 42, rows[0]["contextMax"])
+	require.EqualValues(t, 42, rows[0]["rawContextMax"])
 }
 
 func TestCommandForVerbWithInvokerUsesCustomInvoker(t *testing.T) {

--- a/pkg/jsverbs/jsverbs_test.go
+++ b/pkg/jsverbs/jsverbs_test.go
@@ -705,12 +705,12 @@ func TestFSWatchJsverbUsesInstalledHelper(t *testing.T) {
 	cmd := &Command{CommandDescription: desc, registry: registry, verb: verb}
 	parsedValues, err := runner.ParseCommandValues(cmd, runner.WithValuesForSections(map[string]map[string]interface{}{
 		"default": {
-			"dir":        dir,
-			"fileName":   "nested/from-jsverb.txt",
-			"recursive":  true,
-			"debounceMs": 25,
-			"include":    []string{"**/*.txt"},
-			"exclude":    []string{"**/ignored/**"},
+			"dir":         dir,
+			"file-name":   "nested/from-jsverb.txt",
+			"recursive":   true,
+			"debounce-ms": 25,
+			"include":     []string{"**/*.txt"},
+			"exclude":     []string{"**/ignored/**"},
 		},
 	}))
 	require.NoError(t, err)

--- a/pkg/jsverbs/runtime.go
+++ b/pkg/jsverbs/runtime.go
@@ -11,6 +11,7 @@ import (
 	"github.com/dop251/goja"
 	"github.com/dop251/goja_nodejs/require"
 	"github.com/go-go-golems/glazed/pkg/cmds/fields"
+	"github.com/go-go-golems/glazed/pkg/cmds/schema"
 	"github.com/go-go-golems/glazed/pkg/cmds/values"
 	"github.com/go-go-golems/go-go-goja/pkg/engine"
 )
@@ -148,7 +149,11 @@ func buildArguments(parsedValues *values.Values, plan *VerbBindingPlan, rootDir 
 			args = append(args, cloneMap(sectionValues[binding.SectionSlug]))
 			continue
 		case BindingModePositional:
-			value := sectionValues[binding.SectionSlug][cliFieldName(binding.Field.Name)]
+			fieldName := binding.Field.Name
+			if binding.SectionSlug == "" || binding.SectionSlug == schema.DefaultSlug {
+				fieldName = cliFieldName(fieldName)
+			}
+			value := sectionValues[binding.SectionSlug][fieldName]
 			if binding.Param.Rest {
 				rv := reflect.ValueOf(value)
 				if rv.IsValid() && (rv.Kind() == reflect.Slice || rv.Kind() == reflect.Array) {

--- a/pkg/jsverbs/runtime.go
+++ b/pkg/jsverbs/runtime.go
@@ -148,7 +148,7 @@ func buildArguments(parsedValues *values.Values, plan *VerbBindingPlan, rootDir 
 			args = append(args, cloneMap(sectionValues[binding.SectionSlug]))
 			continue
 		case BindingModePositional:
-			value := sectionValues[binding.SectionSlug][binding.Field.Name]
+			value := sectionValues[binding.SectionSlug][cliFieldName(binding.Field.Name)]
 			if binding.Param.Rest {
 				rv := reflect.ValueOf(value)
 				if rv.IsValid() && (rv.Kind() == reflect.Slice || rv.Kind() == reflect.Array) {

--- a/pkg/jsverbs/runtime.go
+++ b/pkg/jsverbs/runtime.go
@@ -11,7 +11,6 @@ import (
 	"github.com/dop251/goja"
 	"github.com/dop251/goja_nodejs/require"
 	"github.com/go-go-golems/glazed/pkg/cmds/fields"
-	"github.com/go-go-golems/glazed/pkg/cmds/schema"
 	"github.com/go-go-golems/glazed/pkg/cmds/values"
 	"github.com/go-go-golems/go-go-goja/pkg/engine"
 )
@@ -111,28 +110,18 @@ func (r *Registry) InvokeInRuntime(ctx context.Context, runtime *engine.Runtime,
 }
 
 func buildArguments(parsedValues *values.Values, plan *VerbBindingPlan, rootDir string) ([]interface{}, error) {
-	sectionValues := map[string]map[string]interface{}{}
 	if parsedValues == nil {
 		parsedValues = values.New()
 	}
-	allValues := parsedValues.GetDataMap()
-
-	parsedValues.ForEach(func(slug string, value *values.SectionValues) {
-		sectionMap := map[string]interface{}{}
-		value.Fields.ForEach(func(_ string, fieldValue *fields.FieldValue) {
-			if fieldValue == nil || fieldValue.Definition == nil {
-				return
-			}
-			sectionMap[fieldValue.Definition.Name] = fieldValue.Value
-		})
-		sectionValues[slug] = sectionMap
-	})
+	rawSectionValues := collectSectionValues(parsedValues)
+	jsSectionValues := remapSectionValues(rawSectionValues, plan)
+	allValues := flattenSectionValues(jsSectionValues)
 
 	args := make([]interface{}, 0, len(plan.Parameters))
 	for _, binding := range plan.Parameters {
 		switch binding.Mode {
 		case BindingModeAll:
-			args = append(args, allValues)
+			args = append(args, cloneMap(allValues))
 			continue
 		case BindingModeContext:
 			args = append(args, map[string]interface{}{
@@ -141,19 +130,16 @@ func buildArguments(parsedValues *values.Values, plan *VerbBindingPlan, rootDir 
 				"module":     plan.Verb.File.ModulePath,
 				"sourceFile": fileSourcePath(plan.Verb.File),
 				"rootDir":    rootDir,
-				"values":     allValues,
-				"sections":   sectionValues,
+				"values":     cloneMap(allValues),
+				"rawValues":  cloneSectionValues(rawSectionValues),
+				"sections":   cloneSectionValues(jsSectionValues),
 			})
 			continue
 		case BindingModeSection:
-			args = append(args, cloneMap(sectionValues[binding.SectionSlug]))
+			args = append(args, cloneMap(jsSectionValues[binding.SectionSlug]))
 			continue
 		case BindingModePositional:
-			fieldName := binding.Field.Name
-			if binding.SectionSlug == "" || binding.SectionSlug == schema.DefaultSlug {
-				fieldName = cliFieldName(fieldName)
-			}
-			value := sectionValues[binding.SectionSlug][fieldName]
+			value := rawSectionValues[binding.SectionSlug][cliFieldName(binding.Field.Name)]
 			if binding.Param.Rest {
 				rv := reflect.ValueOf(value)
 				if rv.IsValid() && (rv.Kind() == reflect.Slice || rv.Kind() == reflect.Array) {
@@ -274,6 +260,72 @@ func valueString(value goja.Value) string {
 		return "undefined"
 	}
 	return value.String()
+}
+
+func collectSectionValues(parsedValues *values.Values) map[string]map[string]interface{} {
+	sectionValues := map[string]map[string]interface{}{}
+	if parsedValues == nil {
+		return sectionValues
+	}
+	parsedValues.ForEach(func(slug string, value *values.SectionValues) {
+		sectionMap := map[string]interface{}{}
+		value.Fields.ForEach(func(_ string, fieldValue *fields.FieldValue) {
+			if fieldValue == nil || fieldValue.Definition == nil {
+				return
+			}
+			sectionMap[fieldValue.Definition.Name] = fieldValue.Value
+		})
+		sectionValues[slug] = sectionMap
+	})
+	return sectionValues
+}
+
+func remapSectionValues(raw map[string]map[string]interface{}, plan *VerbBindingPlan) map[string]map[string]interface{} {
+	jsValues := cloneSectionValues(raw)
+	if plan == nil {
+		return jsValues
+	}
+	for _, binding := range plan.FieldNames {
+		if binding.SectionSlug == "" || binding.JSName == "" || binding.CLIName == "" {
+			continue
+		}
+		rawSection := raw[binding.SectionSlug]
+		if rawSection == nil {
+			continue
+		}
+		value, ok := rawSection[binding.CLIName]
+		if !ok {
+			continue
+		}
+		jsSection := jsValues[binding.SectionSlug]
+		if jsSection == nil {
+			jsSection = map[string]interface{}{}
+			jsValues[binding.SectionSlug] = jsSection
+		}
+		if binding.CLIName != binding.JSName {
+			delete(jsSection, binding.CLIName)
+		}
+		jsSection[binding.JSName] = value
+	}
+	return jsValues
+}
+
+func flattenSectionValues(in map[string]map[string]interface{}) map[string]interface{} {
+	out := map[string]interface{}{}
+	for _, section := range in {
+		for key, value := range section {
+			out[key] = value
+		}
+	}
+	return out
+}
+
+func cloneSectionValues(in map[string]map[string]interface{}) map[string]map[string]interface{} {
+	out := map[string]map[string]interface{}{}
+	for slug, section := range in {
+		out[slug] = cloneMap(section)
+	}
+	return out
 }
 
 func cloneMap(in map[string]interface{}) map[string]interface{} {

--- a/pkg/xgoja/app/module_sections.go
+++ b/pkg/xgoja/app/module_sections.go
@@ -72,6 +72,11 @@ func addSectionsToCommandDescription(desc *cmds.CommandDescription, sections []s
 
 func appendSectionsToCommandDescription(desc *cmds.CommandDescription, seen map[string]string, sections []schema.Section, source string) error {
 	collected := []schema.Section{}
+	if desc != nil && desc.Schema != nil {
+		desc.Schema.ForEach(func(_ string, section schema.Section) {
+			collected = append(collected, section)
+		})
+	}
 	if err := providerutil.AppendUniqueSections(&collected, seen, sections, source); err != nil {
 		return err
 	}

--- a/pkg/xgoja/app/module_sections_test.go
+++ b/pkg/xgoja/app/module_sections_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/dop251/goja"
 	"github.com/dop251/goja_nodejs/require"
+	"github.com/go-go-golems/glazed/pkg/cmds"
 	"github.com/go-go-golems/glazed/pkg/cmds/fields"
 	"github.com/go-go-golems/glazed/pkg/cmds/schema"
 	"github.com/go-go-golems/glazed/pkg/cmds/values"
@@ -77,6 +78,28 @@ func TestRuntimeFactoryAttachesPackageCapabilitiesToEverySelectedModule(t *testi
 	}
 	if got := sectionSlugs(sections); strings.Join(got, ",") != "xgoja,fixture" {
 		t.Fatalf("section slugs = %v", got)
+	}
+}
+
+func TestAddSectionsToCommandDescriptionPreservesCommandSchema(t *testing.T) {
+	desc := cmds.NewCommandDescription("fixture",
+		cmds.WithArguments(fields.New("query", fields.TypeString)),
+	)
+	runtimeSection, err := schema.NewSection("runtime", "Runtime", schema.WithFields(fields.New("debug", fields.TypeBool)))
+	if err != nil {
+		t.Fatalf("runtime section: %v", err)
+	}
+
+	if err := addSectionsToCommandDescription(desc, []schema.Section{runtimeSection}, "test runtime"); err != nil {
+		t.Fatalf("add sections: %v", err)
+	}
+	if got := desc.GetDefaultArguments(); got == nil {
+		t.Fatalf("expected original query argument to survive, got %#v", got)
+	} else if _, ok := got.Get("query"); !ok {
+		t.Fatalf("expected original query argument to survive, got %#v", got)
+	}
+	if _, ok := desc.GetSection("runtime"); !ok {
+		t.Fatalf("expected runtime section to be appended")
 	}
 }
 

--- a/pkg/xgoja/doc/02-jsverbs.md
+++ b/pkg/xgoja/doc/02-jsverbs.md
@@ -28,7 +28,7 @@ Use the `sources` subcommand under the verbs root to list configured source IDs.
 
 ## Field naming
 
-Top-level JavaScript function parameters and verb fields are exposed as idiomatic kebab-case CLI flags while the JavaScript invocation still receives the original parameter names.
+JavaScript function parameters and verb fields are exposed as idiomatic kebab-case CLI flags while JavaScript invocation still receives the original author-declared names.
 
 For example:
 
@@ -48,4 +48,4 @@ __verb__("indexQuery", {
 
 The generated command exposes `--profile-path`, `--docs-json`, and `--foo-bar`, but `indexQuery` is still called with `profilePath`, `docsJson`, and `foo_bar` argument values.
 
-Section fields currently preserve their declared names because bound sections are passed to JavaScript as objects. This avoids changing object keys such as `filters.localOnly` into `filters["local-only"]`.
+The same rule applies to fields in named sections. A section field declared as `localOnly` is exposed as `--local-only` on the CLI, but a function bound to that section still receives `filters.localOnly`. jsverbs keeps an explicit mapping between the CLI/Glazed field name and the JavaScript object key.

--- a/pkg/xgoja/doc/02-jsverbs.md
+++ b/pkg/xgoja/doc/02-jsverbs.md
@@ -25,3 +25,27 @@ A jsverb command executes inside the generated xgoja runtime module set. The com
 - Provider-shipped sources come from a provider package's embedded filesystem.
 
 Use the `sources` subcommand under the verbs root to list configured source IDs.
+
+## Field naming
+
+Top-level JavaScript function parameters and verb fields are exposed as idiomatic kebab-case CLI flags while the JavaScript invocation still receives the original parameter names.
+
+For example:
+
+```javascript
+function indexQuery(profilePath, docsJson, foo_bar) {
+  return { profilePath, docsJson, foo_bar };
+}
+
+__verb__("indexQuery", {
+  fields: {
+    profilePath: { help: "Profile registry path" },
+    docsJson: { help: "JSON document list" },
+    foo_bar: { help: "Example snake_case field" }
+  }
+});
+```
+
+The generated command exposes `--profile-path`, `--docs-json`, and `--foo-bar`, but `indexQuery` is still called with `profilePath`, `docsJson`, and `foo_bar` argument values.
+
+Section fields currently preserve their declared names because bound sections are passed to JavaScript as objects. This avoids changing object keys such as `filters.localOnly` into `filters["local-only"]`.

--- a/ttmp/2026/06/07/GOJA-JSVERBS-SECTION-FIELD-CLI-NAMES--kebab-case-section-flags-preserve-js-object-keys/changelog.md
+++ b/ttmp/2026/06/07/GOJA-JSVERBS-SECTION-FIELD-CLI-NAMES--kebab-case-section-flags-preserve-js-object-keys/changelog.md
@@ -1,0 +1,17 @@
+---
+Title: Changelog
+Ticket: GOJA-JSVERBS-SECTION-FIELD-CLI-NAMES
+Status: active
+Topics:
+  - goja
+  - xgoja
+  - jsverbs
+DocType: changelog
+Intent: implementation-log
+LastUpdated: 2026-06-07
+---
+
+# Changelog
+
+- 2026-06-07: Created the ticket workspace, tasks, diary, and design/implementation guide for jsverb section-field CLI/JS name remapping (commit a377cd8c6ec660376ee48f6149938a2498e17e4d).
+- 2026-06-07: Implemented kebab-case CLI names for named-section fields plus runtime remapping back to JavaScript field names; added tests and bundled docs; pre-commit lint/generate/tests passed (commit 5698f138feb768a583415e243769ea606be45d4b).

--- a/ttmp/2026/06/07/GOJA-JSVERBS-SECTION-FIELD-CLI-NAMES--kebab-case-section-flags-preserve-js-object-keys/design-doc/01-kebab-case-section-flags-preserve-js-object-keys.md
+++ b/ttmp/2026/06/07/GOJA-JSVERBS-SECTION-FIELD-CLI-NAMES--kebab-case-section-flags-preserve-js-object-keys/design-doc/01-kebab-case-section-flags-preserve-js-object-keys.md
@@ -138,7 +138,7 @@ Then:
 
 - `BindingModeSection` should pass `cloneMap(jsBySection[binding.SectionSlug])`.
 - `BindingModeContext` should expose both the JS-facing `sections` and the raw parsed values if useful.
-- `BindingModeAll` should be evaluated carefully. The safest behavior is to return a JS-facing data map for command-authored fields, because `all` is consumed by JavaScript. If callers need raw CLI names, that can be exposed in context later as `rawValues`.
+- `BindingModeAll` should preserve its historical shape: a flat map of all parsed fields. The field names in that flat map should be JavaScript-facing names, not CLI names. This keeps existing verbs like `options.owner` working while still remapping `profile-path` back to `profilePath`.
 - `BindingModePositional` should look up values using the binding's CLI name, then pass the value positionally.
 
 ## Handling fields not known to the plan
@@ -177,7 +177,7 @@ func buildArguments(parsedValues, plan, rootDir) []interface{} {
         case BindingModeSection:
             args = append(args, cloneMap(js[binding.SectionSlug]))
         case BindingModeAll:
-            args = append(args, js)
+            args = append(args, flatten(js))
         case BindingModeContext:
             args = append(args, map[string]any{
                 "values": js,

--- a/ttmp/2026/06/07/GOJA-JSVERBS-SECTION-FIELD-CLI-NAMES--kebab-case-section-flags-preserve-js-object-keys/design-doc/01-kebab-case-section-flags-preserve-js-object-keys.md
+++ b/ttmp/2026/06/07/GOJA-JSVERBS-SECTION-FIELD-CLI-NAMES--kebab-case-section-flags-preserve-js-object-keys/design-doc/01-kebab-case-section-flags-preserve-js-object-keys.md
@@ -1,0 +1,216 @@
+---
+Title: Kebab-case section flags while preserving JavaScript object keys
+Ticket: GOJA-JSVERBS-SECTION-FIELD-CLI-NAMES
+Status: active
+Topics:
+  - goja
+  - xgoja
+  - jsverbs
+DocType: design-doc
+Intent: implementation-guide
+LastUpdated: 2026-06-07
+RelatedFiles:
+  - Path: /home/manuel/workspaces/2026-05-27/rag-evaluation-system/go-go-goja/pkg/jsverbs/command.go
+    Note: Builds Glazed command descriptions from jsverb binding plans.
+  - Path: /home/manuel/workspaces/2026-05-27/rag-evaluation-system/go-go-goja/pkg/jsverbs/runtime.go
+    Note: Builds JavaScript invocation arguments from parsed Glazed values.
+  - Path: /home/manuel/workspaces/2026-05-27/rag-evaluation-system/go-go-goja/pkg/jsverbs/binding.go
+    Note: Computes the binding plan between JS parameters, sections, and fields.
+  - Path: /home/manuel/workspaces/2026-05-27/rag-evaluation-system/go-go-goja/pkg/jsverbs/jsverbs_test.go
+    Note: Regression tests for CLI names and JavaScript object keys.
+---
+
+# Kebab-case section flags while preserving JavaScript object keys
+
+## Goal
+
+The jsverbs command layer should expose idiomatic kebab-case CLI flags for all user-facing fields. JavaScript code should receive values under the names the JavaScript author declared. This means `localOnly` should appear as `--local-only` on the CLI, but a bound section object should still be read as `filters.localOnly` inside JavaScript.
+
+The current conservative fix only normalizes default-section fields. It prevents broken JavaScript object keys, but it leaves named-section CLI flags inconsistent with the rest of the command surface. This design replaces that compromise with an explicit two-name model.
+
+## Current behavior
+
+The jsverbs system has three relevant layers:
+
+1. `FieldSpec.Name` is the declared JavaScript-facing field name.
+2. `fields.Definition.Name` is the Glazed field name and becomes the CLI/config key.
+3. `buildArguments` converts parsed Glazed values into JavaScript function arguments.
+
+After the top-level normalization change, default-section fields use kebab-case at the CLI boundary:
+
+| Declared JS field | CLI/Glazed field | JS value delivery |
+| --- | --- | --- |
+| `profilePath` | `profile-path` | positional argument value |
+| `docsJson` | `docs-json` | positional argument value |
+
+For named-section fields we temporarily preserved names:
+
+| Declared JS field | CLI/Glazed field | JS value delivery |
+| --- | --- | --- |
+| `localOnly` | `localOnly` | `filters.localOnly` |
+
+The desired behavior is:
+
+| Declared JS field | CLI/Glazed field | JS value delivery |
+| --- | --- | --- |
+| `localOnly` | `local-only` | `filters.localOnly` |
+| `maxResults` | `max-results` | `filters.maxResults` |
+
+## Design decision
+
+Introduce explicit binding metadata for section field names:
+
+- `JSName`: the declared JavaScript/object key.
+- `CLIName`: the normalized Glazed/CLI/config key.
+- `SectionSlug`: the section the field belongs to.
+
+The implementation does not need to change `FieldSpec` itself. It can add derived maps to `VerbBindingPlan`, because the distinction is command/runtime binding metadata, not parse metadata.
+
+## Proposed data structure
+
+Add a small struct in `binding.go`:
+
+```go
+type FieldNameBinding struct {
+    SectionSlug string
+    JSName      string
+    CLIName     string
+}
+```
+
+Add this to `VerbBindingPlan`:
+
+```go
+type VerbBindingPlan struct {
+    Verb               *VerbSpec
+    Parameters         []ParameterBinding
+    ExtraFields        []ExtraFieldBinding
+    ReferencedSections []string
+    FieldNames         []FieldNameBinding
+}
+```
+
+Every field that is registered into a Glazed section should get a field-name binding. The mapping should include:
+
+1. fields declared directly on referenced `__section__` sections,
+2. positional parameter fields,
+3. extra fields placed into the default section,
+4. extra fields placed into named sections.
+
+For default-section positional fields, `JSName` matters mainly for diagnostics and consistency. For named sections and `bind: all`/`bind: context`, the mapping is required to reconstruct JS-facing objects.
+
+## Command construction
+
+`command.go` should register every Glazed field using `CLIName`:
+
+```go
+field, err := buildFieldDefinitionWithName(fieldSpec, cliName)
+```
+
+A cleaner implementation is to replace the boolean `normalizeName` argument with an explicit output name:
+
+```go
+func buildFieldDefinition(spec *FieldSpec, fieldName string) (*fields.Definition, error)
+```
+
+Callers compute `fieldName` with `cliFieldName(spec.Name)` for all CLI-facing fields. This removes ambiguity about whether a caller should normalize.
+
+## Runtime argument construction
+
+`runtime.go` currently creates `sectionValues` by copying parsed Glazed fields under `fieldValue.Definition.Name`, which is the CLI name. That map is correct for the CLI layer but not for JavaScript objects.
+
+Change `buildArguments` to produce a JS-facing section map by applying the plan's field-name bindings:
+
+```go
+parsedBySection := map[string]map[string]interface{}{}
+// parsedBySection["filters"]["local-only"] = value
+
+jsBySection := map[string]map[string]interface{}{}
+for _, binding := range plan.FieldNames {
+    value, ok := parsedBySection[binding.SectionSlug][binding.CLIName]
+    if ok {
+        jsBySection[binding.SectionSlug][binding.JSName] = value
+    }
+}
+```
+
+Then:
+
+- `BindingModeSection` should pass `cloneMap(jsBySection[binding.SectionSlug])`.
+- `BindingModeContext` should expose both the JS-facing `sections` and the raw parsed values if useful.
+- `BindingModeAll` should be evaluated carefully. The safest behavior is to return a JS-facing data map for command-authored fields, because `all` is consumed by JavaScript. If callers need raw CLI names, that can be exposed in context later as `rawValues`.
+- `BindingModePositional` should look up values using the binding's CLI name, then pass the value positionally.
+
+## Handling fields not known to the plan
+
+Some provider/runtime sections may be attached outside the jsverbs binding plan. Those sections should remain accessible under their parsed field names because jsverbs does not know their JavaScript-facing names. The remapping should therefore:
+
+1. start from raw parsed values,
+2. overlay remapped jsverb fields where known,
+3. leave unknown fields unchanged.
+
+This keeps provider config and framework-owned sections intact.
+
+## Pseudocode
+
+```go
+func buildSectionValueMaps(parsedValues, plan) (raw, js map[string]map[string]interface{}) {
+    raw = collectRawParsedValues(parsedValues)
+    js = deepClone(raw)
+
+    for _, b := range plan.FieldNames {
+        value, ok := raw[b.SectionSlug][b.CLIName]
+        if !ok {
+            continue
+        }
+        delete(js[b.SectionSlug], b.CLIName)
+        js[b.SectionSlug][b.JSName] = value
+    }
+    return raw, js
+}
+
+func buildArguments(parsedValues, plan, rootDir) []interface{} {
+    raw, js := buildSectionValueMaps(parsedValues, plan)
+
+    for _, binding := range plan.Parameters {
+        switch binding.Mode {
+        case BindingModeSection:
+            args = append(args, cloneMap(js[binding.SectionSlug]))
+        case BindingModeAll:
+            args = append(args, js)
+        case BindingModeContext:
+            args = append(args, map[string]any{
+                "values": js,
+                "rawValues": raw,
+                "sections": js,
+            })
+        case BindingModePositional:
+            args = append(args, raw[binding.SectionSlug][cliFieldName(binding.Field.Name)])
+        }
+    }
+}
+```
+
+## Tests
+
+Required regression tests:
+
+1. A field declared as `localOnly: { section: "filters" }` is registered as `local-only` in the command schema.
+2. A bound `filters` object receives `filters.localOnly`, not `filters["local-only"]`.
+3. A shared section with `maxResults` is exposed as `max-results` but received as `filters.maxResults`.
+4. Existing top-level behavior remains unchanged: `profilePath` is `--profile-path`, and JS receives the positional value.
+5. `bind: "all"` and `bind: "context"` receive JS-facing values for known jsverb fields.
+
+## Risks
+
+The main compatibility risk is code that already reads section object keys in kebab-case because of the brief intermediate regression. That behavior was never documented as intended and should not be preserved.
+
+The second risk is ambiguity for unknown provider/runtime fields. Leaving unknown fields unchanged avoids lossy behavior.
+
+## Validation commands
+
+```bash
+go test ./pkg/jsverbs -run 'TestTopLevelFieldNamesUseKebabCaseCLI|TestBoundSectionFieldNamesPreserveJavaScriptObjectKeys|TestFSWatchJsverbUsesInstalledHelper' -count=1
+go test ./pkg/jsverbs -count=1
+go test ./pkg/xgoja/app -count=1
+```

--- a/ttmp/2026/06/07/GOJA-JSVERBS-SECTION-FIELD-CLI-NAMES--kebab-case-section-flags-preserve-js-object-keys/index.md
+++ b/ttmp/2026/06/07/GOJA-JSVERBS-SECTION-FIELD-CLI-NAMES--kebab-case-section-flags-preserve-js-object-keys/index.md
@@ -19,6 +19,7 @@ This ticket tracks the follow-up to jsverb top-level field-name normalization. T
 
 - `design-doc/01-kebab-case-section-flags-preserve-js-object-keys.md` — design and implementation guide.
 - `reference/01-diary.md` — chronological implementation diary.
+- `changelog.md` — concise commit and validation log.
 - `tasks.md` — task checklist.
 
 ## Key files

--- a/ttmp/2026/06/07/GOJA-JSVERBS-SECTION-FIELD-CLI-NAMES--kebab-case-section-flags-preserve-js-object-keys/index.md
+++ b/ttmp/2026/06/07/GOJA-JSVERBS-SECTION-FIELD-CLI-NAMES--kebab-case-section-flags-preserve-js-object-keys/index.md
@@ -1,0 +1,29 @@
+---
+Title: Kebab-case section flags while preserving JavaScript object keys
+Ticket: GOJA-JSVERBS-SECTION-FIELD-CLI-NAMES
+Status: active
+Topics:
+  - goja
+  - xgoja
+  - jsverbs
+DocType: index
+Intent: implementation
+LastUpdated: 2026-06-07
+---
+
+# Kebab-case section flags while preserving JavaScript object keys
+
+This ticket tracks the follow-up to jsverb top-level field-name normalization. The target behavior is that every CLI-facing field name is kebab-case, including fields in named sections, while JavaScript-facing values keep the author-declared names.
+
+## Documents
+
+- `design-doc/01-kebab-case-section-flags-preserve-js-object-keys.md` — design and implementation guide.
+- `reference/01-diary.md` — chronological implementation diary.
+- `tasks.md` — task checklist.
+
+## Key files
+
+- `/home/manuel/workspaces/2026-05-27/rag-evaluation-system/go-go-goja/pkg/jsverbs/command.go`
+- `/home/manuel/workspaces/2026-05-27/rag-evaluation-system/go-go-goja/pkg/jsverbs/runtime.go`
+- `/home/manuel/workspaces/2026-05-27/rag-evaluation-system/go-go-goja/pkg/jsverbs/binding.go`
+- `/home/manuel/workspaces/2026-05-27/rag-evaluation-system/go-go-goja/pkg/jsverbs/jsverbs_test.go`

--- a/ttmp/2026/06/07/GOJA-JSVERBS-SECTION-FIELD-CLI-NAMES--kebab-case-section-flags-preserve-js-object-keys/reference/01-diary.md
+++ b/ttmp/2026/06/07/GOJA-JSVERBS-SECTION-FIELD-CLI-NAMES--kebab-case-section-flags-preserve-js-object-keys/reference/01-diary.md
@@ -1,0 +1,71 @@
+---
+Title: Diary
+Ticket: GOJA-JSVERBS-SECTION-FIELD-CLI-NAMES
+Status: active
+Topics:
+  - goja
+  - xgoja
+  - jsverbs
+DocType: reference
+Intent: diary
+LastUpdated: 2026-06-07
+---
+
+# Diary
+
+## Goal
+
+This diary records the implementation of jsverb section-field CLI name normalization: CLI flags should be kebab-case everywhere, while JavaScript function parameters and bound section object keys should retain the author-declared names.
+
+## Step 1: Planning the CLI-name to JS-name Boundary
+
+The first step was to turn the review comment and follow-up discussion into a concrete implementation plan. The key design point is that the jsverbs system needs two names for a field: the CLI/Glazed name used for flags and parsed values, and the JavaScript name used for positional parameters or object keys.
+
+This planning step intentionally happened before code changes. The previous conservative fix protected bound section object keys by not normalizing section fields, but that left named sections with inconsistent CLI flags. The design guide now records the stronger invariant: every CLI-facing field should be kebab-case, and JavaScript-facing values should be remapped to declared names.
+
+### Prompt Context
+
+**User prompt (verbatim):** "Ok, add tasks and a small design/implementation guide, then build it, commit at appropriate intervals, keep a diary as you work."
+
+**Assistant interpretation:** Create project-tracking docs first, then implement the jsverbs field-name remapping behavior with tests and commits.
+
+**Inferred user intent:** Make the section-field naming change deliberate and reviewable, not an ad hoc patch, while preserving a continuation-friendly record of decisions and validation.
+
+**Commit (code):** N/A — planning only.
+
+### What I did
+- Created ticket workspace at `ttmp/2026/06/07/GOJA-JSVERBS-SECTION-FIELD-CLI-NAMES--kebab-case-section-flags-preserve-js-object-keys/`.
+- Wrote `tasks.md` with implementation and validation tasks.
+- Wrote `design-doc/01-kebab-case-section-flags-preserve-js-object-keys.md` with the two-name design and test plan.
+- Started this diary.
+
+### Why
+- The behavior crosses command construction and runtime invocation, so a design note reduces the chance of fixing only one side.
+- The previous regression showed that tests need to prove both the CLI field names and the JS-facing object keys.
+
+### What worked
+- The existing code layout made the boundary clear: `command.go` owns Glazed field registration, `runtime.go` owns JS argument construction, and `binding.go` owns the plan connecting the two.
+
+### What didn't work
+- `docmgr status --summary-only` from inside `go-go-goja` resolved to the parent rag-evaluation-system docmgr config rather than a repo-local go-go-goja ticket workspace, so I created the repo-local `ttmp` workspace manually.
+
+### What I learned
+- `go-go-goja` already has a historical `ttmp/` directory and vocabulary files, but no repo-local `.ttmp.yaml`; parent-directory discovery can pick up the surrounding workspace.
+
+### What was tricky to build
+- The tricky part is not command-name normalization itself. The tricky part is preserving two name domains: Glazed field names for CLI/config parsing and JavaScript names for object keys. A one-name model is simpler but leaks CLI conventions into JS objects.
+
+### What warrants a second pair of eyes
+- The design choice for `bind: "all"` and `bind: "context"` should be reviewed. The proposed behavior is to expose JS-facing values by default while preserving raw parsed values in context.
+
+### What should be done in the future
+- Implement the field-name binding map and verify it with bound-section, shared-section, `all`, and `context` tests.
+
+### Code review instructions
+- Start with `design-doc/01-kebab-case-section-flags-preserve-js-object-keys.md`.
+- Then review `pkg/jsverbs/binding.go`, `pkg/jsverbs/command.go`, and `pkg/jsverbs/runtime.go` after implementation.
+- Validate with `go test ./pkg/jsverbs -count=1`.
+
+### Technical details
+- Current conservative behavior: default section normalizes to kebab-case; named sections preserve declared field names.
+- Target behavior: all CLI-facing field definitions use `cliFieldName(...)`; runtime remaps known parsed CLI names back to declared JS names before invoking JavaScript.

--- a/ttmp/2026/06/07/GOJA-JSVERBS-SECTION-FIELD-CLI-NAMES--kebab-case-section-flags-preserve-js-object-keys/reference/01-diary.md
+++ b/ttmp/2026/06/07/GOJA-JSVERBS-SECTION-FIELD-CLI-NAMES--kebab-case-section-flags-preserve-js-object-keys/reference/01-diary.md
@@ -69,3 +69,92 @@ This planning step intentionally happened before code changes. The previous cons
 ### Technical details
 - Current conservative behavior: default section normalizes to kebab-case; named sections preserve declared field names.
 - Target behavior: all CLI-facing field definitions use `cliFieldName(...)`; runtime remaps known parsed CLI names back to declared JS names before invoking JavaScript.
+
+## Step 2: Implement Section Field CLI/JS Name Remapping
+
+This step implemented the planned two-name boundary. The command schema now exposes named-section fields with kebab-case CLI names, while runtime invocation remaps known parsed fields back to the JavaScript names declared by the verb or shared section.
+
+The implementation also preserved historical `bind: "all"` behavior by keeping it as a flat map, but with JavaScript-facing field names. `bind: "context"` now exposes `values` and `sections` with JS-facing names and adds `rawValues` for callers that need the literal parsed CLI/Glazed names.
+
+### Prompt Context
+
+**User prompt (verbatim):** (same as Step 1)
+
+**Assistant interpretation:** Build the planned jsverbs section-field name remapping change, test it thoroughly, and commit the code separately from ticket bookkeeping.
+
+**Inferred user intent:** Make jsverb CLIs idiomatic everywhere without breaking JavaScript authors who expect camelCase or otherwise authored object keys.
+
+**Commit (code):** 5698f138feb768a583415e243769ea606be45d4b — "jsverbs: remap kebab-case section flags to JS keys"
+
+### What I did
+- Added `FieldNameBinding` metadata to `VerbBindingPlan` in `pkg/jsverbs/binding.go`.
+- Registered positional, extra, local-section, and shared-section fields in the binding plan with both declared JS names and normalized CLI names.
+- Changed `pkg/jsverbs/command.go` so named-section fields are also registered with `cliFieldName(...)`.
+- Changed `pkg/jsverbs/runtime.go` to collect raw parsed section values, remap known CLI names to declared JS names, flatten JS-facing values for `bind: "all"`, and expose `rawValues` in `bind: "context"`.
+- Added regression coverage in `pkg/jsverbs/jsverbs_test.go` for local bound sections, shared sections, top-level fields, `bind: "all"`, `bind: "context"`, and the existing fswatch jsverb path.
+- Updated bundled docs in `pkg/xgoja/doc/02-jsverbs.md` and `pkg/doc/11-jsverbs-example-reference.md`.
+- Ran targeted tests, package tests, app tests, and the repository pre-commit hook.
+
+### Why
+- The prior conservative fix avoided breaking JS object keys by leaving named-section CLI fields unnormalized.
+- The target invariant is stronger and cleaner: all CLI-facing fields should be kebab-case, and JavaScript-facing parameters/objects should use authored names.
+- Keeping a remap table makes this boundary explicit rather than relying on whichever name Glazed stores internally.
+
+### What worked
+- Targeted tests passed after the remapping helpers were in place:
+  - `go test ./pkg/jsverbs -run 'TestTopLevelFieldNamesUseKebabCaseCLI|TestBoundSectionFieldNamesPreserveJavaScriptObjectKeys|TestSharedSectionFieldNamesUseKebabCaseCLIAndCamelCaseObjectKeys|TestBindAllAndContextUseJavaScriptFieldNames|TestFSWatchJsverbUsesInstalledHelper' -count=1 -v`
+- Broader validation passed:
+  - `go test ./pkg/jsverbs -count=1`
+  - `go test ./pkg/xgoja/app -count=1`
+- The commit pre-commit hook passed:
+  - `golangci-lint run -v`
+  - `GOWORK=off go vet -vettool=/tmp/glazed-lint ...`
+  - `go generate ./...`
+  - `go test ./...`
+
+### What didn't work
+- The first targeted test run failed because `runtime.go` still imported `schema` after positional lookup no longer needed it:
+  - `pkg/jsverbs/runtime.go:14:2: "github.com/go-go-golems/glazed/pkg/cmds/schema" imported and not used`
+  - Command: `go test ./pkg/jsverbs -run 'TestTopLevelFieldNamesUseKebabCaseCLI|TestBoundSectionFieldNamesPreserveJavaScriptObjectKeys|TestSharedSectionFieldNamesUseKebabCaseCLIAndCamelCaseObjectKeys|TestBindAllAndContextUseJavaScriptFieldNames|TestFSWatchJsverbUsesInstalledHelper' -count=1 -v`
+- The first full `pkg/jsverbs` run exposed that my initial `bind: "all"` implementation changed its shape from a flat map to a section map:
+  - `expected: "go-go-golems/go-go-goja"`
+  - `actual  : "undefined/undefined"`
+  - Failing test: `TestFixtureCommandsExecute/summarize_bind_all`
+- The same run exposed an older test still feeding `localOnly` as the parsed CLI key after section fields became kebab-case:
+  - `expected: string("from-local")`
+  - `actual  : <nil>(<nil>)`
+  - Failing test: `TestLocalSectionOverridesRegistrySharedSectionDuringCommandExecution`
+
+### What I learned
+- `values.Values.GetDataMap()` historically returns a flat field map, not a map grouped by section. `bind: "all"` needed to preserve that flat shape.
+- `bind: "context"` is the right place to expose both views: JS-facing `values`/`sections` for normal JavaScript code and `rawValues` for diagnostics or low-level callers.
+- Tests that construct parsed maps directly need to use the CLI/Glazed names, because they are standing in for the command parser.
+
+### What was tricky to build
+- The sharp edge was preserving three shapes at once: raw parsed section maps keyed by CLI names, JS-facing section maps keyed by declared names, and historical flat `bind: "all"` maps. The initial implementation conflated section maps with the old flat `all` map, which broke existing examples.
+- Another subtlety is that shared-section and local-section fields are discovered through different paths. The binding plan now records fields from positional parameters, extra/default fields, and every referenced section after section resolution, so remapping works for both local `__section__` declarations and registry-provided shared sections.
+
+### What warrants a second pair of eyes
+- Review the `bind: "context"` contract: `values` is now a flat JS-facing map, `sections` is grouped and JS-facing, and `rawValues` is grouped by section with CLI names. That is useful, but it is a public shape and should be confirmed before release notes are written.
+- Review duplicate/alias behavior if a verb ever declares two fields whose names normalize to the same CLI name inside one section. The current change follows existing CLI collision behavior rather than adding a new conflict detector.
+
+### What should be done in the future
+- Consider documenting `rawValues` as an explicit supported context field if downstream scripts start depending on it.
+- Consider adding a scanner-time or command-build-time validation error for normalized field-name collisions in a section.
+
+### Code review instructions
+- Start in `pkg/jsverbs/binding.go` at `FieldNameBinding` and `addFieldNameBinding` to see how the remap table is built.
+- Then review `pkg/jsverbs/command.go` to confirm all fields are registered with `cliFieldName(...)`.
+- Then review `pkg/jsverbs/runtime.go`, especially `collectSectionValues`, `remapSectionValues`, and `flattenSectionValues`.
+- Validate with `go test ./pkg/jsverbs -count=1`; full pre-commit validation already passed during commit `5698f138feb768a583415e243769ea606be45d4b`.
+
+### Technical details
+- CLI/Glazed field names are stored as kebab-case definitions such as `local-only` and `profile-path`.
+- JavaScript positional lookup reads raw parsed values by `cliFieldName(binding.Field.Name)`.
+- Bound sections receive cloned JS-facing maps, so JavaScript sees `filters.localOnly` rather than `filters["local-only"]`.
+- `bind: "all"` receives a flattened JS-facing map, preserving existing code that reads `options.owner`.
+- `bind: "context"` receives:
+  - `values`: flattened JS-facing map.
+  - `sections`: grouped JS-facing section map.
+  - `rawValues`: grouped raw CLI-name section map.
+

--- a/ttmp/2026/06/07/GOJA-JSVERBS-SECTION-FIELD-CLI-NAMES--kebab-case-section-flags-preserve-js-object-keys/tasks.md
+++ b/ttmp/2026/06/07/GOJA-JSVERBS-SECTION-FIELD-CLI-NAMES--kebab-case-section-flags-preserve-js-object-keys/tasks.md
@@ -1,21 +1,23 @@
 # Tasks
 
-## TODO
-
-- [ ] Add a binding-plan representation that distinguishes JavaScript field names from CLI/Glazed field names.
-- [ ] Register named-section fields with kebab-case CLI names.
-- [ ] Remap parsed named-section values back to declared JavaScript object keys before invoking JS.
-- [ ] Preserve current default/top-level kebab-case behavior.
-- [ ] Preserve `bind: "all"` and `bind: "context"` values in a way that gives JS code declared field keys for section data.
-- [ ] Add regression tests for:
-  - [ ] `localOnly: { section: "filters" }` exposed as `local-only` in command schema.
-  - [ ] bound section object receives `filters.localOnly`, not `filters["local-only"]`.
-  - [ ] shared section fields get kebab-case CLI names but camelCase JS object keys.
-  - [ ] default/top-level `profilePath` remains `profile-path` at the CLI and positional JS parameter value still arrives.
-- [ ] Update bundled jsverbs documentation to describe the CLI-name/JS-name boundary.
-- [ ] Run `go test ./pkg/jsverbs -count=1` and relevant xgoja tests.
-- [ ] Commit the implementation.
-
 ## DONE
 
 - [x] Create ticket workspace, tasks, design guide, and diary before implementation.
+- [x] Add a binding-plan representation that distinguishes JavaScript field names from CLI/Glazed field names.
+- [x] Register named-section fields with kebab-case CLI names.
+- [x] Remap parsed named-section values back to declared JavaScript object keys before invoking JS.
+- [x] Preserve current default/top-level kebab-case behavior.
+- [x] Preserve `bind: "all"` and `bind: "context"` values with JavaScript-facing field names while keeping raw parsed values available in context.
+- [x] Add regression tests for:
+  - [x] `localOnly: { section: "filters" }` exposed as `local-only` in command schema.
+  - [x] bound section object receives `filters.localOnly`, not `filters["local-only"]`.
+  - [x] shared section fields get kebab-case CLI names but camelCase JS object keys.
+  - [x] default/top-level `profilePath` remains `profile-path` at the CLI and positional JS parameter value still arrives.
+  - [x] `bind: "all"` and `bind: "context"` see JavaScript-facing names for known jsverb fields.
+- [x] Update bundled jsverbs documentation to describe the CLI-name/JS-name boundary.
+- [x] Run targeted jsverbs tests plus `go test ./pkg/jsverbs -count=1` and `go test ./pkg/xgoja/app -count=1`.
+
+## TODO
+
+- [x] Run full repository pre-commit/full test suite at commit time.
+- [ ] Consider a future public API for exposing both raw CLI names and JS names more explicitly in `bind: "context"`.

--- a/ttmp/2026/06/07/GOJA-JSVERBS-SECTION-FIELD-CLI-NAMES--kebab-case-section-flags-preserve-js-object-keys/tasks.md
+++ b/ttmp/2026/06/07/GOJA-JSVERBS-SECTION-FIELD-CLI-NAMES--kebab-case-section-flags-preserve-js-object-keys/tasks.md
@@ -1,0 +1,21 @@
+# Tasks
+
+## TODO
+
+- [ ] Add a binding-plan representation that distinguishes JavaScript field names from CLI/Glazed field names.
+- [ ] Register named-section fields with kebab-case CLI names.
+- [ ] Remap parsed named-section values back to declared JavaScript object keys before invoking JS.
+- [ ] Preserve current default/top-level kebab-case behavior.
+- [ ] Preserve `bind: "all"` and `bind: "context"` values in a way that gives JS code declared field keys for section data.
+- [ ] Add regression tests for:
+  - [ ] `localOnly: { section: "filters" }` exposed as `local-only` in command schema.
+  - [ ] bound section object receives `filters.localOnly`, not `filters["local-only"]`.
+  - [ ] shared section fields get kebab-case CLI names but camelCase JS object keys.
+  - [ ] default/top-level `profilePath` remains `profile-path` at the CLI and positional JS parameter value still arrives.
+- [ ] Update bundled jsverbs documentation to describe the CLI-name/JS-name boundary.
+- [ ] Run `go test ./pkg/jsverbs -count=1` and relevant xgoja tests.
+- [ ] Commit the implementation.
+
+## DONE
+
+- [x] Create ticket workspace, tasks, design guide, and diary before implementation.


### PR DESCRIPTION
This PR introduces two main improvements to the xgoja toolchain and a related
bug fix.

**Build Environment Variables**

- Introduces a `go.env` field in the buildspec to pass environment variables
  directly to the `go build` command.
- This is primarily for building complex CGO dependencies that require specific
  linker flags (e.g., `CGO_LDFLAGS` for linking against FAISS), which are not
  well-suited for the existing `ldflags` option.

**JSVerb CLI Flag Normalization**

- Top-level `jsverb` parameters are now exposed as idiomatic `kebab-case` CLI
  flags for a better user experience.
- Automatically converts `camelCase` and `snake_case` parameter names
  (e.g., `profilePath`, `foo_bar`) to `--profile-path` and `--foo-bar` on
  the command line.
- The original parameter names are preserved when invoking the JavaScript
  function, requiring no changes to existing scripts.

**Bug Fix**

- Fixes an issue where adding module sections to a command description could
  overwrite its existing schema, such as arguments or flags. The process now
  correctly preserves and appends to the existing schema.