### PR TITLE
feat(runtime): Improve Express, FS, and module ergonomics

### DIFF
--- a/cmd/bun-demo/js/src/types/goja-modules.d.ts
+++ b/cmd/bun-demo/js/src/types/goja-modules.d.ts
@@ -54,6 +54,7 @@ declare module "exec" {
 declare module "fs" {
   export function appendFile(path: string, data: string | Buffer | Uint8Array | DataView, encoding?: string | {  }): Promise<void>;
   export function appendFileSync(path: string, data: string | Buffer | Uint8Array | DataView, encoding?: string | {  }): void;
+  export function capabilities(): FSCapabilities;
   export function copyFile(src: string, dst: string): Promise<void>;
   export function copyFileSync(src: string, dst: string): void;
   export function exists(path: string): Promise<boolean>;
@@ -82,6 +83,18 @@ declare module "fs" {
   isDir: boolean;
   isFile: boolean;
   }
+  interface FSMountInfo {
+  mount: string;
+  root: string;
+  }
+  interface FSCapabilities {
+  backend: string;
+  read: boolean;
+  write: boolean;
+  embedded: boolean;
+  mounts?: FSMountInfo[];
+  }
+  export const isReadOnly: boolean;
 }
 
 declare module "node:crypto" {
@@ -114,6 +127,7 @@ declare module "node:events" {
 declare module "node:fs" {
   export function appendFile(path: string, data: string | Buffer | Uint8Array | DataView, encoding?: string | {  }): Promise<void>;
   export function appendFileSync(path: string, data: string | Buffer | Uint8Array | DataView, encoding?: string | {  }): void;
+  export function capabilities(): FSCapabilities;
   export function copyFile(src: string, dst: string): Promise<void>;
   export function copyFileSync(src: string, dst: string): void;
   export function exists(path: string): Promise<boolean>;
@@ -142,6 +156,18 @@ declare module "node:fs" {
   isDir: boolean;
   isFile: boolean;
   }
+  interface FSMountInfo {
+  mount: string;
+  root: string;
+  }
+  interface FSCapabilities {
+  backend: string;
+  read: boolean;
+  write: boolean;
+  embedded: boolean;
+  mounts?: FSMountInfo[];
+  }
+  export const isReadOnly: boolean;
 }
 
 declare module "node:os" {

--- a/modules/express/express.go
+++ b/modules/express/express.go
@@ -16,9 +16,12 @@ import (
 
 type Option func(*Registrar)
 
+type StartFunc func(*goja.Runtime) error
+
 type Registrar struct {
-	host *gojahttp.Host
-	name string
+	host  *gojahttp.Host
+	name  string
+	onUse StartFunc
 }
 
 func NewRegistrar(host *gojahttp.Host, opts ...Option) *Registrar {
@@ -35,6 +38,14 @@ func WithName(name string) Option {
 	return func(r *Registrar) {
 		if r != nil && name != "" {
 			r.name = name
+		}
+	}
+}
+
+func WithOnUse(fn StartFunc) Option {
+	return func(r *Registrar) {
+		if r != nil {
+			r.onUse = fn
 		}
 	}
 }
@@ -127,6 +138,9 @@ func (r *Registrar) appObject(vm *goja.Runtime) goja.Value {
 			if !ok {
 				return fmt.Errorf("app.%s(%q) requires a function handler", method, pattern)
 			}
+			if err := r.start(vm); err != nil {
+				return err
+			}
 			r.host.Register(strings.ToUpper(method), pattern, fn)
 			return nil
 		})
@@ -135,12 +149,18 @@ func (r *Registrar) appObject(vm *goja.Runtime) goja.Value {
 		if prefix == "" || dir == "" {
 			return fmt.Errorf("app.static requires prefix and directory")
 		}
+		if err := r.start(vm); err != nil {
+			return err
+		}
 		r.host.RegisterStatic(prefix, dir)
 		return nil
 	})
 	_ = obj.Set("staticFromAssetsModule", func(prefix string, assetsModule goja.Value, root string) error {
 		if prefix == "" || root == "" {
 			return fmt.Errorf("app.staticFromAssetsModule requires prefix and root")
+		}
+		if err := r.start(vm); err != nil {
+			return err
 		}
 		handler, err := fsmod.StaticHandlerFromAssetsModule(vm, assetsModule, root)
 		if err != nil {
@@ -153,6 +173,9 @@ func (r *Registrar) appObject(vm *goja.Runtime) goja.Value {
 		if prefix == "" || root == "" {
 			return fmt.Errorf("app.spaFromAssetsModule requires prefix and root")
 		}
+		if err := r.start(vm); err != nil {
+			return err
+		}
 		spaOptions := spaFromAssetsOptions(vm, options)
 		handler, err := fsmod.SPAHandlerFromAssetsModule(vm, assetsModule, root, spaOptions.Index)
 		if err != nil {
@@ -161,5 +184,13 @@ func (r *Registrar) appObject(vm *goja.Runtime) goja.Value {
 		r.host.RegisterStaticHandlerWithOptions(prefix, handler, spaOptions.ExcludePrefixes)
 		return nil
 	})
+	_ = obj.Set("listen", func() error { return r.start(vm) })
 	return obj
+}
+
+func (r *Registrar) start(vm *goja.Runtime) error {
+	if r.onUse == nil {
+		return nil
+	}
+	return r.onUse(vm)
 }

--- a/modules/fs/backend.go
+++ b/modules/fs/backend.go
@@ -16,6 +16,30 @@ type Backend interface {
 	RemoveAll(path string) error
 }
 
+type MountInfo struct {
+	Mount string `json:"mount"`
+	Root  string `json:"root"`
+}
+
+type Capabilities struct {
+	Backend  string      `json:"backend"`
+	Read     bool        `json:"read"`
+	Write    bool        `json:"write"`
+	Embedded bool        `json:"embedded"`
+	Mounts   []MountInfo `json:"mounts,omitempty"`
+}
+
+type CapabilityReporter interface {
+	FSCapabilities() Capabilities
+}
+
+func CapabilitiesForBackend(backend Backend) Capabilities {
+	if reporter, ok := backend.(CapabilityReporter); ok {
+		return reporter.FSCapabilities()
+	}
+	return Capabilities{Backend: "custom", Read: true, Write: true}
+}
+
 type Option func(*m)
 
 func New(opts ...Option) *m {

--- a/modules/fs/backend_embed.go
+++ b/modules/fs/backend_embed.go
@@ -37,6 +37,14 @@ func NewReadOnlyFSBackend(mounts ...FSMount) *ReadOnlyFSBackend {
 	return out
 }
 
+func (b *ReadOnlyFSBackend) FSCapabilities() Capabilities {
+	mounts := make([]MountInfo, 0, len(b.mounts))
+	for _, mount := range b.mounts {
+		mounts = append(mounts, MountInfo{Mount: mount.Mount, Root: mount.Root})
+	}
+	return Capabilities{Backend: "embedded", Read: true, Write: false, Embedded: true, Mounts: mounts}
+}
+
 func (b *ReadOnlyFSBackend) ReadFile(p string) ([]byte, error) {
 	fsys, subpath, ok := b.resolve(p)
 	if !ok {

--- a/modules/fs/fs.go
+++ b/modules/fs/fs.go
@@ -39,6 +39,18 @@ func (m m) TypeScriptModule() *spec.Module {
 			"  isDir: boolean;",
 			"  isFile: boolean;",
 			"}",
+			"interface FSMountInfo {",
+			"  mount: string;",
+			"  root: string;",
+			"}",
+			"interface FSCapabilities {",
+			"  backend: string;",
+			"  read: boolean;",
+			"  write: boolean;",
+			"  embedded: boolean;",
+			"  mounts?: FSMountInfo[];",
+			"}",
+			"export const isReadOnly: boolean;",
 		},
 		Functions: []spec.Function{
 			{Name: "readFile", Params: []spec.Param{{Name: "path", Type: spec.String()}, {Name: "encoding", Type: spec.Union(spec.String(), spec.Object()), Optional: true}}, Returns: spec.Named("Promise<string | Buffer>")},
@@ -63,8 +75,26 @@ func (m m) TypeScriptModule() *spec.Module {
 			{Name: "renameSync", Params: []spec.Param{{Name: "oldPath", Type: spec.String()}, {Name: "newPath", Type: spec.String()}}, Returns: spec.Void()},
 			{Name: "copyFileSync", Params: []spec.Param{{Name: "src", Type: spec.String()}, {Name: "dst", Type: spec.String()}}, Returns: spec.Void()},
 			{Name: "rmSync", Params: []spec.Param{{Name: "path", Type: spec.String()}, {Name: "options", Type: spec.Object(), Optional: true}}, Returns: spec.Void()},
+			{Name: "capabilities", Returns: spec.Named("FSCapabilities")},
 		},
 	}
+}
+
+func capabilitiesObject(c Capabilities) map[string]any {
+	ret := map[string]any{
+		"backend":  c.Backend,
+		"read":     c.Read,
+		"write":    c.Write,
+		"embedded": c.Embedded,
+	}
+	if len(c.Mounts) > 0 {
+		mounts := make([]map[string]any, 0, len(c.Mounts))
+		for _, mount := range c.Mounts {
+			mounts = append(mounts, map[string]any{"mount": mount.Mount, "root": mount.Root})
+		}
+		ret["mounts"] = mounts
+	}
+	return ret
 }
 
 func (m m) Doc() string {
@@ -90,9 +120,13 @@ func (mod m) Loader(vm *goja.Runtime, moduleObj *goja.Object) {
 	}
 
 	backend := mod.fileSystem()
+	capabilities := CapabilitiesForBackend(backend)
 	if err := exports.DefineDataProperty(backendExportKey, vm.ToValue(backend), goja.FLAG_FALSE, goja.FLAG_FALSE, goja.FLAG_FALSE); err != nil {
 		panic(vm.NewGoError(err))
 	}
+
+	modules.SetExport(exports, mod.Name(), "isReadOnly", !capabilities.Write)
+	modules.SetExport(exports, mod.Name(), "capabilities", func() map[string]any { return capabilitiesObject(capabilities) })
 
 	modules.SetExport(exports, mod.Name(), "readFile", func(call goja.FunctionCall) goja.Value {
 		path := call.Argument(0).String()

--- a/modules/fs/fs_embed_test.go
+++ b/modules/fs/fs_embed_test.go
@@ -16,6 +16,7 @@ func TestReadOnlyEmbeddedFsSync(t *testing.T) {
 	ret, err := rt.Owner.Call(context.Background(), "fs.embedded.sync", func(_ context.Context, vm *goja.Runtime) (any, error) {
 		value, runErr := vm.RunString(`
 			const fs = require("fs:assets");
+			const caps = fs.capabilities();
 			let writeCode = "";
 			let writePath = "";
 			let missingCode = "";
@@ -24,7 +25,7 @@ func TestReadOnlyEmbeddedFsSync(t *testing.T) {
 			const text = fs.readFileSync("/app/config/default.json", "utf8");
 			const entries = fs.readdirSync("/app/config");
 			const stat = fs.statSync("/app/config/default.json");
-			JSON.stringify({ text, entries, exists: fs.existsSync("/app/config/default.json"), missing: fs.existsSync("/app/missing.txt"), isFile: stat.isFile, writeCode, writePath, missingCode });
+			JSON.stringify({ text, entries, exists: fs.existsSync("/app/config/default.json"), missing: fs.existsSync("/app/missing.txt"), isFile: stat.isFile, writeCode, writePath, missingCode, isReadOnly: fs.isReadOnly, capWrite: caps.write, capEmbedded: caps.embedded, capBackend: caps.backend, capMount: caps.mounts[0].mount });
 		`)
 		if runErr != nil {
 			return nil, runErr
@@ -35,7 +36,7 @@ func TestReadOnlyEmbeddedFsSync(t *testing.T) {
 		t.Fatalf("run embedded sync: %v", err)
 	}
 	state := ret.(string)
-	for _, want := range []string{`"text":"{\"ok\":true}"`, `"default.json"`, `"exists":true`, `"missing":false`, `"isFile":true`, `"writeCode":"EROFS"`, `"writePath":"/app/config/default.json"`, `"missingCode":"ENOENT:open"`} {
+	for _, want := range []string{`"text":"{\"ok\":true}"`, `"default.json"`, `"exists":true`, `"missing":false`, `"isFile":true`, `"writeCode":"EROFS"`, `"writePath":"/app/config/default.json"`, `"missingCode":"ENOENT:open"`, `"isReadOnly":true`, `"capWrite":false`, `"capEmbedded":true`, `"capBackend":"embedded"`, `"capMount":"/app"`} {
 		if !strings.Contains(state, want) {
 			t.Fatalf("embedded sync state missing %s: %s", want, state)
 		}

--- a/modules/fs/fs_sync.go
+++ b/modules/fs/fs_sync.go
@@ -11,6 +11,10 @@ type fileStats map[string]any
 
 type OSBackend struct{}
 
+func (OSBackend) FSCapabilities() Capabilities {
+	return Capabilities{Backend: "host", Read: true, Write: true}
+}
+
 func statMap(info os.FileInfo) fileStats {
 	return fileStats{
 		"name":    info.Name(),

--- a/modules/fs/fs_test.go
+++ b/modules/fs/fs_test.go
@@ -13,6 +13,30 @@ import (
 	gggengine "github.com/go-go-golems/go-go-goja/pkg/engine"
 )
 
+func TestHostFsCapabilities(t *testing.T) {
+	rt := newRuntime(t)
+	ret, err := rt.Owner.Call(context.Background(), "fs.capabilities", func(_ context.Context, vm *goja.Runtime) (any, error) {
+		value, runErr := vm.RunString(`
+			const fs = require("fs");
+			const caps = fs.capabilities();
+			JSON.stringify({ isReadOnly: fs.isReadOnly, backend: caps.backend, read: caps.read, write: caps.write, embedded: caps.embedded });
+		`)
+		if runErr != nil {
+			return nil, runErr
+		}
+		return value.String(), nil
+	})
+	if err != nil {
+		t.Fatalf("run capabilities: %v", err)
+	}
+	state := ret.(string)
+	for _, want := range []string{`"isReadOnly":false`, `"backend":"host"`, `"read":true`, `"write":true`, `"embedded":false`} {
+		if !strings.Contains(state, want) {
+			t.Fatalf("host capabilities missing %s: %s", want, state)
+		}
+	}
+}
+
 func TestAsyncFsSmoke(t *testing.T) {
 	dir := t.TempDir()
 	rt := newRuntime(t)

--- a/pkg/xgoja/app/host.go
+++ b/pkg/xgoja/app/host.go
@@ -69,6 +69,7 @@ func (h *Host) AttachDefaultCommands(root *cobra.Command) {
 		h.AttachRepl(root)
 	}
 	h.AttachModules(root)
+	h.AttachSelectedModules(root)
 	if h.RuntimeSpec.Commands.JSVerbs.Enabled {
 		h.AttachVerbs(root)
 	}
@@ -121,7 +122,19 @@ func (h *Host) AttachModules(root *cobra.Command) {
 	}
 	cmd, err := buildGlazedCobraCommand(newModulesCommand(h.Providers, h.RuntimeSpec), h.MiddlewaresFunc)
 	if err != nil {
-		root.AddCommand(commandErrorStub("modules", "List provider modules registered in this generated binary", err))
+		root.AddCommand(commandErrorStub("modules", "List provider modules compiled into this generated binary", err))
+		return
+	}
+	root.AddCommand(cmd)
+}
+
+func (h *Host) AttachSelectedModules(root *cobra.Command) {
+	if root == nil || h == nil {
+		return
+	}
+	cmd, err := buildGlazedCobraCommand(newSelectedModulesCommand(h.RuntimeSpec), h.MiddlewaresFunc)
+	if err != nil {
+		root.AddCommand(commandErrorStub("selected-modules", "List require() modules selected for this generated runtime", err))
 		return
 	}
 	root.AddCommand(cmd)

--- a/pkg/xgoja/app/root.go
+++ b/pkg/xgoja/app/root.go
@@ -154,16 +154,32 @@ type modulesCommand struct {
 	providers *providerapi.ProviderRegistry
 }
 
+type selectedModulesCommand struct {
+	*cmds.CommandDescription
+	runtimeSpec *RuntimeSpec
+}
+
 var _ cmds.GlazeCommand = (*modulesCommand)(nil)
+var _ cmds.GlazeCommand = (*selectedModulesCommand)(nil)
 
 func newModulesCommand(providers *providerapi.ProviderRegistry, runtimeSpec *RuntimeSpec) cmds.Command {
 	_ = runtimeSpec
 	return &modulesCommand{
 		CommandDescription: cmds.NewCommandDescription("modules",
-			cmds.WithShort("List provider modules registered in this generated binary"),
-			cmds.WithLong("List provider modules compiled into this generated xgoja binary."),
+			cmds.WithShort("List provider modules compiled into this generated binary"),
+			cmds.WithLong("List provider modules compiled into this generated xgoja binary. This is a provider catalog, not the selected require() aliases for this runtime. Use selected-modules for runtime aliases."),
 		),
 		providers: providers,
+	}
+}
+
+func newSelectedModulesCommand(runtimeSpec *RuntimeSpec) cmds.Command {
+	return &selectedModulesCommand{
+		CommandDescription: cmds.NewCommandDescription("selected-modules",
+			cmds.WithShort("List require() modules selected for this generated runtime"),
+			cmds.WithLong("List the provider modules selected into this generated xgoja runtime, including the actual CommonJS require() alias and static module config."),
+		),
+		runtimeSpec: runtimeSpec,
 	}
 }
 
@@ -179,13 +195,41 @@ func (c *modulesCommand) RunIntoGlazeProcessor(ctx context.Context, vals *values
 		}
 		sort.Strings(names)
 		for _, name := range names {
+			providerRef := fmt.Sprintf("%s.%s", pkg.ID, name)
 			if err := gp.AddRow(ctx, types.NewRow(
 				types.MRP("package", pkg.ID),
 				types.MRP("module", name),
-				types.MRP("require", fmt.Sprintf("%s.%s", pkg.ID, name)),
+				types.MRP("provider_ref", providerRef),
 			)); err != nil {
 				return err
 			}
+		}
+	}
+	return nil
+}
+
+func (c *selectedModulesCommand) RunIntoGlazeProcessor(ctx context.Context, vals *values.Values, gp middlewares.Processor) error {
+	_ = vals
+	if c.runtimeSpec == nil {
+		return fmt.Errorf("runtime spec is required")
+	}
+	for _, mod := range c.runtimeSpec.Modules {
+		config := "{}"
+		if len(mod.Config) > 0 {
+			data, err := json.Marshal(mod.Config)
+			if err != nil {
+				return fmt.Errorf("marshal config for %s.%s: %w", mod.Package, mod.Name, err)
+			}
+			config = string(data)
+		}
+		if err := gp.AddRow(ctx, types.NewRow(
+			types.MRP("package", mod.Package),
+			types.MRP("module", mod.Name),
+			types.MRP("alias", mod.Alias()),
+			types.MRP("provider_ref", fmt.Sprintf("%s.%s", mod.Package, mod.Name)),
+			types.MRP("config", config),
+		)); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/pkg/xgoja/app/root_test.go
+++ b/pkg/xgoja/app/root_test.go
@@ -338,6 +338,38 @@ func TestGeneratedRootModulesCommand(t *testing.T) {
 	}
 }
 
+func TestGeneratedRootSelectedModulesCommand(t *testing.T) {
+	registry := providerapi.NewProviderRegistry()
+	if err := testprovider.Register(registry); err != nil {
+		t.Fatalf("register provider: %v", err)
+	}
+	specJSON := `{
+  "name": "fixture",
+  "target": {"kind": "xgoja", "output": "dist/fixture"},
+  "packages": [{"id": "fixture"}],
+  "modules": [
+    {"package": "fixture", "name": "hello", "as": "hello"},
+    {"package": "fixture", "name": "hello", "as": "hello:custom", "config": {"message": "hi"}}
+  ],
+  "commands": {"eval": {"enabled": true, "name": "eval"}, "jsverbs": {"enabled": false}}
+}`
+	root, err := NewRootCommand(Options{Providers: registry, SpecJSON: specJSON})
+	if err != nil {
+		t.Fatalf("new root: %v", err)
+	}
+	root.SetArgs([]string{"selected-modules", "--output", "json"})
+	got := captureStdout(t, func() {
+		if err := root.ExecuteContext(context.Background()); err != nil {
+			t.Fatalf("execute selected-modules: %v", err)
+		}
+	})
+	for _, want := range []string{`"alias": "hello"`, `"alias": "hello:custom"`, `"provider_ref": "fixture.hello"`, `"config": "{\"message\":\"hi\"}"`} {
+		if !bytes.Contains([]byte(got), []byte(want)) {
+			t.Fatalf("selected-modules json should contain %q, got %q", want, got)
+		}
+	}
+}
+
 func TestRuntimeFactoryDoesNotExposeImplicitEngineModules(t *testing.T) {
 	registry := providerapi.NewProviderRegistry()
 	if err := testprovider.Register(registry); err != nil {

--- a/pkg/xgoja/providers/http/http.go
+++ b/pkg/xgoja/providers/http/http.go
@@ -116,10 +116,9 @@ func (c *capability) NewExpressLoader() require.ModuleLoader {
 		host := entry.host
 		entry.mu.Unlock()
 
-		if err := c.start(vm, entry); err != nil {
-			panic(vm.NewGoError(err))
-		}
-		express.NewLoader(host)(vm, moduleObj)
+		express.NewLoader(host, express.WithOnUse(func(vm *goja.Runtime) error {
+			return c.start(vm, entry)
+		}))(vm, moduleObj)
 	}
 }
 

--- a/pkg/xgoja/providers/http/http_test.go
+++ b/pkg/xgoja/providers/http/http_test.go
@@ -95,6 +95,49 @@ func TestCapabilityAllowsExplicitHTTPDisable(t *testing.T) {
 	}
 }
 
+func TestExpressRequireDoesNotBindHTTPPort(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve listen address: %v", err)
+	}
+	defer func() { _ = listener.Close() }()
+
+	capability := newHTTPCapability()
+	factory, err := engine.NewRuntimeFactoryBuilder().WithModules(engine.NativeModuleRegistrar{ModuleName: "express", Loader: capability.NewExpressLoader()}).Build()
+	if err != nil {
+		t.Fatalf("build runtime factory: %v", err)
+	}
+	rt, err := factory.NewRuntime(engine.WithStartupContext(context.Background()), engine.WithLifetimeContext(context.Background()))
+	if err != nil {
+		t.Fatalf("new runtime: %v", err)
+	}
+	defer func() { _ = rt.Close(context.Background()) }()
+
+	vals := httpValues(t, map[string]any{"enabled": true, "listen": listener.Addr().String()})
+	if err := capability.InitRuntimeFromSections(context.Background(), vals, testRuntimeInitializerHandle{rt: rt}); err != nil {
+		t.Fatalf("init runtime: %v", err)
+	}
+
+	_, err = rt.Owner.Call(context.Background(), "require express", func(_ context.Context, vm *goja.Runtime) (any, error) {
+		_, runErr := vm.RunString(`require("express")`)
+		return nil, runErr
+	})
+	if err != nil {
+		t.Fatalf("require express should not bind occupied port: %v", err)
+	}
+
+	_, err = rt.Owner.Call(context.Background(), "register route", func(_ context.Context, vm *goja.Runtime) (any, error) {
+		_, runErr := vm.RunString(`require("express").app().get("/healthz", (_req, res) => res.json({ ok: true }))`)
+		return nil, runErr
+	})
+	if err == nil {
+		t.Fatal("expected route registration to report occupied port")
+	}
+	if !strings.Contains(err.Error(), "listen on ") {
+		t.Fatalf("expected listen error after route registration, got %v", err)
+	}
+}
+
 func TestCapabilityStartReportsPortConflictsSynchronously(t *testing.T) {
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -148,9 +191,13 @@ func httpValues(t *testing.T, overrides map[string]any) *values.Values {
 
 type testRuntimeInitializerHandle struct {
 	vm *goja.Runtime
+	rt *engine.Runtime
 }
 
 func (h testRuntimeInitializerHandle) EngineRuntime() *engine.Runtime {
+	if h.rt != nil {
+		return h.rt
+	}
 	return &engine.Runtime{VM: h.vm}
 }
 func (h testRuntimeInitializerHandle) Close(context.Context) error { return nil }

--- a/ttmp/2026/06/08/XGOJA-RUNTIME-POLISH--polish-xgoja-runtime-ergonomics-for-express-fs-assets-and-module-inventory/README.md
+++ b/ttmp/2026/06/08/XGOJA-RUNTIME-POLISH--polish-xgoja-runtime-ergonomics-for-express-fs-assets-and-module-inventory/README.md
@@ -1,0 +1,21 @@
+# Polish xgoja runtime ergonomics for Express FS assets and module inventory
+
+This is the document workspace for ticket XGOJA-RUNTIME-POLISH.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr doc add --ticket XGOJA-RUNTIME-POLISH --doc-type design-doc --title "My Design"`
+- Import sources: `docmgr import file --ticket XGOJA-RUNTIME-POLISH --file /path/to/doc.md`
+- Update metadata: `docmgr meta update --ticket XGOJA-RUNTIME-POLISH --field Status --value review`

--- a/ttmp/2026/06/08/XGOJA-RUNTIME-POLISH--polish-xgoja-runtime-ergonomics-for-express-fs-assets-and-module-inventory/changelog.md
+++ b/ttmp/2026/06/08/XGOJA-RUNTIME-POLISH--polish-xgoja-runtime-ergonomics-for-express-fs-assets-and-module-inventory/changelog.md
@@ -36,3 +36,14 @@ Added fs module capability metadata for host and embedded read-only backends
 - /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/modules/fs/fs.go — JavaScript isReadOnly and capabilities exports
 - /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/ttmp/2026/06/08/XGOJA-RUNTIME-POLISH--polish-xgoja-runtime-ergonomics-for-express-fs-assets-and-module-inventory/reference/01-investigation-diary.md — Step 3 implementation diary
 
+
+## 2026-06-08
+
+Deferred Express HTTP listener binding until route/static registration or app.listen
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/modules/express/express.go — Express start hook on app use
+- /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/xgoja/providers/http/http.go — HTTP provider no longer starts listener during require
+- /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/ttmp/2026/06/08/XGOJA-RUNTIME-POLISH--polish-xgoja-runtime-ergonomics-for-express-fs-assets-and-module-inventory/reference/01-investigation-diary.md — Step 4 implementation diary
+

--- a/ttmp/2026/06/08/XGOJA-RUNTIME-POLISH--polish-xgoja-runtime-ergonomics-for-express-fs-assets-and-module-inventory/changelog.md
+++ b/ttmp/2026/06/08/XGOJA-RUNTIME-POLISH--polish-xgoja-runtime-ergonomics-for-express-fs-assets-and-module-inventory/changelog.md
@@ -47,3 +47,14 @@ Deferred Express HTTP listener binding until route/static registration or app.li
 - /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/xgoja/providers/http/http.go — HTTP provider no longer starts listener during require
 - /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/ttmp/2026/06/08/XGOJA-RUNTIME-POLISH--polish-xgoja-runtime-ergonomics-for-express-fs-assets-and-module-inventory/reference/01-investigation-diary.md — Step 4 implementation diary
 
+
+## 2026-06-08
+
+Finalized runtime polish documentation with rebased commit hashes
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/ttmp/2026/06/08/XGOJA-RUNTIME-POLISH--polish-xgoja-runtime-ergonomics-for-express-fs-assets-and-module-inventory/design-doc/01-runtime-ergonomics-polish-implementation-guide.md — Implemented outcome summary
+- /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/ttmp/2026/06/08/XGOJA-RUNTIME-POLISH--polish-xgoja-runtime-ergonomics-for-express-fs-assets-and-module-inventory/reference/01-investigation-diary.md — Rebased commit references and docs wrap-up diary
+- /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/ttmp/2026/06/08/XGOJA-RUNTIME-POLISH--polish-xgoja-runtime-ergonomics-for-express-fs-assets-and-module-inventory/tasks.md — Final docs task completion
+

--- a/ttmp/2026/06/08/XGOJA-RUNTIME-POLISH--polish-xgoja-runtime-ergonomics-for-express-fs-assets-and-module-inventory/changelog.md
+++ b/ttmp/2026/06/08/XGOJA-RUNTIME-POLISH--polish-xgoja-runtime-ergonomics-for-express-fs-assets-and-module-inventory/changelog.md
@@ -1,0 +1,27 @@
+# Changelog
+
+## 2026-06-08
+
+- Initial workspace created
+
+
+## 2026-06-08
+
+Created runtime polish ticket for Express lazy binding, fs:assets read-only metadata, and selected module inventory
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/ttmp/2026/06/08/XGOJA-RUNTIME-POLISH--polish-xgoja-runtime-ergonomics-for-express-fs-assets-and-module-inventory/design-doc/01-runtime-ergonomics-polish-implementation-guide.md — Primary design guide
+- /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/ttmp/2026/06/08/XGOJA-RUNTIME-POLISH--polish-xgoja-runtime-ergonomics-for-express-fs-assets-and-module-inventory/reference/01-investigation-diary.md — Initial diary
+
+
+## 2026-06-08
+
+Implemented selected-modules structured command and clarified provider modules catalog
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/xgoja/app/host.go — Generated root command attachment
+- /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/xgoja/app/root.go — Selected module command implementation
+- /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/ttmp/2026/06/08/XGOJA-RUNTIME-POLISH--polish-xgoja-runtime-ergonomics-for-express-fs-assets-and-module-inventory/reference/01-investigation-diary.md — Step 2 implementation diary
+

--- a/ttmp/2026/06/08/XGOJA-RUNTIME-POLISH--polish-xgoja-runtime-ergonomics-for-express-fs-assets-and-module-inventory/changelog.md
+++ b/ttmp/2026/06/08/XGOJA-RUNTIME-POLISH--polish-xgoja-runtime-ergonomics-for-express-fs-assets-and-module-inventory/changelog.md
@@ -25,3 +25,14 @@ Implemented selected-modules structured command and clarified provider modules c
 - /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/xgoja/app/root.go — Selected module command implementation
 - /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/ttmp/2026/06/08/XGOJA-RUNTIME-POLISH--polish-xgoja-runtime-ergonomics-for-express-fs-assets-and-module-inventory/reference/01-investigation-diary.md — Step 2 implementation diary
 
+
+## 2026-06-08
+
+Added fs module capability metadata for host and embedded read-only backends
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/modules/fs/backend.go — Capability types and fallback
+- /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/modules/fs/fs.go — JavaScript isReadOnly and capabilities exports
+- /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/ttmp/2026/06/08/XGOJA-RUNTIME-POLISH--polish-xgoja-runtime-ergonomics-for-express-fs-assets-and-module-inventory/reference/01-investigation-diary.md — Step 3 implementation diary
+

--- a/ttmp/2026/06/08/XGOJA-RUNTIME-POLISH--polish-xgoja-runtime-ergonomics-for-express-fs-assets-and-module-inventory/design-doc/01-runtime-ergonomics-polish-implementation-guide.md
+++ b/ttmp/2026/06/08/XGOJA-RUNTIME-POLISH--polish-xgoja-runtime-ergonomics-for-express-fs-assets-and-module-inventory/design-doc/01-runtime-ergonomics-polish-implementation-guide.md
@@ -1,0 +1,189 @@
+---
+Title: Runtime Ergonomics Polish Implementation Guide
+Ticket: XGOJA-RUNTIME-POLISH
+Status: active
+Topics:
+    - xgoja
+    - goja
+    - modules
+    - architecture
+DocType: design-doc
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: go-go-goja/modules/express/express.go
+      Note: |-
+        Express module API where app/route registration/listen behavior should be exposed.
+        Express app API and route registration
+    - Path: go-go-goja/modules/fs/backend_embed.go
+      Note: |-
+        Embedded read-only backend and EROFS mutation behavior.
+        Read-only embedded filesystem backend
+    - Path: go-go-goja/modules/fs/fs.go
+      Note: |-
+        Filesystem module exports and TypeScript declaration surface.
+        Filesystem JavaScript export surface
+    - Path: go-go-goja/pkg/xgoja/app/root.go
+      Note: |-
+        Generated runtime root commands, including provider module catalog command.
+        Generated runtime commands
+    - Path: go-go-goja/pkg/xgoja/app/runtime_spec.go
+      Note: |-
+        Embedded runtime selected module spec used for selected-module inventory.
+        Selected runtime module spec
+    - Path: go-go-goja/pkg/xgoja/providers/http/http.go
+      Note: |-
+        HTTP provider currently owns express host lifecycle and listener startup.
+        HTTP provider listener lifecycle
+ExternalSources: []
+Summary: 'Design guide for three go-go-goja runtime ergonomics fixes: lazy Express listener startup, read-only fs:assets discovery, and structured selected-module inventory.'
+LastUpdated: 2026-06-08T23:50:00-04:00
+WhatFor: Use this to implement small go-go-goja runtime polish items after JSVerb filtering.
+WhenToUse: Read before changing the HTTP provider, Express module, fs module, or generated runtime module inventory commands.
+---
+
+
+# Runtime Ergonomics Polish Implementation Guide
+
+## Executive summary
+
+Yes: these issues belong in the `go-go-goja` package/repository. They are framework/runtime ergonomics issues surfaced by ClubMedMeetup, but the underlying behavior lives in reusable xgoja providers and generated runtime commands.
+
+This ticket tracks three small, separable fixes:
+
+1. `require("express")` should not eagerly bind an HTTP listener just because the module was imported.
+2. Embedded asset filesystem aliases such as `fs:assets` should advertise that they are read-only.
+3. Generated runtime module inventory should clearly distinguish compiled provider modules from selected runtime aliases, and the selected inventory should be a structured Glazed command with normal `--output json` support.
+
+## Scope
+
+In scope:
+
+- `go-go-goja/pkg/xgoja/providers/http/http.go`
+- `go-go-goja/modules/express/express.go`
+- `go-go-goja/modules/fs/*`
+- `go-go-goja/pkg/xgoja/app/root.go`
+- `go-go-goja/pkg/xgoja/app/runtime_spec.go`
+- tests and docs for those behaviors
+
+Out of scope:
+
+- ClubMedMeetup application-specific route changes.
+- go-minitrace provider consolidation.
+- goja-text document helpers.
+- Any broad module architecture rewrite.
+
+## Problem 1: Express eagerly binds on require
+
+Current behavior is surprising for introspection. Requiring the Express module can start or touch the HTTP listener before a script registers routes or explicitly asks to listen. A user running an eval such as:
+
+```bash
+./dist/app eval 'Object.keys(require("express"))'
+```
+
+should not fail because `127.0.0.1:8787` is already occupied.
+
+### Proposed behavior
+
+- `require("express")` creates exports only; no network bind.
+- `express.app()` creates an app object only; no network bind by itself.
+- First route/static registration may autostart the listener when HTTP is enabled, preserving existing `run server.js --keep-alive` behavior.
+- `app.listen([addr])` should be considered as an explicit start path if it does not already exist.
+- `--http-enabled=false` should allow route registration for tests/introspection without binding.
+
+### Implementation sketch
+
+Keep dependency direction clean: `modules/express` should not import `pkg/xgoja/providers/http`. Instead, add an optional callback option to the express registrar:
+
+```go
+type StartFunc func(*goja.Runtime) error
+
+func WithOnUse(fn StartFunc) Option { ... }
+```
+
+Call the hook from route/static registration and `listen`, not from module load. The HTTP provider passes `c.start(vm, entry)` as the hook.
+
+### Tests
+
+- Requiring `express` alone does not bind the port.
+- Registering a route in normal mode still starts serving.
+- Registering a route with HTTP disabled succeeds and does not bind.
+- Existing generated app run behavior still works.
+
+## Problem 2: fs:assets should advertise read-only behavior
+
+The embedded filesystem backend already rejects writes with read-only errors. The issue is discoverability: `Object.keys(require("fs:assets"))` lists write methods, and users have no obvious programmatic way to know the backend is read-only.
+
+### Proposed API
+
+Expose stable metadata on every fs module:
+
+```js
+const fs = require("fs:assets")
+fs.isReadOnly // true
+fs.capabilities()
+// { backend: "embedded", read: true, write: false, embedded: true, mounts: [...] }
+```
+
+For host fs:
+
+```js
+require("fs:host").capabilities()
+// { backend: "host", read: true, write: true, embedded: false }
+```
+
+The first implementation can expose booleans and backend kind before detailed mount metadata if that keeps the patch small.
+
+### Tests
+
+- Embedded backend reports `isReadOnly === true` and `capabilities().write === false`.
+- Host backend reports `isReadOnly === false` and `capabilities().write === true`.
+- Existing EROFS mutation behavior remains unchanged.
+
+## Problem 3: runtime module inventory is confusing
+
+Generated binaries currently have a `modules` command that lists compiled provider modules. That is useful, but it is not the same as selected runtime aliases. Users want to know whether `require("fs:assets")` or `require("fs")` is valid in this generated runtime.
+
+The fix should use Glazed command machinery so users automatically get structured output modes such as `--output json`.
+
+### Proposed command shape
+
+Add a selected inventory command, for example:
+
+```bash
+./dist/app selected-modules --output json
+```
+
+Rows:
+
+- `package`: provider package ID
+- `module`: provider module name
+- `alias`: actual CommonJS `require()` alias
+- `provider_ref`: `<package>.<module>`
+- `config`: static config summary or JSON string
+
+Keep the existing `modules` command as a provider catalog, but rename/clarify columns so it does not imply its provider refs are valid `require()` names.
+
+### Tests
+
+- A runtime spec with two `fs` module instances emits two rows with distinct aliases.
+- The command is implemented as a Glazed command and supports `--output json` through normal middleware.
+- Existing `modules` command still works as provider catalog.
+
+## Implementation order
+
+1. Add selected-module inventory command first. It is additive and low risk.
+2. Add fs read-only metadata. It is local to `modules/fs` and docs/tests.
+3. Change Express lifecycle last. It has the highest compatibility risk and needs careful tests.
+
+## Validation
+
+Run focused tests after each phase, then broader package tests:
+
+```bash
+cd /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja
+go test ./pkg/xgoja/app ./pkg/xgoja/providers/http ./modules/express ./modules/fs -count=1
+go test ./pkg/jsverbs ./cmd/xgoja/internal/buildspec ./cmd/xgoja/internal/generate -count=1
+```
+
+Before PR, run the normal pre-commit hooks or `go test ./...` as appropriate.

--- a/ttmp/2026/06/08/XGOJA-RUNTIME-POLISH--polish-xgoja-runtime-ergonomics-for-express-fs-assets-and-module-inventory/design-doc/01-runtime-ergonomics-polish-implementation-guide.md
+++ b/ttmp/2026/06/08/XGOJA-RUNTIME-POLISH--polish-xgoja-runtime-ergonomics-for-express-fs-assets-and-module-inventory/design-doc/01-runtime-ergonomics-polish-implementation-guide.md
@@ -37,7 +37,7 @@ RelatedFiles:
         HTTP provider listener lifecycle
 ExternalSources: []
 Summary: 'Design guide for three go-go-goja runtime ergonomics fixes: lazy Express listener startup, read-only fs:assets discovery, and structured selected-module inventory.'
-LastUpdated: 2026-06-08T23:50:00-04:00
+LastUpdated: 2026-06-09T00:20:00-04:00
 WhatFor: Use this to implement small go-go-goja runtime polish items after JSVerb filtering.
 WhenToUse: Read before changing the HTTP provider, Express module, fs module, or generated runtime module inventory commands.
 ---
@@ -175,6 +175,22 @@ Keep the existing `modules` command as a provider catalog, but rename/clarify co
 1. Add selected-module inventory command first. It is additive and low risk.
 2. Add fs read-only metadata. It is local to `modules/fs` and docs/tests.
 3. Change Express lifecycle last. It has the highest compatibility risk and needs careful tests.
+
+## Implemented outcome
+
+The ticket has been implemented in three focused code commits after the branch rebase:
+
+1. `dc1b74f` — `Add selected xgoja module inventory`
+   - Adds the structured `selected-modules` Glazed command.
+   - Clarifies that `modules` is a provider catalog by using `provider_ref` for provider identities.
+2. `ef2fb81` — `Expose fs backend capabilities`
+   - Adds backend capability metadata and JavaScript exports `fs.isReadOnly` and `fs.capabilities()`.
+   - Reports embedded asset backends as read-only while preserving existing EROFS mutation failures.
+3. `f16430e` — `Defer Express HTTP listener binding`
+   - Makes `require("express")` side-effect-light.
+   - Defers HTTP listener startup until route/static registration or explicit `app.listen()`.
+
+The documentation wrap-up is recorded separately so reviewers can inspect code behavior and ticket bookkeeping independently.
 
 ## Validation
 

--- a/ttmp/2026/06/08/XGOJA-RUNTIME-POLISH--polish-xgoja-runtime-ergonomics-for-express-fs-assets-and-module-inventory/index.md
+++ b/ttmp/2026/06/08/XGOJA-RUNTIME-POLISH--polish-xgoja-runtime-ergonomics-for-express-fs-assets-and-module-inventory/index.md
@@ -1,0 +1,58 @@
+---
+Title: Polish xgoja runtime ergonomics for Express FS assets and module inventory
+Ticket: XGOJA-RUNTIME-POLISH
+Status: active
+Topics:
+    - xgoja
+    - goja
+    - modules
+    - architecture
+DocType: index
+Intent: long-term
+Owners: []
+RelatedFiles: []
+ExternalSources: []
+Summary: ""
+LastUpdated: 2026-06-08T19:50:22.503474123-04:00
+WhatFor: ""
+WhenToUse: ""
+---
+
+# Polish xgoja runtime ergonomics for Express FS assets and module inventory
+
+## Overview
+
+<!-- Provide a brief overview of the ticket, its goals, and current status -->
+
+## Key Links
+
+- **Related Files**: See frontmatter RelatedFiles field
+- **External Sources**: See frontmatter ExternalSources field
+
+## Status
+
+Current status: **active**
+
+## Topics
+
+- xgoja
+- goja
+- modules
+- architecture
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/2026/06/08/XGOJA-RUNTIME-POLISH--polish-xgoja-runtime-ergonomics-for-express-fs-assets-and-module-inventory/reference/01-investigation-diary.md
+++ b/ttmp/2026/06/08/XGOJA-RUNTIME-POLISH--polish-xgoja-runtime-ergonomics-for-express-fs-assets-and-module-inventory/reference/01-investigation-diary.md
@@ -197,3 +197,91 @@ Result:
 ```text
 ok  	github.com/go-go-golems/go-go-goja/pkg/xgoja/app	0.049s
 ```
+
+## Step 3: Add filesystem read-only capability metadata
+
+I implemented the `fs:assets` discoverability improvement by adding backend capability metadata to the filesystem module. Embedded read-only backends now report that they are read-only, while the host OS backend reports read/write capability. JavaScript code can inspect `fs.isReadOnly` and `fs.capabilities()` without attempting a write just to discover behavior.
+
+The existing mutation behavior is unchanged: embedded filesystems still reject writes, mkdirs, removes, appends, renames, and copies with read-only errors where appropriate. The new API is purely descriptive.
+
+### Prompt Context
+
+**User prompt (verbatim):** (same as Step 1)
+
+**Assistant interpretation:** Continue the task list after selected-module inventory by making `fs:assets` advertise read-only behavior.
+
+**Inferred user intent:** Improve runtime self-discovery so generated xgoja app authors can distinguish writable host fs aliases from read-only embedded asset fs aliases.
+
+**Commit (code):** Pending — to be committed after this diary update.
+
+### What I did
+
+- Added `Capabilities`, `MountInfo`, `CapabilityReporter`, and `CapabilitiesForBackend` in `modules/fs/backend.go`.
+- Added `FSCapabilities()` to `OSBackend`, returning `{backend: "host", read: true, write: true}`.
+- Added `FSCapabilities()` to `ReadOnlyFSBackend`, returning `{backend: "embedded", read: true, write: false, embedded: true, mounts: [...]}`.
+- Exported `isReadOnly` and `capabilities()` from the JavaScript fs module in `modules/fs/fs.go`.
+- Updated TypeScript declaration metadata with `FSMountInfo`, `FSCapabilities`, `isReadOnly`, and `capabilities()`.
+- Added host and embedded fs tests:
+  - `TestHostFsCapabilities`
+  - extended `TestReadOnlyEmbeddedFsSync`
+- Updated `tasks.md` to check off fs capability metadata tasks.
+
+### Why
+
+- `fs:assets` already behaves correctly at mutation time, but users need an introspection API that says writes are impossible.
+- Keeping one fs module API is backward compatible; metadata avoids splitting read-only and writable modules into separate JavaScript APIs.
+
+### What worked
+
+- The backend abstraction was a good place to attach capability reporting because the module can derive `isReadOnly` from actual backend behavior.
+- Focused fs tests passed after normalizing the JS export shape:
+  - `go test ./modules/fs -count=1`
+
+### What didn't work
+
+- My first `capabilities()` export returned the Go `Capabilities` struct directly. In JavaScript, `JSON.stringify(fs.capabilities())` did not expose lower-camel/json-tagged fields as expected; the host test only saw `{"isReadOnly":false}`.
+- The embedded test also failed because `caps.mounts` was undefined:
+  - `TypeError: Cannot read property '0' of undefined at <eval>:12:311(112)`
+- I fixed this by converting `Capabilities` to an explicit `map[string]any` with lower-camel keys before returning it from the JS function.
+
+### What I learned
+
+- Go struct JSON tags are not the right mechanism for shaping Goja-exported JavaScript objects.
+- For JS-facing native module APIs, explicit maps or objects are safer when field casing is part of the public contract.
+
+### What was tricky to build
+
+- The main tricky point was making the capability API backend-owned without forcing every backend implementation to change. `CapabilitiesForBackend` returns custom read/write defaults when a backend does not implement `CapabilityReporter`.
+- Mount metadata needed to avoid exposing `fs.FS` internals. The public mount info only includes virtual mount and cleaned root.
+
+### What warrants a second pair of eyes
+
+- Whether the default for unknown custom backends should be `write: true` or a more conservative `write: false`.
+- Whether detailed mount metadata should include asset IDs when the backend came from xgoja assets; currently the backend only knows mount/root.
+
+### What should be done in the future
+
+- Update `pkg/doc/24-fs-module.md` with the new capability API.
+- Consider exposing backend capabilities through generated module inventory later if useful.
+
+### Code review instructions
+
+- Start with `modules/fs/backend.go` to review the public capability types.
+- Review backend implementations in `modules/fs/fs_sync.go` and `modules/fs/backend_embed.go`.
+- Review JS exports and TypeScript declaration changes in `modules/fs/fs.go`.
+- Validate with:
+  - `go test ./modules/fs -count=1`
+
+### Technical details
+
+Focused validation command:
+
+```bash
+cd go-go-goja && gofmt -w modules/fs/backend.go modules/fs/backend_embed.go modules/fs/fs.go modules/fs/fs_sync.go modules/fs/fs_test.go modules/fs/fs_embed_test.go && go test ./modules/fs -count=1
+```
+
+Result:
+
+```text
+ok  	github.com/go-go-golems/go-go-goja/modules/fs	0.052s
+```

--- a/ttmp/2026/06/08/XGOJA-RUNTIME-POLISH--polish-xgoja-runtime-ergonomics-for-express-fs-assets-and-module-inventory/reference/01-investigation-diary.md
+++ b/ttmp/2026/06/08/XGOJA-RUNTIME-POLISH--polish-xgoja-runtime-ergonomics-for-express-fs-assets-and-module-inventory/reference/01-investigation-diary.md
@@ -1,0 +1,199 @@
+---
+Title: Investigation Diary
+Ticket: XGOJA-RUNTIME-POLISH
+Status: active
+Topics:
+    - xgoja
+    - goja
+    - modules
+    - architecture
+DocType: reference
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: go-go-goja/ttmp/2026/06/08/XGOJA-RUNTIME-POLISH--polish-xgoja-runtime-ergonomics-for-express-fs-assets-and-module-inventory/design-doc/01-runtime-ergonomics-polish-implementation-guide.md
+      Note: |-
+        Initial implementation guide for the runtime polish ticket.
+        Initial runtime polish implementation guide
+ExternalSources: []
+Summary: Chronological diary for the runtime ergonomics polish ticket.
+LastUpdated: 2026-06-08T23:50:00-04:00
+WhatFor: Use this diary when implementing the smaller go-go-goja runtime polish items.
+WhenToUse: Read before resuming work on Express lazy startup, fs:assets capability metadata, or selected module inventory.
+---
+
+
+# Diary
+
+## Goal
+
+Capture the setup and implementation history for small `go-go-goja` runtime ergonomics improvements: Express listener lifecycle, read-only embedded filesystem discovery, and selected runtime module inventory.
+
+## Step 1: Create the runtime polish ticket
+
+I created a new `docmgr` ticket for the smaller follow-up issues that remained after the JSVerb source-filtering work was completed. These items are intentionally grouped because they are all framework/runtime polish items in `go-go-goja`, not site-specific ClubMedMeetup changes.
+
+The initial guide records the ownership answer explicitly: yes, these should live in `go-go-goja`. ClubMedMeetup exposed the pain points, but the code paths are the xgoja HTTP provider, the reusable Express module, the reusable fs module, and generated runtime commands.
+
+### Prompt Context
+
+**User prompt (verbatim):** "Create a new ticket to tackle smaller issues:
+
+- express should not eagerly bind on require
+- fs:assets should avertise read-only behavior
+- runtime module inventory i sonfusing (if we aren't using glazed command for the strucutred that, which then provides the requested --output json flag, then we should do that)"
+
+**Assistant interpretation:** Create a new go-go-goja docmgr ticket for three smaller runtime ergonomics improvements and prepare implementation guidance/tasks.
+
+**Inferred user intent:** Continue addressing the ClubMedMeetup-derived runtime friction, but split the remaining smaller go-go-goja issues out of the JSVerb-focused ticket.
+
+**Commit (code):** N/A — ticket setup only.
+
+### What I did
+
+- Created ticket `XGOJA-RUNTIME-POLISH` under `go-go-goja/ttmp`.
+- Added design doc `design-doc/01-runtime-ergonomics-polish-implementation-guide.md`.
+- Added this diary `reference/01-investigation-diary.md`.
+- Wrote tasks for:
+  - Express lazy/no-eager bind behavior,
+  - `fs:assets` read-only capability metadata,
+  - selected runtime module inventory as a structured Glazed command.
+
+### Why
+
+- The three issues all live in reusable `go-go-goja` runtime/provider/module code.
+- Keeping them in one ticket is reasonable because each is small, but the guide recommends implementing them independently and in risk order.
+- The selected-module inventory issue specifically should use Glazed command machinery to get structured renderers such as `--output json` rather than hand-printing ad hoc text.
+
+### What worked
+
+- `docmgr --root go-go-goja/ttmp ticket create-ticket` created the ticket workspace successfully.
+- The design guide could reuse evidence and file ownership already discovered during the earlier ClubMedMeetup analysis.
+
+### What didn't work
+
+- N/A.
+
+### What I learned
+
+- These issues are best framed as generated runtime ergonomics rather than ClubMedMeetup app bugs.
+- Express lifecycle is the riskiest because changing listener start timing can affect existing apps, so it should come after the additive selected-module and fs metadata work.
+
+### What was tricky to build
+
+- The main tricky point was keeping scope tight. The earlier broad guide also discussed provider pinning, go-minitrace consolidation, and goja-text helpers, but this new ticket should only track the three small runtime polish items named in the prompt.
+
+### What warrants a second pair of eyes
+
+- Express lazy-start compatibility plan.
+- Whether selected-module inventory should be a new command or an option on the existing `modules` provider catalog command.
+- Exact shape of `fs.capabilities()` and whether mount metadata should be included in the first patch.
+
+### What should be done in the future
+
+- Implement selected module inventory first.
+- Implement fs read-only metadata second.
+- Implement Express lazy binding third.
+- Keep this diary updated with tests, failures, and commit hashes.
+
+### Code review instructions
+
+- Start with `design-doc/01-runtime-ergonomics-polish-implementation-guide.md`.
+- Review implementation by subsystem:
+  - generated commands: `pkg/xgoja/app/root.go`, `pkg/xgoja/app/runtime_spec.go`,
+  - fs metadata: `modules/fs/fs.go`, `modules/fs/backend_embed.go`,
+  - Express lifecycle: `pkg/xgoja/providers/http/http.go`, `modules/express/express.go`.
+
+### Technical details
+
+Initial ticket commands:
+
+```bash
+docmgr --root go-go-goja/ttmp ticket create-ticket \
+  --ticket XGOJA-RUNTIME-POLISH \
+  --title "Polish xgoja runtime ergonomics for Express FS assets and module inventory" \
+  --topics xgoja,goja,modules,architecture
+```
+
+## Step 2: Add selected runtime module inventory
+
+I implemented the lowest-risk runtime polish item first: generated binaries now get a `selected-modules` command that lists the actual CommonJS aliases selected into the runtime. The existing `modules` command remains a provider catalog, but its help text and output column now make that clearer by using `provider_ref` instead of implying a valid `require()` name.
+
+This matters because xgoja lets one provider module be selected multiple times under different aliases, such as `fs:host` and `fs:assets`. A provider catalog can tell you that `go-go-goja-host.fs` exists, but only the runtime spec can tell you which aliases the generated binary actually installed.
+
+### Prompt Context
+
+**User prompt (verbatim):** (same as Step 1)
+
+**Assistant interpretation:** Work through the ticket tasks incrementally, starting with a small commit-sized runtime inventory improvement.
+
+**Inferred user intent:** Make generated xgoja runtimes easier to inspect and ensure module inventory output supports structured output such as `--output json`.
+
+**Commit (code):** Pending — to be committed after this diary update.
+
+### What I did
+
+- Added `selectedModulesCommand` in `pkg/xgoja/app/root.go`.
+- Attached it from `Host.AttachDefaultCommands` via new `AttachSelectedModules` in `pkg/xgoja/app/host.go`.
+- Kept `modules` as a compiled provider catalog, but clarified its long help and changed the structured column from `require` to `provider_ref`.
+- Added a test in `pkg/xgoja/app/root_test.go` that runs `selected-modules --output json` and checks aliases, provider refs, and config output.
+- Updated `tasks.md` to check off the module inventory tasks.
+
+### Why
+
+- This is additive, low risk, and directly addresses the confusing distinction between compiled provider modules and selected runtime aliases.
+- Implementing it as a Glazed command means existing renderer/middleware support provides `--output json` without custom JSON printing.
+
+### What worked
+
+- The existing `modulesCommand` pattern was already a Glazed command, so `selectedModulesCommand` could follow the same structure.
+- Runtime spec already carries `Modules`, including `package`, `name`, `as`, and static config, so no schema change was needed.
+- Focused test passed:
+  - `go test ./pkg/xgoja/app -run 'TestGeneratedRoot(ModulesCommand|SelectedModulesCommand)' -count=1`
+
+### What didn't work
+
+- My first selected-modules test tried to capture output through `Options.Out`, but Glazed JSON output was written to stdout in this test path.
+- The failed test printed the JSON to the console and then saw an empty buffer.
+- I fixed the test by using the existing `captureStdout(...)` helper.
+
+### What I learned
+
+- `Options.Out` is sufficient for some generated command paths but not all Glazed renderer output in tests.
+- Testing the actual `--output json` invocation is valuable because it proves the command is structured rather than hand-printed.
+
+### What was tricky to build
+
+- The main tricky point was compatibility: changing `modules` too aggressively could break users who expect a provider catalog. I kept the command and clarified it rather than replacing it.
+- Config output is represented as a compact JSON string per row. This keeps table output simple while preserving structured data for JSON renderers.
+
+### What warrants a second pair of eyes
+
+- Whether `modules` should keep a legacy `require` column for one release in addition to `provider_ref`.
+- Whether `selected-modules.config` should eventually be a nested object rather than a JSON string.
+
+### What should be done in the future
+
+- Add user-facing docs for `selected-modules` after the full runtime polish ticket lands.
+- Consider adding `selected-modules` examples to xgoja generated binary docs.
+
+### Code review instructions
+
+- Start in `pkg/xgoja/app/host.go` to see command attachment.
+- Then review `pkg/xgoja/app/root.go`, especially `selectedModulesCommand` and the clarified provider catalog command.
+- Validate with:
+  - `go test ./pkg/xgoja/app -run 'TestGeneratedRoot(ModulesCommand|SelectedModulesCommand)' -count=1`
+
+### Technical details
+
+Focused validation command:
+
+```bash
+cd go-go-goja && gofmt -w pkg/xgoja/app/root.go pkg/xgoja/app/host.go pkg/xgoja/app/root_test.go && go test ./pkg/xgoja/app -run 'TestGeneratedRoot(ModulesCommand|SelectedModulesCommand)' -count=1
+```
+
+Result:
+
+```text
+ok  	github.com/go-go-golems/go-go-goja/pkg/xgoja/app	0.049s
+```

--- a/ttmp/2026/06/08/XGOJA-RUNTIME-POLISH--polish-xgoja-runtime-ergonomics-for-express-fs-assets-and-module-inventory/reference/01-investigation-diary.md
+++ b/ttmp/2026/06/08/XGOJA-RUNTIME-POLISH--polish-xgoja-runtime-ergonomics-for-express-fs-assets-and-module-inventory/reference/01-investigation-diary.md
@@ -17,7 +17,7 @@ RelatedFiles:
         Initial runtime polish implementation guide
 ExternalSources: []
 Summary: Chronological diary for the runtime ergonomics polish ticket.
-LastUpdated: 2026-06-08T23:50:00-04:00
+LastUpdated: 2026-06-09T00:20:00-04:00
 WhatFor: Use this diary when implementing the smaller go-go-goja runtime polish items.
 WhenToUse: Read before resuming work on Express lazy startup, fs:assets capability metadata, or selected module inventory.
 ---
@@ -129,7 +129,7 @@ This matters because xgoja lets one provider module be selected multiple times u
 
 **Inferred user intent:** Make generated xgoja runtimes easier to inspect and ensure module inventory output supports structured output such as `--output json`.
 
-**Commit (code):** Pending — to be committed after this diary update.
+**Commit (code):** `dc1b74f` — `Add selected xgoja module inventory`
 
 ### What I did
 
@@ -212,7 +212,7 @@ The existing mutation behavior is unchanged: embedded filesystems still reject w
 
 **Inferred user intent:** Improve runtime self-discovery so generated xgoja app authors can distinguish writable host fs aliases from read-only embedded asset fs aliases.
 
-**Commit (code):** Pending — to be committed after this diary update.
+**Commit (code):** `ef2fb81` — `Expose fs backend capabilities`
 
 ### What I did
 
@@ -300,7 +300,7 @@ This keeps introspection safe while preserving the generated app pattern where `
 
 **Inferred user intent:** Make `require("express")` safe for eval/repl/introspection and avoid port conflicts unless the script actually starts using HTTP server behavior.
 
-**Commit (code):** Pending — to be committed after this diary update.
+**Commit (code):** `f16430e` — `Defer Express HTTP listener binding`
 
 ### What I did
 
@@ -370,4 +370,76 @@ Result:
 ```text
 ok  	github.com/go-go-golems/go-go-goja/pkg/xgoja/providers/http	0.027s
 ok  	github.com/go-go-golems/go-go-goja/modules/express	0.035s
+```
+
+## Step 5: Finalize runtime polish documentation
+
+I performed the docs-only wrap-up after the runtime polish implementation commits had been rebased. The important part was to avoid stale commit references: the selected-module, fs capability, and Express lifecycle commits now have different hashes than the earlier pre-rebase history.
+
+This step marks the ticket documentation as implementation-complete without mixing more code changes into the runtime commits.
+
+### Prompt Context
+
+**User prompt (verbatim):** "1-4 and commit, we rebased the branch also so you need new hashes."
+
+**Assistant interpretation:** Complete the documentation wrap-up tasks, use the rebased commit hashes, validate the ticket, and commit the docs-only changes.
+
+**Inferred user intent:** Keep the ticket docs accurate for review after rebasing changed commit IDs.
+
+**Commit (code):** N/A — docs-only wrap-up commit follows this diary entry.
+
+### What I did
+
+- Checked the rebased branch history and recorded the new runtime polish commit hashes:
+  - `dc1b74f` — `Add selected xgoja module inventory`
+  - `ef2fb81` — `Expose fs backend capabilities`
+  - `f16430e` — `Defer Express HTTP listener binding`
+- Added an implemented-outcome section to the design doc.
+- Replaced pending diary commit markers in Steps 2–4 with the rebased hashes.
+- Checked off the final docs/diary task in `tasks.md`.
+
+### Why
+
+- Stale hashes make ticket docs harder to use during review, especially after branch rebases.
+- Keeping this as a docs-only wrap-up commit preserves the separation between implementation and bookkeeping.
+
+### What worked
+
+- `git log --oneline --decorate -10` clearly showed the post-rebase commit IDs.
+- The ticket docs already had the right structure, so the update was targeted.
+
+### What didn't work
+
+- N/A.
+
+### What I learned
+
+- After rebases, diary commit references should be treated as mutable review aids rather than historical facts until the branch is finalized.
+
+### What was tricky to build
+
+- The only tricky part was ensuring the repeated `Pending — to be committed after this diary update` marker was replaced with the correct hash for each step. I used surrounding intent text to disambiguate the three entries.
+
+### What warrants a second pair of eyes
+
+- Confirm the implemented-outcome section points to the intended rebased commits.
+- Confirm no implementation documentation still references old pre-rebase hashes.
+
+### What should be done in the future
+
+- Upload the runtime polish bundle to reMarkable if a paper-review copy is desired.
+
+### Code review instructions
+
+- Review the design doc implemented-outcome section first.
+- Then review diary Steps 2–5 for commit references and validation details.
+- Validate with:
+  - `docmgr --root go-go-goja/ttmp doctor --ticket XGOJA-RUNTIME-POLISH --stale-after 30`
+
+### Technical details
+
+Commands used for orientation:
+
+```bash
+git -C go-go-goja log --oneline --decorate -10
 ```

--- a/ttmp/2026/06/08/XGOJA-RUNTIME-POLISH--polish-xgoja-runtime-ergonomics-for-express-fs-assets-and-module-inventory/reference/01-investigation-diary.md
+++ b/ttmp/2026/06/08/XGOJA-RUNTIME-POLISH--polish-xgoja-runtime-ergonomics-for-express-fs-assets-and-module-inventory/reference/01-investigation-diary.md
@@ -285,3 +285,89 @@ Result:
 ```text
 ok  	github.com/go-go-golems/go-go-goja/modules/fs	0.052s
 ```
+
+## Step 4: Make Express require side-effect-light
+
+I changed the xgoja HTTP provider and Express module so that `require("express")` no longer binds the configured HTTP listener. Listener startup is now deferred until the app is actually used for route/static registration or `app.listen()` is called.
+
+This keeps introspection safe while preserving the generated app pattern where `server.js` requires Express, creates an app, registers routes/static mounts, and then relies on `run --keep-alive` to keep the runtime alive.
+
+### Prompt Context
+
+**User prompt (verbatim):** (same as Step 1)
+
+**Assistant interpretation:** Continue the runtime polish task list by addressing Express eager binding.
+
+**Inferred user intent:** Make `require("express")` safe for eval/repl/introspection and avoid port conflicts unless the script actually starts using HTTP server behavior.
+
+**Commit (code):** Pending — to be committed after this diary update.
+
+### What I did
+
+- Added `StartFunc` and `WithOnUse` to `modules/express`.
+- Added `Registrar.start(vm)` as a small helper that invokes the optional start hook.
+- Changed route registration (`get`, `post`, `put`, `patch`, `delete`, `all`) to call the start hook before registering the handler.
+- Changed static/SPAs mount helpers to call the start hook before registering static handlers.
+- Added `app.listen()` as an explicit start path.
+- Changed `pkg/xgoja/providers/http.NewExpressLoader` so module loading only constructs exports and passes the start hook into Express; it no longer calls `c.start(...)` during `require("express")`.
+- Added `TestExpressRequireDoesNotBindHTTPPort` in `pkg/xgoja/providers/http/http_test.go`.
+- Updated `tasks.md` to check off Express lifecycle and test tasks.
+
+### Why
+
+- CommonJS `require()` should be safe for introspection and should not perform network IO merely by loading a module.
+- Route/static registration is a better compatibility boundary because existing server scripts register routes immediately after creating the app.
+- An explicit `app.listen()` hook gives scripts a direct start path without importing provider internals.
+
+### What worked
+
+- The existing Express registrar option pattern made it easy to add `WithOnUse` without creating an import cycle between `modules/express` and `pkg/xgoja/providers/http`.
+- Focused tests passed:
+  - `go test ./pkg/xgoja/providers/http ./modules/express -count=1`
+
+### What didn't work
+
+- N/A for the final implementation. The design fit the existing registrar structure cleanly.
+
+### What I learned
+
+- The HTTP provider already centralizes listener state in `runtimeEntry`; the Express module only needed a start callback to defer listener binding.
+- This is a cleaner separation than having Express know about xgoja HTTP settings.
+
+### What was tricky to build
+
+- The main tricky point was preserving compatibility. Starting only on explicit `listen()` would be cleaner, but it could break existing scripts that expect route registration to be enough. Starting on first route/static registration preserves that behavior while fixing require-only introspection.
+- The test needed to prove both sides: require-only succeeds while route registration still reports an occupied port when configured to bind one.
+
+### What warrants a second pair of eyes
+
+- Whether `app.listen()` should accept a listen address override. The first implementation simply triggers the configured xgoja listener.
+- Whether static handler construction should happen before or after start. The current implementation starts first, matching route behavior.
+
+### What should be done in the future
+
+- Document the lifecycle: `require()` is pure, route/static registration autostarts when HTTP is enabled, `app.listen()` explicitly starts.
+- Consider exposing server state for diagnostics if users ask for it.
+
+### Code review instructions
+
+- Review `pkg/xgoja/providers/http/http.go` to confirm listener startup moved out of module load.
+- Review `modules/express/express.go` for the `WithOnUse` callback and the registration-time start calls.
+- Review `pkg/xgoja/providers/http/http_test.go` for the require-only port-conflict regression test.
+- Validate with:
+  - `go test ./pkg/xgoja/providers/http ./modules/express -count=1`
+
+### Technical details
+
+Focused validation command:
+
+```bash
+cd go-go-goja && gofmt -w modules/express/express.go pkg/xgoja/providers/http/http.go pkg/xgoja/providers/http/http_test.go && go test ./pkg/xgoja/providers/http ./modules/express -count=1
+```
+
+Result:
+
+```text
+ok  	github.com/go-go-golems/go-go-goja/pkg/xgoja/providers/http	0.027s
+ok  	github.com/go-go-golems/go-go-goja/modules/express	0.035s
+```

--- a/ttmp/2026/06/08/XGOJA-RUNTIME-POLISH--polish-xgoja-runtime-ergonomics-for-express-fs-assets-and-module-inventory/tasks.md
+++ b/ttmp/2026/06/08/XGOJA-RUNTIME-POLISH--polish-xgoja-runtime-ergonomics-for-express-fs-assets-and-module-inventory/tasks.md
@@ -2,11 +2,11 @@
 
 ## Runtime ergonomics polish
 
-- [ ] Make `require("express")` side-effect-light: it must not eagerly bind the HTTP listener merely because the module is required.
-- [ ] Preserve current `run server.js --keep-alive` behavior: route/static registration should still start serving when HTTP is enabled, or an explicit `app.listen()` path should be provided.
+- [x] Make `require("express")` side-effect-light: it must not eagerly bind the HTTP listener merely because the module is required.
+- [x] Preserve current `run server.js --keep-alive` behavior: route/static registration should still start serving when HTTP is enabled, or an explicit `app.listen()` path should be provided.
 - [x] Add `fs:assets`/embedded filesystem capability metadata, for example `isReadOnly` and `capabilities()`.
 - [x] Keep read-only mutation failures unchanged (`EROFS`), but make read-only behavior discoverable from JavaScript and TypeScript docs/declarations.
 - [x] Clarify generated runtime module inventory: distinguish compiled provider catalog from selected runtime aliases.
 - [x] Ensure selected module inventory is a Glazed structured command that supports normal output flags such as `--output json`.
-- [ ] Add tests for Express require-only behavior, fs capabilities, and selected-module output.
+- [x] Add tests for Express require-only behavior, fs capabilities, and selected-module output.
 - [ ] Update docs/examples and diary as implementation proceeds.

--- a/ttmp/2026/06/08/XGOJA-RUNTIME-POLISH--polish-xgoja-runtime-ergonomics-for-express-fs-assets-and-module-inventory/tasks.md
+++ b/ttmp/2026/06/08/XGOJA-RUNTIME-POLISH--polish-xgoja-runtime-ergonomics-for-express-fs-assets-and-module-inventory/tasks.md
@@ -9,4 +9,4 @@
 - [x] Clarify generated runtime module inventory: distinguish compiled provider catalog from selected runtime aliases.
 - [x] Ensure selected module inventory is a Glazed structured command that supports normal output flags such as `--output json`.
 - [x] Add tests for Express require-only behavior, fs capabilities, and selected-module output.
-- [ ] Update docs/examples and diary as implementation proceeds.
+- [x] Update docs/examples and diary as implementation proceeds.

--- a/ttmp/2026/06/08/XGOJA-RUNTIME-POLISH--polish-xgoja-runtime-ergonomics-for-express-fs-assets-and-module-inventory/tasks.md
+++ b/ttmp/2026/06/08/XGOJA-RUNTIME-POLISH--polish-xgoja-runtime-ergonomics-for-express-fs-assets-and-module-inventory/tasks.md
@@ -4,8 +4,8 @@
 
 - [ ] Make `require("express")` side-effect-light: it must not eagerly bind the HTTP listener merely because the module is required.
 - [ ] Preserve current `run server.js --keep-alive` behavior: route/static registration should still start serving when HTTP is enabled, or an explicit `app.listen()` path should be provided.
-- [ ] Add `fs:assets`/embedded filesystem capability metadata, for example `isReadOnly` and `capabilities()`.
-- [ ] Keep read-only mutation failures unchanged (`EROFS`), but make read-only behavior discoverable from JavaScript and TypeScript docs/declarations.
+- [x] Add `fs:assets`/embedded filesystem capability metadata, for example `isReadOnly` and `capabilities()`.
+- [x] Keep read-only mutation failures unchanged (`EROFS`), but make read-only behavior discoverable from JavaScript and TypeScript docs/declarations.
 - [x] Clarify generated runtime module inventory: distinguish compiled provider catalog from selected runtime aliases.
 - [x] Ensure selected module inventory is a Glazed structured command that supports normal output flags such as `--output json`.
 - [ ] Add tests for Express require-only behavior, fs capabilities, and selected-module output.

--- a/ttmp/2026/06/08/XGOJA-RUNTIME-POLISH--polish-xgoja-runtime-ergonomics-for-express-fs-assets-and-module-inventory/tasks.md
+++ b/ttmp/2026/06/08/XGOJA-RUNTIME-POLISH--polish-xgoja-runtime-ergonomics-for-express-fs-assets-and-module-inventory/tasks.md
@@ -1,0 +1,12 @@
+# Tasks
+
+## Runtime ergonomics polish
+
+- [ ] Make `require("express")` side-effect-light: it must not eagerly bind the HTTP listener merely because the module is required.
+- [ ] Preserve current `run server.js --keep-alive` behavior: route/static registration should still start serving when HTTP is enabled, or an explicit `app.listen()` path should be provided.
+- [ ] Add `fs:assets`/embedded filesystem capability metadata, for example `isReadOnly` and `capabilities()`.
+- [ ] Keep read-only mutation failures unchanged (`EROFS`), but make read-only behavior discoverable from JavaScript and TypeScript docs/declarations.
+- [x] Clarify generated runtime module inventory: distinguish compiled provider catalog from selected runtime aliases.
+- [x] Ensure selected module inventory is a Glazed structured command that supports normal output flags such as `--output json`.
+- [ ] Add tests for Express require-only behavior, fs capabilities, and selected-module output.
+- [ ] Update docs/examples and diary as implementation proceeds.


### PR DESCRIPTION
This change introduces several quality-of-life improvements to the Goja
runtime, focusing on lazy initialization for the Express server, exposing
filesystem capabilities to scripts, and enhancing module introspection via the
CLI.

### Lazy Express Server Initialization

- The `express` module no longer starts the HTTP server immediately upon
  `require('express')`.
- The server is now started lazily on the first call to register a route
  (e.g., `app.get(...)`, `app.static(...)`) or when `app.listen()` is
  explicitly called.
- This prevents unnecessary port binding and provides more intuitive error
  reporting for port conflicts, which now occur at the point of use.

### Filesystem Capabilities

- The `fs` module now exposes its capabilities to the JavaScript runtime,
  allowing scripts to adapt to their environment.
- A new function `fs.capabilities()` returns an object with details about the
  backend (`host`, `embedded`), read/write access, and mount points.
- A new boolean constant, `fs.isReadOnly`, is provided for convenience.

### Module Introspection CLI

- A new `selected-modules` CLI command lists the modules configured for the
  current runtime, including their `require()` alias and static configuration.
- The existing `modules` command has been clarified to list all *available*
  provider modules compiled into the binary, serving as a catalog. This
  distinguishes between available and active modules.