### PR TITLE
Feat: Require explicit `__verb__` metadata for jsverb commands

### DIFF
--- a/cmd/xgoja/doc/06-buildspec-reference.md
+++ b/cmd/xgoja/doc/06-buildspec-reference.md
@@ -227,6 +227,18 @@ jsverbs:
     path: verbs
 ```
 
+When a jsverb command file requires helper modules, include those helper files in the same source. Only functions with explicit `__verb__()` metadata become commands; helper functions remain loader-visible but are not exposed as commands:
+
+```yaml
+jsverbs:
+  - id: local
+    path: verbs
+    include:
+      - site.js
+      - server.js
+      - lib/**/*.js
+```
+
 The resulting generated command shape is `./dist/app serve <package> <verb> --http-listen 127.0.0.1:8787`. The selected verb registers Express routes and the provider-backed command keeps the runtime alive. Development builds can add `--hot-reload` plus optional `--hot-reload-watch-root` and `--hot-reload-smoke-path` flags to reload runtime filesystem jsverb sources with last-known-good fallback. See `examples/xgoja/13-http-serve-jsverbs` and `xgoja help tutorial-http-serve-jsverbs`.
 
 Generated binaries can opt into Glazed-style environment variable parsing with `appName` or `envPrefix`:

--- a/cmd/xgoja/doc/12-tutorial-http-serve-jsverbs.md
+++ b/cmd/xgoja/doc/12-tutorial-http-serve-jsverbs.md
@@ -85,6 +85,20 @@ jsverbs:
     path: verbs
 ```
 
+If the serve verb is a small wrapper that calls `require("./server.js")`, include the helper files too:
+
+```yaml
+jsverbs:
+  - id: local
+    path: verbs
+    include:
+      - site.js
+      - server.js
+      - lib/**/*.js
+```
+
+The helper files stay available to the jsverb `require()` loader, but only functions with explicit `__verb__()` metadata become generated commands.
+
 The single top-level `modules:` list is the module set used by generated commands and provider commands. There is no separate runtime profile selection for this mode.
 
 ## 3. Validate, build, and run

