### PR TITLE
feat(http): Add structured request logging

### DIFF
--- a/cmd/xgoja/internal/buildexec/buildexec.go
+++ b/cmd/xgoja/internal/buildexec/buildexec.go
@@ -25,7 +25,7 @@ func GoRun(ctx context.Context, dir string, env map[string]string) (Result, erro
 }
 
 func GoBuild(ctx context.Context, dir string, output string, tags []string, ldflags []string, env map[string]string) (Result, error) {
-	args := []string{"build", "-o", output}
+	args := []string{"build", "-buildvcs=false", "-o", output}
 	if len(tags) > 0 {
 		args = append(args, "-tags", joinSpace(tags))
 	}

--- a/cmd/xgoja/internal/buildexec/buildexec_test.go
+++ b/cmd/xgoja/internal/buildexec/buildexec_test.go
@@ -32,8 +32,8 @@ func TestSortedEnvAndCommandString(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("sortedEnv = %#v, want %#v", got, want)
 	}
-	cmd := commandString(env, "go", []string{"build", "."})
-	if !strings.HasPrefix(cmd, "A=b CGO_LDFLAGS=-L/usr/local/lib -lfaiss go build .") {
+	cmd := commandString(env, "go", []string{"build", "-buildvcs=false", "."})
+	if !strings.HasPrefix(cmd, "A=b CGO_LDFLAGS=-L/usr/local/lib -lfaiss go build -buildvcs=false .") {
 		t.Fatalf("commandString = %q", cmd)
 	}
 }

--- a/cmd/xgoja/internal/generate/generate_test.go
+++ b/cmd/xgoja/internal/generate/generate_test.go
@@ -1093,7 +1093,7 @@ func startGeneratedCommand(t *testing.T, ctx context.Context, buildSpec *buildsp
 		t.Fatalf("go mod tidy: %v\n%s", err, out)
 	}
 	binPath := filepath.Join(dir, "generated-test")
-	cmd = exec.Command("go", "build", "-o", binPath, ".")
+	cmd = exec.Command("go", "build", "-buildvcs=false", "-o", binPath, ".")
 	cmd.Dir = dir
 	cmd.Env = append(os.Environ(), "GOWORK=off")
 	if out, err := cmd.CombinedOutput(); err != nil {

--- a/pkg/gojahttp/access_log.go
+++ b/pkg/gojahttp/access_log.go
@@ -1,0 +1,121 @@
+package gojahttp
+
+import (
+	"bufio"
+	"io"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	zlog "github.com/rs/zerolog/log"
+)
+
+const requestIDHeader = "X-Request-Id"
+
+type accessLogResponseWriter struct {
+	http.ResponseWriter
+	status      int
+	bytes       int64
+	wroteHeader bool
+}
+
+func newAccessLogResponseWriter(w http.ResponseWriter) *accessLogResponseWriter {
+	return &accessLogResponseWriter{ResponseWriter: w, status: http.StatusOK}
+}
+
+func (w *accessLogResponseWriter) WriteHeader(status int) {
+	if w.wroteHeader {
+		return
+	}
+	w.status = status
+	w.wroteHeader = true
+	w.ResponseWriter.WriteHeader(status)
+}
+
+func (w *accessLogResponseWriter) Write(p []byte) (int, error) {
+	if !w.wroteHeader {
+		w.WriteHeader(http.StatusOK)
+	}
+	n, err := w.ResponseWriter.Write(p)
+	w.bytes += int64(n)
+	return n, err
+}
+
+func (w *accessLogResponseWriter) Flush() {
+	if flusher, ok := w.ResponseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
+func (w *accessLogResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	hijacker, ok := w.ResponseWriter.(http.Hijacker)
+	if !ok {
+		return nil, nil, http.ErrNotSupported
+	}
+	return hijacker.Hijack()
+}
+
+func (w *accessLogResponseWriter) ReadFrom(r io.Reader) (int64, error) {
+	if !w.wroteHeader {
+		w.WriteHeader(http.StatusOK)
+	}
+	if readerFrom, ok := w.ResponseWriter.(io.ReaderFrom); ok {
+		n, err := readerFrom.ReadFrom(r)
+		w.bytes += n
+		return n, err
+	}
+	n, err := io.Copy(w.ResponseWriter, r)
+	w.bytes += n
+	return n, err
+}
+
+func (w *accessLogResponseWriter) Push(target string, opts *http.PushOptions) error {
+	pusher, ok := w.ResponseWriter.(http.Pusher)
+	if !ok {
+		return http.ErrNotSupported
+	}
+	return pusher.Push(target, opts)
+}
+
+func (w *accessLogResponseWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}
+
+func ensureRequestID(w http.ResponseWriter, r *http.Request) string {
+	requestID := r.Header.Get(requestIDHeader)
+	if requestID == "" {
+		requestID = uuid.NewString()
+	}
+	w.Header().Set(requestIDHeader, requestID)
+	return requestID
+}
+
+func requestLogger(r *http.Request, requestID string) zerolog.Logger {
+	return zlog.With().
+		Str("component", "gojahttp").
+		Str("request_id", requestID).
+		Str("method", r.Method).
+		Str("path", r.URL.Path).
+		Str("query", r.URL.RawQuery).
+		Str("remote_addr", r.RemoteAddr).
+		Str("user_agent", r.UserAgent()).
+		Int64("request_content_length", r.ContentLength).
+		Logger()
+}
+
+func logRequestDone(logger zerolog.Logger, rw *accessLogResponseWriter, started time.Time) {
+	event := logger.Info()
+	if rw.status >= 500 {
+		event = logger.Error()
+	} else if rw.status >= 400 {
+		event = logger.Warn()
+	}
+	event.
+		Str("event", "http_request_completed").
+		Int("status", rw.status).
+		Int64("response_bytes", rw.bytes).
+		Dur("duration", time.Since(started)).
+		Msg("http request completed")
+}

--- a/pkg/gojahttp/access_log.go
+++ b/pkg/gojahttp/access_log.go
@@ -21,8 +21,9 @@ type accessLogResponseWriter struct {
 	wroteHeader bool
 }
 
-func newAccessLogResponseWriter(w http.ResponseWriter) *accessLogResponseWriter {
-	return &accessLogResponseWriter{ResponseWriter: w, status: http.StatusOK}
+func newAccessLogResponseWriter(w http.ResponseWriter) (*accessLogResponseWriter, http.ResponseWriter) {
+	logger := &accessLogResponseWriter{ResponseWriter: w, status: http.StatusOK}
+	return logger, accessLogOptionalInterfaces(logger, w)
 }
 
 func (w *accessLogResponseWriter) WriteHeader(status int) {
@@ -43,40 +44,137 @@ func (w *accessLogResponseWriter) Write(p []byte) (int, error) {
 	return n, err
 }
 
-func (w *accessLogResponseWriter) Flush() {
-	if flusher, ok := w.ResponseWriter.(http.Flusher); ok {
-		flusher.Flush()
-	}
+type accessLogFlusher struct{ *accessLogResponseWriter }
+
+type accessLogHijacker struct{ *accessLogResponseWriter }
+
+type accessLogReaderFrom struct{ *accessLogResponseWriter }
+
+type accessLogPusher struct{ *accessLogResponseWriter }
+
+func (w accessLogFlusher) Flush() {
+	w.ResponseWriter.(http.Flusher).Flush()
 }
 
-func (w *accessLogResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
-	hijacker, ok := w.ResponseWriter.(http.Hijacker)
-	if !ok {
-		return nil, nil, http.ErrNotSupported
-	}
-	return hijacker.Hijack()
+func (w accessLogHijacker) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return w.ResponseWriter.(http.Hijacker).Hijack()
 }
 
-func (w *accessLogResponseWriter) ReadFrom(r io.Reader) (int64, error) {
+func (w accessLogReaderFrom) ReadFrom(r io.Reader) (int64, error) {
 	if !w.wroteHeader {
 		w.WriteHeader(http.StatusOK)
 	}
-	if readerFrom, ok := w.ResponseWriter.(io.ReaderFrom); ok {
-		n, err := readerFrom.ReadFrom(r)
-		w.bytes += n
-		return n, err
-	}
-	n, err := io.Copy(w.ResponseWriter, r)
+	n, err := w.ResponseWriter.(io.ReaderFrom).ReadFrom(r)
 	w.bytes += n
 	return n, err
 }
 
-func (w *accessLogResponseWriter) Push(target string, opts *http.PushOptions) error {
-	pusher, ok := w.ResponseWriter.(http.Pusher)
-	if !ok {
-		return http.ErrNotSupported
+func (w accessLogPusher) Push(target string, opts *http.PushOptions) error {
+	return w.ResponseWriter.(http.Pusher).Push(target, opts)
+}
+
+func accessLogOptionalInterfaces(logger *accessLogResponseWriter, underlying http.ResponseWriter) http.ResponseWriter {
+	_, flusher := underlying.(http.Flusher)
+	_, hijacker := underlying.(http.Hijacker)
+	_, readerFrom := underlying.(io.ReaderFrom)
+	_, pusher := underlying.(http.Pusher)
+
+	switch {
+	case flusher && hijacker && readerFrom && pusher:
+		return struct {
+			*accessLogResponseWriter
+			accessLogFlusher
+			accessLogHijacker
+			accessLogReaderFrom
+			accessLogPusher
+		}{logger, accessLogFlusher{logger}, accessLogHijacker{logger}, accessLogReaderFrom{logger}, accessLogPusher{logger}}
+	case flusher && hijacker && readerFrom:
+		return struct {
+			*accessLogResponseWriter
+			accessLogFlusher
+			accessLogHijacker
+			accessLogReaderFrom
+		}{logger, accessLogFlusher{logger}, accessLogHijacker{logger}, accessLogReaderFrom{logger}}
+	case flusher && hijacker && pusher:
+		return struct {
+			*accessLogResponseWriter
+			accessLogFlusher
+			accessLogHijacker
+			accessLogPusher
+		}{logger, accessLogFlusher{logger}, accessLogHijacker{logger}, accessLogPusher{logger}}
+	case flusher && readerFrom && pusher:
+		return struct {
+			*accessLogResponseWriter
+			accessLogFlusher
+			accessLogReaderFrom
+			accessLogPusher
+		}{logger, accessLogFlusher{logger}, accessLogReaderFrom{logger}, accessLogPusher{logger}}
+	case hijacker && readerFrom && pusher:
+		return struct {
+			*accessLogResponseWriter
+			accessLogHijacker
+			accessLogReaderFrom
+			accessLogPusher
+		}{logger, accessLogHijacker{logger}, accessLogReaderFrom{logger}, accessLogPusher{logger}}
+	case flusher && hijacker:
+		return struct {
+			*accessLogResponseWriter
+			accessLogFlusher
+			accessLogHijacker
+		}{logger, accessLogFlusher{logger}, accessLogHijacker{logger}}
+	case flusher && readerFrom:
+		return struct {
+			*accessLogResponseWriter
+			accessLogFlusher
+			accessLogReaderFrom
+		}{logger, accessLogFlusher{logger}, accessLogReaderFrom{logger}}
+	case flusher && pusher:
+		return struct {
+			*accessLogResponseWriter
+			accessLogFlusher
+			accessLogPusher
+		}{logger, accessLogFlusher{logger}, accessLogPusher{logger}}
+	case hijacker && readerFrom:
+		return struct {
+			*accessLogResponseWriter
+			accessLogHijacker
+			accessLogReaderFrom
+		}{logger, accessLogHijacker{logger}, accessLogReaderFrom{logger}}
+	case hijacker && pusher:
+		return struct {
+			*accessLogResponseWriter
+			accessLogHijacker
+			accessLogPusher
+		}{logger, accessLogHijacker{logger}, accessLogPusher{logger}}
+	case readerFrom && pusher:
+		return struct {
+			*accessLogResponseWriter
+			accessLogReaderFrom
+			accessLogPusher
+		}{logger, accessLogReaderFrom{logger}, accessLogPusher{logger}}
+	case flusher:
+		return struct {
+			*accessLogResponseWriter
+			accessLogFlusher
+		}{logger, accessLogFlusher{logger}}
+	case hijacker:
+		return struct {
+			*accessLogResponseWriter
+			accessLogHijacker
+		}{logger, accessLogHijacker{logger}}
+	case readerFrom:
+		return struct {
+			*accessLogResponseWriter
+			accessLogReaderFrom
+		}{logger, accessLogReaderFrom{logger}}
+	case pusher:
+		return struct {
+			*accessLogResponseWriter
+			accessLogPusher
+		}{logger, accessLogPusher{logger}}
+	default:
+		return logger
 	}
-	return pusher.Push(target, opts)
 }
 
 func (w *accessLogResponseWriter) Unwrap() http.ResponseWriter {

--- a/pkg/gojahttp/access_log_test.go
+++ b/pkg/gojahttp/access_log_test.go
@@ -1,0 +1,116 @@
+package gojahttp
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+)
+
+type accessLogTestResponseWriter struct {
+	header http.Header
+	body   bytes.Buffer
+	status int
+}
+
+func (w *accessLogTestResponseWriter) Header() http.Header {
+	if w.header == nil {
+		w.header = make(http.Header)
+	}
+	return w.header
+}
+
+func (w *accessLogTestResponseWriter) Write(p []byte) (int, error) {
+	return w.body.Write(p)
+}
+
+func (w *accessLogTestResponseWriter) WriteHeader(status int) {
+	w.status = status
+}
+
+type accessLogTestFlusher struct {
+	*accessLogTestResponseWriter
+	flushed bool
+}
+
+func (w *accessLogTestFlusher) Flush() {
+	w.flushed = true
+}
+
+type accessLogTestReaderFrom struct {
+	*accessLogTestResponseWriter
+}
+
+func (w *accessLogTestReaderFrom) ReadFrom(r io.Reader) (int64, error) {
+	return w.body.ReadFrom(r)
+}
+
+func TestAccessLogResponseWriterDoesNotInventOptionalInterfaces(t *testing.T) {
+	_, wrapped := newAccessLogResponseWriter(&accessLogTestResponseWriter{})
+
+	if _, ok := wrapped.(http.Flusher); ok {
+		t.Fatalf("wrapped writer unexpectedly implements http.Flusher")
+	}
+	if _, ok := wrapped.(http.Hijacker); ok {
+		t.Fatalf("wrapped writer unexpectedly implements http.Hijacker")
+	}
+	if _, ok := wrapped.(http.Pusher); ok {
+		t.Fatalf("wrapped writer unexpectedly implements http.Pusher")
+	}
+	if _, ok := wrapped.(io.ReaderFrom); ok {
+		t.Fatalf("wrapped writer unexpectedly implements io.ReaderFrom")
+	}
+}
+
+func TestHostStaticHandlerDoesNotSeeInventedFlusher(t *testing.T) {
+	host := NewHost(HostOptions{})
+	var sawFlusher bool
+	host.RegisterStaticHandler("/", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, sawFlusher = w.(http.Flusher)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	req, err := http.NewRequest(http.MethodGet, "/events", nil)
+	if err != nil {
+		t.Fatalf("NewRequest returned error: %v", err)
+	}
+	host.ServeHTTP(&accessLogTestResponseWriter{}, req)
+
+	if sawFlusher {
+		t.Fatalf("static handler saw http.Flusher even though the underlying writer does not support it")
+	}
+}
+
+func TestAccessLogResponseWriterPreservesFlusherWhenUnderlyingSupportsIt(t *testing.T) {
+	underlying := &accessLogTestFlusher{accessLogTestResponseWriter: &accessLogTestResponseWriter{}}
+	_, wrapped := newAccessLogResponseWriter(underlying)
+
+	flusher, ok := wrapped.(http.Flusher)
+	if !ok {
+		t.Fatalf("wrapped writer does not implement http.Flusher")
+	}
+	flusher.Flush()
+	if !underlying.flushed {
+		t.Fatalf("Flush was not forwarded to the underlying writer")
+	}
+}
+
+func TestAccessLogResponseWriterPreservesReaderFromAndCountsBytes(t *testing.T) {
+	underlying := &accessLogTestReaderFrom{accessLogTestResponseWriter: &accessLogTestResponseWriter{}}
+	logger, wrapped := newAccessLogResponseWriter(underlying)
+
+	readerFrom, ok := wrapped.(io.ReaderFrom)
+	if !ok {
+		t.Fatalf("wrapped writer does not implement io.ReaderFrom")
+	}
+	n, err := readerFrom.ReadFrom(bytes.NewBufferString("hello"))
+	if err != nil {
+		t.Fatalf("ReadFrom returned error: %v", err)
+	}
+	if n != 5 || logger.bytes != 5 {
+		t.Fatalf("ReadFrom bytes = %d, logger bytes = %d; want 5 and 5", n, logger.bytes)
+	}
+	if logger.status != http.StatusOK || !logger.wroteHeader {
+		t.Fatalf("ReadFrom did not record implicit status: status=%d wroteHeader=%v", logger.status, logger.wroteHeader)
+	}
+}

--- a/pkg/gojahttp/host.go
+++ b/pkg/gojahttp/host.go
@@ -96,9 +96,9 @@ func (h *Host) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	requestID := ensureRequestID(w, r)
 	logger := requestLogger(r, requestID)
 	logger.Info().Str("event", "http_request_started").Msg("http request started")
-	loggingWriter := newAccessLogResponseWriter(w)
+	loggingWriter, wrappedWriter := newAccessLogResponseWriter(w)
 	defer logRequestDone(logger, loggingWriter, started)
-	w = loggingWriter
+	w = wrappedWriter
 
 	for _, mount := range h.static {
 		if staticMountMatches(mount.Prefix, r.URL.Path) {

--- a/pkg/gojahttp/host.go
+++ b/pkg/gojahttp/host.go
@@ -92,6 +92,14 @@ func staticMountExcluded(excludePrefixes []string, requestPath string) bool {
 }
 
 func (h *Host) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	started := time.Now()
+	requestID := ensureRequestID(w, r)
+	logger := requestLogger(r, requestID)
+	logger.Info().Str("event", "http_request_started").Msg("http request started")
+	loggingWriter := newAccessLogResponseWriter(w)
+	defer logRequestDone(logger, loggingWriter, started)
+	w = loggingWriter
+
 	for _, mount := range h.static {
 		if staticMountMatches(mount.Prefix, r.URL.Path) {
 			if staticMountExcluded(mount.ExcludePrefixes, r.URL.Path) {
@@ -141,6 +149,9 @@ func (h *Host) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if promise, ok := ret.(*goja.Promise); ok {
 			err = h.awaitAndFinishPromise(r.Context(), res, promise)
 		}
+	}
+	if err != nil {
+		logger.Error().Err(err).Str("event", "http_handler_error").Msg("http handler error")
 	}
 	if err != nil && !res.Sent() {
 		if h.dev {

--- a/pkg/gojahttp/request_response.go
+++ b/pkg/gojahttp/request_response.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -150,14 +151,22 @@ func (r *Response) HTML(vm *goja.Runtime, v goja.Value) error {
 }
 
 func (r *Response) JSON(vm *goja.Runtime, v goja.Value) error {
+	payload, err := json.Marshal(v.Export())
+	if err != nil {
+		return err
+	}
+	payload = append(payload, '\n')
+
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.sent {
 		return nil
 	}
-	r.w.Header().Set("Content-Type", "application/json")
+	r.headers["Content-Type"] = "application/json"
+	r.headers["Content-Length"] = strconv.Itoa(len(payload))
 	r.applyLocked()
-	return json.NewEncoder(r.w).Encode(v.Export())
+	_, err = r.w.Write(payload)
+	return err
 }
 
 func (r *Response) writeString(s string) error {
@@ -169,13 +178,15 @@ func (r *Response) writeString(s string) error {
 	if r.headers["Content-Type"] == "" {
 		trim := strings.TrimSpace(s)
 		if strings.HasPrefix(trim, "<") {
-			r.w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			r.headers["Content-Type"] = "text/html; charset=utf-8"
 		} else {
-			r.w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			r.headers["Content-Type"] = "text/plain; charset=utf-8"
 		}
 	}
+	payload := []byte(s)
+	r.headers["Content-Length"] = strconv.Itoa(len(payload))
 	r.applyLocked()
-	_, err := r.w.Write([]byte(s))
+	_, err := r.w.Write(payload)
 	return err
 }
 


### PR DESCRIPTION
This change introduces structured, `zerolog`-based logging for all incoming HTTP
requests handled by `gojahttp`. This provides improved observability and makes
debugging and monitoring significantly easier.

Key features of the new logging middleware:

- **Request ID:** Injects a unique `X-Request-Id` header into every request/response
  pair for easier tracing. It will use an existing header value if provided.
- **Lifecycle Events:** Logs distinct events for the start and completion of each
  request.
- **Performance Metrics:** The completion log includes the final `status` code,
  total `duration`, and `response_bytes`.
- **Status-based Log Levels:** Automatically adjusts the log level for the
  completion event: `WARN` for 4xx status codes and `ERROR` for 5xx.
- **Handler Error Logging:** Captures and logs errors that occur within the
  JavaScript handler.

To support accurate response size logging, `Content-Length` headers are now
explicitly set for JSON and plain text responses.