### PR TITLE
Feat: Add filters for JSVerb sources

### DIFF
--- a/cmd/xgoja/internal/buildspec/build_spec.go
+++ b/cmd/xgoja/internal/buildspec/build_spec.go
@@ -122,11 +122,14 @@ type CommandProviderInstanceSpec struct {
 }
 
 type JSVerbSourceSpec struct {
-	ID      string `yaml:"id" json:"id"`
-	Path    string `yaml:"path" json:"path,omitempty"`
-	Embed   bool   `yaml:"embed" json:"embed"`
-	Package string `yaml:"package" json:"package,omitempty"`
-	Source  string `yaml:"source" json:"source,omitempty"`
+	ID         string   `yaml:"id" json:"id"`
+	Path       string   `yaml:"path" json:"path,omitempty"`
+	Embed      bool     `yaml:"embed" json:"embed"`
+	Package    string   `yaml:"package" json:"package,omitempty"`
+	Source     string   `yaml:"source" json:"source,omitempty"`
+	Include    []string `yaml:"include,omitempty" json:"include,omitempty"`
+	Exclude    []string `yaml:"exclude,omitempty" json:"exclude,omitempty"`
+	Extensions []string `yaml:"extensions,omitempty" json:"extensions,omitempty"`
 }
 
 type HelpSpec struct {

--- a/cmd/xgoja/internal/buildspec/validate.go
+++ b/cmd/xgoja/internal/buildspec/validate.go
@@ -376,6 +376,7 @@ func validateJSVerbs(report *Report, buildSpec *BuildSpec, packageIDs map[string
 		} else {
 			ids[id] = struct{}{}
 		}
+		validateJSVerbFilters(report, path, source)
 		if strings.TrimSpace(source.Package) != "" || strings.TrimSpace(source.Source) != "" {
 			if strings.TrimSpace(source.Package) == "" || strings.TrimSpace(source.Source) == "" {
 				report.AddError("jsverb-provider-source", path, "provider jsverb sources require both package and source")
@@ -401,6 +402,27 @@ func validateJSVerbs(report *Report, buildSpec *BuildSpec, packageIDs map[string
 		} else {
 			report.AddOK("jsverb-path", path+".path", "runtime filesystem source")
 		}
+	}
+}
+
+func validateJSVerbFilters(report *Report, path string, source JSVerbSourceSpec) {
+	for i, pattern := range source.Include {
+		if strings.TrimSpace(pattern) == "" {
+			report.AddError("jsverb-include", fmt.Sprintf("%s.include[%d]", path, i), "include pattern cannot be empty")
+		}
+	}
+	for i, pattern := range source.Exclude {
+		if strings.TrimSpace(pattern) == "" {
+			report.AddError("jsverb-exclude", fmt.Sprintf("%s.exclude[%d]", path, i), "exclude pattern cannot be empty")
+		}
+	}
+	for i, ext := range source.Extensions {
+		if strings.TrimSpace(ext) == "" {
+			report.AddError("jsverb-extension", fmt.Sprintf("%s.extensions[%d]", path, i), "extension cannot be empty")
+		}
+	}
+	if len(source.Include) > 0 || len(source.Exclude) > 0 || len(source.Extensions) > 0 {
+		report.AddOK("jsverb-filters", path, "jsverb source filters declared")
 	}
 }
 

--- a/cmd/xgoja/internal/buildspec/validate.go
+++ b/cmd/xgoja/internal/buildspec/validate.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/bmatcuk/doublestar/v4"
 )
 
 func Validate(buildSpec *BuildSpec) *Report {
@@ -407,14 +409,10 @@ func validateJSVerbs(report *Report, buildSpec *BuildSpec, packageIDs map[string
 
 func validateJSVerbFilters(report *Report, path string, source JSVerbSourceSpec) {
 	for i, pattern := range source.Include {
-		if strings.TrimSpace(pattern) == "" {
-			report.AddError("jsverb-include", fmt.Sprintf("%s.include[%d]", path, i), "include pattern cannot be empty")
-		}
+		validateJSVerbGlob(report, "jsverb-include", fmt.Sprintf("%s.include[%d]", path, i), "include", pattern)
 	}
 	for i, pattern := range source.Exclude {
-		if strings.TrimSpace(pattern) == "" {
-			report.AddError("jsverb-exclude", fmt.Sprintf("%s.exclude[%d]", path, i), "exclude pattern cannot be empty")
-		}
+		validateJSVerbGlob(report, "jsverb-exclude", fmt.Sprintf("%s.exclude[%d]", path, i), "exclude", pattern)
 	}
 	for i, ext := range source.Extensions {
 		if strings.TrimSpace(ext) == "" {
@@ -423,6 +421,18 @@ func validateJSVerbFilters(report *Report, path string, source JSVerbSourceSpec)
 	}
 	if len(source.Include) > 0 || len(source.Exclude) > 0 || len(source.Extensions) > 0 {
 		report.AddOK("jsverb-filters", path, "jsverb source filters declared")
+	}
+}
+
+func validateJSVerbGlob(report *Report, name string, path string, kind string, pattern string) {
+	pattern = filepath.ToSlash(strings.TrimSpace(pattern))
+	pattern = strings.TrimPrefix(pattern, "./")
+	if pattern == "" {
+		report.AddError(name, path, fmt.Sprintf("%s pattern cannot be empty", kind))
+		return
+	}
+	if !doublestar.ValidatePathPattern(pattern) {
+		report.AddError(name, path, fmt.Sprintf("invalid %s glob pattern", kind))
 	}
 }
 

--- a/cmd/xgoja/internal/buildspec/validate_test.go
+++ b/cmd/xgoja/internal/buildspec/validate_test.go
@@ -309,6 +309,18 @@ func TestValidateJSVerbFiltersAcceptNonEmptyPatterns(t *testing.T) {
 	assertCheck(t, report, StatusOK, "jsverb-filters", "jsverbs[0]")
 }
 
+func TestValidateJSVerbFiltersRejectMalformedGlobs(t *testing.T) {
+	buildSpec := validSpec()
+	buildSpec.JSVerbs = []JSVerbSourceSpec{{ID: "site", Path: "verbs", Include: []string{"verbs/["}, Exclude: []string{"assets/["}}}
+
+	report := Validate(buildSpec)
+	if !report.HasErrors() {
+		t.Fatalf("expected validation errors, got %#v", report.Checks)
+	}
+	assertCheck(t, report, StatusError, "jsverb-include", "jsverbs[0].include[0]")
+	assertCheck(t, report, StatusError, "jsverb-exclude", "jsverbs[0].exclude[0]")
+}
+
 func assertCheck(t *testing.T, report *Report, status Status, name string, path string) {
 	t.Helper()
 	for _, check := range report.Checks {

--- a/cmd/xgoja/internal/buildspec/validate_test.go
+++ b/cmd/xgoja/internal/buildspec/validate_test.go
@@ -286,6 +286,29 @@ func TestValidateJSVerbCommandMountRejectsUnknownValue(t *testing.T) {
 	assertCheck(t, report, StatusError, "command-mount", "commands.jsverbs.mount")
 }
 
+func TestValidateJSVerbFiltersRejectEmptyPatterns(t *testing.T) {
+	buildSpec := validSpec()
+	buildSpec.JSVerbs = []JSVerbSourceSpec{{ID: "site", Path: "verbs", Include: []string{""}, Exclude: []string{"assets/**"}, Extensions: []string{" "}}}
+
+	report := Validate(buildSpec)
+	if !report.HasErrors() {
+		t.Fatalf("expected validation errors, got %#v", report.Checks)
+	}
+	assertCheck(t, report, StatusError, "jsverb-include", "jsverbs[0].include[0]")
+	assertCheck(t, report, StatusError, "jsverb-extension", "jsverbs[0].extensions[0]")
+}
+
+func TestValidateJSVerbFiltersAcceptNonEmptyPatterns(t *testing.T) {
+	buildSpec := validSpec()
+	buildSpec.JSVerbs = []JSVerbSourceSpec{{ID: "site", Path: "verbs", Include: []string{"site.js"}, Exclude: []string{"assets/**"}, Extensions: []string{"js", ".cjs"}}}
+
+	report := Validate(buildSpec)
+	if report.HasErrors() {
+		t.Fatalf("expected no validation errors, got %#v", report.Checks)
+	}
+	assertCheck(t, report, StatusOK, "jsverb-filters", "jsverbs[0]")
+}
+
 func assertCheck(t *testing.T, report *Report, status Status, name string, path string) {
 	t.Helper()
 	for _, check := range report.Checks {

--- a/cmd/xgoja/internal/generate/generate_test.go
+++ b/cmd/xgoja/internal/generate/generate_test.go
@@ -380,7 +380,7 @@ func TestRenderEmbeddedSpecIncludesRuntimeAppSettings(t *testing.T) {
 func TestRenderMainIncludesEmbeddedVerbFS(t *testing.T) {
 	buildSpec := buildableSpec("xgoja", "", "")
 	buildSpec.Commands.JSVerbs = buildspec.CommandSpec{Enabled: true, Name: "verbs"}
-	buildSpec.JSVerbs = []buildspec.JSVerbSourceSpec{{ID: "local", Path: "verbs", Embed: true}}
+	buildSpec.JSVerbs = []buildspec.JSVerbSourceSpec{{ID: "local", Path: "verbs", Embed: true, Include: []string{"site.js"}, Exclude: []string{"assets/**"}, Extensions: []string{".js", ".mjs"}}}
 	got := RenderMain(buildSpec)
 	for _, want := range []string{
 		`"embed"`,
@@ -393,8 +393,18 @@ func TestRenderMainIncludesEmbeddedVerbFS(t *testing.T) {
 		}
 	}
 	embeddedSpec := RenderEmbeddedSpec(buildSpec)
-	if !strings.Contains(embeddedSpec, `"path": "xgoja_embed/jsverbs/local"`) {
-		t.Fatalf("expected embedded runtime spec to rewrite local embedded path, got:\n%s", embeddedSpec)
+	for _, want := range []string{
+		`"path": "xgoja_embed/jsverbs/local"`,
+		`"include": [`,
+		`"site.js"`,
+		`"exclude": [`,
+		`"assets/**"`,
+		`"extensions": [`,
+		`".mjs"`,
+	} {
+		if !strings.Contains(embeddedSpec, want) {
+			t.Fatalf("expected embedded runtime spec to contain %q, got:\n%s", want, embeddedSpec)
+		}
 	}
 }
 

--- a/examples/xgoja/06-runtime-filesystem/README.md
+++ b/examples/xgoja/06-runtime-filesystem/README.md
@@ -44,3 +44,20 @@ jsverbs:
     path: ./verbs
     embed: false
 ```
+
+If your runtime source root contains generated files or browser bundles, keep the root narrow or add filters:
+
+```yaml
+jsverbs:
+  - id: local-dev
+    path: .
+    embed: false
+    include:
+      - verbs/**/*.js
+      - site.js
+    exclude:
+      - assets/**
+      - dist/**
+```
+
+`include` and `exclude` match slash-separated paths relative to `path`.

--- a/examples/xgoja/07-embedded-jsverbs/README.md
+++ b/examples/xgoja/07-embedded-jsverbs/README.md
@@ -43,3 +43,21 @@ jsverbs:
     path: ./verbs
     embed: true
 ```
+
+Embedded sources also support filters. This is useful when the embedded source root is an application directory rather than a dedicated `verbs/` directory:
+
+```yaml
+jsverbs:
+  - id: local
+    path: .
+    embed: true
+    include:
+      - site.js
+      - jsverbs/**/*.js
+    exclude:
+      - assets/**
+      - dist/**
+      - webapp/**
+```
+
+Filters are preserved in the generated runtime spec and are applied when the embedded filesystem is scanned.

--- a/examples/xgoja/08-provider-shipped-jsverbs/README.md
+++ b/examples/xgoja/08-provider-shipped-jsverbs/README.md
@@ -38,6 +38,20 @@ jsverbs:
     source: verbs
 ```
 
+Provider sources can also be filtered by paths relative to the provider source root:
+
+```yaml
+jsverbs:
+  - id: provider-defaults
+    package: fixture
+    source: verbs
+    include:
+      - tools.js
+      - commands/**/*.js
+    exclude:
+      - generated/**
+```
+
 The provider fixture exposes that source from:
 
 ```text

--- a/examples/xgoja/README.md
+++ b/examples/xgoja/README.md
@@ -23,6 +23,34 @@ Each example directory has its own `README.md`, `Makefile`, and `xgoja.yaml`. St
 
 The Discord bot xgoja example lives in the sibling `discord-bot` repository because it demonstrates inserting xgoja into an existing host-owned runner rather than a standalone generated binary.
 
+## JSVerb source filters
+
+Generated xgoja binaries can mount JavaScript verbs from three source kinds:
+
+- runtime filesystem directories (`path`, `embed: false`),
+- local directories copied and embedded into the generated binary (`path`, `embed: true`),
+- provider-shipped sources (`package` + `source`).
+
+Each source can optionally declare `include`, `exclude`, and `extensions` filters. Filters match slash-separated paths relative to that source root and are applied before a file is read or parsed.
+
+```yaml
+jsverbs:
+  - id: site
+    path: .
+    include:
+      - site.js
+      - jsverbs/**/*.js
+    exclude:
+      - assets/**
+      - dist/**
+      - webapp/**
+    extensions:
+      - .js
+      - .cjs
+```
+
+Use filters when the source root also contains bundled browser assets, generated files, or other JavaScript that should not declare CLI verbs. Prefer a narrow `path` such as `./verbs` when possible; filters are most useful for application roots or provider sources that intentionally contain multiple kinds of JavaScript.
+
 ## Run all examples
 
 ```bash

--- a/pkg/doc/08-jsverbs-example-overview.md
+++ b/pkg/doc/08-jsverbs-example-overview.md
@@ -36,6 +36,8 @@ Under the hood, the scanner now parses metadata literals directly from the tree-
 
 By default, public top-level functions become commands even without explicit `__verb__` metadata. Files under subdirectories become nested command groups.
 
+Library callers and generated xgoja binaries can narrow directory/`fs.FS` scans with include/exclude filters. The filters match slash-separated paths relative to the scan root and are intended for application layouts that contain both authored verb files and generated JavaScript assets. For example, an xgoja app can scan `path: .` but include only `site.js` and exclude `assets/**` or `dist/**`.
+
 ## Command shape
 
 Each discovered function is compiled into an ordinary Glazed command. Scalar parameters become Glazed fields, file-local sections become flag groups, and the JavaScript result is converted back into rows:
@@ -110,7 +112,7 @@ jsverbs-example --log-level debug --dir ./examples/jsverbs/basic list
 | --- | --- | --- |
 | A command prints nothing | A required positional argument was omitted earlier and the function returned `undefined` | Re-run with the required positional argument or inspect `--help` |
 | Relative `require()` fails | The helper file is outside the scanned directory or uses an unsupported resolution path | Keep helper files under the scanned tree and use relative imports like `./helper` |
-| A function is not listed | It is not top-level, starts with `_`, is only defined as an object method, or metadata parsing failed | Export it as a top-level function and check the scanner error output for invalid metadata |
+| A function is not listed | It is not top-level, starts with `_`, is only defined as an object method, metadata parsing failed, or scan filters excluded the file | Export it as a top-level function, check scanner errors, and verify include/exclude filters |
 | A `__verb__` block seems to be ignored | The metadata used dynamic JavaScript instead of static literals | Restrict metadata to literal objects, arrays, strings, numbers, booleans, and `null` |
 | The `fswatch` fixture says `fswatch is not defined` | The default `jsverbs-example` runtime does not install host-specific connected helpers | Run the integration test or embed `pkg/jsverbs` with a runtime that installs `jsevents.Install()` and `jsevents.FSWatchHelper(...)`; see `connected-eventemitters-developer-guide`. |
 

--- a/pkg/doc/10-jsverbs-example-developer-guide.md
+++ b/pkg/doc/10-jsverbs-example-developer-guide.md
@@ -101,6 +101,8 @@ Use it as a map:
 
 The fixture tree is still disk-based because it is meant to be browsed by humans and exercised by the example runner. The package itself is now broader than that. It can also scan a generic `fs.FS` or a raw list of in-memory source files. That matters when you move from “example runner” thinking to “library API” thinking. The fixture tree teaches the metadata format and runtime behavior; it does not define the full list of supported source origins anymore.
 
+Directory and `fs.FS` scanning can also be filtered. `ScanOptions.Include` and `ScanOptions.Exclude` match slash-separated paths relative to the scan root. This is important for generated xgoja applications where the source tree may contain both authored verb files and bundled assets. For example, an app can scan only `site.js` and `jsverbs/**/*.js` while excluding `assets/**`, `dist/**`, and `webapp/**`. Keep the scan root narrow when you can; use filters when the application layout makes that difficult.
+
 When you are unsure how a feature should behave, start by adding or changing a fixture first and then make the implementation satisfy it.
 
 This is not just a testing convenience. It is a design discipline. The fixture tree acts as the most concrete form of subsystem documentation because it shows what JavaScript authors are actually expected to write. A fixture is harder to misread than a prose sentence and easier to stabilize than an informal code comment. In practice, the safest development loop is: write or update a fixture, make the scanner see it, make the compiler shape it, and then make the runtime execute it.
@@ -477,8 +479,9 @@ The main habit to build here is phase isolation. Ask first whether the issue is 
 When a verb is missing:
 
 1. run `jsverbs-example --dir ... list`
-2. if it is absent, debug `scan.go`
-3. if it is present but malformed, debug `command.go`
+2. if the host/xgoja app configured include/exclude filters, confirm the relative source path matches the intended filter set
+3. if it is absent, debug `scan.go`
+4. if it is present but malformed, debug `command.go`
 
 When a verb is listed but crashes:
 

--- a/pkg/doc/11-jsverbs-example-reference.md
+++ b/pkg/doc/11-jsverbs-example-reference.md
@@ -48,6 +48,46 @@ Runtime entrypoints:
 
 The example runner uses `ScanDir(...)` plus the default `registry.Commands()` path, but the package itself is no longer limited to disk directories or to runtime-owning command wrappers.
 
+## Scan options
+
+`ScanDir(...)` and `ScanFS(...)` accept `ScanOptions`. Defaults come from `DefaultScanOptions()`:
+
+- `IncludePublicFunctions: true`
+- `Extensions: [".js", ".cjs"]`
+- `FailOnErrorDiagnostics: true`
+- no include/exclude path filters
+
+Path filters are evaluated against slash-separated paths relative to the scan root. This keeps filters stable across platforms and across disk-backed and `fs.FS` sources.
+
+Filtering order:
+
+1. compute the relative slash path, for example `site.js` or `assets/public/bundle.js`;
+2. require the file extension to match `Extensions`;
+3. if `Include` is non-empty, require the relative path to match at least one include glob;
+4. reject the file if it matches any exclude glob;
+5. read and parse only the remaining files.
+
+Extensions may be written with or without a leading dot. These are equivalent:
+
+```go
+jsverbs.ScanOptions{Extensions: []string{"js", "cjs"}}
+jsverbs.ScanOptions{Extensions: []string{".js", ".cjs"}}
+```
+
+Example: scan an application root while ignoring generated assets and build output:
+
+```go
+registry, err := jsverbs.ScanDir(".", jsverbs.ScanOptions{
+    IncludePublicFunctions: true,
+    Extensions:             []string{".js", ".cjs"},
+    FailOnErrorDiagnostics: true,
+    Include:                []string{"site.js", "jsverbs/**/*.js"},
+    Exclude:                []string{"assets/**", "dist/**", "webapp/**"},
+})
+```
+
+Use include/exclude filters when the scan root contains bundled browser assets, generated files, copied dependencies, or other JavaScript that is not intended to declare CLI verbs. Prefer a narrow scan root when possible; filters are the safety valve for application layouts where a narrow root is inconvenient.
+
 Supported function declarations:
 
 - top-level `function name(...) {}`

--- a/pkg/jsverbs/jsverbs_test.go
+++ b/pkg/jsverbs/jsverbs_test.go
@@ -87,6 +87,19 @@ func TestScanFSIncludeFilters(t *testing.T) {
 	require.Equal(t, "site.js", registry.Files[0].RelPath)
 }
 
+func TestScanRejectsInvalidFilterGlob(t *testing.T) {
+	_, err := ScanFS(fstest.MapFS{
+		"site.js": &fstest.MapFile{Data: []byte(`function start() { return { ok: true }; }`)},
+	}, ".", ScanOptions{
+		IncludePublicFunctions: true,
+		Extensions:             []string{"js"},
+		FailOnErrorDiagnostics: true,
+		Exclude:                []string{"assets/["},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid jsverb exclude glob")
+}
+
 func TestFixtureCommandsExecute(t *testing.T) {
 	registry := mustRegistry(t)
 	commandMap := mustCommandMap(t, registry)

--- a/pkg/jsverbs/jsverbs_test.go
+++ b/pkg/jsverbs/jsverbs_test.go
@@ -47,6 +47,46 @@ func TestScanDirDiscoversExpectedPaths(t *testing.T) {
 	}, paths)
 }
 
+func TestScanDirIncludeExcludeFilters(t *testing.T) {
+	dir := t.TempDir()
+	writeFile := func(rel, body string) {
+		t.Helper()
+		path := filepath.Join(dir, filepath.FromSlash(rel))
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte(body), 0o644))
+	}
+	writeFile("site.js", `function start() { return { ok: true }; }`)
+	writeFile("assets/public/bundle.js", `function generated() { return { skip: true }; }`)
+	writeFile("dist/app.js", `function built() { return { skip: true }; }`)
+	writeFile("notes.txt", `function ignored() {}`)
+
+	registry, err := ScanDir(dir, ScanOptions{
+		IncludePublicFunctions: true,
+		Extensions:             []string{".js"},
+		FailOnErrorDiagnostics: true,
+		Include:                []string{"*.js", "**/*.js"},
+		Exclude:                []string{"assets/**", "dist/**"},
+	})
+	require.NoError(t, err)
+	require.Len(t, registry.Files, 1)
+	require.Equal(t, "site.js", registry.Files[0].RelPath)
+}
+
+func TestScanFSIncludeFilters(t *testing.T) {
+	registry, err := ScanFS(fstest.MapFS{
+		"site.js":                 &fstest.MapFile{Data: []byte(`function start() { return { ok: true }; }`)},
+		"assets/public/bundle.js": &fstest.MapFile{Data: []byte(`function generated() { return { skip: true }; }`)},
+	}, ".", ScanOptions{
+		IncludePublicFunctions: true,
+		Extensions:             []string{"js"},
+		FailOnErrorDiagnostics: true,
+		Include:                []string{"site.js"},
+	})
+	require.NoError(t, err)
+	require.Len(t, registry.Files, 1)
+	require.Equal(t, "site.js", registry.Files[0].RelPath)
+}
+
 func TestFixtureCommandsExecute(t *testing.T) {
 	registry := mustRegistry(t)
 	commandMap := mustCommandMap(t, registry)

--- a/pkg/jsverbs/model.go
+++ b/pkg/jsverbs/model.go
@@ -58,6 +58,8 @@ type ScanOptions struct {
 	IncludePublicFunctions bool
 	Extensions             []string
 	FailOnErrorDiagnostics bool
+	Include                []string
+	Exclude                []string
 }
 
 func DefaultScanOptions() ScanOptions {

--- a/pkg/jsverbs/scan.go
+++ b/pkg/jsverbs/scan.go
@@ -20,6 +20,9 @@ func ScanDir(root string, opts ...ScanOptions) (*Registry, error) {
 	if len(opts) > 0 {
 		options = opts[0]
 	}
+	if err := validateScanPatterns(options); err != nil {
+		return nil, err
+	}
 
 	absRoot, err := filepath.Abs(root)
 	if err != nil {
@@ -53,7 +56,11 @@ func ScanDir(root string, opts ...ScanOptions) (*Registry, error) {
 			return fmt.Errorf("relpath %s: %w", filePath, err)
 		}
 		relPathSlash := filepath.ToSlash(relPath)
-		if !supportsExtension(relPathSlash, options.Extensions) || !matchesScanPatterns(relPathSlash, options) {
+		matched, err := matchesScanPatterns(relPathSlash, options)
+		if err != nil {
+			return err
+		}
+		if !supportsExtension(relPathSlash, options.Extensions) || !matched {
 			return nil
 		}
 		source, err := rootHandle.ReadFile(relPath)
@@ -80,6 +87,9 @@ func ScanFS(fsys fs.FS, root string, opts ...ScanOptions) (*Registry, error) {
 	if len(opts) > 0 {
 		options = opts[0]
 	}
+	if err := validateScanPatterns(options); err != nil {
+		return nil, err
+	}
 	root = strings.TrimSpace(root)
 	if root == "" {
 		root = "."
@@ -105,7 +115,11 @@ func ScanFS(fsys fs.FS, root string, opts ...ScanOptions) (*Registry, error) {
 			return fmt.Errorf("relpath %s: %w", filePath, err)
 		}
 		relPathSlash := filepath.ToSlash(relPath)
-		if !supportsExtension(relPathSlash, options.Extensions) || !matchesScanPatterns(relPathSlash, options) {
+		matched, err := matchesScanPatterns(relPathSlash, options)
+		if err != nil {
+			return err
+		}
+		if !supportsExtension(relPathSlash, options.Extensions) || !matched {
 			return nil
 		}
 		source, err := fs.ReadFile(fsys, filePath)
@@ -134,6 +148,9 @@ func ScanSources(files []SourceFile, opts ...ScanOptions) (*Registry, error) {
 	options := DefaultScanOptions()
 	if len(opts) > 0 {
 		options = opts[0]
+	}
+	if err := validateScanPatterns(options); err != nil {
+		return nil, err
 	}
 
 	inputs := make([]sourceInput, 0, len(files))
@@ -212,30 +229,61 @@ func supportsExtension(filePath string, extensions []string) bool {
 	return false
 }
 
-func matchesScanPatterns(relPath string, options ScanOptions) bool {
-	relPath = filepath.ToSlash(strings.TrimPrefix(relPath, "./"))
-	if len(options.Include) > 0 && !matchesAnyScanPattern(relPath, options.Include) {
-		return false
+func validateScanPatterns(options ScanOptions) error {
+	if err := validateScanPatternSet("include", options.Include); err != nil {
+		return err
 	}
-	if matchesAnyScanPattern(relPath, options.Exclude) {
-		return false
-	}
-	return true
+	return validateScanPatternSet("exclude", options.Exclude)
 }
 
-func matchesAnyScanPattern(relPath string, patterns []string) bool {
+func validateScanPatternSet(kind string, patterns []string) error {
+	for i, pattern := range patterns {
+		pattern = normalizeScanPattern(pattern)
+		if pattern == "" {
+			continue
+		}
+		if !doublestar.ValidatePathPattern(pattern) {
+			return fmt.Errorf("invalid jsverb %s glob at index %d: %q", kind, i, patterns[i])
+		}
+	}
+	return nil
+}
+
+func matchesScanPatterns(relPath string, options ScanOptions) (bool, error) {
+	relPath = filepath.ToSlash(strings.TrimPrefix(relPath, "./"))
+	if len(options.Include) > 0 {
+		matched, err := matchesAnyScanPattern(relPath, options.Include)
+		if err != nil || !matched {
+			return false, err
+		}
+	}
+	excluded, err := matchesAnyScanPattern(relPath, options.Exclude)
+	if err != nil || excluded {
+		return false, err
+	}
+	return true, nil
+}
+
+func matchesAnyScanPattern(relPath string, patterns []string) (bool, error) {
 	for _, pattern := range patterns {
-		pattern = filepath.ToSlash(strings.TrimSpace(pattern))
-		pattern = strings.TrimPrefix(pattern, "./")
+		pattern = normalizeScanPattern(pattern)
 		if pattern == "" {
 			continue
 		}
 		matched, err := doublestar.PathMatch(pattern, relPath)
-		if err == nil && matched {
-			return true
+		if err != nil {
+			return false, fmt.Errorf("match jsverb glob %q against %q: %w", pattern, relPath, err)
+		}
+		if matched {
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
+}
+
+func normalizeScanPattern(pattern string) string {
+	pattern = filepath.ToSlash(strings.TrimSpace(pattern))
+	return strings.TrimPrefix(pattern, "./")
 }
 
 func shouldSkipDir(name string) bool {

--- a/pkg/jsverbs/scan.go
+++ b/pkg/jsverbs/scan.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/bmatcuk/doublestar/v4"
 	tree_sitter "github.com/tree-sitter/go-tree-sitter"
 	tree_sitter_javascript "github.com/tree-sitter/tree-sitter-javascript/bindings/go"
 )
@@ -47,12 +48,13 @@ func ScanDir(root string, opts ...ScanOptions) (*Registry, error) {
 			}
 			return nil
 		}
-		if !supportsExtension(filePath, options.Extensions) {
-			return nil
-		}
 		relPath, err := filepath.Rel(absRoot, filePath)
 		if err != nil {
 			return fmt.Errorf("relpath %s: %w", filePath, err)
+		}
+		relPathSlash := filepath.ToSlash(relPath)
+		if !supportsExtension(relPathSlash, options.Extensions) || !matchesScanPatterns(relPathSlash, options) {
+			return nil
 		}
 		source, err := rootHandle.ReadFile(relPath)
 		if err != nil {
@@ -60,7 +62,7 @@ func ScanDir(root string, opts ...ScanOptions) (*Registry, error) {
 		}
 		inputs = append(inputs, sourceInput{
 			AbsPath:    filePath,
-			RelPath:    filepath.ToSlash(relPath),
+			RelPath:    relPathSlash,
 			ModulePath: modulePathFromRelative(relPath),
 			Source:     source,
 		})
@@ -98,19 +100,20 @@ func ScanFS(fsys fs.FS, root string, opts ...ScanOptions) (*Registry, error) {
 			}
 			return nil
 		}
-		if !supportsExtension(filePath, options.Extensions) {
+		relPath, err := filepath.Rel(root, filePath)
+		if err != nil {
+			return fmt.Errorf("relpath %s: %w", filePath, err)
+		}
+		relPathSlash := filepath.ToSlash(relPath)
+		if !supportsExtension(relPathSlash, options.Extensions) || !matchesScanPatterns(relPathSlash, options) {
 			return nil
 		}
 		source, err := fs.ReadFile(fsys, filePath)
 		if err != nil {
 			return fmt.Errorf("read %s: %w", filePath, err)
 		}
-		relPath, err := filepath.Rel(root, filePath)
-		if err != nil {
-			return fmt.Errorf("relpath %s: %w", filePath, err)
-		}
 		inputs = append(inputs, sourceInput{
-			RelPath:    filepath.ToSlash(relPath),
+			RelPath:    relPathSlash,
 			ModulePath: modulePathFromRelative(relPath),
 			Source:     source,
 		})
@@ -195,7 +198,40 @@ func scanInputs(rootDir string, inputs []sourceInput, options ScanOptions) (*Reg
 func supportsExtension(filePath string, extensions []string) bool {
 	ext := strings.ToLower(filepath.Ext(filePath))
 	for _, candidate := range extensions {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" {
+			continue
+		}
+		if !strings.HasPrefix(candidate, ".") {
+			candidate = "." + candidate
+		}
 		if strings.EqualFold(ext, candidate) {
+			return true
+		}
+	}
+	return false
+}
+
+func matchesScanPatterns(relPath string, options ScanOptions) bool {
+	relPath = filepath.ToSlash(strings.TrimPrefix(relPath, "./"))
+	if len(options.Include) > 0 && !matchesAnyScanPattern(relPath, options.Include) {
+		return false
+	}
+	if matchesAnyScanPattern(relPath, options.Exclude) {
+		return false
+	}
+	return true
+}
+
+func matchesAnyScanPattern(relPath string, patterns []string) bool {
+	for _, pattern := range patterns {
+		pattern = filepath.ToSlash(strings.TrimSpace(pattern))
+		pattern = strings.TrimPrefix(pattern, "./")
+		if pattern == "" {
+			continue
+		}
+		matched, err := doublestar.PathMatch(pattern, relPath)
+		if err == nil && matched {
 			return true
 		}
 	}

--- a/pkg/xgoja/app/jsverb_sources.go
+++ b/pkg/xgoja/app/jsverb_sources.go
@@ -30,11 +30,14 @@ func (s *jsVerbSourceSet) ListJSVerbSources() []providerapi.JSVerbSourceDescript
 	out := make([]providerapi.JSVerbSourceDescriptor, 0, len(s.sources))
 	for _, source := range s.sources {
 		out = append(out, providerapi.JSVerbSourceDescriptor{
-			ID:      source.ID,
-			Path:    source.Path,
-			Embed:   source.Embed,
-			Package: source.Package,
-			Source:  source.Source,
+			ID:         source.ID,
+			Path:       source.Path,
+			Embed:      source.Embed,
+			Package:    source.Package,
+			Source:     source.Source,
+			Include:    append([]string(nil), source.Include...),
+			Exclude:    append([]string(nil), source.Exclude...),
+			Extensions: append([]string(nil), source.Extensions...),
 		})
 	}
 	return out

--- a/pkg/xgoja/app/root.go
+++ b/pkg/xgoja/app/root.go
@@ -268,6 +268,7 @@ func buildVerbCommands(providers *providerapi.ProviderRegistry, factory *Runtime
 }
 
 func scanVerbSource(providers *providerapi.ProviderRegistry, embeddedJSVerbs fs.FS, source JSVerbSourceSpec) (*jsverbs.Registry, error) {
+	scanOptions := jsVerbScanOptions(source)
 	if source.Package != "" || source.Source != "" {
 		if providers == nil {
 			return nil, fmt.Errorf("scan jsverb source %s: providers registry is required", source.ID)
@@ -279,7 +280,7 @@ func scanVerbSource(providers *providerapi.ProviderRegistry, embeddedJSVerbs fs.
 		if providerSource.FS == nil {
 			return nil, fmt.Errorf("scan jsverb source %s: provider verb source %s.%s has no filesystem", source.ID, source.Package, source.Source)
 		}
-		registry, err := jsverbs.ScanFS(providerSource.FS, providerSource.Root)
+		registry, err := jsverbs.ScanFS(providerSource.FS, providerSource.Root, scanOptions)
 		if err != nil {
 			return nil, fmt.Errorf("scan provider jsverb source %s (%s.%s): %w", source.ID, source.Package, source.Source, err)
 		}
@@ -292,17 +293,27 @@ func scanVerbSource(providers *providerapi.ProviderRegistry, embeddedJSVerbs fs.
 		if embeddedJSVerbs == nil {
 			return nil, fmt.Errorf("scan jsverb source %s: embedded jsverbs filesystem is not configured", source.ID)
 		}
-		registry, err := jsverbs.ScanFS(embeddedJSVerbs, source.Path)
+		registry, err := jsverbs.ScanFS(embeddedJSVerbs, source.Path, scanOptions)
 		if err != nil {
 			return nil, fmt.Errorf("scan embedded jsverb source %s: %w", source.ID, err)
 		}
 		return registry, nil
 	}
-	registry, err := jsverbs.ScanDir(source.Path)
+	registry, err := jsverbs.ScanDir(source.Path, scanOptions)
 	if err != nil {
 		return nil, fmt.Errorf("scan jsverb source %s: %w", source.ID, err)
 	}
 	return registry, nil
+}
+
+func jsVerbScanOptions(source JSVerbSourceSpec) jsverbs.ScanOptions {
+	options := jsverbs.DefaultScanOptions()
+	if len(source.Extensions) > 0 {
+		options.Extensions = append([]string(nil), source.Extensions...)
+	}
+	options.Include = append([]string(nil), source.Include...)
+	options.Exclude = append([]string(nil), source.Exclude...)
+	return options
 }
 
 func commandName(command CommandSpec, fallback string) string {

--- a/pkg/xgoja/app/runtime_spec.go
+++ b/pkg/xgoja/app/runtime_spec.go
@@ -87,11 +87,14 @@ type CommandProviderInstanceSpec struct {
 }
 
 type JSVerbSourceSpec struct {
-	ID      string `json:"id"`
-	Path    string `json:"path,omitempty"`
-	Embed   bool   `json:"embed"`
-	Package string `json:"package,omitempty"`
-	Source  string `json:"source,omitempty"`
+	ID         string   `json:"id"`
+	Path       string   `json:"path,omitempty"`
+	Embed      bool     `json:"embed"`
+	Package    string   `json:"package,omitempty"`
+	Source     string   `json:"source,omitempty"`
+	Include    []string `json:"include,omitempty"`
+	Exclude    []string `json:"exclude,omitempty"`
+	Extensions []string `json:"extensions,omitempty"`
 }
 
 type HelpSpec struct {

--- a/pkg/xgoja/providerapi/commands.go
+++ b/pkg/xgoja/providerapi/commands.go
@@ -26,11 +26,14 @@ type RuntimeFactory interface {
 // JSVerbSourceDescriptor describes one configured JavaScript verb source in the
 // generated binary's runtime spec.
 type JSVerbSourceDescriptor struct {
-	ID      string
-	Path    string
-	Embed   bool
-	Package string
-	Source  string
+	ID         string
+	Path       string
+	Embed      bool
+	Package    string
+	Source     string
+	Include    []string
+	Exclude    []string
+	Extensions []string
 }
 
 // JSVerbSourceSet lets command providers discover and scan the JavaScript verb

--- a/ttmp/2026/06/08/XGOJA-CLUBMED-MODULES--address-xgoja-goja-module-improvements-from-clubmedmeetup-usage/README.md
+++ b/ttmp/2026/06/08/XGOJA-CLUBMED-MODULES--address-xgoja-goja-module-improvements-from-clubmedmeetup-usage/README.md
@@ -1,0 +1,21 @@
+# Address xgoja/goja module improvements from ClubMedMeetup usage
+
+This is the document workspace for ticket XGOJA-CLUBMED-MODULES.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr doc add --ticket XGOJA-CLUBMED-MODULES --doc-type design-doc --title "My Design"`
+- Import sources: `docmgr import file --ticket XGOJA-CLUBMED-MODULES --file /path/to/doc.md`
+- Update metadata: `docmgr meta update --ticket XGOJA-CLUBMED-MODULES --field Status --value review`

--- a/ttmp/2026/06/08/XGOJA-CLUBMED-MODULES--address-xgoja-goja-module-improvements-from-clubmedmeetup-usage/changelog.md
+++ b/ttmp/2026/06/08/XGOJA-CLUBMED-MODULES--address-xgoja-goja-module-improvements-from-clubmedmeetup-usage/changelog.md
@@ -1,0 +1,38 @@
+# Changelog
+
+## 2026-06-08
+
+- Initial workspace created
+
+
+## 2026-06-08
+
+Created intern-facing go-go-goja design guide and investigation diary for ClubMedMeetup-derived xgoja/goja module improvements
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/ttmp/2026/06/08/XGOJA-CLUBMED-MODULES--address-xgoja-goja-module-improvements-from-clubmedmeetup-usage/design-doc/01-xgoja-clubmedmeetup-module-improvements-implementation-guide.md — Primary design deliverable
+- /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/ttmp/2026/06/08/XGOJA-CLUBMED-MODULES--address-xgoja-goja-module-improvements-from-clubmedmeetup-usage/reference/01-investigation-diary.md — Chronological investigation diary
+
+
+## 2026-06-08
+
+Refocused ticket on JSVerb source filtering; added focused guide and implemented include/exclude/extensions scan filters with focused tests passing
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/cmd/xgoja/internal/buildspec/build_spec.go — JSVerb source schema fields
+- /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/jsverbs/scan.go — Scanner filtering implementation
+- /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/ttmp/2026/06/08/XGOJA-CLUBMED-MODULES--address-xgoja-goja-module-improvements-from-clubmedmeetup-usage/design-doc/02-jsverb-source-filtering-implementation-guide.md — Focused JSVerb implementation guide
+
+
+## 2026-06-08
+
+Updated user-facing jsverbs and xgoja example documentation for JSVerb include/exclude/extensions filters
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/examples/xgoja/README.md — XGoja source filter overview
+- /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/doc/11-jsverbs-example-reference.md — ScanOptions reference
+- /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/ttmp/2026/06/08/XGOJA-CLUBMED-MODULES--address-xgoja-goja-module-improvements-from-clubmedmeetup-usage/reference/01-investigation-diary.md — Recorded documentation update step
+

--- a/ttmp/2026/06/08/XGOJA-CLUBMED-MODULES--address-xgoja-goja-module-improvements-from-clubmedmeetup-usage/changelog.md
+++ b/ttmp/2026/06/08/XGOJA-CLUBMED-MODULES--address-xgoja-goja-module-improvements-from-clubmedmeetup-usage/changelog.md
@@ -36,3 +36,13 @@ Updated user-facing jsverbs and xgoja example documentation for JSVerb include/e
 - /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/doc/11-jsverbs-example-reference.md — ScanOptions reference
 - /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/ttmp/2026/06/08/XGOJA-CLUBMED-MODULES--address-xgoja-goja-module-improvements-from-clubmedmeetup-usage/reference/01-investigation-diary.md — Recorded documentation update step
 
+
+## 2026-06-08
+
+Committed JSVerb source filtering implementation and docs (commit 3ae1cbb5cf5303b4dc8d7cf7b12817240b11734d)
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/jsverbs/scan.go — Committed scanner implementation
+- /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/ttmp/2026/06/08/XGOJA-CLUBMED-MODULES--address-xgoja-goja-module-improvements-from-clubmedmeetup-usage/reference/01-investigation-diary.md — Updated diary with commit hash
+

--- a/ttmp/2026/06/08/XGOJA-CLUBMED-MODULES--address-xgoja-goja-module-improvements-from-clubmedmeetup-usage/design-doc/01-xgoja-clubmedmeetup-module-improvements-implementation-guide.md
+++ b/ttmp/2026/06/08/XGOJA-CLUBMED-MODULES--address-xgoja-goja-module-improvements-from-clubmedmeetup-usage/design-doc/01-xgoja-clubmedmeetup-module-improvements-implementation-guide.md
@@ -1,0 +1,931 @@
+---
+Title: XGoja ClubMedMeetup Module Improvements Implementation Guide
+Ticket: XGOJA-CLUBMED-MODULES
+Status: active
+Topics:
+    - xgoja
+    - goja
+    - modules
+    - architecture
+    - clubmedmeetup
+DocType: design-doc
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: ClubMedMeetup/ttmp/2026/06/08/xgoja-modules-improvement-second-edition--improve-xgoja-and-goja-modules-from-clubmedmeetup-usage-patterns-second-edition/design-doc/01-xgoja-and-goja-module-improvement-map-second-edition.md
+      Note: |-
+        Source analysis that identified the ClubMedMeetup usage patterns and improvement opportunities.
+        Source analysis for ClubMedMeetup-derived xgoja/goja module improvements
+    - Path: go-go-goja/cmd/xgoja/internal/buildspec/build_spec.go
+      Note: |-
+        Build-time xgoja.yaml schema to extend for JSVerb filtering and provider version warnings.
+        Buildspec schema for JSVerb filters and package version fields
+    - Path: go-go-goja/modules/fs/backend_embed.go
+      Note: Read-only embedded fs backend and EROFS mutation behavior.
+    - Path: go-go-goja/modules/fs/fs.go
+      Note: |-
+        Filesystem module API surface that exposes mutating calls even for read-only embedded assets.
+        Filesystem module exports and TypeScript API to extend with capabilities
+    - Path: go-go-goja/pkg/jsverbs/scan.go
+      Note: |-
+        Directory scanner whose broad traversal caused the ClubMedMeetup duplicate JSVerb path failure.
+        Directory scanner to extend with include/exclude filtering
+    - Path: go-go-goja/pkg/xgoja/app/factory.go
+      Note: |-
+        Runtime factory that maps selected module instances to require() aliases.
+        Runtime alias registration path for selected modules
+    - Path: go-go-goja/pkg/xgoja/app/root.go
+      Note: |-
+        Generated runtime root commands, provider catalog command, and JSVerb source scanning hook.
+        Generated runtime commands and JSVerb scan dispatch
+    - Path: go-go-goja/pkg/xgoja/providers/http/http.go
+      Note: |-
+        HTTP provider lifecycle that currently starts the listener from require("express").
+        HTTP provider lifecycle and current eager listener startup
+ExternalSources: []
+Summary: Intern-facing design and implementation guide for addressing xgoja/goja module improvements discovered through the ClubMedMeetup minitrace-viz integration.
+LastUpdated: 2026-06-08T18:05:00-04:00
+WhatFor: 'Use this ticket to implement go-go-goja-side improvements: JSVerb filtering, selected-module introspection, provider pin doctor warnings, safer Express lifecycle, and fs capability metadata.'
+WhenToUse: Read before changing xgoja buildspec schema, generated runtime commands, JSVerb scanning, HTTP provider startup, or fs module discovery behavior.
+---
+
+
+# XGoja ClubMedMeetup Module Improvements Implementation Guide
+
+## Executive summary
+
+ClubMedMeetup's `minitrace-viz` site is a strong real-world integration test for `go-go-goja` because it uses a generated `xgoja` binary as an application server, not just as a toy scripting shell. The source analysis in the ClubMedMeetup ticket shows that the site selects thirteen runtime modules from seven provider packages, serves a React SPA from embedded assets, registers HTTP routes with `require("express")`, exposes local JavaScript verbs, and relies on two differently configured filesystem aliases (`fs:host` and `fs:assets`). That combination uncovered several concrete improvements that belong in `go-go-goja`.
+
+This ticket focuses on the `go-go-goja` side of the issue. The goal is not to rewrite ClubMedMeetup. The goal is to make generated xgoja applications easier to inspect, safer to operate, and less surprising for interns and application authors. The work should produce reusable behavior in `go-go-goja`: JSVerb source include/exclude filters, a runtime command that lists selected module aliases, a doctor warning for unpinned provider packages, safer Express/HTTP lifecycle semantics, and capability metadata for read-only filesystem modules.
+
+The most important implementation rule is to preserve the existing provider contract while improving observability around it. Existing xgoja applications already depend on provider packages registering modules through `providerapi.Module`, xgoja selecting instances through `ModuleInstanceSpec`, and the generated runtime registering CommonJS loaders under the selected `as` alias. Do not bypass that model. Instead, add small, well-tested extensions around the current seams.
+
+## Problem statement and scope
+
+The ClubMedMeetup source document reported the following go-go-goja issues from actual usage:
+
+- `jsverbs.path: .` caused the JSVerb scanner to walk bundled Vite assets under `assets/public`, eventually producing a duplicate generated verb path. This is a source hygiene and scanner configurability problem.
+- `xgoja list-modules -f xgoja.yaml` lists selected `require()` aliases, but the generated binary's `modules` command lists compiled provider modules. A new user can confuse provider catalog entries such as `go-go-goja-host.fs` with actual aliases such as `fs:host` and `fs:assets`.
+- Generated builds depend on provider package `version` and `replace` settings. If an xgoja buildspec selects provider packages without `version` or `replace`, builds can drift across workstations, CI, and Docker.
+- `require("express")` in the generated runtime starts or touches the xgoja HTTP listener. That makes eval/repl introspection fail when the default port is already in use, even when the user only wants to inspect module exports.
+- A read-only embedded filesystem module exposes the same method list and TypeScript declaration as a host filesystem module. Mutating methods correctly fail with read-only errors, but discovery does not explain that writes are impossible.
+
+This ticket is scoped to `go-go-goja`. It should not implement the ClubMedMeetup app changes, the `go-minitrace` upstream consolidation, or `goja-text` document helpers. Those are related follow-up tickets in sibling repositories. This ticket can, however, provide the `go-go-goja` runtime affordances those follow-ups depend on.
+
+## Current-state architecture
+
+### Build-time model: xgoja.yaml as declarative input
+
+The xgoja buildspec schema lives in `cmd/xgoja/internal/buildspec/build_spec.go`. The top-level `BuildSpec` contains build-only information such as Go module settings, provider packages, selected module instances, commands, JavaScript verb sources, help sources, and embedded assets. Lines 12-30 define the top-level structure, and lines 68-74 define `PackageSpec` with `ID`, `Import`, `Version`, `Register`, and `Replace`.
+
+The most important part for module selection is `ModuleInstanceSpec` at `cmd/xgoja/internal/buildspec/build_spec.go:76-84`:
+
+```go
+type ModuleInstanceSpec struct {
+    Package string         `yaml:"package" json:"package"`
+    Name    string         `yaml:"name" json:"name"`
+    As      string         `yaml:"as" json:"as,omitempty"`
+    Config  map[string]any `yaml:"config" json:"config,omitempty"`
+}
+```
+
+`Alias()` at lines 86-91 returns `As` when present and falls back to `Name`. This is the semantic center of xgoja module selection: `as` is not a label; it is the actual CommonJS `require()` name installed into the generated runtime.
+
+The JSVerb schema is currently too small for source hygiene. `JSVerbSourceSpec` at `build_spec.go:124-130` only has `id`, `path`, `embed`, `package`, and `source`. There is no way to say "scan only `site.js`" or "scan this directory except `assets/**` and `dist/**`." The scanner therefore has to treat a configured directory as the entire source tree.
+
+### Build execution and generated go.mod
+
+`cmd/xgoja/cmd_build.go` implements the `xgoja build` command. It loads the buildspec, validates it, writes generated Go files, runs `go mod tidy`, and builds the generated module. Lines 92-106 are the high-level orchestration: load the spec, reject source-only target kinds, compute the output/work directory, and write generated files. Lines 128-140 run `go mod tidy`, resolve the output path, and run `go build`.
+
+Generated module dependency determinism is controlled by `cmd/xgoja/internal/generate/gomod.go`. `RenderGoMod` always requires the xgoja runtime module (`github.com/go-go-golems/go-go-goja`) at the selected xgoja version. It only adds provider package modules when the provider's `PackageSpec.Version` is non-empty (`gomod.go:28-34`). It only adds replacements for packages whose `PackageSpec.Replace` is non-empty (`gomod.go:63-67`). Therefore an unpinned provider package is not explicitly recorded in the generated `require` block by this code path. Go can still resolve it transitively, but the buildspec is not self-describing or deterministic.
+
+The required improvement is not to force every local development build to pin versions. Instead, `xgoja doctor` should warn when a provider package has neither `version` nor `replace`, and the documentation should explain when the warning is acceptable.
+
+### Runtime model: embedded RuntimeSpec and provider modules
+
+Generated binaries do not use the full buildspec at runtime. `pkg/xgoja/app/runtime_spec.go` defines the runtime-side `RuntimeSpec`, which intentionally omits build-only fields such as provider import paths, provider versions, replacements, target root, and base directories. It keeps packages by ID, selected modules, commands, command providers, JSVerb sources, help sources, and assets.
+
+Runtime module selection is implemented by `pkg/xgoja/app/factory.go`. The key flow is:
+
+1. `RuntimeFactory.NewRuntimeFromSections` loads selected module descriptors from the runtime spec (`factory.go:74-81`).
+2. It asks provider package capabilities to contribute host services (`factory.go:82-85`, `factory.go:143-173`).
+3. It iterates every selected `RuntimeSpec.Modules` entry, resolves the provider module by `package` and `name`, merges config, and creates a `providerRuntimeModuleRegistrar` (`factory.go:96-110`).
+4. The registrar calls the provider module's `NewModuleFactory` with `ModuleSetupContext`, including `Name`, `As`, static/merged config, host services, runtime owner, and closer registration (`factory.go:46-54`).
+5. The registrar installs the loader under `s.instance.Alias()` with `reg.RegisterNativeModule` (`factory.go:58`).
+
+This means a selected module entry like:
+
+```yaml
+modules:
+  - package: go-go-goja-host
+    name: fs
+    as: fs:assets
+    config:
+      embedded:
+        allow: true
+```
+
+produces `require("fs:assets")`, not `require("fs")`. The provider module name remains `fs`; the runtime alias is `fs:assets`.
+
+### Provider API contract
+
+Provider packages register entries in `providerapi.ProviderRegistry`. `providerapi.Module` at `pkg/xgoja/providerapi/module.go:40-49` is the selected native module contract. It has a provider-owned `Name`, optional `DefaultAs`, description, config schema, and `NewModuleFactory`.
+
+`ModuleSetupContext` at `module.go:12-22` is the runtime setup context passed to provider modules. The important fields for this ticket are:
+
+- `Name`: provider module name from the package, for example `fs`.
+- `As`: selected runtime alias, for example `fs:assets`.
+- `Config`: selected module config after xgoja/glazed config merging.
+- `Host`: runtime host services such as asset resolution.
+- `RuntimeOwner` and `AddCloser`: lifecycle hooks.
+
+Package capabilities are defined in `pkg/xgoja/providerapi/capabilities.go`. The important interfaces are:
+
+- `GlazedConfigSectionCapability` (`capabilities.go:39-46`) exposes public command/config sections.
+- `XGojaConfigSectionCapability` (`capabilities.go:60-68`) maps public values into provider-internal module config.
+- `HostServiceContributionCapability` (`capabilities.go:91-98`) contributes Go-backed services before the runtime is constructed.
+- `RuntimeInitializerCapability` (`capabilities.go:109-115`) initializes a runtime after the VM exists.
+
+The proposed Express lifecycle changes should use this existing capability model instead of adding ad hoc globals.
+
+### Generated runtime commands
+
+`pkg/xgoja/app/root.go` attaches generated runtime commands. The generated `modules` command currently lists provider modules compiled into the binary, not selected runtime aliases. `newModulesCommand` ignores `runtimeSpec` (`root.go:159-161`) and iterates `providers.Packages()`. It emits rows with columns `package`, `module`, and `require`, where `require` is currently a provider-qualified string like `go-go-goja-host.fs` (`root.go:174-187`).
+
+This is technically a provider catalog, not a runtime module inventory. The command name and `require` column make it too easy to believe the row is a valid CommonJS import. The intern should implement a separate selected-module command and rename the existing provider catalog column to avoid implying `require("go-go-goja-host.fs")` works.
+
+The xgoja CLI already has a buildspec-level command for selected modules. `cmd/xgoja/cmd_list_modules.go` loads `xgoja.yaml` and emits `file`, `package`, `module`, and `alias` for each selected module. The generated runtime needs an equivalent that uses embedded `RuntimeSpec`, so it works after distribution without the original YAML file.
+
+### JSVerb scanning
+
+JSVerb scanning is split between runtime source selection and scanner implementation:
+
+- `pkg/xgoja/app/root.go:270-302` chooses provider, embedded, or filesystem JSVerb sources and then calls `jsverbs.ScanFS` or `jsverbs.ScanDir`.
+- `pkg/jsverbs/scan.go:17-73` implements `ScanDir` by walking every file under the configured root whose extension matches the scanner options.
+- `pkg/jsverbs/scan.go:40-48` skips only `node_modules` and dot-directories via `shouldSkipDir`; normal directories like `assets`, `dist`, `webapp`, and `lib` are scanned.
+- `pkg/jsverbs/scan.go:50-66` appends every supported JavaScript source into the scanner input list.
+
+The scanner is correct for a carefully scoped source directory. It is too broad for application roots that also contain bundled assets. The right fix is to make the scanner configurable and make xgoja expose that config in `JSVerbSourceSpec`.
+
+### HTTP provider and Express lifecycle
+
+The HTTP provider lives in `pkg/xgoja/providers/http/http.go`. It registers provider package `go-go-goja-http` and module `express` (`http.go:25-35`). The provider also registers an HTTP config capability and a `serve` command provider (`http.go:36-44`).
+
+The current lifecycle surprise is visible in `NewExpressLoader` (`http.go:109-123`). Loading the module:
+
+1. Gets or creates a runtime entry.
+2. Creates a `gojahttp.Host` if needed.
+3. Calls `c.start(vm, entry)` immediately.
+4. Delegates to `express.NewLoader(host)`.
+
+`start` binds a TCP listener if HTTP is enabled (`http.go:137-164`). Because the default runtime entry has `settings{Enabled: true, Listen: "127.0.0.1:8787"}` (`http.go:126-134`), simply requiring Express can attempt to bind the default port. The `InitRuntimeFromSections` path can set HTTP disabled when values exist (`http.go:87-107`), but a user inspecting exports may not expect `require("express")` to perform network IO at all.
+
+### Filesystem module and read-only assets
+
+The host provider registers `fs` and `node:fs` as guarded modules in `pkg/xgoja/providers/host/host.go`. The module config schema explicitly supports either host access (`allow: true`) or embedded read-only mounts (`embedded.allow: true`) and rejects combining both in one alias (`host.go:101-123`). This is a good design: applications should use distinct aliases such as `fs:host` and `fs:assets`.
+
+The filesystem module's TypeScript declaration and exported method list are backend-independent. `modules/fs/fs.go:43-65` declares read and write methods. `modules/fs/fs.go:97-139` exports async read/write/mkdir/remove methods, and `fs.go:142-190` exports sync methods. The read-only embedded backend correctly rejects mutations: `modules/fs/backend_embed.go:49-63` returns a mutation error for write and mkdir, and `backend_embed.go:90-118` returns mutation errors for remove, append, rename/copy write targets, and recursive remove.
+
+The gap is discoverability. A developer can inspect `Object.keys(require("fs:assets"))` and see methods that cannot succeed. The implementation should expose capabilities such as `isReadOnly`, `capabilities()`, or a backend descriptor so the API is self-describing.
+
+## Proposed solution
+
+### Overview
+
+Implement five small `go-go-goja` improvements:
+
+1. **JSVerb source filters:** Extend buildspec and runtime `JSVerbSourceSpec` with `include`, `exclude`, and optional `extensions`, then apply those patterns in `jsverbs.ScanDir` and `ScanFS`.
+2. **Selected runtime module inventory:** Add a generated runtime command, tentatively `selected-modules`, that lists `RuntimeSpec.Modules` with actual aliases and config summaries. Adjust the existing `modules` command wording/columns so it is clearly a provider catalog.
+3. **Provider pin doctor warning:** Add an `xgoja doctor`/validation warning for provider packages without `version` or `replace`, preferably suppressible for intentional workspace builds.
+4. **Lazy or explicit Express start:** Change the HTTP provider so `require("express")` creates module exports but does not bind a port until HTTP is initialized and an app registers routes/static handlers or explicitly calls `listen`.
+5. **Filesystem capability metadata:** Add read-only/backend capability metadata to the fs module exports and TypeScript declarations.
+
+These changes share one architectural principle: each feature is metadata/configuration around existing contracts. Do not add a second module registry, a second HTTP host model, or a new filesystem module for assets. Extend the existing seams.
+
+## Target architecture diagrams
+
+### Build-to-runtime path
+
+```mermaid
+flowchart TD
+  YAML[xgoja.yaml BuildSpec] --> Validate[buildspec.LoadFile + Validate]
+  Validate --> Gen[generate.WriteAll]
+  Gen --> RuntimeJSON[embedded app.RuntimeSpec JSON]
+  Gen --> GoMod[generated go.mod]
+  GoMod --> Binary[generated xgoja app binary]
+  RuntimeJSON --> Binary
+  Binary --> Host[app.NewHost]
+  Host --> Factory[RuntimeFactory]
+  Factory --> Selected[RuntimeSpec.Modules]
+  Selected --> Require[CommonJS require aliases]
+```
+
+The intern should remember that `PackageSpec.Version` and `PackageSpec.Replace` affect `go.mod`, but they do not survive into `RuntimeSpec`. Runtime commands can report selected aliases and static config, but not provider import paths or version pins unless the runtime schema is deliberately extended.
+
+### Runtime module registration
+
+```mermaid
+sequenceDiagram
+  participant Run as generated run/eval/repl
+  participant Factory as RuntimeFactory
+  participant Registry as ProviderRegistry
+  participant Provider as providerapi.Module
+  participant Require as goja require.Registry
+
+  Run->>Factory: NewRuntimeFromSections(vals)
+  Factory->>Factory: selectedModuleDescriptors()
+  Factory->>Registry: ResolveModule(package,name)
+  Registry-->>Factory: providerapi.Module
+  Factory->>Provider: NewModuleFactory(ModuleSetupContext{Name, As, Config, Host})
+  Provider-->>Factory: require.ModuleLoader
+  Factory->>Require: RegisterNativeModule(Alias(), loader)
+  Run->>Require: require("alias")
+```
+
+### JSVerb filtered scanning
+
+```mermaid
+flowchart LR
+  Source[JSVerbSourceSpec] --> Patterns[include/exclude/extensions]
+  Patterns --> Walk[ScanDir or ScanFS]
+  Walk --> Filter{matches?}
+  Filter -- skip --> Ignored[assets/dist/webapp ignored]
+  Filter -- include --> Parse[tree-sitter parse]
+  Parse --> Registry[jsverbs.Registry]
+  Registry --> Commands[generated verbs commands]
+```
+
+### HTTP lifecycle target
+
+```mermaid
+stateDiagram-v2
+  [*] --> ModuleLoaded: require("express")
+  ModuleLoaded --> AppCreated: express.app()
+  AppCreated --> RoutesRegistered: app.get/post/static/spa
+  RoutesRegistered --> Listening: autoStart or app.listen()
+  AppCreated --> Closed: runtime.Close()
+  Listening --> Closed: runtime closer / shutdown
+```
+
+In the target lifecycle, the `ModuleLoaded` state must not bind a TCP port. Binding should happen at `RoutesRegistered` or explicit `app.listen()` depending on the chosen compatibility policy.
+
+## Detailed design and API references
+
+### Feature 1: JSVerb source filters
+
+#### Public xgoja.yaml API
+
+Extend both build-time and runtime JSVerb source specs:
+
+```go
+type JSVerbSourceSpec struct {
+    ID         string   `yaml:"id" json:"id"`
+    Path       string   `yaml:"path" json:"path,omitempty"`
+    Embed      bool     `yaml:"embed" json:"embed"`
+    Package    string   `yaml:"package" json:"package,omitempty"`
+    Source     string   `yaml:"source" json:"source,omitempty"`
+    Include    []string `yaml:"include,omitempty" json:"include,omitempty"`
+    Exclude    []string `yaml:"exclude,omitempty" json:"exclude,omitempty"`
+    Extensions []string `yaml:"extensions,omitempty" json:"extensions,omitempty"`
+}
+```
+
+Example buildspec usage:
+
+```yaml
+jsverbs:
+  - id: minitrace-viz-site
+    path: .
+    include:
+      - site.js
+      - jsverbs/**/*.js
+    exclude:
+      - assets/**
+      - dist/**
+      - webapp/**
+      - node_modules/**
+```
+
+`include` should be interpreted relative to the configured source root. If `include` is empty, all supported files are candidates. `exclude` removes candidates after include matching. `extensions` defaults to existing scanner extensions.
+
+#### Scanner API
+
+Extend `pkg/jsverbs` scan options. The current `ScanOptions` definition was not opened in this session, but the implementation already uses `options.Extensions` and `options.FailOnErrorDiagnostics`. Add fields similar to:
+
+```go
+type ScanOptions struct {
+    Extensions []string
+    FailOnErrorDiagnostics bool
+    Include []string
+    Exclude []string
+}
+```
+
+Pseudocode for candidate filtering:
+
+```text
+for each walked file:
+    rel = slash-relative-path(root, file)
+    if !supportsExtension(rel, options.Extensions):
+        continue
+    if len(options.Include) > 0 and !matchesAny(rel, options.Include):
+        continue
+    if matchesAny(rel, options.Exclude):
+        continue
+    read and append source input
+```
+
+Pattern matching should use a predictable glob helper. If the repo already has a doublestar dependency, use it. Otherwise implement a small helper around `path.Match` plus `**` support, and add tests before using it in scanner code. Do not use OS-specific path separators in matching; convert to slash paths before matching.
+
+#### xgoja app integration
+
+`pkg/xgoja/app/root.go:270-302` currently calls `jsverbs.ScanFS(providerSource.FS, providerSource.Root)`, `jsverbs.ScanFS(embeddedJSVerbs, source.Path)`, or `jsverbs.ScanDir(source.Path)` without options. Construct `ScanOptions` from `source.Include`, `source.Exclude`, and `source.Extensions`, and pass it through in each path.
+
+Provider-supplied JSVerb sources need a design choice:
+
+- Option A: apply the xgoja selected source's include/exclude filters to provider sources too.
+- Option B: reject include/exclude on provider sources because provider sources are already curated.
+
+Prefer Option A. It is more general and keeps the schema behavior consistent. Document that paths are relative to the provider source root.
+
+#### Validation and doctor warnings
+
+In `cmd/xgoja/internal/buildspec/validate.go`, validate that include/exclude patterns are non-empty strings when present. Also add a warning when a filesystem JSVerb source uses `path: .` with no include/exclude filters. The warning should say why: scanning an application root can pick up bundled assets, generated files, or unrelated JavaScript.
+
+#### Tests
+
+Add scanner-level tests under `pkg/jsverbs`:
+
+- include only `site.js` while ignoring `assets/public/app.js`.
+- exclude `assets/**` and `dist/**` while keeping `site.js`.
+- extension override works for `.mjs` or `.cjs` if already supported.
+- path matching is slash-normalized.
+
+Add xgoja app tests around `scanVerbSource` if practical:
+
+```go
+runtimeSpec := &RuntimeSpec{JSVerbs: []JSVerbSourceSpec{{
+    ID: "site", Path: fixtureDir,
+    Include: []string{"site.js"},
+    Exclude: []string{"assets/**"},
+}}}
+```
+
+Expected result: the registry contains only verbs from `site.js`.
+
+### Feature 2: selected runtime module inventory
+
+#### User-facing command
+
+Add a generated runtime command named `selected-modules` or add `--selected` to the existing `modules` command. Prefer a separate command first because it avoids breaking users who parse the existing `modules` output.
+
+Rows should include:
+
+| Column | Meaning |
+| --- | --- |
+| `package` | provider package ID from `RuntimeSpec.Modules[].Package` |
+| `module` | provider module name from `RuntimeSpec.Modules[].Name` |
+| `alias` | actual `require()` name from `ModuleInstanceSpec.Alias()` |
+| `provider_ref` | stable provider reference, for example `go-go-goja-host.fs` |
+| `config` | JSON-encoded static config or omitted/summary for table output |
+
+Example JSON output:
+
+```json
+[
+  {
+    "package": "go-go-goja-host",
+    "module": "fs",
+    "alias": "fs:host",
+    "provider_ref": "go-go-goja-host.fs",
+    "config": { "allow": true }
+  },
+  {
+    "package": "go-go-goja-host",
+    "module": "fs",
+    "alias": "fs:assets",
+    "provider_ref": "go-go-goja-host.fs",
+    "config": { "embedded": { "allow": true } }
+  }
+]
+```
+
+#### Existing provider catalog command
+
+Update `newModulesCommand` in `pkg/xgoja/app/root.go` so the existing command is clearly a provider catalog:
+
+- Short description: "List provider modules compiled into this generated binary".
+- Column rename: change `require` to `provider_ref`.
+- Optional extra columns: `default_alias` and `description`, if available from `providerapi.Module`.
+
+Do not remove the command or change it to selected modules in place unless the project is ready for a breaking CLI output change.
+
+#### Implementation pseudocode
+
+```go
+type selectedModulesCommand struct {
+    *cmds.CommandDescription
+    runtimeSpec *RuntimeSpec
+}
+
+func newSelectedModulesCommand(runtimeSpec *RuntimeSpec) cmds.Command {
+    return &selectedModulesCommand{runtimeSpec: runtimeSpec, ...}
+}
+
+func (c *selectedModulesCommand) RunIntoGlazeProcessor(ctx context.Context, vals *values.Values, gp middlewares.Processor) error {
+    for _, mod := range c.runtimeSpec.Modules {
+        configJSON := "{}"
+        if mod.Config != nil { configJSON = marshalCompact(mod.Config) }
+        gp.AddRow(ctx, types.NewRow(
+            types.MRP("package", mod.Package),
+            types.MRP("module", mod.Name),
+            types.MRP("alias", mod.Alias()),
+            types.MRP("provider_ref", mod.Package+"."+mod.Name),
+            types.MRP("config", configJSON),
+        ))
+    }
+    return nil
+}
+```
+
+Attach it in `Host.AttachDefaultCommands` near the existing `modules` command.
+
+#### Tests
+
+Add a test under `pkg/xgoja/app` that constructs a `RuntimeSpec` with two `fs` module instances and asserts the selected command emits both aliases. If command testing infrastructure is awkward, unit-test the row-builder function as a pure helper.
+
+### Feature 3: provider pin doctor warning
+
+#### Rationale
+
+`generate.RenderGoMod` only adds provider modules to generated `go.mod` when `PackageSpec.Version` is set. It only adds provider replacements when `PackageSpec.Replace` is set. This is visible at `cmd/xgoja/internal/generate/gomod.go:28-34` and `gomod.go:63-67`. Therefore a buildspec with neither field can build, but it does not document the intended provider version.
+
+#### Proposed doctor behavior
+
+Add a warning, not an error:
+
+```text
+WARN package-version packages[3]: provider package "goja-text" has neither version nor replace; generated builds may drift across environments
+```
+
+This belongs in validation/doctor output because:
+
+- local workspace builds may intentionally use `go.work` or a parent module strategy;
+- Docker/release builds should pin versions;
+- older buildspecs should not become invalid overnight.
+
+#### Implementation notes
+
+Find the `Report` type in `cmd/xgoja/internal/buildspec` and confirm whether it supports warnings. If it only supports OK/error checks, add warning severity carefully and update output consumers. If adding warning severity is too broad for this phase, implement the check in `xgoja doctor` first, where warnings likely already exist or are easier to present.
+
+Pseudocode:
+
+```go
+for i, pkg := range buildSpec.Packages {
+    if strings.TrimSpace(pkg.Version) == "" && strings.TrimSpace(pkg.Replace) == "" {
+        report.AddWarning("package-version", fmt.Sprintf("packages[%d]", i),
+            fmt.Sprintf("provider package %q has neither version nor replace", pkg.ID))
+    }
+}
+```
+
+Add an optional suppression flag only if the repo already has a suppression mechanism. Do not invent a large policy system for this ticket.
+
+#### Tests
+
+- Buildspec with `version` only: no warning.
+- Buildspec with `replace` only: no warning.
+- Buildspec with neither: warning.
+- Buildspec with both: no warning, unless an existing validation rule forbids both.
+
+### Feature 4: safer Express lifecycle
+
+#### Current behavior to change
+
+`pkg/xgoja/providers/http/http.go:109-123` starts the HTTP server inside `NewExpressLoader`. This means CommonJS module loading has network side effects. The target behavior is: module loading creates exports; app creation and route registration prepare handlers; listener binding occurs when the runtime has been initialized and the app actually needs serving, or when an explicit `listen()` call occurs.
+
+#### Compatibility policy
+
+Preserve existing `run server.js --keep-alive` behavior. Existing scripts that only do:
+
+```js
+const express = require("express")
+const app = express.app()
+app.get("/healthz", ...)
+```
+
+should still serve routes when run normally. The difference is that introspection code such as:
+
+```bash
+./dist/app eval 'Object.keys(require("express"))'
+```
+
+should not bind the default port just by requiring the module.
+
+A practical compromise:
+
+- `require("express")`: create/get host, export `app`, no bind.
+- `express.app()`: return app object, no bind by itself.
+- First route/static registration: if HTTP enabled and autostart enabled, start listener.
+- `app.listen([addr])`: explicit listener start, optionally overriding configured address.
+- `--http-enabled=false`: never start, but allow route registration for tests/introspection.
+
+#### API sketch
+
+```js
+const express = require("express")
+const app = express.app({ autoStart: true })
+app.get("/healthz", (_req, res) => res.json({ ok: true }))
+
+// Optional explicit mode:
+const app2 = express.app({ autoStart: false })
+app2.get("/healthz", handler)
+app2.listen("127.0.0.1:8787")
+```
+
+#### Go implementation sketch
+
+Add an autostart hook to the Express registrar rather than making `modules/express` import the HTTP provider package. Keep dependency direction clean:
+
+```go
+type StartFunc func(*goja.Runtime) error
+
+type Registrar struct {
+    host *gojahttp.Host
+    name string
+    onUse StartFunc
+}
+
+func WithOnUse(fn StartFunc) Option { ... }
+
+func (r *Registrar) appObject(vm *goja.Runtime) goja.Value {
+    obj := vm.NewObject()
+    for _, method := range methods {
+        _ = obj.Set(method, func(pattern string, handler goja.Value) error {
+            if r.onUse != nil {
+                if err := r.onUse(vm); err != nil { return err }
+            }
+            r.host.Register(...)
+            return nil
+        })
+    }
+    _ = obj.Set("listen", func(optionalListen string) error {
+        return r.listen(vm, optionalListen)
+    })
+    return obj
+}
+```
+
+In the HTTP provider:
+
+```go
+func (c *capability) NewExpressLoader() require.ModuleLoader {
+    return func(vm *goja.Runtime, moduleObj *goja.Object) {
+        entry := c.entry(vm)
+        host := c.ensureHost(entry)
+        express.NewLoader(host, express.WithOnUse(func(vm *goja.Runtime) error {
+            return c.start(vm, entry)
+        }))(vm, moduleObj)
+    }
+}
+```
+
+This changes the side effect boundary from module load to application use. To make pure route registration possible with HTTP disabled, `c.start` already returns nil when `cfg.Enabled` is false (`http.go:140-144`).
+
+#### Tests
+
+- Requiring express without route registration does not bind the configured port.
+- Registering a route in normal mode starts the listener and serves the route.
+- Registering a route with `--http-enabled=false` succeeds but does not bind.
+- Existing `run server.js --keep-alive` smoke still serves registered routes.
+- If the port is occupied, the error occurs at route registration or `app.listen`, not at `require("express")`.
+
+### Feature 5: filesystem capability metadata
+
+#### API shape
+
+Expose a simple capability object on every fs module:
+
+```js
+const fs = require("fs:assets")
+fs.isReadOnly === true
+fs.capabilities()
+// {
+//   backend: "embedded",
+//   read: true,
+//   write: false,
+//   embedded: true,
+//   mounts: [{ mount: "/app", root: "public", asset: "minitrace-widget-spa" }]
+// }
+```
+
+For host fs:
+
+```js
+require("fs:host").capabilities()
+// { backend: "host", read: true, write: true, embedded: false, mounts: [] }
+```
+
+The initial implementation can omit detailed mount metadata if the backend does not expose it yet. The minimum useful API is:
+
+```js
+{ backend: "host" | "embedded", read: true, write: boolean, embedded: boolean }
+```
+
+#### Go implementation sketch
+
+Add a small interface in `modules/fs`:
+
+```go
+type CapabilityReporter interface {
+    FSCapabilities() Capabilities
+}
+
+type Capabilities struct {
+    Backend string `json:"backend"`
+    Read bool `json:"read"`
+    Write bool `json:"write"`
+    Embedded bool `json:"embedded"`
+    Mounts []MountInfo `json:"mounts,omitempty"`
+}
+```
+
+Implement it for `OSBackend` and `ReadOnlyFSBackend`. In `m.Loader`, after `backend := mod.fileSystem()`, export:
+
+```go
+caps := capabilitiesForBackend(backend)
+modules.SetExport(exports, mod.Name(), "isReadOnly", !caps.Write)
+modules.SetExport(exports, mod.Name(), "capabilities", func() Capabilities { return caps })
+```
+
+Update `TypeScriptModule()` to include `isReadOnly` and `capabilities()`.
+
+#### Tests
+
+- `fs:assets.isReadOnly` is true for `ReadOnlyFSBackend`.
+- `fs:assets.capabilities().write` is false and `embedded` is true.
+- `fs:host.capabilities().write` is true and `embedded` is false.
+- Existing EROFS behavior remains unchanged.
+
+## Implementation phases for a new intern
+
+### Phase 0: Set up and read the system
+
+Run these commands first:
+
+```bash
+cd /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja
+go test ./pkg/xgoja/... ./pkg/jsverbs/... ./modules/fs/... ./modules/express/... ./pkg/xgoja/providers/http/... -count=1
+```
+
+Then read the files in this order:
+
+1. `cmd/xgoja/internal/buildspec/build_spec.go` — understand buildspec DTOs.
+2. `cmd/xgoja/internal/generate/gomod.go` — understand version/replace behavior.
+3. `pkg/xgoja/app/runtime_spec.go` — understand runtime DTOs.
+4. `pkg/xgoja/app/factory.go` — understand how aliases become `require()` modules.
+5. `pkg/xgoja/app/root.go` — understand generated commands and JSVerb scanning.
+6. `pkg/jsverbs/scan.go` — understand scanner traversal.
+7. `pkg/xgoja/providers/http/http.go` and `modules/express/express.go` — understand HTTP lifecycle.
+8. `pkg/xgoja/providers/host/host.go`, `modules/fs/fs.go`, and `modules/fs/backend_embed.go` — understand fs aliases and read-only backend behavior.
+
+Do not start by coding. First draw the alias flow on paper: buildspec module entry -> runtime spec module entry -> provider module resolution -> `RegisterNativeModule(alias, loader)`.
+
+### Phase 1: selected runtime module command
+
+This is the safest first implementation because it is mostly additive.
+
+Steps:
+
+1. Add a `selectedModulesCommand` type in `pkg/xgoja/app/root.go` or a new file such as `selected_modules_command.go`.
+2. Attach it from `Host.AttachDefaultCommands` next to `modules`.
+3. Emit `package`, `module`, `alias`, `provider_ref`, and `config`.
+4. Rename the existing `modules` command's `require` column to `provider_ref`, or add `provider_ref` while keeping `require` for one release if compatibility is important.
+5. Add tests.
+
+Validation:
+
+```bash
+go test ./pkg/xgoja/app -count=1
+```
+
+If you have a generated sample app, verify:
+
+```bash
+./dist/app selected-modules --output json
+./dist/app modules --output table
+```
+
+### Phase 2: JSVerb include/exclude filters
+
+Steps:
+
+1. Add fields to build-time `JSVerbSourceSpec` and runtime `JSVerbSourceSpec`.
+2. Ensure generation copies those fields into the embedded runtime spec. If runtime generation uses JSON marshal of a cloned buildspec, this may work automatically after both structs are updated; still add a test.
+3. Extend `jsverbs.ScanOptions`.
+4. Implement slash-normalized include/exclude matching in `pkg/jsverbs/scan.go`.
+5. Pass scan options from `pkg/xgoja/app/root.go:scanVerbSource`.
+6. Add validation warnings for `path: .` with no filters.
+7. Add scanner and xgoja generation tests.
+
+Validation:
+
+```bash
+go test ./pkg/jsverbs ./pkg/xgoja/app ./cmd/xgoja/internal/buildspec ./cmd/xgoja/internal/generate -count=1
+```
+
+Regression fixture idea:
+
+```text
+fixture/
+  site.js                  # contains __package__/__verb__
+  assets/public/bundle.js  # contains similar generated names or duplicate path bait
+  dist/app.js
+```
+
+Expected result: only `site.js` is scanned when configured with `include: [site.js]` or `exclude: [assets/**, dist/**]`.
+
+### Phase 3: provider pin doctor warning
+
+Steps:
+
+1. Inspect `cmd/xgoja/internal/buildspec/report.go` and `cmd/xgoja/cmd_doctor.go`.
+2. Decide whether warnings belong in `Validate` or doctor-only logic.
+3. Add warning for packages with empty `version` and empty `replace`.
+4. Make sure `xgoja build` does not fail on warnings.
+5. Add tests.
+
+Validation:
+
+```bash
+go test ./cmd/xgoja/internal/buildspec ./cmd/xgoja -count=1
+xgoja doctor -f path/to/fixture.yaml
+```
+
+### Phase 4: Express lifecycle
+
+Steps:
+
+1. Add an optional `onUse`/`onListen` hook to `modules/express.Registrar` without importing provider/http into modules/express.
+2. Move HTTP provider `c.start` call out of `NewExpressLoader` module load and into route/static registration or explicit `listen`.
+3. Add `app.listen()` if it does not exist yet.
+4. Preserve autostart behavior for normal `run server.js --keep-alive`.
+5. Add tests for require-only behavior, route-registration behavior, disabled HTTP behavior, and occupied-port behavior.
+
+Validation:
+
+```bash
+go test ./modules/express ./pkg/xgoja/providers/http ./pkg/xgoja/app -count=1
+```
+
+Manual smoke:
+
+```bash
+# Should not bind or fail if 8787 is busy:
+./dist/app eval 'JSON.stringify(Object.keys(require("express")))'
+
+# Should serve routes:
+./dist/app run server.js --http-listen 127.0.0.1:18787 --keep-alive
+curl -fsS http://127.0.0.1:18787/healthz
+```
+
+### Phase 5: fs capability metadata
+
+Steps:
+
+1. Add capability structs/interfaces in `modules/fs`.
+2. Implement capability reporting for `OSBackend` and `ReadOnlyFSBackend`.
+3. Export `isReadOnly` and `capabilities()` in `fs.go`.
+4. Update TypeScript declarations.
+5. Add tests.
+
+Validation:
+
+```bash
+go test ./modules/fs ./pkg/xgoja/providers/host -count=1
+```
+
+Manual JS assertions:
+
+```js
+const assets = require("fs:assets")
+if (!assets.isReadOnly) throw new Error("expected fs:assets to be read-only")
+if (assets.capabilities().write) throw new Error("expected write=false")
+```
+
+## Decision records
+
+### Decision: Add selected-module inventory as a new generated command
+
+- **Context:** The generated `modules` command lists compiled provider modules, while users need to know selected aliases.
+- **Options considered:** Replace `modules`; add `--selected`; add a new `selected-modules` command.
+- **Decision:** Add `selected-modules` first and clarify the existing `modules` command as a provider catalog.
+- **Rationale:** This is additive and avoids breaking existing scripts.
+- **Consequences:** There are two commands, but their names and descriptions can be explicit.
+- **Status:** proposed
+
+### Decision: Implement JSVerb filters in scanner options, not only in xgoja
+
+- **Context:** The immediate failure came from xgoja, but `pkg/jsverbs` is reusable.
+- **Options considered:** Filter paths only in `scanVerbSource`; add scanner-level include/exclude options; require users to move JSVerb files.
+- **Decision:** Add scanner-level include/exclude options and expose them through xgoja schema.
+- **Rationale:** This gives reusable behavior to direct scanner callers and keeps matching near traversal.
+- **Consequences:** Requires careful pattern tests and JSON/YAML schema propagation.
+- **Status:** proposed
+
+### Decision: Warn, do not fail, on unpinned provider packages
+
+- **Context:** Generated builds can drift when packages lack `version` or `replace`, but local workspace builds may intentionally use ambient module resolution.
+- **Options considered:** Make it an error; warn in doctor; ignore.
+- **Decision:** Add a doctor/validation warning.
+- **Rationale:** It nudges release-quality buildspecs without breaking development workflows.
+- **Consequences:** Release pipelines should decide whether warnings are fatal.
+- **Status:** proposed
+
+### Decision: Move Express port binding out of module load
+
+- **Context:** `require("express")` currently can bind the default HTTP port.
+- **Options considered:** Keep current behavior; require users to pass `--http-enabled=false`; make binding lazy/explicit.
+- **Decision:** Make module loading pure and start HTTP on route/static registration or explicit `app.listen()`.
+- **Rationale:** CommonJS module loading should be safe for introspection, eval, and REPL usage.
+- **Consequences:** The HTTP provider must preserve normal app-server behavior through autostart tests.
+- **Status:** proposed
+
+### Decision: Expose fs backend capabilities instead of hiding mutating methods
+
+- **Context:** `fs:assets` is read-only but currently exports mutating methods that fail.
+- **Options considered:** Remove mutating methods from read-only modules; create a separate assets fs module; expose capability metadata.
+- **Decision:** Expose `isReadOnly` and `capabilities()` while keeping methods stable.
+- **Rationale:** This is backward-compatible and improves discovery.
+- **Consequences:** TypeScript declarations should document that writes may fail when `write=false`.
+- **Status:** proposed
+
+## Testing strategy
+
+Run focused tests after each phase, then run broader xgoja tests before handoff:
+
+```bash
+cd /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja
+go test ./pkg/jsverbs ./pkg/xgoja/app ./cmd/xgoja/internal/buildspec ./cmd/xgoja/internal/generate ./modules/fs ./modules/express ./pkg/xgoja/providers/http -count=1
+```
+
+For an end-to-end check, build or reuse an xgoja sample app that selects:
+
+- two aliases for the same provider module (`fs:host`, `fs:assets`);
+- `express`;
+- a filtered JSVerb source;
+- at least one provider help source if present.
+
+Manual acceptance criteria:
+
+- `selected-modules --output json` shows actual aliases.
+- `modules --output table` clearly reads as a provider catalog.
+- `verbs list` or generated verb commands ignore `assets/**` when excluded.
+- `require("express")` does not bind the default port by itself.
+- route registration still serves HTTP in normal run mode.
+- `fs:assets.capabilities().write === false` and read-only writes still fail with EROFS.
+- `xgoja doctor` warns about unpinned provider packages.
+
+## Risks and open questions
+
+### Risks
+
+- **CLI output compatibility:** Changing `modules` columns may affect scripts. Prefer adding columns before removing old ones.
+- **Glob semantics:** Poorly specified include/exclude matching can create cross-platform surprises. Normalize to slash paths and test Windows-style cases if the repo supports them.
+- **HTTP lifecycle regressions:** Moving `start` later can accidentally prevent existing apps from serving. Add end-to-end HTTP tests before merging.
+- **RuntimeSpec growth:** Adding fields to runtime JSVerb specs is fine, but do not add build-only provider version data to runtime unless a command explicitly needs it.
+- **Read-only fs metadata drift:** If capabilities are computed manually, they can diverge from backend behavior. Prefer backend-owned capability reporting.
+
+### Open questions
+
+1. Should `selected-modules` include config values by default, or should config only appear in JSON output to avoid exposing secrets in table output?
+2. Should JSVerb include/exclude filters support only glob patterns, or also gitignore-style negation?
+3. Should provider pin warnings be part of `Validate` or only `doctor`?
+4. Should `app.listen()` accept a port/address override, or only start the configured `--http-listen` address?
+5. Should `fs.capabilities()` expose exact embedded asset IDs and mount roots, or only read/write/backend booleans in the first phase?
+
+## References
+
+### Source analysis
+
+- `/home/manuel/workspaces/2026-06-07/club-meetup-site/ClubMedMeetup/ttmp/2026/06/08/xgoja-modules-improvement-second-edition--improve-xgoja-and-goja-modules-from-clubmedmeetup-usage-patterns-second-edition/design-doc/01-xgoja-and-goja-module-improvement-map-second-edition.md`
+
+### go-go-goja files
+
+- `/home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/cmd/xgoja/internal/buildspec/build_spec.go`
+- `/home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/cmd/xgoja/internal/buildspec/validate.go`
+- `/home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/cmd/xgoja/internal/generate/gomod.go`
+- `/home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/cmd/xgoja/cmd_build.go`
+- `/home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/cmd/xgoja/cmd_list_modules.go`
+- `/home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/xgoja/app/runtime_spec.go`
+- `/home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/xgoja/app/factory.go`
+- `/home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/xgoja/app/module_sections.go`
+- `/home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/xgoja/app/root.go`
+- `/home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/jsverbs/scan.go`
+- `/home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/xgoja/providerapi/module.go`
+- `/home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/xgoja/providerapi/capabilities.go`
+- `/home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/xgoja/providers/http/http.go`
+- `/home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/modules/express/express.go`
+- `/home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/xgoja/providers/host/host.go`
+- `/home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/modules/fs/fs.go`
+- `/home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/modules/fs/backend_embed.go`

--- a/ttmp/2026/06/08/XGOJA-CLUBMED-MODULES--address-xgoja-goja-module-improvements-from-clubmedmeetup-usage/design-doc/02-jsverb-source-filtering-implementation-guide.md
+++ b/ttmp/2026/06/08/XGOJA-CLUBMED-MODULES--address-xgoja-goja-module-improvements-from-clubmedmeetup-usage/design-doc/02-jsverb-source-filtering-implementation-guide.md
@@ -1,0 +1,160 @@
+---
+Title: JSVerb Source Filtering Implementation Guide
+Ticket: XGOJA-CLUBMED-MODULES
+Status: active
+Topics:
+    - xgoja
+    - goja
+    - modules
+    - architecture
+    - clubmedmeetup
+DocType: design-doc
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: go-go-goja/cmd/xgoja/internal/buildspec/build_spec.go
+      Note: |-
+        Build-time JSVerbSourceSpec schema extended with include/exclude/extensions.
+        Build-time JSVerb source filter schema
+    - Path: go-go-goja/cmd/xgoja/internal/buildspec/validate.go
+      Note: Validation for JSVerb filter entries
+    - Path: go-go-goja/pkg/jsverbs/jsverbs_test.go
+      Note: Scanner include/exclude regression tests
+    - Path: go-go-goja/pkg/jsverbs/model.go
+      Note: |-
+        ScanOptions model extended with include/exclude path patterns.
+        ScanOptions include/exclude fields
+    - Path: go-go-goja/pkg/jsverbs/scan.go
+      Note: |-
+        Scanner traversal and pattern filtering implementation.
+        Filtered ScanDir/ScanFS traversal
+    - Path: go-go-goja/pkg/xgoja/app/root.go
+      Note: |-
+        scanVerbSource passes configured filters into local, embedded, and provider sources.
+        Passes JSVerb source filters into scanner calls
+    - Path: go-go-goja/pkg/xgoja/app/runtime_spec.go
+      Note: |-
+        Runtime JSVerbSourceSpec schema used by generated binaries.
+        Runtime JSVerb source filter schema
+ExternalSources: []
+Summary: Focused implementation guide for fixing broad JSVerb source scanning with include/exclude/extensions filters.
+LastUpdated: 2026-06-08T18:20:00-04:00
+WhatFor: Use this as the focused reference for the JSVerb-only implementation path in XGOJA-CLUBMED-MODULES.
+WhenToUse: Read before changing JSVerbSourceSpec, jsverbs.ScanOptions, scan traversal, or generated runtime JSVerb source handling.
+---
+
+
+# JSVerb Source Filtering Implementation Guide
+
+## Executive summary
+
+The ClubMedMeetup `minitrace-viz` app configured its JavaScript verb source as `path: .`. That caused the JSVerb scanner to walk the full application tree, including bundled Vite assets under `assets/public`. Those generated assets looked enough like JavaScript source to be parsed and produced a duplicate generated verb path failure. The immediate site workaround is to narrow the source directory, but the reusable `go-go-goja` fix is to let xgoja buildspecs declare explicit scan filters.
+
+This guide focuses only on the JSVerb part of the larger ticket. The implementation should add `include`, `exclude`, and `extensions` to JSVerb source specs, carry those fields into generated runtime specs, and apply the filters in `pkg/jsverbs` for filesystem, embedded, and provider-shipped JSVerb sources.
+
+## Problem statement
+
+Current JSVerb scanning assumes that the configured source root is already clean. `pkg/jsverbs/scan.go` skips only `node_modules` and dot-directories. It does not skip common generated or bundled directories such as `assets`, `dist`, `webapp`, or `public`. That is a reasonable default for small examples, but it is fragile for generated xgoja applications that colocate source files, bundled browser assets, and runtime scripts.
+
+The failure mode is not just performance. Scanning generated bundles can create false commands, duplicate command paths, confusing diagnostics, or parse errors from minified/browser-oriented JavaScript.
+
+## Proposed focused API
+
+Add these optional fields to both build-time and runtime `JSVerbSourceSpec`:
+
+```yaml
+jsverbs:
+  - id: minitrace-viz-site
+    path: .
+    include:
+      - site.js
+      - jsverbs/**/*.js
+    exclude:
+      - assets/**
+      - dist/**
+      - webapp/**
+    extensions:
+      - .js
+      - .cjs
+```
+
+Semantics:
+
+- `include` is evaluated against slash-normalized paths relative to the configured source root.
+- If `include` is empty, every file with a supported extension is initially eligible.
+- `exclude` removes files after include matching.
+- `extensions` overrides the default scanner extension list.
+- Extensions may be written with or without a leading dot; the scanner normalizes them.
+- The same filter semantics apply to local filesystem, embedded filesystem, and provider-shipped JSVerb sources.
+
+## Data flow
+
+```mermaid
+flowchart TD
+  YAML[xgoja.yaml jsverbs entry] --> BuildSpec[buildspec.JSVerbSourceSpec]
+  BuildSpec --> Validate[buildspec.Validate]
+  BuildSpec --> Generate[generate.RenderEmbeddedSpec]
+  Generate --> RuntimeSpec[app.JSVerbSourceSpec]
+  RuntimeSpec --> Root[app.scanVerbSource]
+  Root --> Options[jsverbs.ScanOptions]
+  Options --> ScanDir[jsverbs.ScanDir]
+  Options --> ScanFS[jsverbs.ScanFS]
+  ScanDir --> Registry[jsverbs.Registry]
+  ScanFS --> Registry
+```
+
+## Implementation checklist
+
+1. Extend `cmd/xgoja/internal/buildspec.BuildSpec`'s `JSVerbSourceSpec` with `Include`, `Exclude`, and `Extensions`.
+2. Extend `pkg/xgoja/app.RuntimeSpec`'s `JSVerbSourceSpec` with matching JSON fields.
+3. Extend `providerapi.JSVerbSourceDescriptor` so command providers can inspect the configured filters.
+4. Extend `pkg/jsverbs.ScanOptions` with `Include` and `Exclude`.
+5. In `pkg/jsverbs/scan.go`, normalize relative paths to slash paths, check extensions, check includes, and then check excludes before reading/parsing each file.
+6. In `pkg/xgoja/app/root.go`, translate `JSVerbSourceSpec` into `jsverbs.ScanOptions` and pass the options into all `ScanDir`/`ScanFS` calls.
+7. In `cmd/xgoja/internal/buildspec/validate.go`, reject empty include/exclude/extension entries and emit an OK check when filters are declared.
+8. Add tests for scanner filtering, runtime spec preservation, and validation.
+9. Run focused tests.
+
+## Pseudocode
+
+```text
+function shouldScan(relPath, options):
+    relPath = slashNormalize(relPath)
+    if extension(relPath) not in normalized(options.extensions):
+        return false
+    if options.include is not empty:
+        if relPath does not match any include glob:
+            return false
+    if relPath matches any exclude glob:
+        return false
+    return true
+```
+
+## Acceptance criteria
+
+- A fixture containing `site.js`, `assets/public/bundle.js`, and `dist/app.js` can scan only `site.js` using include/exclude filters.
+- `ScanDir` and `ScanFS` both honor filters.
+- Generated runtime JSON preserves `include`, `exclude`, and `extensions` entries.
+- `scanVerbSource` applies filters to provider, embedded, and filesystem sources.
+- Empty filter strings are validation errors.
+- Existing JSVerb tests continue to pass with default options.
+
+## Validation commands
+
+```bash
+cd /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja
+gofmt -w \
+  cmd/xgoja/internal/buildspec/build_spec.go \
+  cmd/xgoja/internal/buildspec/validate.go \
+  cmd/xgoja/internal/buildspec/validate_test.go \
+  cmd/xgoja/internal/generate/generate_test.go \
+  pkg/xgoja/app/runtime_spec.go \
+  pkg/xgoja/app/root.go \
+  pkg/xgoja/app/jsverb_sources.go \
+  pkg/xgoja/providerapi/commands.go \
+  pkg/jsverbs/model.go \
+  pkg/jsverbs/scan.go \
+  pkg/jsverbs/jsverbs_test.go
+
+go test ./pkg/jsverbs ./pkg/xgoja/app ./cmd/xgoja/internal/buildspec ./cmd/xgoja/internal/generate -count=1
+```

--- a/ttmp/2026/06/08/XGOJA-CLUBMED-MODULES--address-xgoja-goja-module-improvements-from-clubmedmeetup-usage/index.md
+++ b/ttmp/2026/06/08/XGOJA-CLUBMED-MODULES--address-xgoja-goja-module-improvements-from-clubmedmeetup-usage/index.md
@@ -1,0 +1,60 @@
+---
+Title: Address xgoja/goja module improvements from ClubMedMeetup usage
+Ticket: XGOJA-CLUBMED-MODULES
+Status: active
+Topics:
+    - xgoja
+    - goja
+    - modules
+    - architecture
+    - clubmedmeetup
+DocType: index
+Intent: long-term
+Owners: []
+RelatedFiles: []
+ExternalSources: []
+Summary: ""
+LastUpdated: 2026-06-08T17:53:55.31089272-04:00
+WhatFor: ""
+WhenToUse: ""
+---
+
+# Address xgoja/goja module improvements from ClubMedMeetup usage
+
+## Overview
+
+<!-- Provide a brief overview of the ticket, its goals, and current status -->
+
+## Key Links
+
+- **Related Files**: See frontmatter RelatedFiles field
+- **External Sources**: See frontmatter ExternalSources field
+
+## Status
+
+Current status: **active**
+
+## Topics
+
+- xgoja
+- goja
+- modules
+- architecture
+- clubmedmeetup
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/2026/06/08/XGOJA-CLUBMED-MODULES--address-xgoja-goja-module-improvements-from-clubmedmeetup-usage/reference/01-investigation-diary.md
+++ b/ttmp/2026/06/08/XGOJA-CLUBMED-MODULES--address-xgoja-goja-module-improvements-from-clubmedmeetup-usage/reference/01-investigation-diary.md
@@ -1,0 +1,415 @@
+---
+Title: Investigation Diary
+Ticket: XGOJA-CLUBMED-MODULES
+Status: active
+Topics:
+    - xgoja
+    - goja
+    - modules
+    - architecture
+    - clubmedmeetup
+DocType: reference
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: ClubMedMeetup/ttmp/2026/06/08/xgoja-modules-improvement-second-edition--improve-xgoja-and-goja-modules-from-clubmedmeetup-usage-patterns-second-edition/design-doc/01-xgoja-and-goja-module-improvement-map-second-edition.md
+      Note: |-
+        User-specified source analysis read before creating this ticket.
+        Initial prompt-specified source analysis
+    - Path: go-go-goja/examples/xgoja/07-embedded-jsverbs/README.md
+      Note: Embedded JSVerb source filter example
+    - Path: go-go-goja/examples/xgoja/README.md
+      Note: XGoja examples overview documents jsverb source filters
+    - Path: go-go-goja/pkg/doc/10-jsverbs-example-developer-guide.md
+      Note: Developer guide updated with scanner filter model and debugging guidance
+    - Path: go-go-goja/pkg/doc/11-jsverbs-example-reference.md
+      Note: Reference documentation for ScanOptions include/exclude/extensions
+    - Path: go-go-goja/pkg/jsverbs/scan.go
+      Note: Main implementation file for JSVerb filtering
+    - Path: go-go-goja/ttmp/2026/06/08/XGOJA-CLUBMED-MODULES--address-xgoja-goja-module-improvements-from-clubmedmeetup-usage/design-doc/01-xgoja-clubmedmeetup-module-improvements-implementation-guide.md
+      Note: |-
+        Primary design and implementation guide created for this ticket.
+        Primary design guide created in this ticket
+    - Path: go-go-goja/ttmp/2026/06/08/XGOJA-CLUBMED-MODULES--address-xgoja-goja-module-improvements-from-clubmedmeetup-usage/design-doc/02-jsverb-source-filtering-implementation-guide.md
+      Note: Focused JSVerb-only guide added during refocus
+ExternalSources: []
+Summary: Chronological diary for the XGOJA-CLUBMED-MODULES documentation and delivery work.
+LastUpdated: 2026-06-08T18:06:00-04:00
+WhatFor: Use this diary to understand how the ticket was created, what evidence was read, and how the design guide was prepared and delivered.
+WhenToUse: Read when resuming this ticket or reviewing why these go-go-goja improvements were selected.
+---
+
+
+
+
+# Diary
+
+## Goal
+
+This diary records the creation of the `XGOJA-CLUBMED-MODULES` ticket in `go-go-goja/ttmp`, the evidence read from the ClubMedMeetup second-edition analysis, and the design guide written for a new intern.
+
+## Step 1: Create the ticket and write the intern-facing design guide
+
+I created a new docmgr ticket under `go-go-goja/ttmp` for the go-go-goja-side improvements identified by the ClubMedMeetup minitrace-viz usage analysis. The ticket is intentionally scoped to reusable xgoja/goja runtime improvements rather than site-specific ClubMedMeetup application changes.
+
+I then read the source analysis and key go-go-goja implementation files, mapped the relevant build/runtime/provider flows, and wrote a detailed design document with prose, diagrams, API sketches, pseudocode, implementation phases, tests, and file references.
+
+### Prompt Context
+
+**User prompt (verbatim):** "Read @ClubMedMeetup/ttmp/2026/06/08/xgoja-modules-improvement-second-edition--improve-xgoja-and-goja-modules-from-clubmedmeetup-usage-patterns-second-edition/design-doc/01-xgoja-and-goja-module-improvement-map-second-edition.md and create a new ticket in go-go-goja/ttmp/ using `docmgr --root go-go-goja/ttmp ...`  to address the issue, and Create  a detailed analysis / design / implementation guide that is for a new intern, explaining all the parts of the system needed to understand what it is, with prose paragraphs and bullet point sand pseudocode and diagrams and api references and file references. It should be very clear and technical. Store in the ticket and the nupload to remarkable."
+
+**Assistant interpretation:** Create a new docmgr ticket in the `go-go-goja` ticket workspace, use the existing ClubMedMeetup analysis as input evidence, write a comprehensive intern-facing design/implementation guide, store it in the ticket, and upload the resulting bundle to reMarkable.
+
+**Inferred user intent:** Preserve the ClubMedMeetup-derived xgoja/goja module improvement plan as actionable go-go-goja ticket documentation that a new intern can use to implement the work.
+
+**Commit (code):** N/A — documentation-only work in ticket workspace.
+
+### What I did
+
+- Ran `docmgr --root go-go-goja/ttmp status --summary-only` to confirm the target documentation root.
+- Created ticket `XGOJA-CLUBMED-MODULES` with title `Address xgoja/goja module improvements from ClubMedMeetup usage`.
+- Added a design document: `go-go-goja/ttmp/2026/06/08/XGOJA-CLUBMED-MODULES--address-xgoja-goja-module-improvements-from-clubmedmeetup-usage/design-doc/01-xgoja-clubmedmeetup-module-improvements-implementation-guide.md`.
+- Added this investigation diary: `go-go-goja/ttmp/2026/06/08/XGOJA-CLUBMED-MODULES--address-xgoja-goja-module-improvements-from-clubmedmeetup-usage/reference/01-investigation-diary.md`.
+- Read the user-specified source analysis under `ClubMedMeetup/ttmp/.../01-xgoja-and-goja-module-improvement-map-second-edition.md`.
+- Read and referenced key go-go-goja files:
+  - `cmd/xgoja/internal/buildspec/build_spec.go`
+  - `cmd/xgoja/internal/buildspec/validate.go`
+  - `cmd/xgoja/internal/generate/gomod.go`
+  - `cmd/xgoja/cmd_build.go`
+  - `cmd/xgoja/cmd_list_modules.go`
+  - `pkg/xgoja/app/runtime_spec.go`
+  - `pkg/xgoja/app/factory.go`
+  - `pkg/xgoja/app/module_sections.go`
+  - `pkg/xgoja/app/root.go`
+  - `pkg/jsverbs/scan.go`
+  - `pkg/xgoja/providerapi/module.go`
+  - `pkg/xgoja/providerapi/capabilities.go`
+  - `pkg/xgoja/providers/http/http.go`
+  - `modules/express/express.go`
+  - `pkg/xgoja/providers/host/host.go`
+  - `modules/fs/fs.go`
+  - `modules/fs/backend_embed.go`
+- Wrote an intern-facing guide covering JSVerb filters, selected-module inventory, provider pin warnings, Express lifecycle, and fs capability metadata.
+
+### Why
+
+- The ClubMedMeetup analysis identified real integration pressure against xgoja modules, not isolated style issues.
+- The requested deliverable needed to be clear enough for a new intern, so the guide starts with system architecture and moves gradually toward implementation tasks.
+- The ticket needed to live in `go-go-goja/ttmp` because most selected improvements belong in the xgoja runtime and module framework.
+
+### What worked
+
+- `docmgr --root go-go-goja/ttmp ticket create-ticket ...` created the new ticket workspace successfully.
+- `docmgr --root go-go-goja/ttmp doc add ...` created both the design doc and diary in the correct ticket.
+- The source analysis already contained a strong problem inventory, allowing this ticket to focus on turning those findings into go-go-goja implementation guidance.
+- The go-go-goja source files contained clear seams for each proposed change: buildspec DTOs, runtime spec DTOs, scanner options, generated runtime commands, provider capabilities, HTTP provider startup, and fs backend behavior.
+
+### What didn't work
+
+- Reading `go-go-goja/modules/fs/module.go` failed because the actual filesystem module implementation file is `go-go-goja/modules/fs/fs.go`.
+  - Exact error: `ENOENT: no such file or directory, access '/home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/modules/fs/module.go'`
+- Reading `go-go-goja/pkg/xgoja/providerapi/provider.go` failed because provider API files are split across `provider_registry.go`, `module.go`, `capabilities.go`, `help.go`, `commands.go`, and related files.
+  - Exact error: `ENOENT: no such file or directory, access '/home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/xgoja/providerapi/provider.go'`
+
+### What I learned
+
+- `ModuleInstanceSpec.As` is the actual CommonJS alias installed into the runtime, and this is implemented consistently in both build-time and runtime spec types.
+- Generated runtime `modules` currently reports provider catalog entries, while `xgoja list-modules -f xgoja.yaml` reports selected buildspec aliases. This explains the confusion observed in the ClubMedMeetup source analysis.
+- The HTTP provider starts the listener from `NewExpressLoader`, which means `require("express")` can bind the configured port.
+- The fs module already has a clean read-only backend; the missing piece is discoverable metadata, not mutation enforcement.
+
+### What was tricky to build
+
+- The main tricky part was separating repository responsibilities. The source analysis includes improvements for ClubMedMeetup, go-minitrace, goja-text, and rag-widget-site, but the new ticket is in `go-go-goja/ttmp`. The design therefore had to extract only the go-go-goja-owned work while still explaining the ClubMedMeetup evidence that motivated it.
+- Another tricky part was documenting Express lifecycle changes without breaking existing xgoja apps. The guide proposes moving listener binding out of module load but preserving normal autostart behavior when routes are registered in `run server.js --keep-alive` flows.
+- JSVerb filtering required careful wording because the immediate app-level workaround is to narrow `jsverbs.path`, but the reusable go-go-goja improvement should live in scanner options and xgoja schema.
+
+### What warrants a second pair of eyes
+
+- The proposed Express autostart boundary should be reviewed carefully because it changes when port binding errors occur.
+- The provider pin warning should be reviewed against existing `Report`/doctor severity semantics before implementation.
+- The `modules` command column rename should be checked for CLI compatibility if any generated app scripts parse it.
+- JSVerb glob semantics should be agreed before implementation so docs, tests, and behavior match.
+
+### What should be done in the future
+
+- Validate the ticket with `docmgr doctor --ticket XGOJA-CLUBMED-MODULES --stale-after 30` after docmgr relations/changelog/tasks are updated.
+- Upload the design/diary bundle to reMarkable as requested.
+- Implement the phases in order: selected-module command, JSVerb filters, provider pin warnings, Express lifecycle, fs capabilities.
+
+### Code review instructions
+
+- Start with the design doc section `Current-state architecture` to understand the evidence and current implementation seams.
+- Review proposed implementation phases against these files:
+  - `pkg/xgoja/app/root.go`
+  - `pkg/jsverbs/scan.go`
+  - `cmd/xgoja/internal/buildspec/build_spec.go`
+  - `pkg/xgoja/providers/http/http.go`
+  - `modules/express/express.go`
+  - `modules/fs/fs.go`
+- Validate future implementation with focused tests:
+  - `go test ./pkg/jsverbs ./pkg/xgoja/app ./cmd/xgoja/internal/buildspec ./cmd/xgoja/internal/generate ./modules/fs ./modules/express ./pkg/xgoja/providers/http -count=1`
+
+### Technical details
+
+Commands used:
+
+```bash
+docmgr --root go-go-goja/ttmp status --summary-only
+docmgr --root go-go-goja/ttmp ticket create-ticket \
+  --ticket XGOJA-CLUBMED-MODULES \
+  --title "Address xgoja/goja module improvements from ClubMedMeetup usage" \
+  --topics xgoja,goja,modules,architecture,clubmedmeetup
+docmgr --root go-go-goja/ttmp doc add \
+  --ticket XGOJA-CLUBMED-MODULES \
+  --doc-type design-doc \
+  --title "XGoja ClubMedMeetup Module Improvements Implementation Guide"
+docmgr --root go-go-goja/ttmp doc add \
+  --ticket XGOJA-CLUBMED-MODULES \
+  --doc-type reference \
+  --title "Investigation Diary"
+```
+
+## Step 2: Refocus on JSVerb source filtering and implement it
+
+The ticket was narrowed from the broad xgoja/goja module improvement map to the JSVerb source scanning issue only. I created a second guide focused exclusively on JSVerb filters, then implemented the focused code path one task at a time: schema fields, scanner options, runtime scan dispatch, validation, tests, formatting, and focused test execution.
+
+The implementation keeps existing defaults unchanged while adding opt-in filtering. Existing JSVerb sources still scan `.js` and `.cjs` files unless configured otherwise, but xgoja buildspec authors can now declare include/exclude glob patterns and extension overrides to keep generated assets out of the scanner.
+
+### Prompt Context
+
+**User prompt (verbatim):** "nvm, I wantt o address the jsverb part only. create a second guide that focuses exclusively on that, then add tasks to the tticket, and work on them one by one, keeping a detailed diary as you work."
+
+**Assistant interpretation:** Narrow the ticket to the JSVerb scanning problem, add a focused guide, update ticket tasks, implement the JSVerb work incrementally, and keep the diary detailed as implementation proceeds.
+
+**Inferred user intent:** Avoid spending time on unrelated xgoja module improvements and turn the concrete ClubMedMeetup JSVerb scanner failure into a completed, test-backed go-go-goja change.
+
+**Commit (code):** Not committed yet — working tree contains code and ticket documentation changes.
+
+### What I did
+
+- Added a focused design document:
+  - `go-go-goja/ttmp/2026/06/08/XGOJA-CLUBMED-MODULES--address-xgoja-goja-module-improvements-from-clubmedmeetup-usage/design-doc/02-jsverb-source-filtering-implementation-guide.md`
+- Rewrote `tasks.md` so the active checklist is JSVerb-only and broader ticket items are deferred.
+- Extended build-time `JSVerbSourceSpec` in `cmd/xgoja/internal/buildspec/build_spec.go` with:
+  - `Include []string`
+  - `Exclude []string`
+  - `Extensions []string`
+- Extended runtime `JSVerbSourceSpec` in `pkg/xgoja/app/runtime_spec.go` with matching JSON fields.
+- Extended `providerapi.JSVerbSourceDescriptor` in `pkg/xgoja/providerapi/commands.go` so command providers can inspect filters.
+- Updated `pkg/xgoja/app/jsverb_sources.go` to include filter fields when listing JSVerb source descriptors.
+- Extended `pkg/jsverbs.ScanOptions` in `pkg/jsverbs/model.go` with include/exclude slices.
+- Implemented slash-normalized include/exclude matching in `pkg/jsverbs/scan.go` using `github.com/bmatcuk/doublestar/v4`.
+- Normalized extension matching so configured extensions can be written with or without a leading dot.
+- Updated `pkg/xgoja/app/root.go` so `scanVerbSource` builds scan options from the runtime source spec and passes them into provider, embedded, and filesystem source scans.
+- Added validation in `cmd/xgoja/internal/buildspec/validate.go` for empty include/exclude/extension entries.
+- Added tests:
+  - `pkg/jsverbs/jsverbs_test.go`: `TestScanDirIncludeExcludeFilters`
+  - `pkg/jsverbs/jsverbs_test.go`: `TestScanFSIncludeFilters`
+  - `cmd/xgoja/internal/buildspec/validate_test.go`: filter validation tests
+  - `cmd/xgoja/internal/generate/generate_test.go`: embedded runtime spec preserves `include`, `exclude`, and `extensions`
+- Ran formatting and focused tests.
+
+### Why
+
+- The ClubMedMeetup failure was caused by scanning too much JavaScript, not by JSVerb extraction itself.
+- The safest reusable fix is to let application authors constrain scan candidates declaratively in `xgoja.yaml`.
+- Putting the filter logic in `pkg/jsverbs` instead of only in xgoja makes the behavior available to direct scanner callers and keeps traversal decisions close to scanner traversal.
+
+### What worked
+
+- Adding fields to both build-time and runtime specs was straightforward because `generate.RenderEmbeddedSpec` marshals `buildspec.JSVerbSourceSpec` into embedded runtime JSON.
+- Existing scanner structure already collected relative paths before reading files, so filtering could be inserted before file reads/parsing.
+- `doublestar.PathMatch` was already present in `go.mod` as an indirect dependency, so globstar-style patterns such as `assets/**` could be supported without writing a custom matcher.
+- Focused validation passed:
+  - `go test ./pkg/jsverbs ./pkg/xgoja/app ./cmd/xgoja/internal/buildspec ./cmd/xgoja/internal/generate -count=1`
+
+### What didn't work
+
+- My first attempt to update `cmd/xgoja/internal/generate/generate_test.go` used an `oldText` block that appeared twice, so the edit tool rejected it.
+  - Exact tool error: `Found 2 occurrences of edits[0] in go-go-goja/cmd/xgoja/internal/generate/generate_test.go. Each oldText must be unique. Please provide more context to make it unique.`
+- I corrected this by including the surrounding `func TestRenderMainIncludesEmbeddedVerbFS` context in the replacement.
+
+### What I learned
+
+- `ScanDir` previously checked extensions before computing the slash-normalized relative path. The new filtering flow benefits from computing `relPathSlash` first, then applying both extension and pattern filters to the same normalized path.
+- `ScanFS` needed the same filtering behavior as `ScanDir`; otherwise embedded and provider-shipped JSVerb sources would behave differently from filesystem sources.
+- Runtime command providers see configured JSVerb sources through `providerapi.JSVerbSourceDescriptor`, so adding filters there keeps introspection consistent.
+- Generated runtime spec preservation was important to test because build-time and runtime source spec types live in different packages.
+
+### What was tricky to build
+
+- The main implementation sharp edge was preserving default behavior. `ScanOptions` already had defaults for public function inclusion, extensions, and diagnostic behavior. The new `jsVerbScanOptions` helper in `pkg/xgoja/app/root.go` starts from `jsverbs.DefaultScanOptions()` and only overrides extensions when the source explicitly provides them, so old buildspecs keep scanning `.js` and `.cjs`.
+- Another tricky part was path matching order. Matching OS-native paths would make filters platform-dependent, so the implementation normalizes relative paths and patterns with `filepath.ToSlash` before matching.
+- Extension matching needed to be forgiving. The scanner now treats `js` and `.js` equivalently by adding a leading dot when necessary.
+
+### What warrants a second pair of eyes
+
+- Confirm that `doublestar.PathMatch` semantics match expected xgoja documentation, especially whether root-level files require both `*.js` and `**/*.js` include patterns.
+- Review whether invalid glob patterns should be validation errors earlier. The current matcher ignores invalid patterns at scan time by treating them as non-matches; stricter validation could be added later.
+- Review whether provider-shipped JSVerb sources should honor buildspec include/exclude filters. This implementation applies filters uniformly to provider, embedded, and filesystem sources.
+
+### What should be done in the future
+
+- Add user-facing documentation/examples for `include`, `exclude`, and `extensions` in xgoja docs or help pages.
+- Consider adding a doctor warning for `jsverbs.path: .` with no filters once the report model supports warnings.
+- Consider stricter glob validation if users need early feedback on malformed patterns.
+
+### Code review instructions
+
+- Start with the focused guide `design-doc/02-jsverb-source-filtering-implementation-guide.md`.
+- Review schema changes first:
+  - `cmd/xgoja/internal/buildspec/build_spec.go`
+  - `pkg/xgoja/app/runtime_spec.go`
+  - `pkg/xgoja/providerapi/commands.go`
+- Review scanner behavior next:
+  - `pkg/jsverbs/model.go`
+  - `pkg/jsverbs/scan.go`
+- Review xgoja runtime wiring:
+  - `pkg/xgoja/app/root.go`
+  - `pkg/xgoja/app/jsverb_sources.go`
+- Review tests:
+  - `pkg/jsverbs/jsverbs_test.go`
+  - `cmd/xgoja/internal/buildspec/validate_test.go`
+  - `cmd/xgoja/internal/generate/generate_test.go`
+- Validate with:
+  - `cd go-go-goja && go test ./pkg/jsverbs ./pkg/xgoja/app ./cmd/xgoja/internal/buildspec ./cmd/xgoja/internal/generate -count=1`
+
+### Technical details
+
+Validation command run:
+
+```bash
+cd go-go-goja && gofmt -w \
+  cmd/xgoja/internal/buildspec/build_spec.go \
+  cmd/xgoja/internal/buildspec/validate.go \
+  cmd/xgoja/internal/buildspec/validate_test.go \
+  cmd/xgoja/internal/generate/generate_test.go \
+  pkg/xgoja/app/runtime_spec.go \
+  pkg/xgoja/app/root.go \
+  pkg/xgoja/app/jsverb_sources.go \
+  pkg/xgoja/providerapi/commands.go \
+  pkg/jsverbs/model.go \
+  pkg/jsverbs/scan.go \
+  pkg/jsverbs/jsverbs_test.go && go test ./pkg/jsverbs ./pkg/xgoja/app ./cmd/xgoja/internal/buildspec ./cmd/xgoja/internal/generate -count=1
+```
+
+Result:
+
+```text
+ok  	github.com/go-go-golems/go-go-goja/pkg/jsverbs	0.139s
+ok  	github.com/go-go-golems/go-go-goja/pkg/xgoja/app	0.142s
+ok  	github.com/go-go-golems/go-go-goja/cmd/xgoja/internal/buildspec	0.006s
+ok  	github.com/go-go-golems/go-go-goja/cmd/xgoja/internal/generate	23.501s
+```
+
+## Step 3: Update user-facing JSVerb and xgoja documentation
+
+After the code and focused guide were in place, I updated the product-facing documentation so users can discover the new JSVerb filtering options without reading ticket notes or source code. The documentation now covers both library-level `ScanOptions` and xgoja buildspec-level `jsverbs.include` / `jsverbs.exclude` / `jsverbs.extensions` fields.
+
+The docs emphasize the operational reason for the feature: application roots often contain authored verb files next to bundled browser assets, generated files, or distribution output. Narrow scan roots remain the best default, but filters provide a safe declarative escape hatch when the layout cannot be narrowed cleanly.
+
+### Prompt Context
+
+**User prompt (verbatim):** "update docs."
+
+**Assistant interpretation:** Update repository documentation for the JSVerb filtering feature implemented in Step 2.
+
+**Inferred user intent:** Make the new feature discoverable and explain how to use it safely in both direct `pkg/jsverbs` callers and generated xgoja applications.
+
+**Commit (code):** Not committed yet — working tree contains code and documentation changes.
+
+### What I did
+
+- Updated `pkg/doc/11-jsverbs-example-reference.md` with a new `Scan options` section covering:
+  - default scanner options,
+  - filtering order,
+  - slash-relative path matching,
+  - extension normalization,
+  - a `ScanDir` example with include/exclude filters.
+- Updated `pkg/doc/10-jsverbs-example-developer-guide.md` to explain scanner filters in the onboarding guide and add filter checks to the missing-verb debugging path.
+- Updated `pkg/doc/08-jsverbs-example-overview.md` to mention that library callers and generated xgoja binaries can filter directory/`fs.FS` scans.
+- Updated xgoja example docs:
+  - `examples/xgoja/README.md`
+  - `examples/xgoja/06-runtime-filesystem/README.md`
+  - `examples/xgoja/07-embedded-jsverbs/README.md`
+  - `examples/xgoja/08-provider-shipped-jsverbs/README.md`
+- Updated `tasks.md` to include the documentation update as a completed JSVerb task.
+- Ran focused validation including `pkg/doc`.
+
+### Why
+
+- The code feature changes xgoja buildspec shape, so the docs need to show the YAML fields explicitly.
+- Direct `pkg/jsverbs` callers also need the `ScanOptions` contract, not only xgoja examples.
+- The original ClubMedMeetup failure involved bundled assets under an application root, so the docs should explain when filters are appropriate and when a narrow source root is still preferable.
+
+### What worked
+
+- The docs were already organized around jsverbs overview/developer/reference pages, so the new content fit naturally:
+  - overview: quick concept,
+  - developer guide: operational debugging and mental model,
+  - reference: exact API and rules.
+- The xgoja examples already separate runtime filesystem, embedded local, and provider-shipped JSVerb sources, making it straightforward to document that filters apply to all three source kinds.
+- Focused validation passed:
+  - `go test ./pkg/doc ./pkg/jsverbs ./pkg/xgoja/app ./cmd/xgoja/internal/buildspec ./cmd/xgoja/internal/generate -count=1`
+
+### What didn't work
+
+- While searching docs with `bash`, I used a command string containing unescaped backticks. Bash attempted command substitution for names such as `jsverbs-example`, `debug`, and `list`.
+  - Exact stderr included:
+    - `/bin/bash: line 35: jsverbs-example: command not found`
+    - `/bin/bash: line 35: debug: command not found`
+    - `/bin/bash: line 35: list: command not found`
+- The command still returned useful surrounding document lines, but this is a reminder to avoid unquoted backticks in shell snippets.
+
+### What I learned
+
+- The docs already distinguish between `jsverbs-example` as a simple harness and `pkg/jsverbs` as a broader library. That was the right place to explain `ScanOptions`.
+- xgoja users need examples at the source-kind level: runtime filesystem, embedded local, and provider-shipped sources.
+- Documentation should explicitly say filters are relative to the source root; otherwise users may try repo-root-relative patterns that do not match.
+
+### What was tricky to build
+
+- The main tricky part was avoiding over-documenting this as an invitation to scan large application roots by default. The docs now say to prefer a narrow `path` when possible and use filters when a narrow root is inconvenient.
+- Another tricky point was documenting root-level include patterns. Because glob semantics can vary, the examples use explicit patterns such as `site.js` plus `jsverbs/**/*.js` instead of implying one pattern handles every layout.
+
+### What warrants a second pair of eyes
+
+- Review whether the examples should also modify actual example `xgoja.yaml` files, or whether documenting optional filters in README snippets is sufficient.
+- Review if a dedicated xgoja buildspec reference page should be added later; currently the guidance is distributed across examples and jsverbs help pages.
+
+### What should be done in the future
+
+- Add a concise schema/reference page for all xgoja buildspec fields if the project does not already have one.
+- Consider adding `xgoja doctor` warnings for `jsverbs.path: .` without include/exclude filters.
+
+### Code review instructions
+
+- Review documentation changes in this order:
+  - `pkg/doc/11-jsverbs-example-reference.md`
+  - `pkg/doc/10-jsverbs-example-developer-guide.md`
+  - `pkg/doc/08-jsverbs-example-overview.md`
+  - `examples/xgoja/README.md`
+  - `examples/xgoja/06-runtime-filesystem/README.md`
+  - `examples/xgoja/07-embedded-jsverbs/README.md`
+  - `examples/xgoja/08-provider-shipped-jsverbs/README.md`
+- Validate with:
+  - `cd go-go-goja && go test ./pkg/doc ./pkg/jsverbs ./pkg/xgoja/app ./cmd/xgoja/internal/buildspec ./cmd/xgoja/internal/generate -count=1`
+
+### Technical details
+
+Validation command run:
+
+```bash
+cd go-go-goja && gofmt -w pkg/doc/doc.go >/dev/null && go test ./pkg/doc ./pkg/jsverbs ./pkg/xgoja/app ./cmd/xgoja/internal/buildspec ./cmd/xgoja/internal/generate -count=1
+```
+
+Result:
+
+```text
+?   	github.com/go-go-golems/go-go-goja/pkg/doc	[no test files]
+ok  	github.com/go-go-golems/go-go-goja/pkg/jsverbs	0.148s
+ok  	github.com/go-go-golems/go-go-goja/pkg/xgoja/app	0.135s
+ok  	github.com/go-go-golems/go-go-goja/cmd/xgoja/internal/buildspec	0.005s
+ok  	github.com/go-go-golems/go-go-goja/cmd/xgoja/internal/generate	29.130s
+```

--- a/ttmp/2026/06/08/XGOJA-CLUBMED-MODULES--address-xgoja-goja-module-improvements-from-clubmedmeetup-usage/reference/01-investigation-diary.md
+++ b/ttmp/2026/06/08/XGOJA-CLUBMED-MODULES--address-xgoja-goja-module-improvements-from-clubmedmeetup-usage/reference/01-investigation-diary.md
@@ -413,3 +413,94 @@ ok  	github.com/go-go-golems/go-go-goja/pkg/xgoja/app	0.135s
 ok  	github.com/go-go-golems/go-go-goja/cmd/xgoja/internal/buildspec	0.005s
 ok  	github.com/go-go-golems/go-go-goja/cmd/xgoja/internal/generate	29.130s
 ```
+
+## Step 4: Reject malformed JSVerb filter globs
+
+I addressed a pull-request review finding on PR #63: malformed JSVerb include/exclude glob patterns were previously treated as non-matches by the scanner. That meant an invalid exclude pattern could fail open and allow generated or bundled JavaScript back into the parser.
+
+The fix validates glob syntax during buildspec validation and also at scanner entry points, so direct `pkg/jsverbs` callers receive an error instead of silently scanning with a broken filter.
+
+### Prompt Context
+
+**User prompt (verbatim):** "pkg/jsverbs/scan.go
+Comment on lines +233 to +234
+        matched, err := doublestar.PathMatch(pattern, relPath)
+        if err == nil && matched {
+@chatgpt-codex-connector
+chatgpt-codex-connector Bot
+15 minutes ago
+
+P2 Badge Reject invalid JSVerb filter globs
+
+When a configured include/exclude pattern is malformed, doublestar.PathMatch returns an error, but this code silently treats it as no match. Since buildspec validation only rejects empty strings, a typo in an exclude glob (for example an unterminated character class) will fail open and scan the files the user intended to omit, which reintroduces the broad-source parsing problem this feature is meant to solve; malformed patterns should be surfaced during validation or scanning instead of ignored.
+
+Useful? React with 👍 / 👎.
+
+Address code review comment on go-go-goja"
+
+**Assistant interpretation:** Fix PR #63 so invalid JSVerb include/exclude glob patterns are reported instead of ignored.
+
+**Inferred user intent:** Close the reviewer’s fail-open concern for malformed filter globs before merging the JSVerb source filter pull request.
+
+**Commit (code):** Pending.
+
+### What I did
+
+- Read this diary to recover the JSVerb filtering context and prior TODO about stricter glob validation.
+- Added scanner-side validation in `pkg/jsverbs/scan.go` with `doublestar.ValidatePathPattern` for include/exclude patterns.
+- Changed `matchesScanPatterns` and `matchesAnyScanPattern` to return errors, preserving errors from `doublestar.PathMatch` rather than ignoring them.
+- Added buildspec validation for malformed include/exclude globs in `cmd/xgoja/internal/buildspec/validate.go`.
+- Added tests for malformed buildspec filters and direct scanner filter errors.
+
+### Why
+
+- Invalid excludes must not fail open, because the feature exists to keep broad source roots from parsing generated assets.
+- Validation catches mistakes early in `xgoja.yaml`, while scanner errors protect library callers and any runtime path that bypasses buildspec validation.
+
+### What worked
+
+- `doublestar.ValidatePathPattern` matched the scanner’s matching semantics and rejected unterminated character classes.
+- Focused validation passed:
+  - `go test ./pkg/jsverbs ./cmd/xgoja/internal/buildspec -count=1`
+
+### What didn't work
+
+- N/A.
+
+### What I learned
+
+- The previous diary had already identified malformed glob validation as a future review item; the PR review confirmed it needed to be fixed immediately.
+
+### What was tricky to build
+
+- The scanner intentionally continues to skip empty patterns for direct `ScanOptions` compatibility, while buildspec validation still rejects empty configured strings. Malformed non-empty globs are now errors in both layers.
+
+### What warrants a second pair of eyes
+
+- Confirm that using `ValidatePathPattern` is the desired validation surface for slash-normalized xgoja path globs.
+- Confirm direct `ScanSources` should validate patterns even though it does not currently filter the in-memory source list.
+
+### What should be done in the future
+
+- N/A.
+
+### Code review instructions
+
+- Start with `pkg/jsverbs/scan.go`, especially `validateScanPatterns`, `matchesScanPatterns`, and `matchesAnyScanPattern`.
+- Review buildspec validation in `cmd/xgoja/internal/buildspec/validate.go`.
+- Validate with `go test ./pkg/jsverbs ./cmd/xgoja/internal/buildspec -count=1`.
+
+### Technical details
+
+Validation command run:
+
+```bash
+cd go-go-goja && gofmt -w pkg/jsverbs/scan.go pkg/jsverbs/jsverbs_test.go cmd/xgoja/internal/buildspec/validate.go cmd/xgoja/internal/buildspec/validate_test.go && go test ./pkg/jsverbs ./cmd/xgoja/internal/buildspec -count=1
+```
+
+Result:
+
+```text
+ok  	github.com/go-go-golems/go-go-goja/pkg/jsverbs	0.177s
+ok  	github.com/go-go-golems/go-go-goja/cmd/xgoja/internal/buildspec	0.008s
+```

--- a/ttmp/2026/06/08/XGOJA-CLUBMED-MODULES--address-xgoja-goja-module-improvements-from-clubmedmeetup-usage/reference/01-investigation-diary.md
+++ b/ttmp/2026/06/08/XGOJA-CLUBMED-MODULES--address-xgoja-goja-module-improvements-from-clubmedmeetup-usage/reference/01-investigation-diary.md
@@ -184,7 +184,7 @@ The implementation keeps existing defaults unchanged while adding opt-in filteri
 
 **Inferred user intent:** Avoid spending time on unrelated xgoja module improvements and turn the concrete ClubMedMeetup JSVerb scanner failure into a completed, test-backed go-go-goja change.
 
-**Commit (code):** Not committed yet — working tree contains code and ticket documentation changes.
+**Commit (code):** 3ae1cbb5cf5303b4dc8d7cf7b12817240b11734d — "Add JSVerb source filters"
 
 ### What I did
 
@@ -317,7 +317,7 @@ The docs emphasize the operational reason for the feature: application roots oft
 
 **Inferred user intent:** Make the new feature discoverable and explain how to use it safely in both direct `pkg/jsverbs` callers and generated xgoja applications.
 
-**Commit (code):** Not committed yet — working tree contains code and documentation changes.
+**Commit (code):** 3ae1cbb5cf5303b4dc8d7cf7b12817240b11734d — "Add JSVerb source filters"
 
 ### What I did
 

--- a/ttmp/2026/06/08/XGOJA-CLUBMED-MODULES--address-xgoja-goja-module-improvements-from-clubmedmeetup-usage/tasks.md
+++ b/ttmp/2026/06/08/XGOJA-CLUBMED-MODULES--address-xgoja-goja-module-improvements-from-clubmedmeetup-usage/tasks.md
@@ -1,0 +1,28 @@
+# Tasks
+
+## JSVerb source filtering focus
+
+- [x] Create focused JSVerb-only implementation guide.
+- [x] Extend JSVerb source specs with include/exclude/extensions fields.
+- [x] Extend jsverbs scan options with include/exclude filtering.
+- [x] Pass JSVerb filters through generated runtime scan dispatch.
+- [x] Add validation for empty JSVerb filter entries.
+- [x] Add focused tests for ScanDir/ScanFS filtering, validation, and embedded runtime spec preservation.
+- [x] Run focused gofmt and go test validation.
+- [x] Fix any validation/test failures.
+- [x] Update user-facing JSVerb/xgoja documentation.
+- [x] Update diary and changelog with final JSVerb implementation result.
+
+## Deferred from broader guide
+
+- [ ] Implement selected runtime module inventory command in generated xgoja binaries.
+- [ ] Add xgoja doctor warning for provider packages without version or replace.
+- [ ] Move Express HTTP listener startup out of require("express") module load while preserving normal app autostart.
+- [ ] Add filesystem backend capability metadata for host and embedded read-only fs modules.
+
+## Done before refocus
+
+- [x] Create ticket workspace in go-go-goja/ttmp.
+- [x] Read ClubMedMeetup second-edition source analysis.
+- [x] Write broad intern-facing design and implementation guide.
+- [x] Write investigation diary.


### PR DESCRIPTION
This change introduces filtering capabilities for JSVerb sources, allowing for
more precise control over which files are scanned for commands.

Key changes:

- **Build Specification**: The `JSVerbSourceSpec` in `xgoja.yaml` now supports
  three new optional fields:
  - `include`: A list of glob patterns for paths to include.
  - `exclude`: A list of glob patterns for paths to exclude.
  - `extensions`: A list of file extensions to consider (e.g., `.js`, `.mjs`).

- **Scanning Logic**: The core `jsverbs.Scan` function has been updated to
  accept and apply these filters. It now evaluates `exclude` patterns first,
  then `include` patterns, and finally checks the file extension.

- **Validation**: Added validation to ensure that filter patterns and
  extensions in the build spec are not empty strings.

- **Code Generation**: The filters are persisted from the build-time
  configuration into the generated runtime spec, making them effective for
  embedded sources as well.

- **Documentation**: Updated examples, READMEs, and developer guides to
  document the new feature and provide usage examples. Added new internal
  design and implementation guides.