--- a/examples/jsverbs/basic/packaged.js
+++ b/examples/jsverbs/basic/packaged.js
@@ -7,3 +7,7 @@ __package__({
 function ping() {
   return { ok: true };
 }
+
+__verb__("ping", {
+  short: "Ping package metadata demo"
+});

--- a/pkg/doc/10-jsverbs-example-developer-guide.md
+++ b/pkg/doc/10-jsverbs-example-developer-guide.md
@@ -94,10 +94,10 @@ The test fixture directory at `examples/jsverbs/basic` is the shortest path to u
 
 Use it as a map:
 
-- `basics.js` shows public functions, explicit verb metadata, file-local sections, `bind: "all"`, `bind: "context"`, structured output, and text output.
+- `basics.js` shows explicit verb metadata, file-local sections, `bind: "all"`, `bind: "context"`, structured output, and text output.
 - `advanced/numbers.js` shows integer arguments, async results, and rest parameters.
 - `nested/with-helper.js` and `nested/sub/helper.js` show relative `require()` behavior.
-- `packaged.js` shows `__package__` metadata and automatic exposure of public functions.
+- `packaged.js` shows `__package__` metadata plus explicit `__verb__()` command metadata.
 
 The fixture tree is still disk-based because it is meant to be browsed by humans and exercised by the example runner. The package itself is now broader than that. It can also scan a generic `fs.FS` or a raw list of in-memory source files. That matters when you move from “example runner” thinking to “library API” thinking. The fixture tree teaches the metadata format and runtime behavior; it does not define the full list of supported source origins anymore.
 

--- a/pkg/doc/11-jsverbs-example-reference.md
+++ b/pkg/doc/11-jsverbs-example-reference.md
@@ -52,7 +52,6 @@ The example runner uses `ScanDir(...)` plus the default `registry.Commands()` pa
 
 `ScanDir(...)` and `ScanFS(...)` accept `ScanOptions`. Defaults come from `DefaultScanOptions()`:
 
-- `IncludePublicFunctions: true`
 - `Extensions: [".js", ".cjs"]`
 - `FailOnErrorDiagnostics: true`
 - no include/exclude path filters
@@ -78,7 +77,6 @@ Example: scan an application root while ignoring generated assets and build outp
 
 ```go
 registry, err := jsverbs.ScanDir(".", jsverbs.ScanOptions{
-    IncludePublicFunctions: true,
     Extensions:             []string{".js", ".cjs"},
     FailOnErrorDiagnostics: true,
     Include:                []string{"site.js", "jsverbs/**/*.js"},
@@ -88,14 +86,15 @@ registry, err := jsverbs.ScanDir(".", jsverbs.ScanOptions{
 
 Use include/exclude filters when the scan root contains bundled browser assets, generated files, copied dependencies, or other JavaScript that is not intended to declare CLI verbs. Prefer a narrow scan root when possible; filters are the safety valve for application layouts where a narrow root is inconvenient.
 
-Supported function declarations:
+Supported command declarations:
 
-- top-level `function name(...) {}`
-- top-level `const name = (...) => {}`
-- top-level `const name = function(...) {}`
+- top-level `function name(...) {}` with matching `__verb__("name", ...)` metadata
+- top-level `const name = (...) => {}` with matching `__verb__("name", ...)` metadata
+- top-level `const name = function(...) {}` with matching `__verb__("name", ...)` metadata
 
 Ignored for command discovery:
 
+- functions without explicit `__verb__()` metadata
 - nested functions
 - object methods
 - functions whose names start with `_`

--- a/pkg/jsverbs/jsverbs_test.go
+++ b/pkg/jsverbs/jsverbs_test.go
@@ -61,7 +61,6 @@ func TestScanDirIncludeExcludeFilters(t *testing.T) {
 	writeFile("notes.txt", `function ignored() {}`)
 
 	registry, err := ScanDir(dir, ScanOptions{
-		IncludePublicFunctions: true,
 		Extensions:             []string{".js"},
 		FailOnErrorDiagnostics: true,
 		Include:                []string{"*.js", "**/*.js"},
@@ -77,7 +76,6 @@ func TestScanFSIncludeFilters(t *testing.T) {
 		"site.js":                 &fstest.MapFile{Data: []byte(`function start() { return { ok: true }; }`)},
 		"assets/public/bundle.js": &fstest.MapFile{Data: []byte(`function generated() { return { skip: true }; }`)},
 	}, ".", ScanOptions{
-		IncludePublicFunctions: true,
 		Extensions:             []string{"js"},
 		FailOnErrorDiagnostics: true,
 		Include:                []string{"site.js"},
@@ -91,7 +89,6 @@ func TestScanRejectsInvalidFilterGlob(t *testing.T) {
 	_, err := ScanFS(fstest.MapFS{
 		"site.js": &fstest.MapFile{Data: []byte(`function start() { return { ok: true }; }`)},
 	}, ".", ScanOptions{
-		IncludePublicFunctions: true,
 		Extensions:             []string{"js"},
 		FailOnErrorDiagnostics: true,
 		Exclude:                []string{"assets/["},
@@ -261,7 +258,6 @@ __verb__("render", {
 			Data: []byte(`exports.decorate = (prefix, target) => prefix + ":" + target;`),
 		},
 	}, ".", ScanOptions{
-		IncludePublicFunctions: true,
 		Extensions:             []string{".js"},
 		FailOnErrorDiagnostics: true,
 	})
@@ -356,6 +352,8 @@ func TestCommandsFailForObjectParamWithoutBind(t *testing.T) {
 function summarize({ owner }) {
   return { owner };
 }
+
+__verb__("summarize", {});
 `)
 	require.NoError(t, err)
 
@@ -536,7 +534,6 @@ __verb__("render", {
 			Data: []byte(`exports.decorate = (value) => "decorated:" + value;`),
 		},
 	}, ".", ScanOptions{
-		IncludePublicFunctions: true,
 		Extensions:             []string{".js"},
 		FailOnErrorDiagnostics: true,
 	})

--- a/pkg/jsverbs/model.go
+++ b/pkg/jsverbs/model.go
@@ -55,7 +55,6 @@ func (e *ScanError) Error() string {
 }
 
 type ScanOptions struct {
-	IncludePublicFunctions bool
 	Extensions             []string
 	FailOnErrorDiagnostics bool
 	Include                []string
@@ -64,7 +63,6 @@ type ScanOptions struct {
 
 func DefaultScanOptions() ScanOptions {
 	return ScanOptions{
-		IncludePublicFunctions: true,
 		Extensions:             []string{".js", ".cjs"},
 		FailOnErrorDiagnostics: true,
 	}

--- a/pkg/jsverbs/scan.go
+++ b/pkg/jsverbs/scan.go
@@ -348,26 +348,6 @@ func (r *Registry) finalizeVerbs() error {
 				return err
 			}
 		}
-
-		if !r.options.IncludePublicFunctions {
-			continue
-		}
-		for _, fn := range file.Functions {
-			if strings.HasPrefix(fn.Name, "_") {
-				continue
-			}
-			if _, ok := file.VerbMeta[fn.Name]; ok {
-				continue
-			}
-			verb := &VerbSpec{
-				FunctionName: fn.Name,
-				Fields:       map[string]*FieldSpec{},
-				OutputMode:   OutputModeGlaze,
-			}
-			if err := r.finalizeVerb(file, verb); err != nil {
-				return err
-			}
-		}
 	}
 	return nil
 }

--- a/pkg/jsverbscli/command.go
+++ b/pkg/jsverbscli/command.go
@@ -103,7 +103,6 @@ func newCommandWithInvokerFactory(bootstrap jsverbrepos.Bootstrap, invokers Invo
 
 func ScanRepositories(bootstrap jsverbrepos.Bootstrap) ([]ScannedRepository, error) {
 	opts := jsverbs.DefaultScanOptions()
-	opts.IncludePublicFunctions = false
 
 	ret := make([]ScannedRepository, 0, len(bootstrap.Repositories))
 	for _, repo := range bootstrap.Repositories {

--- a/pkg/xgoja/app/command_providers_test.go
+++ b/pkg/xgoja/app/command_providers_test.go
@@ -84,6 +84,36 @@ func TestHostAttachCommandProvidersPassesSelectedModules(t *testing.T) {
 	}
 }
 
+func TestJSVerbSourcesOnlyExposeExplicitVerbsButKeepHelpersLoadable(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "site.js"), []byte(`
+__package__({ name: "site" });
+__verb__("start", { name: "start", short: "Start", output: "text" });
+function start() { return require("./helper.js").helper(); }
+`), 0o644); err != nil {
+		t.Fatalf("write site jsverb: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "helper.js"), []byte(`
+function helper() { return "helper"; }
+function helperThatMustNotBecomeACommand() { return "hidden"; }
+module.exports = { helper };
+`), 0o644); err != nil {
+		t.Fatalf("write helper module: %v", err)
+	}
+
+	registry, err := scanVerbSource(providerapi.NewProviderRegistry(), nil, JSVerbSourceSpec{ID: "local", Path: dir})
+	if err != nil {
+		t.Fatalf("scan source: %v", err)
+	}
+	verbs := registry.Verbs()
+	if len(verbs) != 1 || verbs[0].FullPath() != "site start" {
+		t.Fatalf("verbs = %#v, want only explicit site start", verbs)
+	}
+	if _, err := registry.RequireLoader()("/helper.js"); err != nil {
+		t.Fatalf("registry loader lost helper module: %v", err)
+	}
+}
+
 func TestHostAttachCommandProvidersProvidesJSVerbSources(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "tools.js"), []byte(`

--- a/pkg/xgoja/providers/http/serve_test.go
+++ b/pkg/xgoja/providers/http/serve_test.go
@@ -76,6 +76,93 @@ func TestNewServeCommandSetBuildsVerbCommandsWithHTTPSection(t *testing.T) {
 	}
 }
 
+func TestServeVerbLoadsIncludedHelperModulesWithoutHelperCommands(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "site.js"), []byte(`
+__package__({ name: "site" });
+function start() {
+  const express = require("express");
+  const app = express.app();
+  require("./server.js").register(app);
+}
+__verb__("start", { name: "start", short: "Serve site", output: "text" });
+`), 0o644); err != nil {
+		t.Fatalf("write site.js: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "server.js"), []byte(`
+function register(app) {
+  app.get("/healthz", (_req, res) => res.json({ ok: true, source: "helper" }));
+}
+function helperThatMustNotBecomeACommand() {
+  return "helper";
+}
+module.exports = { register };
+`), 0o644); err != nil {
+		t.Fatalf("write server.js: %v", err)
+	}
+
+	registry, err := jsverbs.ScanDir(dir)
+	if err != nil {
+		t.Fatalf("scan dir: %v", err)
+	}
+	if verbs := registry.Verbs(); len(verbs) != 1 || verbs[0].FullPath() != "site start" {
+		t.Fatalf("verbs = %#v, want only site start", verbs)
+	}
+	set, err := newServeCommandSet(providerapi.CommandSetContext{
+		Name:           "serve",
+		RuntimeFactory: fakeRuntimeFactory{},
+		JSVerbs:        fakeJSVerbSourceSet{registries: []*jsverbs.Registry{registry}},
+	})
+	if err != nil {
+		t.Fatalf("new serve command set: %v", err)
+	}
+	if len(set.Commands) != 1 {
+		t.Fatalf("serve commands = %d, want only the explicit start command", len(set.Commands))
+	}
+
+	providers := providerapi.NewProviderRegistry()
+	if err := Register(providers); err != nil {
+		t.Fatalf("register http provider: %v", err)
+	}
+	capabilities, ok := providers.ResolvePackageCapabilities(PackageID)
+	if !ok || len(capabilities) != 1 {
+		t.Fatalf("http capabilities = %#v", capabilities)
+	}
+	runtimeSpec := &app.RuntimeSpec{Modules: []app.ModuleInstanceSpec{{Package: PackageID, Name: "express", As: "express"}}}
+	factory := app.NewRuntimeFactory(providers, runtimeSpec, app.HostServices{})
+	addr := freeServeTestAddr(t)
+	parsedValues := serveHotReloadTestValues(t, addr, map[string]any{})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		verb, _ := registry.Verb("site start")
+		_, err := serveVerb(ctx, providerapi.CommandSetContext{
+			RuntimeFactory: factory,
+			SelectedModules: []providerapi.ModuleDescriptor{{
+				PackageID:           PackageID,
+				ModuleID:            "express",
+				As:                  "express",
+				PackageCapabilities: capabilities,
+			}},
+		}, registry, verb, parsedValues)
+		done <- err
+	}()
+
+	if body := waitForServeTestBody(t, "http://"+addr+"/healthz", done); !strings.Contains(body, `"source":"helper"`) {
+		t.Fatalf("health body = %s", body)
+	}
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil && !strings.Contains(err.Error(), "context canceled") {
+			t.Fatalf("serve returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("serve did not stop after cancel")
+	}
+}
+
 func TestServeVerbHotReloadServesStatusAndReloadsChangedSource(t *testing.T) {
 	dir := t.TempDir()
 	verbPath := filepath.Join(dir, "sites.js")

--- a/ttmp/2026/06/09/xgoja-jsverbs-loader-only-sources--separate-jsverb-command-discovery-from-require-loader-sources/README.md
+++ b/ttmp/2026/06/09/xgoja-jsverbs-loader-only-sources--separate-jsverb-command-discovery-from-require-loader-sources/README.md
@@ -1,0 +1,21 @@
+# Separate jsverb command discovery from require loader sources
+
+This is the document workspace for ticket xgoja-jsverbs-loader-only-sources.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr doc add --ticket xgoja-jsverbs-loader-only-sources --doc-type design-doc --title "My Design"`
+- Import sources: `docmgr import file --ticket xgoja-jsverbs-loader-only-sources --file /path/to/doc.md`
+- Update metadata: `docmgr meta update --ticket xgoja-jsverbs-loader-only-sources --field Status --value review`

--- a/ttmp/2026/06/09/xgoja-jsverbs-loader-only-sources--separate-jsverb-command-discovery-from-require-loader-sources/changelog.md
+++ b/ttmp/2026/06/09/xgoja-jsverbs-loader-only-sources--separate-jsverb-command-discovery-from-require-loader-sources/changelog.md
@@ -1,0 +1,48 @@
+# Changelog
+
+## 2026-06-09
+
+- Initial workspace created
+
+
+## 2026-06-09
+
+Created implementation guide, task list, and initial diary for exposing explicit-only jsverb discovery in xgoja.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/ttmp/2026/06/09/xgoja-jsverbs-loader-only-sources--separate-jsverb-command-discovery-from-require-loader-sources/design-doc/01-implementation-guide.md — Ticket implementation guide
+- /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/ttmp/2026/06/09/xgoja-jsverbs-loader-only-sources--separate-jsverb-command-discovery-from-require-loader-sources/reference/01-investigation-diary.md — Initial diary entry
+
+
+## 2026-06-09
+
+Implemented clean-break __verb__-only jsverb command discovery and removed public-function compatibility option; targeted xgoja/jsverbs/http tests pass.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/jsverbs/model.go — Removed IncludePublicFunctions scan option
+- /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/jsverbs/scan.go — Removed implicit public-function command discovery
+- /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/xgoja/providers/http/serve_test.go — Regression coverage for helper modules without helper commands
+- /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/ttmp/2026/06/09/xgoja-jsverbs-loader-only-sources--separate-jsverb-command-discovery-from-require-loader-sources/reference/01-investigation-diary.md — Implementation diary step 2
+
+
+## 2026-06-09
+
+Validated ClubMed minitrace-viz with local clean-break xgoja: direct smoke passed and devctl up reached healthy service.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-07/club-meetup-site/ClubMedMeetup/minitrace-viz/xgoja.yaml — Dependent app source includes site/server/lib helper files
+- /home/manuel/workspaces/2026-06-07/club-meetup-site/ClubMedMeetup/scripts/devctl/clubmed.py — devctl launch/build path validated
+
+
+## 2026-06-09
+
+Committed clean-break jsverb metadata implementation as 833edd587db205318cc408464053566d74c11b5f and updated diary with validation.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/jsverbs/scan.go — Commit 833edd5 removes implicit public-function discovery
+- /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/ttmp/2026/06/09/xgoja-jsverbs-loader-only-sources--separate-jsverb-command-discovery-from-require-loader-sources/reference/01-investigation-diary.md — Records commit and validation results
+

--- a/ttmp/2026/06/09/xgoja-jsverbs-loader-only-sources--separate-jsverb-command-discovery-from-require-loader-sources/design-doc/01-implementation-guide.md
+++ b/ttmp/2026/06/09/xgoja-jsverbs-loader-only-sources--separate-jsverb-command-discovery-from-require-loader-sources/design-doc/01-implementation-guide.md
@@ -1,0 +1,132 @@
+---
+Title: Implementation guide
+Ticket: xgoja-jsverbs-loader-only-sources
+Status: active
+Topics:
+    - xgoja
+    - jsverbs
+DocType: design-doc
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - path: /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/cmd/xgoja/internal/buildspec/build_spec.go
+      note: Buildspec JSVerbSourceSpec must not grow compatibility options
+    - path: /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/xgoja/app/runtime_spec.go
+      note: Runtime JSVerbSourceSpec must stay option-free
+    - path: /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/xgoja/app/root.go
+      note: Maps source filters to jsverbs.ScanOptions
+    - path: /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/jsverbs/model.go
+      note: ScanOptions no longer exposes public-function discovery
+    - path: /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/jsverbs/scan.go
+      note: Explicit __verb__ metadata is now the only command discovery path
+    - path: /home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/xgoja/providers/http/serve.go
+      note: HTTP serve consumes registry verbs and registry require loader
+ExternalSources: []
+Summary: "Clean-break implementation guide for making jsverbs/xgoja command discovery explicit: only __verb__ metadata creates commands, while scanned helper files remain require-loader visible."
+LastUpdated: 2026-06-09T01:20:00-04:00
+WhatFor: "Implementation plan for removing implicit public-function command discovery from jsverbs and xgoja."
+WhenToUse: "Use when modifying jsverbs scanning, xgoja jsverb sources, or HTTP serve command-provider module loading."
+---
+
+# Implementation guide
+
+## Executive Summary
+
+`jsverbs` now uses a clean explicit contract: a JavaScript function becomes a command only when the file declares matching `__verb__()` metadata. Top-level public functions are no longer auto-promoted into commands.
+
+This fixes xgoja HTTP serve applications that include normal CommonJS helper files. The scanner can still include `server.js` and `lib/**/*.js` so `Registry.RequireLoader()` can resolve `require("./server.js")`, but helper functions in those files remain helpers unless they have `__verb__()` metadata.
+
+## Problem Statement
+
+Before this change, `jsverbs.ScanOptions` had `IncludePublicFunctions`, defaulted it to `true`, and `scan.go` created implicit commands for every public top-level function. That was convenient for small CLI sketches but unsafe for applications with helper modules.
+
+The failure mode was:
+
+1. `site.js` exposes `__verb__("start", ...)` and calls `require("./server.js")`.
+2. If only `site.js` is scanned, `serve site start` exists but `require("./server.js")` fails because the registry loader does not know `server.js`.
+3. If `server.js` and `lib/**/*.js` are scanned, `require()` can resolve them, but helper functions become unintended commands.
+
+## Proposed Solution
+
+Remove implicit public-function discovery entirely.
+
+The only command declaration model is now:
+
+```js
+function start(options) {
+  require("./server.js");
+}
+
+__verb__("start", {
+  name: "start",
+  short: "Start the site",
+  fields: {
+    options: { bind: "all" }
+  }
+});
+```
+
+The corresponding xgoja source can include helper files without extra options:
+
+```yaml
+jsverbs:
+  - id: site
+    path: .
+    include:
+      - site.js
+      - server.js
+      - lib/**/*.js
+```
+
+## Design Decisions
+
+### Decision 1: No compatibility option
+
+Status: accepted.
+
+The user explicitly requested a clean break: remove the option and backwards-compatibility behavior. Therefore there is no `includePublicFunctions` field and no scanner flag for legacy public-function discovery.
+
+### Decision 2: Keep helper files loader-visible
+
+Status: accepted.
+
+Scanned files are still registered in the `Registry.RequireLoader()` map. The only removed behavior is implicit command creation. This keeps xgoja HTTP serve apps ergonomic without creating a separate loader-only source model yet.
+
+### Decision 3: Update fixtures to declare commands explicitly
+
+Status: accepted.
+
+Any test fixture or example that intends to expose a command must include `__verb__()`. This makes examples match the new contract.
+
+## Implementation Plan
+
+1. Delete `ScanOptions.IncludePublicFunctions` from `pkg/jsverbs/model.go`.
+2. Delete the implicit public-function loop in `pkg/jsverbs/scan.go::finalizeVerbs`.
+3. Remove the transient `includePublicFunctions` field from xgoja buildspec/runtime/provider descriptor structs.
+4. Remove xgoja scan-option wiring for the deleted field.
+5. Add/adjust tests:
+   - explicit commands still work,
+   - helper files remain available through `Registry.RequireLoader()`,
+   - HTTP serve can require a helper module without exposing helper commands.
+6. Update docs to say `__verb__()` metadata is required.
+7. Validate targeted packages and then the ClubMed minitrace-viz runtime path.
+8. Commit code and docs at a coherent interval.
+
+## Validation
+
+Passing targeted validation:
+
+```bash
+go test ./pkg/jsverbs ./pkg/xgoja/app ./cmd/xgoja/internal/... ./pkg/xgoja/providers/http
+```
+
+## Open Questions
+
+- Whether to add a future `loaderInclude`/`verbInclude` split for more precise source modeling. This is not required for the clean-break fix.
+
+## References
+
+- `/home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/jsverbs/model.go`
+- `/home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/jsverbs/scan.go`
+- `/home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/xgoja/app/root.go`
+- `/home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/xgoja/providers/http/serve_test.go`

--- a/ttmp/2026/06/09/xgoja-jsverbs-loader-only-sources--separate-jsverb-command-discovery-from-require-loader-sources/index.md
+++ b/ttmp/2026/06/09/xgoja-jsverbs-loader-only-sources--separate-jsverb-command-discovery-from-require-loader-sources/index.md
@@ -1,0 +1,54 @@
+---
+Title: Separate jsverb command discovery from require loader sources
+Ticket: xgoja-jsverbs-loader-only-sources
+Status: active
+Topics:
+    - xgoja
+    - jsverbs
+DocType: index
+Intent: long-term
+Owners: []
+RelatedFiles: []
+ExternalSources: []
+Summary: ""
+LastUpdated: 2026-06-09T00:49:33.154647803-04:00
+WhatFor: ""
+WhenToUse: ""
+---
+
+# Separate jsverb command discovery from require loader sources
+
+## Overview
+
+<!-- Provide a brief overview of the ticket, its goals, and current status -->
+
+## Key Links
+
+- **Related Files**: See frontmatter RelatedFiles field
+- **External Sources**: See frontmatter ExternalSources field
+
+## Status
+
+Current status: **active**
+
+## Topics
+
+- xgoja
+- jsverbs
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/2026/06/09/xgoja-jsverbs-loader-only-sources--separate-jsverb-command-discovery-from-require-loader-sources/reference/01-investigation-diary.md
+++ b/ttmp/2026/06/09/xgoja-jsverbs-loader-only-sources--separate-jsverb-command-discovery-from-require-loader-sources/reference/01-investigation-diary.md
@@ -1,0 +1,238 @@
+---
+Title: Investigation diary
+Ticket: xgoja-jsverbs-loader-only-sources
+Status: active
+Topics:
+    - xgoja
+    - jsverbs
+DocType: reference
+Intent: long-term
+Owners: []
+RelatedFiles: []
+ExternalSources: []
+Summary: "Chronological implementation diary for separating jsverb command discovery from helper-module require visibility in xgoja."
+LastUpdated: 2026-06-09T00:49:33.733960289-04:00
+WhatFor: "Record implementation decisions, commands, failures, validation, and review notes for this ticket."
+WhenToUse: "Read before resuming work on xgoja jsverb source scanning or HTTP serve helper-module loading."
+---
+
+# Diary
+
+## Goal
+
+Capture the implementation of a small xgoja improvement that lets HTTP serve jsverb applications include CommonJS helper files for `require()` without accidentally exposing every helper function as a CLI command.
+
+## Step 1: Create ticket and pin down the implementation shape
+
+This step turned the ClubMed devctl failure into a focused xgoja task. The central observation is that xgoja already has a scanner-level `IncludePublicFunctions` switch, but the xgoja buildspec/runtime source schema does not expose it.
+
+The chosen first pass is intentionally narrow: add per-source `includePublicFunctions` with default-preserving semantics, then validate it with tests before considering larger `loaderInclude`/`verbInclude` separation.
+
+### Prompt Context
+
+**User prompt (verbatim):** "Ok, create a ticket in `docmgr --root go-go-goja/ttmp/ ...` and a clear concise implementation guide and tasks, and then work on it task by task, keeping a diary as you work, and committing at appropriat eintervals"
+
+**Assistant interpretation:** Create a docmgr ticket under the go-go-goja ticket root, document the design and task list, then implement the xgoja/jsverbs fix incrementally with diary updates and commits.
+
+**Inferred user intent:** Convert the ad-hoc devctl debugging result into a tracked upstream xgoja improvement and complete it carefully enough to unblock the dependent ClubMed app.
+
+**Commit (code):** N/A — planning/docs only so far.
+
+### What I did
+- Created ticket `xgoja-jsverbs-loader-only-sources` under `go-go-goja/ttmp`.
+- Added `design-doc/01-implementation-guide.md`.
+- Added this diary at `reference/01-investigation-diary.md`.
+- Replaced the default `tasks.md` placeholder with a concrete seven-step checklist.
+- Re-read the relevant implementation files:
+  - `/home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/cmd/xgoja/internal/buildspec/build_spec.go`
+  - `/home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/xgoja/app/runtime_spec.go`
+  - `/home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/xgoja/app/root.go`
+  - `/home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/jsverbs/model.go`
+  - `/home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/jsverbs/scan.go`
+  - `/home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/xgoja/providers/http/serve.go`
+
+### Why
+- The ClubMed app needs `site.js` to expose one `start` command while `server.js` and `lib/**/*.js` remain regular modules.
+- xgoja currently has no buildspec knob for this shape even though the underlying jsverbs scanner supports explicit-only discovery.
+
+### What worked
+- `docmgr --root go-go-goja/ttmp ticket create-ticket ...` created the desired workspace.
+- The existing scanner option provides a small implementation path.
+
+### What didn't work
+- Earlier debugging showed that including helper files in `jsverbs.include` caused the scanner to discover many helper functions as public commands.
+- Earlier debugging also showed that including only `site.js` made `require("./server.js")` fail at runtime because `Registry.RequireLoader()` only serves scanned files.
+
+### What I learned
+- The bug is not only an app launch issue; it is an xgoja ergonomics/API issue.
+- The smallest safe fix is option propagation rather than a new loader architecture.
+
+### What was tricky to build
+- The tricky invariant is preserving current jsverbs behavior. `jsverbs.DefaultScanOptions()` enables public function discovery by default, so xgoja must not turn omission into false accidentally.
+- The implementation should likely use a pointer/nullable bool in the xgoja source spec so explicit `false` can be distinguished from an omitted field.
+
+### What warrants a second pair of eyes
+- The exact YAML/JSON field name: `includePublicFunctions` is clear and maps directly to the scanner option, but reviewers should confirm it is the right long-term API name.
+- The generated runtime JSON semantics should be checked so old buildspecs remain unchanged.
+
+### What should be done in the future
+- Consider a larger follow-up with separate `loaderInclude` and command-discovery include globs if explicit-only discovery is insufficient for larger applications.
+
+### Code review instructions
+- Start with the implementation guide, then review `JSVerbSourceSpec` in buildspec/runtime structs and `jsVerbScanOptions`.
+- Validate with targeted tests before exercising generated binaries.
+
+### Technical details
+- Current scanner switch: `jsverbs.ScanOptions.IncludePublicFunctions`.
+- Current default: `jsverbs.DefaultScanOptions().IncludePublicFunctions == true`.
+- Desired xgoja config:
+
+```yaml
+jsverbs:
+  - id: minitrace-viz-site
+    path: .
+    includePublicFunctions: false
+    include:
+      - site.js
+      - server.js
+      - lib/**/*.js
+```
+
+## Step 2: Remove implicit public-function command discovery
+
+This step changed the design from a configurable opt-out to a clean break. The scanner now treats `__verb__()` metadata as the only command declaration mechanism, while scanned helper modules remain available to the jsverb `require()` loader.
+
+The immediate result is simpler than the first-pass option design: xgoja source specs do not need a compatibility field, and application authors do not need to mark helper modules specially. If a function should be a command, it must have matching `__verb__()` metadata.
+
+### Prompt Context
+
+**User prompt (verbatim):** "let's remove the option in its entirety, and only allow __verb__ . remove the options and backwards wrappers and compabitility."
+
+**Assistant interpretation:** Do not add or keep `includePublicFunctions`; remove implicit public-function discovery from jsverbs/xgoja entirely and make explicit `__verb__()` metadata mandatory.
+
+**Inferred user intent:** Prefer a clean, non-legacy API over a backwards-compatible switch, even if existing public-function-only fixtures need to be updated.
+
+**Commit (code):** 833edd587db205318cc408464053566d74c11b5f — "Require explicit jsverb command metadata"
+
+### What I did
+- Removed `ScanOptions.IncludePublicFunctions` from `/home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/jsverbs/model.go`.
+- Removed the implicit public-function verb creation loop from `/home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/jsverbs/scan.go`.
+- Removed transient `includePublicFunctions` schema/descriptor wiring from:
+  - `/home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/cmd/xgoja/internal/buildspec/build_spec.go`
+  - `/home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/xgoja/app/runtime_spec.go`
+  - `/home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/xgoja/providerapi/commands.go`
+  - `/home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/xgoja/app/jsverb_sources.go`
+  - `/home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/xgoja/app/root.go`
+- Updated fixtures/tests so intended commands have explicit `__verb__()` metadata.
+- Added/kept HTTP serve regression coverage in `/home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/xgoja/providers/http/serve_test.go` showing helper functions do not become commands while helper modules remain require-loadable.
+- Updated docs in:
+  - `/home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/cmd/xgoja/doc/06-buildspec-reference.md`
+  - `/home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/cmd/xgoja/doc/12-tutorial-http-serve-jsverbs.md`
+  - `/home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/doc/10-jsverbs-example-developer-guide.md`
+  - `/home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/doc/11-jsverbs-example-reference.md`
+
+### Why
+- Public-function command discovery is convenient for sketches but too surprising for apps with helper modules.
+- The user requested no compatibility wrappers/options, so the final API should have exactly one command declaration mechanism.
+
+### What worked
+- Targeted validation passes:
+
+```bash
+go test ./pkg/jsverbs ./pkg/xgoja/app ./cmd/xgoja/internal/... ./pkg/xgoja/providers/http
+```
+
+- The code commit pre-commit hook also passed full repository lint/generate/test:
+
+```text
+✔️ lint (10.52 seconds)
+✔️ test (45.67 seconds)
+```
+
+- `rg -n "IncludePublicFunctions|includePublicFunctions" -S --glob '!ttmp/**'` returns no active code/doc references.
+
+### What didn't work
+- The first HTTP serve regression test attempt timed out:
+
+```text
+--- FAIL: TestServeVerbLoadsIncludedHelperModulesWithoutHelperCommands (5.05s)
+    serve_test.go:148: timed out waiting for http://127.0.0.1:33719/healthz
+```
+
+- Root cause: the test used a fresh `newHTTPCapability()` in `SelectedModules`, but the Express module loader was registered with the capability instance stored inside the provider registry. Section initialization configured the wrong capability instance.
+- Fix: obtain the provider capability via `providers.ResolvePackageCapabilities(PackageID)` and pass that exact capability slice in `SelectedModules`.
+
+### What I learned
+- The HTTP provider capability stores runtime listener settings per Goja runtime, so tests that manually construct `CommandSetContext.SelectedModules` must use the same capability instance as the provider registry.
+- Removing implicit discovery did not require loader changes because scanned files are still stored in `registry.filesByModule`; only command finalization changed.
+
+### What was tricky to build
+- The main tricky part was separating two facts that used to be coupled: a scanned file is loader-visible, but a scanned function is not automatically a command. The implementation had to remove only the implicit command creation loop while leaving file scanning and `RequireLoader()` untouched.
+- The HTTP regression test also needed realistic command-provider section initialization. Without the correct capability instance, route registration appeared to succeed from JavaScript but no listener was configured on the expected address.
+
+### What warrants a second pair of eyes
+- Confirm the clean break is acceptable for any external users who relied on public-function-only command discovery.
+- Review docs/examples to ensure no remaining prose suggests plain public functions become commands.
+- Review the HTTP test for its manual `CommandSetContext` construction; it mirrors generated-provider behavior but is slightly lower-level than a full generated binary test.
+
+### What should be done in the future
+- Validate the dependent ClubMed `minitrace-viz` devctl path by rebuilding with the local xgoja checkout and scanning `site.js`, `server.js`, and `lib/**/*.js`.
+- Consider a future `loaderInclude`/`verbInclude` split only if explicit `__verb__()` discovery is not enough.
+
+### Code review instructions
+- Start in `/home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/jsverbs/scan.go`, specifically `finalizeVerbs`.
+- Then review `/home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/jsverbs/model.go` to confirm the scanner option is gone.
+- Check `/home/manuel/workspaces/2026-06-07/club-meetup-site/go-go-goja/pkg/xgoja/providers/http/serve_test.go` for the helper-module regression.
+- Validate with:
+
+```bash
+go test ./pkg/jsverbs ./pkg/xgoja/app ./cmd/xgoja/internal/... ./pkg/xgoja/providers/http
+```
+
+### Technical details
+- New discovery rule: scanned top-level functions are only command candidates when a matching `__verb__()` declaration exists.
+- Helper modules are still available through `Registry.RequireLoader()` because scanning still records every included source file in `registry.filesByModule`.
+
+### Validation addendum: ClubMed devctl path
+
+After the targeted go-go-goja tests passed, I rebuilt the dependent ClubMed binary with the local xgoja checkout and the local go-go-goja module replacement:
+
+```bash
+cd ClubMedMeetup/minitrace-viz
+go run ../../go-go-goja/cmd/xgoja build -f xgoja.yaml --xgoja-version v0.8.6 --xgoja-replace "$(cd ../../go-go-goja && pwd)"
+```
+
+The generated command tree contained the intended command only:
+
+```text
+minitrace-viz serve site start
+```
+
+The direct smoke test passed:
+
+```bash
+cd ClubMedMeetup/minitrace-viz
+(lsof -ti tcp:18787 | xargs -r kill || true) && bash test-fixtures/smoke-test.sh
+```
+
+Result:
+
+```text
+=== Results: 6 passed, 0 failed ===
+```
+
+The original devctl path also passed:
+
+```bash
+cd ClubMedMeetup
+(lsof -ti tcp:8787 | xargs -r kill || true) && devctl build && devctl up
+devctl status
+curl -fsS http://127.0.0.1:8787/api/widget/health
+```
+
+Result:
+
+```text
+up complete services=1
+{"service":"minitrace-viz-widget-site","status":"ok"}
+```

--- a/ttmp/2026/06/09/xgoja-jsverbs-loader-only-sources--separate-jsverb-command-discovery-from-require-loader-sources/tasks.md
+++ b/ttmp/2026/06/09/xgoja-jsverbs-loader-only-sources--separate-jsverb-command-discovery-from-require-loader-sources/tasks.md
@@ -1,0 +1,12 @@
+# Tasks
+
+## TODO
+
+- [x] 1. Remove implicit public-function verb discovery from `pkg/jsverbs`.
+- [x] 2. Remove transient `includePublicFunctions` option plumbing from xgoja buildspec/runtime/provider descriptors.
+- [x] 3. Update tests and fixtures so intended commands use explicit `__verb__()` metadata.
+- [x] 4. Add HTTP serve regression coverage proving helper files can be require-loaded without becoming commands.
+- [x] 5. Update xgoja/jsverbs docs to describe `__verb__()`-only discovery.
+- [x] 6. Validate targeted packages.
+- [x] 7. Validate the ClubMed minitrace-viz devctl path against the new xgoja behavior.
+- [x] 8. Commit the code changes and update ticket diary/changelog/relations.


### PR DESCRIPTION
This change simplifies the jsverb loading mechanism by removing the automatic
discovery of public functions as commands. This approach was brittle and made
the contract for exposing commands implicit.

Key changes:

- **Explicit Verb Declaration**: All functions intended to be CLI commands must
  now be explicitly registered using `__verb__()` metadata. The logic for
  automatically exposing all public functions within a `__package__` has been
  removed.

- **Simplified Scanner**: The removal of automatic discovery significantly
  simplifies the verb scanning and loading implementation.

- **New `include` Option**: To support multi-file verbs where one file might
  `require()` helpers from another, a new `include` field has been added to
  the `jsverbs` build configuration. This allows bundling of helper scripts
  without accidentally exposing their functions as commands.

- **Documentation**: All relevant documentation, tutorials, and examples have
  been updated to reflect this new, more explicit approach.