### PR TITLE
Feat(xgoja): Replace runtime spec with v2-native runtime plan

### DIFF
--- a/cmd/xgoja/doc/01-overview.md
+++ b/cmd/xgoja/doc/01-overview.md
@@ -17,7 +17,7 @@ ShowPerDefault: true
 SectionType: Application
 ---
 
-`xgoja` builds custom goja-powered command-line programs by generating a normal Go program and compiling it with the Go toolchain. The generated program imports selected provider packages, registers their native modules, embeds a normalized runtime specification, and exposes commands such as the configured `eval` command, `run`, rich `repl`, `modules`, and configured JavaScript verbs.
+`xgoja` builds custom goja-powered command-line programs by generating a normal Go program and compiling it with the Go toolchain. The generated program imports selected provider packages, registers their native modules, embeds a v2-native `app.RuntimePlan`, and exposes commands such as `eval`, `run`, rich `repl`, `modules`, configured JavaScript verbs, and provider command sets.
 
 The design is intentionally compile-time oriented. Go-backed native modules are selected before the generated binary is built. JavaScript code can still be loaded at runtime or embedded into the generated binary, but the Go packages that implement native `require()` modules are ordinary Go imports in the generated source.
 
@@ -25,16 +25,16 @@ The design is intentionally compile-time oriented. Go-backed native modules are 
 
 The build has two separate decisions.
 
-1. **Build-time package selection** decides which provider packages are compiled into the binary.
-2. **Module set selection** decides which compiled-in modules are available to one command invocation.
+1. **Build-time provider selection** decides which provider packages are compiled into the binary.
+2. **Runtime plan selection** decides which compiled-in modules, sources, commands, and artifacts are active.
 
-A provider package contributes named modules and optional JavaScript verb sources. A top-level `modules` selects provider modules by package ID and module name, then assigns the `require()` alias used by JavaScript.
+A provider package contributes named modules, optional command sets, and optional source descriptors. `runtime.modules` selects provider modules by provider ID and module name, then assigns the `require()` alias used by JavaScript. `commands[]` selects built-in command surfaces and provider command sets.
 
 ```text
 xgoja.yaml
   -> generated go.mod + main.go
   -> provider Register functions
-  -> embedded runtime spec
+  -> embedded app.RuntimePlan
   -> go build
   -> generated binary
   -> module set
@@ -51,23 +51,26 @@ func Register(registry *providerapi.ProviderRegistry) error {
         providerapi.Module{
             Name:      "hello",
             DefaultAs: "hello",
-            New:       newHelloModule,
+            NewModuleFactory: func(ctx providerapi.ModuleSetupContext) (require.ModuleLoader, error) {
+                return newHelloModule(ctx)
+            },
         },
     )
 }
 ```
 
-The generated program imports this package and calls the registration function at startup. If the package is not listed in `packages:`, it is not part of the generated binary.
+The generated program imports this package and calls the registration function at startup. If the package is not listed in `providers:`, it is not part of the generated binary.
 
 ## Module selections
 
-A module set lists the modules that should be registered for a command invocation.
+The runtime module list selects the modules that should be registered for runtime-backed command invocations.
 
 ```yaml
-modules:
-  - package: fixture
-    name: hello
-    as: hello
+runtime:
+  modules:
+    - provider: fixture
+      name: hello
+      as: hello
 ```
 
 The `as` field controls the JavaScript module name:
@@ -76,17 +79,17 @@ The `as` field controls the JavaScript module name:
 const hello = require("hello")
 ```
 
-The top-level module list makes the JavaScript capability surface explicit. A provider package can be compiled into the binary without exposing every module it registers; only modules listed in `modules` are registered for generated runtime-backed commands.
+The runtime module list makes the JavaScript capability surface explicit. A provider package can be compiled into the binary without exposing every module it registers; only modules listed in `runtime.modules` are registered for generated runtime-backed commands.
 
 ## Generated commands
 
 A pure xgoja generated binary currently provides these command families:
 
-- the configured `commands.eval.name` command evaluates a JavaScript string in a generated module set.
-- the configured `commands.run.name` command executes a JavaScript file with script-local module resolution.
-- the configured `commands.repl.name` command starts an interactive Bubble Tea REPL for a generated module set.
+- a `commands[]` entry with `type: builtin.eval` evaluates a JavaScript string in the generated runtime.
+- a `commands[]` entry with `type: builtin.run` executes a JavaScript file with script-local module resolution.
+- a `commands[]` entry with `type: builtin.repl` starts an interactive Bubble Tea REPL for the generated runtime.
 - `modules` lists provider modules registered in the binary.
-- the configured `jsverbs` command mounts JavaScript functions as Glazed/Cobra commands when enabled.
+- a `commands[]` entry with `type: builtin.jsverbs` mounts JavaScript functions as Glazed/Cobra commands.
 
 Provider packages can also contribute command families. For example, the HTTP provider can mount `serve` commands that run JavaScript verbs as long-lived Express site setup functions.
 

--- a/cmd/xgoja/doc/02-user-guide.md
+++ b/cmd/xgoja/doc/02-user-guide.md
@@ -30,6 +30,8 @@ SectionType: GeneralTopic
 
 `xgoja.yaml` is now a native `schema: xgoja/v2` document. The v2 schema is an intent-level runtime compiler input: it selects Go provider packages, chooses runtime modules, describes source sets, exposes command surfaces, and declares generated artifacts.
 
+Generated binaries and runtime packages embed a v2-native `app.RuntimePlan` with schema `xgoja/runtime/v2`. That runtime plan contains `providers`, `runtime.modules`, unified `sources`, `commands`, and `artifacts`; it does not use the old generated runtime bridge shape.
+
 Legacy v1 specs are accepted only by `xgoja migrate-spec`. Normal commands such as `doctor`, `build`, `generate`, `gen-dts`, and `list-modules` expect `schema: xgoja/v2`.
 
 ## Minimal v2 spec
@@ -170,6 +172,8 @@ commands:
     sources: [verbs]
 ```
 
+`commands[].sources` is command-scoped. Providers receive a `SourceRegistry` containing only the selected source IDs for that command. For example, HTTP `serve` scans and hot-reloads only the jsverb sources listed on its command, not every jsverb source in the generated application.
+
 A provider command set is different from a runtime module. A runtime module makes a Go-backed CommonJS module available to JavaScript through `require(...)` or an externalized TypeScript import. A provider command set contributes one or more user-facing CLI commands. The HTTP provider commonly contributes both: the `express` runtime module and the `serve` command set.
 
 For an HTTP application, the usual shape is:
@@ -220,7 +224,7 @@ artifacts:
     sources: [verbs, docs]
 ```
 
-When a binary/runtime-package/source/template-style artifact lists jsverb or help source IDs in `sources`, xgoja copies those local source sets into the generated embedded filesystem.
+When a binary/runtime-package/source/template-style artifact lists jsverb or help source IDs in `sources`, xgoja copies those local source sets into the generated embedded filesystem and records them as v2 `sources[]` entries in the embedded runtime plan.
 
 Static assets use a separate artifact:
 

--- a/cmd/xgoja/doc/10-migrating-xgoja-provider-engine-api.md
+++ b/cmd/xgoja/doc/10-migrating-xgoja-provider-engine-api.md
@@ -36,7 +36,7 @@ Use this page when updating code written against the older xgoja provider API or
 | `providerapi.RuntimeHandle` | `providerapi.RuntimeInitializerHandle` |
 | `RuntimeInitializerHandle.Runtime()` | `RuntimeInitializerHandle.EngineRuntime()` |
 | `CommandSetProvider.New` | `CommandSetProvider.NewCommandSet` |
-| `app.Spec` | `app.RuntimeSpec` |
+| `app.Spec` / `app.RuntimeSpec` | `app.RuntimePlan` |
 
 Removed aliases:
 
@@ -89,13 +89,13 @@ providerapi.Module{
 }
 ```
 
-Decode embedded runtime specs in generated or generated-like binaries:
+Decode embedded runtime plans in generated or generated-like binaries:
 
 ```go
-func decodeSpec() *app.RuntimeSpec {
-    spec := &app.RuntimeSpec{}
-    must(json.Unmarshal([]byte(embeddedSpecJSON), spec))
-    return spec
+func decodeRuntimePlan() *app.RuntimePlan {
+    runtimePlan := &app.RuntimePlan{}
+    must(json.Unmarshal([]byte(embeddedRuntimePlanJSON), runtimePlan))
+    return runtimePlan
 }
 ```
 
@@ -159,7 +159,7 @@ If workspace mode passes but `GOWORK=off` fails, inspect the relevant `go.mod`. 
 | `undefined: providerapi.ProviderRegistry` after migrating source | The module still depends on an older `go-go-goja` release. | Upgrade `github.com/go-go-golems/go-go-goja` in the active `go.mod`; check nested generated command modules too. |
 | `unknown field New in struct literal of type providerapi.Module` | `providerapi.Module.New` was renamed. | Use `NewModuleFactory: func(providerapi.ModuleSetupContext) (require.ModuleLoader, error) { ... }`. |
 | `undefined: providerapi.ModuleContext` | Module setup context was renamed. | Use `providerapi.ModuleSetupContext`. |
-| `undefined: app.Spec` | Generated or generated-like xgoja source still references the old runtime spec DTO. | Use `app.RuntimeSpec`, or regenerate the binary with the current xgoja generator. |
+| `undefined: app.Spec` or `undefined: app.RuntimeSpec` | Generated or generated-like xgoja source still references an old runtime DTO. | Use `app.RuntimePlan`, or regenerate the binary with the current xgoja generator. |
 | `provider.New undefined` | `CommandSetProvider.New` was renamed. | Use `provider.NewCommandSet`. |
 | `handle.Runtime undefined` | Runtime initializer handles now expose the engine runtime explicitly. | Use `handle.EngineRuntime()` and then `.VM` for the raw Goja VM. |
 | `RuntimeCloserRegistry` is missing | Cleanup registration moved onto `engine.Runtime`. | Use `handle.EngineRuntime().AddCloser(...)`. |

--- a/cmd/xgoja/doc/11-provider-runtime-config-and-host-services.md
+++ b/cmd/xgoja/doc/11-provider-runtime-config-and-host-services.md
@@ -24,6 +24,8 @@ The second phase is provider module setup. A selected module receives `providera
 
 Use this page when a provider needs parsed command/config/env values before `Module.NewModuleFactory` runs, or when a provider package needs to contribute Go services such as tool registries, middleware factories, stores, event sinks, clients, caches, or other runtime-owned objects.
 
+Generated hosts are driven by a v2-native `app.RuntimePlan`. Provider-facing command code receives the selected module descriptors and a command-scoped `providerapi.SourceRegistry`; it should not inspect generated JSON directly or assume all application sources are visible.
+
 ## The runtime construction sequence
 
 For generated commands, xgoja constructs a runtime in this order:
@@ -321,6 +323,40 @@ mux.HandleFunc("GET /ws/rooms/{roomID}", func(w http.ResponseWriter, r *http.Req
 ```
 
 This is especially important for WebSocket servers, where the Go handler normally owns upgrade behavior, origin checks, subprotocol negotiation, and transport-specific routing.
+
+## Command-scoped source registry
+
+Provider command sets receive `providerapi.CommandSetContext`. The important v2 fields are:
+
+```go
+type CommandSetContext struct {
+    ID              string
+    Provider        string
+    Name            string
+    Mount           string
+    Config          map[string]any
+    SelectedModules []ModuleDescriptor
+    Sources         SourceRegistry
+    RuntimeFactory  RuntimeFactory
+}
+```
+
+`Sources` is scoped to the command's `commands[].sources` list. A provider command should use it as the source of truth:
+
+```go
+func newCommandSet(ctx providerapi.CommandSetContext) (*providerapi.CommandSet, error) {
+    jsverbSources := ctx.Sources.JSVerbs()
+    registries, err := jsverbSources.ScanAllJSVerbSources()
+    if err != nil {
+        return nil, err
+    }
+    // Build commands from the scoped registries only.
+}
+```
+
+For HTTP `serve`, this means both the initial verb discovery and hot reload watch roots are limited to the source IDs declared on the `serve` command. If a provider needs help or asset sources, use `ctx.Sources.ListSourcesByKind(...)` or `ctx.Sources.SourceByID(...)` rather than scanning global runtime metadata.
+
+`ctx.JSVerbs` is a transition adapter for older providers. New provider code should use `ctx.Sources` directly.
 
 ## Reading host services during module setup
 

--- a/cmd/xgoja/doc/11-provider-runtime-config-and-host-services.md
+++ b/cmd/xgoja/doc/11-provider-runtime-config-and-host-services.md
@@ -356,8 +356,6 @@ func newCommandSet(ctx providerapi.CommandSetContext) (*providerapi.CommandSet, 
 
 For HTTP `serve`, this means both the initial verb discovery and hot reload watch roots are limited to the source IDs declared on the `serve` command. If a provider needs help or asset sources, use `ctx.Sources.ListSourcesByKind(...)` or `ctx.Sources.SourceByID(...)` rather than scanning global runtime metadata.
 
-`ctx.JSVerbs` is a transition adapter for older providers. New provider code should use `ctx.Sources` directly.
-
 ## Reading host services during module setup
 
 Provider modules read contributed services from `ModuleSetupContext.Host` by asserting `providerapi.HostServiceLookup`.

--- a/cmd/xgoja/doc/15-tutorial-protobuf-builder-provider.md
+++ b/cmd/xgoja/doc/15-tutorial-protobuf-builder-provider.md
@@ -132,6 +132,8 @@ Once a provider package registers the module, xgoja projects select it like any 
 
 ```yaml
 schema: xgoja/v2
+workspace:
+  mode: auto
 providers:
   - id: protobuf-builder-example
     import: github.com/go-go-golems/go-go-goja/examples/xgoja/15-protobuf-builder-provider/provider
@@ -154,6 +156,8 @@ runtime:
 ```
 
 If you use an alias, scripts should call `require("pb:tasks")`, and generated TypeScript declarations should also use the alias.
+
+Prefer `workspace.mode: auto` for local provider examples that live in a repository with a `go.work` file. That lets xgoja derive local module replacements from the workspace plan instead of requiring every provider entry to carry a hand-written `module.replace` path.
 
 ## 4. Write JavaScript against the generated API
 

--- a/cmd/xgoja/doc/16-migrating-to-xgoja-v2.md
+++ b/cmd/xgoja/doc/16-migrating-to-xgoja-v2.md
@@ -25,6 +25,11 @@ xgoja/v2 is the native configuration format for the hard cutover. Legacy v1
 files are migration input only. Convert them with `xgoja migrate-spec` before
 using v2-era build, doctor, generation, and declaration workflows.
 
+Generated v2 outputs embed `app.RuntimePlan` JSON with schema
+`xgoja/runtime/v2`. The old generated runtime bridge shape is not part of the
+active runtime contract: providers, runtime modules, unified sources, commands,
+and artifacts are the authoritative concepts.
+
 ## Core rule
 
 xgoja only compiles or bundles code that runs inside goja. Browser applications,
@@ -153,6 +158,11 @@ commands:
     sources: [sites]
 ```
 
+The `sources` list is command-scoped. Provider command code receives a
+`SourceRegistry` limited to those source IDs. If an old application relied on a
+provider command seeing every jsverb source, make that dependency explicit by
+listing the needed source IDs on the command.
+
 A `template` artifact is generated output. It is not a runtime module and it is
 not how HTTP routes or WebSocket handlers are mounted. HTTP serving behavior
 belongs in provider command sets, runtime modules, host services, and JavaScript
@@ -198,5 +208,8 @@ artifacts:
    runtime HTTP behavior.
 7. Check local replacements and prefer `workspace.mode: auto` when a `go.work`
    file already covers the local module.
-8. Run `xgoja doctor -f xgoja.v2.yaml` once the v2 planner is available.
-9. Run the example or application smoke test.
+8. If you generate a runtime package, update host code/docs to use
+   `EmbeddedRuntimePlanJSON` and `DecodeRuntimePlan` for direct metadata access;
+   `NewBundle` and `Bundle.NewRuntime` remain the preferred APIs.
+9. Run `xgoja doctor -f xgoja.v2.yaml` once the v2 planner is available.
+10. Run the example or application smoke test.

--- a/cmd/xgoja/doc/17-xgoja-v2-reference.md
+++ b/cmd/xgoja/doc/17-xgoja-v2-reference.md
@@ -30,6 +30,11 @@ It describes provider packages, selected Go-backed runtime modules,
 goja-executed source sets, command surfaces, generated artifacts, and local Go
 workspace behavior.
 
+The planner renders generated binaries and runtime packages around a v2-native
+`app.RuntimePlan` (`schema: xgoja/runtime/v2`). That runtime plan is the active
+runtime contract: `providers`, `runtime.modules`, unified `sources`, `commands`,
+and `artifacts` are authoritative.
+
 The central rule is simple and strict: xgoja compiles or bundles code that runs
 inside goja. Browser applications, frontend bundles, workers, and other
 non-goja JavaScript outputs should be built by their own tools and included as
@@ -141,7 +146,7 @@ workspace:
 ```
 
 Workspace planning is build-time behavior. It does not enter the generated
-runtime spec.
+runtime plan.
 
 - `auto` searches upward from the spec directory for `go.work` and uses matching
   local modules.
@@ -281,8 +286,7 @@ loaders, or polyfills in v2 source config.
 
 ## Commands
 
-Commands are explicit surfaces. Builtin commands and provider command sets use
-the same list.
+Commands are explicit surfaces. Generated runtimes store built-in commands and provider command sets in the same ordered `commands[]` list.
 
 ```yaml
 commands:
@@ -313,6 +317,11 @@ Supported builtin command types are:
 `provider.command-set` mounts a command set contributed by a selected provider.
 Provider command sets commonly depend on source sets. For example, the HTTP
 `serve` provider command uses jsverb sources to register Express routes.
+
+`commands[].sources` is command-scoped. Provider commands receive a
+`SourceRegistry` containing only the declared source IDs, and should read sources
+through `ctx.Sources`. HTTP `serve` uses that scoped registry for jsverb command
+discovery, hot reload rescans, and default watch roots.
 
 Runtime modules and provider command sets are separate provider outputs. A
 runtime module is selected under `runtime.modules` and is imported by JavaScript
@@ -354,7 +363,7 @@ Common artifact types are:
 | `binary` | Generated xgoja binary. When `sources` lists local jsverb/help source sets, those sources are copied into the generated embedded filesystem. |
 | `dts` | TypeScript declaration output for selected runtime modules. |
 | `embedded-assets` | Static assets embedded into the generated host. |
-| `runtime-package` | Generated runtime package output. |
+| `runtime-package` | Generated runtime package output exposing `EmbeddedRuntimePlanJSON`, `DecodeRuntimePlan`, `NewBundle`, and `Bundle.NewRuntime`. |
 | `adapter`, `cobra`, `source`, `template` | Additional generated output shapes consumed through the v2 plan-backed generator. |
 
 For binary/runtime-package style artifacts, `sources` marks local jsverb and
@@ -471,9 +480,47 @@ mux.HandleFunc("GET /ws/rooms/{roomID}", func(w http.ResponseWriter, r *http.Req
 
 This keeps JavaScript responsible for composition and keeps Go responsible for Go-owned HTTP routing and WebSocket upgrade behavior.
 
+## Troubleshooting
+
+### Provider command does not see a jsverb
+
+Check `commands[].sources`. Provider command sets see only the source IDs listed
+on the command. For HTTP serve, use this shape:
+
+```yaml
+commands:
+  - id: http-serve
+    type: provider.command-set
+    provider: http
+    name: serve
+    mount: serve
+    sources: [local-sites]
+```
+
+Then verify the generated command and flags:
+
+```bash
+xgoja build -f xgoja.yaml --output dist/app
+./dist/app serve sites demo --help --long-help
+./dist/app serve sites demo --http-listen 127.0.0.1:8787
+```
+
+### CLI mount vs HTTP mount
+
+`commands[].mount` controls the CLI tree, for example whether provider commands
+appear under `serve`. It does not mount an HTTP handler. HTTP mounting happens
+inside JavaScript route code with Express APIs such as `app.mount("/ws", handler)`.
+
+### Local provider replacement is stale
+
+Prefer `workspace.mode: auto` when the repository has a `go.work` containing the
+provider module. `xgoja doctor` reports the selected module resolution source so
+you can confirm whether the build uses a workspace module, CLI replacement, or
+versioned dependency.
+
 ## Current limits
 
-The normal command path is v2-plan-native: `doctor`, `build`, `generate`, `gen-dts`, and `list-modules` load `schema: xgoja/v2` and consume `plan.Plan` directly.
+The normal command path is v2-plan-native: `doctor`, `build`, `generate`, `gen-dts`, and `list-modules` load `schema: xgoja/v2`, consume `plan.Plan`, and generate embedded `app.RuntimePlan` metadata directly.
 
 Known limits:
 
@@ -484,8 +531,8 @@ Known limits:
 ## Migration policy
 
 Legacy v1 specs remain supported as migration input for `xgoja migrate-spec`.
-New examples and docs should use `schema: xgoja/v2`. Normal command paths are
-moving toward v2-only behavior.
+New examples and docs should use `schema: xgoja/v2`. Normal command paths use
+the v2 planner and runtime-plan model.
 
 Use:
 

--- a/cmd/xgoja/internal/generate/generate.go
+++ b/cmd/xgoja/internal/generate/generate.go
@@ -32,7 +32,7 @@ func CleanGenerated(dir string) error {
 	}
 	for _, name := range []string{
 		"xgoja_runtime.gen.go",
-		"spec.gen.go",
+		"runtime_plan.gen.go",
 		"providers.gen.go",
 		"bundle.gen.go",
 		"embed.gen.go",

--- a/cmd/xgoja/internal/generate/generate_test.go
+++ b/cmd/xgoja/internal/generate/generate_test.go
@@ -57,22 +57,20 @@ func TestRenderEmbeddedSpecFromPlanUsesRuntimeShapeAndEmbeddedRoots(t *testing.T
 		{ID: "binary", Type: "binary", Output: "dist/fixture", Sources: []string{"verbs", "docs"}},
 		{ID: "assets", Type: "embedded-assets", Sources: []string{"assets"}},
 	}
-	var runtimeSpec app.RuntimeSpec
-	if err := json.Unmarshal([]byte(RenderEmbeddedSpecFromPlan(compiled)), &runtimeSpec); err != nil {
+	var runtimePlan app.RuntimePlan
+	if err := json.Unmarshal([]byte(RenderEmbeddedSpecFromPlan(compiled)), &runtimePlan); err != nil {
 		t.Fatalf("decode embedded runtime spec: %v", err)
 	}
-	if len(runtimeSpec.Packages) != 1 || runtimeSpec.Packages[0].ID != "fixture" {
-		t.Fatalf("expected runtime provider ids only, got %#v", runtimeSpec.Packages)
+	if runtimePlan.Schema != app.RuntimePlanSchema {
+		t.Fatalf("runtime plan schema = %q", runtimePlan.Schema)
 	}
-	if runtimeSpec.JSVerbs[0].Path != "xgoja_embed/jsverbs/verbs" || !runtimeSpec.JSVerbs[0].Embed {
-		t.Fatalf("unexpected jsverb runtime source: %#v", runtimeSpec.JSVerbs[0])
+	if len(runtimePlan.Providers) != 1 || runtimePlan.Providers[0].ID != "fixture" {
+		t.Fatalf("expected runtime provider ids only, got %#v", runtimePlan.Providers)
 	}
-	if runtimeSpec.Help.Sources[0].Path != "xgoja_embed/help/docs" || !runtimeSpec.Help.Sources[0].Embed {
-		t.Fatalf("unexpected help runtime source: %#v", runtimeSpec.Help.Sources[0])
-	}
-	if runtimeSpec.Assets[0].Path != "xgoja_embed/assets/assets" || !runtimeSpec.Assets[0].Embed {
-		t.Fatalf("unexpected asset runtime source: %#v", runtimeSpec.Assets[0])
-	}
+	assertNoLegacyRuntimeKeys(t, RenderEmbeddedSpecFromPlan(compiled))
+	assertRuntimeSource(t, runtimePlan, app.SourceKindJSVerbs, "xgoja_embed/jsverbs/verbs", true)
+	assertRuntimeSource(t, runtimePlan, app.SourceKindHelp, "xgoja_embed/help/docs", true)
+	assertRuntimeSource(t, runtimePlan, app.SourceKindAssets, "xgoja_embed/assets/assets", true)
 }
 
 func TestWriteAllPlanCopiesEmbeddedSources(t *testing.T) {
@@ -122,6 +120,29 @@ func TestTemplateDataJSONFromPlan(t *testing.T) {
 	for _, want := range []string{"\"PackageName\": \"xgojaruntime\"", "\"ProviderImports\""} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("template data missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func assertRuntimeSource(t *testing.T, runtimePlan app.RuntimePlan, kind app.SourceKind, path string, embed bool) {
+	t.Helper()
+	for _, source := range runtimePlan.Sources {
+		if source.Kind == kind && source.Path == path && source.Embed == embed {
+			return
+		}
+	}
+	t.Fatalf("missing runtime source kind=%s path=%s embed=%v in %#v", kind, path, embed, runtimePlan.Sources)
+}
+
+func assertNoLegacyRuntimeKeys(t *testing.T, specJSON string) {
+	t.Helper()
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(specJSON), &payload); err != nil {
+		t.Fatalf("decode runtime payload: %v", err)
+	}
+	for _, key := range []string{"packages", "modules", "commandProviders", "jsverbs", "help", "assets"} {
+		if _, ok := payload[key]; ok {
+			t.Fatalf("runtime payload contains legacy key %q: %s", key, specJSON)
 		}
 	}
 }

--- a/cmd/xgoja/internal/generate/generate_test.go
+++ b/cmd/xgoja/internal/generate/generate_test.go
@@ -117,6 +117,21 @@ func TestWriteAllPlanCopiesEmbeddedSources(t *testing.T) {
 	}
 }
 
+func TestRenderPackagePlanUsesRuntimePlanAPI(t *testing.T) {
+	got := RenderPackagePlan(fixturePlan(t), "xgojaruntime")
+	for _, want := range []string{"EmbeddedRuntimePlanJSON", "DecodeRuntimePlan() (*app.RuntimePlan, error)", "RuntimePlan *app.RuntimePlan", "NewBundle", "NewRuntime"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("generated runtime package missing %q:\n%s", want, got)
+		}
+	}
+	for _, legacy := range []string{"EmbeddedSpecJSON", "DecodeSpec", "RuntimeSpec"} {
+		if strings.Contains(got, legacy) {
+			t.Fatalf("generated runtime package contains legacy %q:\n%s", legacy, got)
+		}
+	}
+	assertNoLegacyRuntimeKeys(t, RenderEmbeddedSpecFromPlan(fixturePlan(t)))
+}
+
 func TestTemplateDataJSONFromPlan(t *testing.T) {
 	got, err := TemplateDataJSONFromPlan(fixturePlan(t), "xgojaruntime")
 	if err != nil {

--- a/cmd/xgoja/internal/generate/generate_test.go
+++ b/cmd/xgoja/internal/generate/generate_test.go
@@ -51,7 +51,7 @@ func TestRenderGoModPlanUsesWorkspaceModulePlan(t *testing.T) {
 	}
 }
 
-func TestRenderEmbeddedSpecFromPlanUsesRuntimeShapeAndEmbeddedRoots(t *testing.T) {
+func TestRenderRuntimePlanJSONFromPlanUsesRuntimeShapeAndEmbeddedRoots(t *testing.T) {
 	compiled := fixturePlan(t)
 	compiled.Config.Sources = []specv2.SourceSpec{
 		{ID: "verbs", Kind: specv2.SourceKindJSVerbs, From: specv2.SourceFromSpec{Dir: "verbs"}, Language: "typescript", Compile: &specv2.CompileSpec{Bundle: true}},
@@ -63,8 +63,8 @@ func TestRenderEmbeddedSpecFromPlanUsesRuntimeShapeAndEmbeddedRoots(t *testing.T
 		{ID: "assets", Type: "embedded-assets", Sources: []string{"assets"}},
 	}
 	var runtimePlan app.RuntimePlan
-	if err := json.Unmarshal([]byte(RenderEmbeddedSpecFromPlan(compiled)), &runtimePlan); err != nil {
-		t.Fatalf("decode embedded runtime spec: %v", err)
+	if err := json.Unmarshal([]byte(RenderRuntimePlanJSONFromPlan(compiled)), &runtimePlan); err != nil {
+		t.Fatalf("decode embedded runtime plan: %v", err)
 	}
 	if runtimePlan.Schema != app.RuntimePlanSchema {
 		t.Fatalf("runtime plan schema = %q", runtimePlan.Schema)
@@ -72,7 +72,7 @@ func TestRenderEmbeddedSpecFromPlanUsesRuntimeShapeAndEmbeddedRoots(t *testing.T
 	if len(runtimePlan.Providers) != 1 || runtimePlan.Providers[0].ID != "fixture" {
 		t.Fatalf("expected runtime provider ids only, got %#v", runtimePlan.Providers)
 	}
-	assertNoLegacyRuntimeKeys(t, RenderEmbeddedSpecFromPlan(compiled))
+	assertNoLegacyRuntimeKeys(t, RenderRuntimePlanJSONFromPlan(compiled))
 	assertRuntimeSource(t, runtimePlan, app.SourceKindJSVerbs, "xgoja_embed/jsverbs/verbs", true)
 	assertRuntimeSource(t, runtimePlan, app.SourceKindHelp, "xgoja_embed/help/docs", true)
 	assertRuntimeSource(t, runtimePlan, app.SourceKindAssets, "xgoja_embed/assets/assets", true)
@@ -106,7 +106,7 @@ func TestWriteAllPlanCopiesEmbeddedSources(t *testing.T) {
 		"xgoja_embed/assets/assets/app.css",
 		"go.mod",
 		"main.go",
-		"xgoja.gen.json",
+		"xgoja.runtime.json",
 	} {
 		if _, err := os.Stat(filepath.Join(out, filepath.FromSlash(path))); err != nil {
 			t.Fatalf("expected generated %s: %v", path, err)
@@ -129,7 +129,7 @@ func TestRenderPackagePlanUsesRuntimePlanAPI(t *testing.T) {
 			t.Fatalf("generated runtime package contains legacy %q:\n%s", legacy, got)
 		}
 	}
-	assertNoLegacyRuntimeKeys(t, RenderEmbeddedSpecFromPlan(fixturePlan(t)))
+	assertNoLegacyRuntimeKeys(t, RenderRuntimePlanJSONFromPlan(fixturePlan(t)))
 }
 
 func TestTemplateDataJSONFromPlan(t *testing.T) {

--- a/cmd/xgoja/internal/generate/generate_test.go
+++ b/cmd/xgoja/internal/generate/generate_test.go
@@ -36,6 +36,8 @@ func TestRenderGoModPlanDeterministic(t *testing.T) {
 
 func TestRenderGoModPlanUsesWorkspaceModulePlan(t *testing.T) {
 	compiled := fixturePlan(t)
+	compiled.Config.Providers[0].Import = "github.com/example/local/pkg/provider"
+	compiled.Config.Providers[0].Module.Replace = ""
 	compiled.GoModules = &workspace.Plan{Modules: []workspace.GoModulePlan{{ModulePath: "github.com/example/local", Version: "", LocalDir: "/tmp/local"}}}
 	got := RenderGoModPlan(compiled, Options{XGojaModuleVersion: "v0.1.0", GoModules: compiled.GoModules})
 	if !strings.Contains(got, "github.com/example/local v0.0.0") {
@@ -43,6 +45,9 @@ func TestRenderGoModPlanUsesWorkspaceModulePlan(t *testing.T) {
 	}
 	if !strings.Contains(got, "replace github.com/example/local => /tmp/local") {
 		t.Fatalf("expected local module replace:\n%s", got)
+	}
+	if strings.Contains(got, "../") {
+		t.Fatalf("unexpected provider-local replace without provider.module.replace; workspace plan should own local replacements:\n%s", got)
 	}
 }
 

--- a/cmd/xgoja/internal/generate/main.go
+++ b/cmd/xgoja/internal/generate/main.go
@@ -26,9 +26,9 @@ func RenderPackagePlan(compiled *plan.Plan, packageName string) string {
 func RenderSourceFragmentsPlan(compiled *plan.Plan, packageName string) map[string]string {
 	data := packageTemplateDataFromPlan(compiled, packageName)
 	fragments := map[string]func(packageTemplateData) (string, error){
-		"spec.gen.go":      renderSpecFragmentTemplate,
-		"providers.gen.go": renderProvidersFragmentTemplate,
-		"bundle.gen.go":    renderBundleFragmentTemplate,
+		"runtime_plan.gen.go": renderSpecFragmentTemplate,
+		"providers.gen.go":    renderProvidersFragmentTemplate,
+		"bundle.gen.go":       renderBundleFragmentTemplate,
 	}
 	if data.HasEmbedded {
 		fragments["embed.gen.go"] = renderEmbedFragmentTemplate

--- a/cmd/xgoja/internal/generate/plan.go
+++ b/cmd/xgoja/internal/generate/plan.go
@@ -31,9 +31,9 @@ func WriteAllPlan(dir string, compiled *plan.Plan, opts Options) error {
 		return err
 	}
 	files := map[string]string{
-		"go.mod":         RenderGoModPlan(compiled, opts),
-		"main.go":        RenderMainPlan(compiled),
-		"xgoja.gen.json": RenderEmbeddedSpecFromPlan(compiled),
+		"go.mod":             RenderGoModPlan(compiled, opts),
+		"main.go":            RenderMainPlan(compiled),
+		"xgoja.runtime.json": RenderRuntimePlanJSONFromPlan(compiled),
 	}
 	for name, content := range files {
 		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {

--- a/cmd/xgoja/internal/generate/templates.go
+++ b/cmd/xgoja/internal/generate/templates.go
@@ -20,7 +20,7 @@ import (
 var templateFS embed.FS
 
 type mainTemplateData struct {
-	SpecJSON          string
+	RuntimePlanJSON   string
 	HasEmbedded       bool
 	HasEmbeddedJSVerb bool
 	HasEmbeddedHelp   bool
@@ -38,7 +38,7 @@ type mainTemplateData struct {
 
 type packageTemplateData struct {
 	PackageName       string
-	SpecJSON          string
+	RuntimePlanJSON   string
 	HasEmbedded       bool
 	HasEmbeddedJSVerb bool
 	HasEmbeddedHelp   bool
@@ -48,7 +48,7 @@ type packageTemplateData struct {
 }
 
 type dtsGenTemplateData struct {
-	SpecJSON        string
+	RuntimePlanJSON string
 	ProviderImports []providerImport
 	ExtraImports    []extraImport
 	Strict          bool
@@ -175,7 +175,7 @@ func mainTemplateDataFromPlan(compiled *plan.Plan) mainTemplateData {
 		rootFn = "NewRootCommand"
 	}
 	data := mainTemplateData{
-		SpecJSON:          escapeRawString(RenderEmbeddedSpecFromPlan(compiled)),
+		RuntimePlanJSON:   escapeRawString(RenderRuntimePlanJSONFromPlan(compiled)),
 		HasEmbedded:       hasEmbedded,
 		HasEmbeddedJSVerb: hasEmbeddedJSVerb,
 		HasEmbeddedHelp:   hasEmbeddedHelp,
@@ -201,18 +201,18 @@ func mainTemplateDataFromPlan(compiled *plan.Plan) mainTemplateData {
 		embeddedAssetsArg = "embeddedAssets"
 	}
 	if hasEmbedded {
-		data.HostConstruction = fmt.Sprintf("host := app.NewHostWithOptions(registry, buildSpec, app.HostOptions{EmbeddedJSVerbs: %s, EmbeddedHelp: %s, EmbeddedAssets: %s})", embeddedJSVerbArg, embeddedHelpArg, embeddedAssetsArg)
-		data.RootConstruction = fmt.Sprintf("root, err := app.NewRootCommand(app.Options{Providers: registry, SpecJSON: embeddedSpecJSON, EmbeddedJSVerbs: %s, EmbeddedHelp: %s, EmbeddedAssets: %s})", embeddedJSVerbArg, embeddedHelpArg, embeddedAssetsArg)
+		data.HostConstruction = fmt.Sprintf("host := app.NewHostWithOptions(registry, runtimePlan, app.HostOptions{EmbeddedJSVerbs: %s, EmbeddedHelp: %s, EmbeddedAssets: %s})", embeddedJSVerbArg, embeddedHelpArg, embeddedAssetsArg)
+		data.RootConstruction = fmt.Sprintf("root, err := app.NewRootCommand(app.Options{Providers: registry, RuntimePlanJSON: embeddedRuntimePlanJSON, EmbeddedJSVerbs: %s, EmbeddedHelp: %s, EmbeddedAssets: %s})", embeddedJSVerbArg, embeddedHelpArg, embeddedAssetsArg)
 	} else {
-		data.HostConstruction = "host := app.NewHost(registry, buildSpec)"
-		data.RootConstruction = "root, err := app.NewRootCommand(app.Options{Providers: registry, SpecJSON: embeddedSpecJSON})"
+		data.HostConstruction = "host := app.NewHost(registry, runtimePlan)"
+		data.RootConstruction = "root, err := app.NewRootCommand(app.Options{Providers: registry, RuntimePlanJSON: embeddedRuntimePlanJSON})"
 	}
 	return data
 }
 
 func dtsGenTemplateDataFromPlan(compiled *plan.Plan, strict bool) dtsGenTemplateData {
 	return dtsGenTemplateData{
-		SpecJSON:        escapeRawString(RenderEmbeddedSpecFromPlan(compiled)),
+		RuntimePlanJSON: escapeRawString(RenderRuntimePlanJSONFromPlan(compiled)),
 		ProviderImports: providerImportsFromPlan(compiled),
 		ExtraImports:    extraImportsFromPlan(compiled),
 		Strict:          strict,
@@ -226,7 +226,7 @@ func packageTemplateDataFromPlan(compiled *plan.Plan, packageName string) packag
 	hasEmbeddedAssets := len(paths.AssetRoots) > 0
 	return packageTemplateData{
 		PackageName:       packageName,
-		SpecJSON:          escapeRawString(RenderEmbeddedSpecFromPlan(compiled)),
+		RuntimePlanJSON:   escapeRawString(RenderRuntimePlanJSONFromPlan(compiled)),
 		HasEmbedded:       hasEmbeddedJSVerb || hasEmbeddedHelp || hasEmbeddedAssets,
 		HasEmbeddedJSVerb: hasEmbeddedJSVerb,
 		HasEmbeddedHelp:   hasEmbeddedHelp,
@@ -339,7 +339,7 @@ func embeddedPlanRoots(sources []specv2.SourceSpec, kind specv2.SourceKind, embe
 	return roots
 }
 
-func RenderEmbeddedSpecFromPlan(compiled *plan.Plan) string {
+func RenderRuntimePlanJSONFromPlan(compiled *plan.Plan) string {
 	if compiled == nil {
 		return "null\n"
 	}

--- a/cmd/xgoja/internal/generate/templates.go
+++ b/cmd/xgoja/internal/generate/templates.go
@@ -434,7 +434,7 @@ func applyPlanRuntimeCommand(commands *app.CommandsSpec, providers *[]app.Comman
 	case "builtin.jsverbs":
 		commands.JSVerbs = spec
 	case "provider.command-set":
-		*providers = append(*providers, app.CommandProviderInstanceSpec{ID: command.ID, Package: command.Provider, Name: command.Name, Mount: command.Mount, Modules: append([]string(nil), command.Modules...), Config: command.Config, Lazy: command.Lazy})
+		*providers = append(*providers, app.CommandProviderInstanceSpec{ID: command.ID, Package: command.Provider, Name: command.Name, Mount: command.Mount, Sources: append([]string(nil), command.Sources...), Modules: append([]string(nil), command.Modules...), Config: command.Config, Lazy: command.Lazy})
 	}
 }
 

--- a/cmd/xgoja/internal/generate/templates.go
+++ b/cmd/xgoja/internal/generate/templates.go
@@ -345,68 +345,36 @@ func RenderEmbeddedSpecFromPlan(compiled *plan.Plan) string {
 	}
 	cfg := compiled.Config
 	paths := embeddedPlanPaths(cfg)
-	var configFile *app.ConfigFileSpec
+	var configFile *app.ConfigFilePlan
 	if cfg.App.ConfigFile != nil {
-		configFile = &app.ConfigFileSpec{Enabled: cfg.App.ConfigFile.Enabled, Layers: append([]string(nil), cfg.App.ConfigFile.Layers...), FileName: cfg.App.ConfigFile.FileName}
+		configFile = &app.ConfigFilePlan{Enabled: cfg.App.ConfigFile.Enabled, Layers: append([]string(nil), cfg.App.ConfigFile.Layers...), FileName: cfg.App.ConfigFile.FileName}
 	}
-	helpSpec := &app.HelpSpec{}
-	runtimeSpec := app.RuntimeSpec{
-		Name:       cfg.Name,
-		AppName:    cfg.App.Name,
-		EnvPrefix:  cfg.App.EnvPrefix,
-		ConfigFile: configFile,
-		Target:     app.TargetSpec{Kind: targetDataFromPlanArtifacts(cfg.Artifacts).Kind, Output: targetOutputFromPlanArtifacts(cfg.Artifacts)},
+	runtimePlan := app.RuntimePlan{
+		Schema: app.RuntimePlanSchema,
+		Name:   cfg.Name,
+		App: app.AppPlan{
+			Name:       cfg.App.Name,
+			EnvPrefix:  cfg.App.EnvPrefix,
+			ConfigFile: configFile,
+		},
+		Target: app.TargetPlan{Kind: targetDataFromPlanArtifacts(cfg.Artifacts).Kind, Output: targetOutputFromPlanArtifacts(cfg.Artifacts)},
 	}
 	for _, provider := range cfg.Providers {
-		runtimeSpec.Packages = append(runtimeSpec.Packages, app.PackageSpec{ID: provider.ID})
+		runtimePlan.Providers = append(runtimePlan.Providers, app.ProviderPlan{ID: provider.ID})
 	}
 	for _, module := range cfg.Runtime.Modules {
-		runtimeSpec.Modules = append(runtimeSpec.Modules, app.ModuleInstanceSpec{Package: module.Provider, Name: module.Name, As: module.As, Config: module.Config})
-	}
-	for _, command := range cfg.Commands {
-		applyPlanRuntimeCommand(&runtimeSpec.Commands, &runtimeSpec.CommandProviders, command)
+		runtimePlan.Runtime.Modules = append(runtimePlan.Runtime.Modules, app.RuntimeModulePlan{Provider: module.Provider, Name: module.Name, As: module.As, Config: module.Config})
 	}
 	for _, source := range cfg.Sources {
-		switch source.Kind {
-		case specv2.SourceKindJSVerbs:
-			runtimeSpec.JSVerbs = append(runtimeSpec.JSVerbs, runtimeJSVerbSourceFromPlan(source, paths.JSVerbRoots[source.ID]))
-		case specv2.SourceKindHelp:
-			helpSpec.Sources = append(helpSpec.Sources, runtimeHelpSourceFromPlan(source, paths.HelpRoots[source.ID]))
-		case specv2.SourceKindAssets:
-			runtimeSpec.Assets = append(runtimeSpec.Assets, runtimeAssetSourceFromPlan(source, paths.AssetRoots[source.ID]))
-		case specv2.SourceKindScript:
-		}
+		runtimePlan.Sources = append(runtimePlan.Sources, runtimeSourceFromPlan(source, paths))
 	}
-	payload := struct {
-		Name             string                            `json:"name"`
-		AppName          string                            `json:"appName,omitempty"`
-		EnvPrefix        string                            `json:"envPrefix,omitempty"`
-		ConfigFile       *app.ConfigFileSpec               `json:"configFile,omitempty"`
-		Target           app.TargetSpec                    `json:"target"`
-		Packages         []app.PackageSpec                 `json:"packages"`
-		Modules          []app.ModuleInstanceSpec          `json:"modules"`
-		Commands         app.CommandsSpec                  `json:"commands"`
-		CommandProviders []app.CommandProviderInstanceSpec `json:"commandProviders,omitempty"`
-		JSVerbs          []app.JSVerbSourceSpec            `json:"jsverbs,omitempty"`
-		Help             *app.HelpSpec                     `json:"help,omitempty"`
-		Assets           []app.AssetSourceSpec             `json:"assets,omitempty"`
-	}{
-		Name:             runtimeSpec.Name,
-		AppName:          runtimeSpec.AppName,
-		EnvPrefix:        runtimeSpec.EnvPrefix,
-		ConfigFile:       runtimeSpec.ConfigFile,
-		Target:           runtimeSpec.Target,
-		Packages:         runtimeSpec.Packages,
-		Modules:          runtimeSpec.Modules,
-		Commands:         runtimeSpec.Commands,
-		CommandProviders: runtimeSpec.CommandProviders,
-		JSVerbs:          runtimeSpec.JSVerbs,
-		Assets:           runtimeSpec.Assets,
+	for _, command := range cfg.Commands {
+		runtimePlan.Commands = append(runtimePlan.Commands, runtimeCommandFromPlan(command))
 	}
-	if len(helpSpec.Sources) > 0 {
-		payload.Help = helpSpec
+	for _, artifact := range cfg.Artifacts {
+		runtimePlan.Artifacts = append(runtimePlan.Artifacts, app.ArtifactPlan{ID: artifact.ID, Type: artifact.Type, Output: artifact.Output, Package: artifact.Package, Import: artifact.Import, Root: artifact.Root, Sources: append([]string(nil), artifact.Sources...), Strict: artifact.Strict})
 	}
-	data, err := json.MarshalIndent(payload, "", "  ")
+	data, err := json.MarshalIndent(runtimePlan, "", "  ")
 	if err != nil {
 		panic(err)
 	}
@@ -422,26 +390,24 @@ func targetOutputFromPlanArtifacts(artifacts []specv2.ArtifactSpec) string {
 	return "dist/xgoja-app"
 }
 
-func applyPlanRuntimeCommand(commands *app.CommandsSpec, providers *[]app.CommandProviderInstanceSpec, command specv2.CommandSurfaceSpec) {
-	spec := app.CommandSpec{Enabled: true, Name: command.Name, Mount: command.Mount}
-	switch command.Type {
-	case "builtin.eval":
-		commands.Eval = spec
-	case "builtin.run":
-		commands.Run = spec
-	case "builtin.repl":
-		commands.Repl = spec
-	case "builtin.jsverbs":
-		commands.JSVerbs = spec
-	case "provider.command-set":
-		*providers = append(*providers, app.CommandProviderInstanceSpec{ID: command.ID, Package: command.Provider, Name: command.Name, Mount: command.Mount, Sources: append([]string(nil), command.Sources...), Modules: append([]string(nil), command.Modules...), Config: command.Config, Lazy: command.Lazy})
-	}
+func runtimeCommandFromPlan(command specv2.CommandSurfaceSpec) app.CommandPlan {
+	return app.CommandPlan{ID: command.ID, Type: command.Type, Name: command.Name, Mount: command.Mount, Provider: command.Provider, Sources: append([]string(nil), command.Sources...), Modules: append([]string(nil), command.Modules...), Config: command.Config, Lazy: command.Lazy}
 }
 
-func runtimeJSVerbSourceFromPlan(source specv2.SourceSpec, embeddedRoot string) app.JSVerbSourceSpec {
-	out := app.JSVerbSourceSpec{ID: source.ID, Embed: embeddedRoot != "", Include: append([]string(nil), source.Include...), Exclude: append([]string(nil), source.Exclude...), Extensions: append([]string(nil), source.Extensions...)}
+func runtimeSourceFromPlan(source specv2.SourceSpec, paths planEmbeddedPaths) app.SourcePlan {
+	embeddedRoot := ""
+	switch source.Kind {
+	case specv2.SourceKindJSVerbs:
+		embeddedRoot = paths.JSVerbRoots[source.ID]
+	case specv2.SourceKindHelp:
+		embeddedRoot = paths.HelpRoots[source.ID]
+	case specv2.SourceKindAssets:
+		embeddedRoot = paths.AssetRoots[source.ID]
+	case specv2.SourceKindScript:
+	}
+	out := app.SourcePlan{ID: source.ID, Kind: app.SourceKind(source.Kind), Embed: embeddedRoot != "", Include: append([]string(nil), source.Include...), Exclude: append([]string(nil), source.Exclude...), Extensions: append([]string(nil), source.Extensions...)}
 	if source.From.Provider != nil {
-		out.Package = source.From.Provider.Provider
+		out.Provider = source.From.Provider.Provider
 		out.Source = source.From.Provider.Source
 	} else if embeddedRoot != "" {
 		out.Path = embeddedRoot
@@ -449,7 +415,7 @@ func runtimeJSVerbSourceFromPlan(source specv2.SourceSpec, embeddedRoot string) 
 		out.Path = source.From.Dir
 	}
 	if strings.EqualFold(source.Language, "typescript") || source.Compile != nil {
-		out.TypeScript = &app.TypeScriptSpec{Enabled: strings.EqualFold(source.Language, "typescript"), Bundle: source.Compile != nil && source.Compile.Bundle}
+		out.TypeScript = &app.TypeScriptPlan{Enabled: strings.EqualFold(source.Language, "typescript"), Bundle: source.Compile != nil && source.Compile.Bundle}
 		if source.Compile != nil {
 			out.TypeScript.Define = cloneStringMapFromPlan(source.Compile.Define)
 			if source.Compile.Check != nil {
@@ -458,25 +424,4 @@ func runtimeJSVerbSourceFromPlan(source specv2.SourceSpec, embeddedRoot string) 
 		}
 	}
 	return out
-}
-
-func runtimeHelpSourceFromPlan(source specv2.SourceSpec, embeddedRoot string) app.HelpSourceSpec {
-	out := app.HelpSourceSpec{ID: source.ID, Embed: embeddedRoot != ""}
-	if source.From.Provider != nil {
-		out.Package = source.From.Provider.Provider
-		out.Source = source.From.Provider.Source
-	} else if embeddedRoot != "" {
-		out.Path = embeddedRoot
-	} else {
-		out.Path = source.From.Dir
-	}
-	return out
-}
-
-func runtimeAssetSourceFromPlan(source specv2.SourceSpec, embeddedRoot string) app.AssetSourceSpec {
-	path := source.From.Dir
-	if embeddedRoot != "" {
-		path = embeddedRoot
-	}
-	return app.AssetSourceSpec{ID: source.ID, Path: path, Embed: embeddedRoot != ""}
 }

--- a/cmd/xgoja/internal/generate/templates/bundle_fragment.go.tmpl
+++ b/cmd/xgoja/internal/generate/templates/bundle_fragment.go.tmpl
@@ -24,7 +24,7 @@ type Options struct {
 
 type Bundle struct {
 	Providers   *providerapi.ProviderRegistry
-	RuntimeSpec *app.RuntimeSpec
+	RuntimePlan *app.RuntimePlan
 	Host        *app.Host
 }
 
@@ -33,11 +33,11 @@ func NewBundle(opts Options) (*Bundle, error) {
 	if err := RegisterProviders(registry); err != nil {
 		return nil, err
 	}
-	runtimeSpec, err := DecodeSpec()
+	runtimePlan, err := DecodeSpec()
 	if err != nil {
 		return nil, err
 	}
-	host := app.NewHostWithOptions(registry, runtimeSpec, app.HostOptions{
+	host := app.NewHostWithOptions(registry, runtimePlan, app.HostOptions{
 {{- if .HasEmbeddedJSVerb }}
 		EmbeddedJSVerbs: embeddedJSVerbs,
 {{- end }}
@@ -51,7 +51,7 @@ func NewBundle(opts Options) (*Bundle, error) {
 		MiddlewaresFunc: opts.MiddlewaresFunc,
 		ConfigureServices: opts.ConfigureServices,
 	})
-	return &Bundle{Providers: registry, RuntimeSpec: runtimeSpec, Host: host}, nil
+	return &Bundle{Providers: registry, RuntimePlan: runtimePlan, Host: host}, nil
 }
 
 func (b *Bundle) TypeScriptDeclarations() (string, error) {

--- a/cmd/xgoja/internal/generate/templates/bundle_fragment.go.tmpl
+++ b/cmd/xgoja/internal/generate/templates/bundle_fragment.go.tmpl
@@ -33,7 +33,7 @@ func NewBundle(opts Options) (*Bundle, error) {
 	if err := RegisterProviders(registry); err != nil {
 		return nil, err
 	}
-	runtimePlan, err := DecodeSpec()
+	runtimePlan, err := DecodeRuntimePlan()
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/xgoja/internal/generate/templates/dtsgen_main.go.tmpl
+++ b/cmd/xgoja/internal/generate/templates/dtsgen_main.go.tmpl
@@ -17,7 +17,7 @@ import (
 {{- end }}
 )
 
-const embeddedSpecJSON = `{{ .SpecJSON }}`
+const embeddedRuntimePlanJSON = `{{ .RuntimePlanJSON }}`
 
 func main() {
 	registry := providerapi.NewProviderRegistry()
@@ -25,7 +25,7 @@ func main() {
 	must({{ .Alias }}.{{ .Register }}(registry))
 {{- end }}
 	runtimePlan := &app.RuntimePlan{}
-	must(json.Unmarshal([]byte(embeddedSpecJSON), runtimePlan))
+	must(json.Unmarshal([]byte(embeddedRuntimePlanJSON), runtimePlan))
 	modules := make([]dtsgen.ModuleInstance, 0, len(runtimePlan.Runtime.Modules))
 	for _, mod := range runtimePlan.Runtime.Modules {
 		modules = append(modules, dtsgen.ModuleInstance{Package: mod.Provider, Name: mod.Name, As: mod.As})

--- a/cmd/xgoja/internal/generate/templates/dtsgen_main.go.tmpl
+++ b/cmd/xgoja/internal/generate/templates/dtsgen_main.go.tmpl
@@ -24,11 +24,11 @@ func main() {
 {{- range .ProviderImports }}
 	must({{ .Alias }}.{{ .Register }}(registry))
 {{- end }}
-	runtimeSpec := &app.RuntimeSpec{}
-	must(json.Unmarshal([]byte(embeddedSpecJSON), runtimeSpec))
-	modules := make([]dtsgen.ModuleInstance, 0, len(runtimeSpec.Modules))
-	for _, mod := range runtimeSpec.Modules {
-		modules = append(modules, dtsgen.ModuleInstance{Package: mod.Package, Name: mod.Name, As: mod.As})
+	runtimePlan := &app.RuntimePlan{}
+	must(json.Unmarshal([]byte(embeddedSpecJSON), runtimePlan))
+	modules := make([]dtsgen.ModuleInstance, 0, len(runtimePlan.Runtime.Modules))
+	for _, mod := range runtimePlan.Runtime.Modules {
+		modules = append(modules, dtsgen.ModuleInstance{Package: mod.Provider, Name: mod.Name, As: mod.As})
 	}
 	result, err := dtsgen.RenderModules(registry, modules, dtsgen.Options{Strict: {{ .Strict }}})
 	must(err)

--- a/cmd/xgoja/internal/generate/templates/main.go.tmpl
+++ b/cmd/xgoja/internal/generate/templates/main.go.tmpl
@@ -25,7 +25,7 @@ import (
 {{- end }}
 )
 
-const embeddedSpecJSON = `{{ .SpecJSON }}`
+const embeddedRuntimePlanJSON = `{{ .RuntimePlanJSON }}`
 
 {{- if .HasEmbeddedJSVerb }}
 //go:embed xgoja_embed/jsverbs/*
@@ -46,12 +46,12 @@ func main() {
 	must({{ .Alias }}.{{ .Register }}(registry))
 {{- end }}
 {{- if eq .TargetKind "adapter" }}
-	buildSpec := decodeSpec()
+	runtimePlan := decodeRuntimePlan()
 	{{ .HostConstruction }}
 	root, err := target.Build(context.Background(), host)
 	must(err)
 {{- else if eq .TargetKind "cobra" }}
-	buildSpec := decodeSpec()
+	runtimePlan := decodeRuntimePlan()
 	{{ .HostConstruction }}
 	root := target.{{ .TargetRoot }}()
 	host.AttachDefaultCommands(root)
@@ -65,10 +65,10 @@ func main() {
 	}
 }
 
-func decodeSpec() *app.RuntimePlan {
-	buildSpec := &app.RuntimePlan{}
-	must(json.Unmarshal([]byte(embeddedSpecJSON), buildSpec))
-	return buildSpec
+func decodeRuntimePlan() *app.RuntimePlan {
+	runtimePlan := &app.RuntimePlan{}
+	must(json.Unmarshal([]byte(embeddedRuntimePlanJSON), runtimePlan))
+	return runtimePlan
 }
 
 func must(err error) {

--- a/cmd/xgoja/internal/generate/templates/main.go.tmpl
+++ b/cmd/xgoja/internal/generate/templates/main.go.tmpl
@@ -65,8 +65,8 @@ func main() {
 	}
 }
 
-func decodeSpec() *app.RuntimeSpec {
-	buildSpec := &app.RuntimeSpec{}
+func decodeSpec() *app.RuntimePlan {
+	buildSpec := &app.RuntimePlan{}
 	must(json.Unmarshal([]byte(embeddedSpecJSON), buildSpec))
 	return buildSpec
 }

--- a/cmd/xgoja/internal/generate/templates/runtime_package.go.tmpl
+++ b/cmd/xgoja/internal/generate/templates/runtime_package.go.tmpl
@@ -26,7 +26,7 @@ import (
 {{- end }}
 )
 
-const EmbeddedRuntimePlanJSON = `{{ .SpecJSON }}`
+const EmbeddedRuntimePlanJSON = `{{ .RuntimePlanJSON }}`
 
 {{- if .HasEmbeddedJSVerb }}
 //go:embed xgoja_embed/jsverbs/*

--- a/cmd/xgoja/internal/generate/templates/runtime_package.go.tmpl
+++ b/cmd/xgoja/internal/generate/templates/runtime_package.go.tmpl
@@ -49,7 +49,7 @@ type Options struct {
 
 type Bundle struct {
 	Providers   *providerapi.ProviderRegistry
-	RuntimeSpec *app.RuntimeSpec
+	RuntimePlan *app.RuntimePlan
 	Host        *app.Host
 }
 
@@ -65,12 +65,12 @@ func RegisterProviders(registry *providerapi.ProviderRegistry) error {
 	return nil
 }
 
-func DecodeSpec() (*app.RuntimeSpec, error) {
-	runtimeSpec := &app.RuntimeSpec{}
-	if err := json.Unmarshal([]byte(EmbeddedSpecJSON), runtimeSpec); err != nil {
+func DecodeSpec() (*app.RuntimePlan, error) {
+	runtimePlan := &app.RuntimePlan{}
+	if err := json.Unmarshal([]byte(EmbeddedSpecJSON), runtimePlan); err != nil {
 		return nil, err
 	}
-	return runtimeSpec, nil
+	return runtimePlan, nil
 }
 
 func NewBundle(opts Options) (*Bundle, error) {
@@ -78,11 +78,11 @@ func NewBundle(opts Options) (*Bundle, error) {
 	if err := RegisterProviders(registry); err != nil {
 		return nil, err
 	}
-	runtimeSpec, err := DecodeSpec()
+	runtimePlan, err := DecodeSpec()
 	if err != nil {
 		return nil, err
 	}
-	host := app.NewHostWithOptions(registry, runtimeSpec, app.HostOptions{
+	host := app.NewHostWithOptions(registry, runtimePlan, app.HostOptions{
 {{- if .HasEmbeddedJSVerb }}
 		EmbeddedJSVerbs: embeddedJSVerbs,
 {{- end }}
@@ -96,7 +96,7 @@ func NewBundle(opts Options) (*Bundle, error) {
 		MiddlewaresFunc: opts.MiddlewaresFunc,
 		ConfigureServices: opts.ConfigureServices,
 	})
-	return &Bundle{Providers: registry, RuntimeSpec: runtimeSpec, Host: host}, nil
+	return &Bundle{Providers: registry, RuntimePlan: runtimePlan, Host: host}, nil
 }
 
 func (b *Bundle) TypeScriptDeclarations() (string, error) {

--- a/cmd/xgoja/internal/generate/templates/runtime_package.go.tmpl
+++ b/cmd/xgoja/internal/generate/templates/runtime_package.go.tmpl
@@ -26,7 +26,7 @@ import (
 {{- end }}
 )
 
-const EmbeddedSpecJSON = `{{ .SpecJSON }}`
+const EmbeddedRuntimePlanJSON = `{{ .SpecJSON }}`
 
 {{- if .HasEmbeddedJSVerb }}
 //go:embed xgoja_embed/jsverbs/*
@@ -65,9 +65,9 @@ func RegisterProviders(registry *providerapi.ProviderRegistry) error {
 	return nil
 }
 
-func DecodeSpec() (*app.RuntimePlan, error) {
+func DecodeRuntimePlan() (*app.RuntimePlan, error) {
 	runtimePlan := &app.RuntimePlan{}
-	if err := json.Unmarshal([]byte(EmbeddedSpecJSON), runtimePlan); err != nil {
+	if err := json.Unmarshal([]byte(EmbeddedRuntimePlanJSON), runtimePlan); err != nil {
 		return nil, err
 	}
 	return runtimePlan, nil
@@ -78,7 +78,7 @@ func NewBundle(opts Options) (*Bundle, error) {
 	if err := RegisterProviders(registry); err != nil {
 		return nil, err
 	}
-	runtimePlan, err := DecodeSpec()
+	runtimePlan, err := DecodeRuntimePlan()
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/xgoja/internal/generate/templates/spec_fragment.go.tmpl
+++ b/cmd/xgoja/internal/generate/templates/spec_fragment.go.tmpl
@@ -9,10 +9,10 @@ import (
 
 const EmbeddedSpecJSON = `{{ .SpecJSON }}`
 
-func DecodeSpec() (*app.RuntimeSpec, error) {
-	runtimeSpec := &app.RuntimeSpec{}
-	if err := json.Unmarshal([]byte(EmbeddedSpecJSON), runtimeSpec); err != nil {
+func DecodeSpec() (*app.RuntimePlan, error) {
+	runtimePlan := &app.RuntimePlan{}
+	if err := json.Unmarshal([]byte(EmbeddedSpecJSON), runtimePlan); err != nil {
 		return nil, err
 	}
-	return runtimeSpec, nil
+	return runtimePlan, nil
 }

--- a/cmd/xgoja/internal/generate/templates/spec_fragment.go.tmpl
+++ b/cmd/xgoja/internal/generate/templates/spec_fragment.go.tmpl
@@ -7,7 +7,7 @@ import (
 	"github.com/go-go-golems/go-go-goja/pkg/xgoja/app"
 )
 
-const EmbeddedRuntimePlanJSON = `{{ .SpecJSON }}`
+const EmbeddedRuntimePlanJSON = `{{ .RuntimePlanJSON }}`
 
 func DecodeRuntimePlan() (*app.RuntimePlan, error) {
 	runtimePlan := &app.RuntimePlan{}

--- a/cmd/xgoja/internal/generate/templates/spec_fragment.go.tmpl
+++ b/cmd/xgoja/internal/generate/templates/spec_fragment.go.tmpl
@@ -7,11 +7,11 @@ import (
 	"github.com/go-go-golems/go-go-goja/pkg/xgoja/app"
 )
 
-const EmbeddedSpecJSON = `{{ .SpecJSON }}`
+const EmbeddedRuntimePlanJSON = `{{ .SpecJSON }}`
 
-func DecodeSpec() (*app.RuntimePlan, error) {
+func DecodeRuntimePlan() (*app.RuntimePlan, error) {
 	runtimePlan := &app.RuntimePlan{}
-	if err := json.Unmarshal([]byte(EmbeddedSpecJSON), runtimePlan); err != nil {
+	if err := json.Unmarshal([]byte(EmbeddedRuntimePlanJSON), runtimePlan); err != nil {
 		return nil, err
 	}
 	return runtimePlan, nil

--- a/cmd/xgoja/root_test.go
+++ b/cmd/xgoja/root_test.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-go-golems/go-go-goja/cmd/xgoja/internal/specv2"
 )
@@ -251,6 +253,39 @@ func TestBuildCommandBuildsBinary(t *testing.T) {
 	}
 	if _, err := os.Stat(outputPath); err != nil {
 		t.Fatalf("expected output binary: %v", err)
+	}
+}
+
+func TestBuildCommandProviderServeUsesCommandScopedSources(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds a generated xgoja binary")
+	}
+	out := &bytes.Buffer{}
+	root, err := newRootCommand(out)
+	if err != nil {
+		t.Fatalf("new root command: %v", err)
+	}
+	specPath := writeHTTPServeScopedSourcesSpec(t)
+	outputPath := filepath.Join(t.TempDir(), "scoped-serve")
+	repoRoot, err := filepath.Abs("../..")
+	if err != nil {
+		t.Fatalf("repo root: %v", err)
+	}
+	root.SetArgs([]string{"build", "-f", specPath, "--output", outputPath, "--xgoja-replace", repoRoot})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute build: %v\noutput:\n%s", err, out.String())
+	}
+
+	help := runGeneratedBinary(t, outputPath, "serve", "sitea", "start", "--help", "--long-help")
+	for _, want := range []string{"Start A", "--http-listen", "--hot-reload"} {
+		if !strings.Contains(help, want) {
+			t.Fatalf("expected scoped serve help to contain %q, got:\n%s", want, help)
+		}
+	}
+
+	serveHelp := runGeneratedBinary(t, outputPath, "serve", "--help")
+	if strings.Contains(serveHelp, "siteb") || strings.Contains(serveHelp, "Start B") {
+		t.Fatalf("unexpectedly exposed site-b command outside command sources; output:\n%s", serveHelp)
 	}
 }
 
@@ -569,6 +604,77 @@ func writeBuildableSpec(t *testing.T) string {
 	return writeV2ArtifactSpec(t, "fixture", "binary", "dist/fixture", "", "")
 }
 
+func writeHTTPServeScopedSourcesSpec(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	siteADir := filepath.Join(dir, "site-a")
+	siteBDir := filepath.Join(dir, "site-b")
+	if err := os.MkdirAll(siteADir, 0o755); err != nil {
+		t.Fatalf("mkdir site-a: %v", err)
+	}
+	if err := os.MkdirAll(siteBDir, 0o755); err != nil {
+		t.Fatalf("mkdir site-b: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(siteADir, "a.js"), []byte(`
+__package__({ name: "sitea" });
+__verb__("start", { name: "start", short: "Start A", output: "text" });
+function start() { return "a"; }
+`), 0o644); err != nil {
+		t.Fatalf("write site-a jsverb: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(siteBDir, "b.js"), []byte(`
+__package__({ name: "siteb" });
+__verb__("start", { name: "start", short: "Start B", output: "text" });
+function start() { return "b"; }
+`), 0o644); err != nil {
+		t.Fatalf("write site-b jsverb: %v", err)
+	}
+	specPath := filepath.Join(dir, "xgoja.yaml")
+	if err := os.WriteFile(specPath, []byte(`
+schema: xgoja/v2
+name: scoped-serve
+go:
+  module: xgoja.generated/scoped-serve
+  version: "1.26"
+workspace:
+  mode: off
+providers:
+  - id: go-go-goja-http
+    import: github.com/go-go-golems/go-go-goja/pkg/xgoja/providers/http
+runtime:
+  modules:
+    - provider: go-go-goja-http
+      name: express
+      as: express
+sources:
+  - id: site-a
+    kind: jsverbs
+    from:
+      dir: `+filepath.ToSlash(siteADir)+`
+    language: javascript
+  - id: site-b
+    kind: jsverbs
+    from:
+      dir: `+filepath.ToSlash(siteBDir)+`
+    language: javascript
+commands:
+  - id: serve
+    type: provider.command-set
+    provider: go-go-goja-http
+    name: serve
+    mount: serve
+    sources: [site-a]
+artifacts:
+  - id: binary
+    type: binary
+    output: dist/scoped-serve
+    sources: [site-a, site-b]
+`), 0o644); err != nil {
+		t.Fatalf("write scoped serve v2 spec: %v", err)
+	}
+	return specPath
+}
+
 func writeTypedCoreV2Spec(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
@@ -653,6 +759,21 @@ artifacts:
 		t.Fatalf("write v2 artifact spec: %v", err)
 	}
 	return specPath
+}
+
+func runGeneratedBinary(t *testing.T, binary string, args ...string) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binary, args...)
+	data, err := cmd.CombinedOutput()
+	if ctx.Err() != nil {
+		t.Fatalf("generated binary timed out: %v\noutput:\n%s", ctx.Err(), data)
+	}
+	if err != nil {
+		t.Fatalf("run generated binary %v: %v\noutput:\n%s", args, err, data)
+	}
+	return string(data)
 }
 
 func writeV2Spec(t *testing.T) string {

--- a/cmd/xgoja/root_test.go
+++ b/cmd/xgoja/root_test.go
@@ -74,7 +74,7 @@ func TestBuildCommandWired(t *testing.T) {
 			t.Fatalf("expected build output to contain %q, got %q", want, rendered)
 		}
 	}
-	for _, name := range []string{"go.mod", "main.go", "xgoja.gen.json"} {
+	for _, name := range []string{"go.mod", "main.go", "xgoja.runtime.json"} {
 		if _, err := os.Stat(filepath.Join(workDir, name)); err != nil {
 			t.Fatalf("expected generated %s: %v", name, err)
 		}
@@ -135,7 +135,7 @@ func TestGenerateCommandPrintsTemplateData(t *testing.T) {
 		t.Fatalf("execute generate template-data: %v", err)
 	}
 	rendered := out.String()
-	for _, want := range []string{`"PackageName": "xgoja_runtime"`, `"ProviderImports"`, `"SpecJSON"`} {
+	for _, want := range []string{`"PackageName": "xgoja_runtime"`, `"ProviderImports"`, `"RuntimePlanJSON"`} {
 		if !strings.Contains(rendered, want) {
 			t.Fatalf("expected template data to contain %s, got %s", want, rendered)
 		}
@@ -174,7 +174,7 @@ func TestGenerateCommandCleanRemovesKnownGeneratedFiles(t *testing.T) {
 	if _, err := os.Stat(keep); err != nil {
 		t.Fatalf("expected non-generated file preserved: %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(outputDir, "spec.gen.go")); err != nil {
+	if _, err := os.Stat(filepath.Join(outputDir, "runtime_plan.gen.go")); err != nil {
 		t.Fatalf("expected regenerated source fragment: %v", err)
 	}
 }
@@ -191,7 +191,7 @@ func TestGenerateCommandWritesSourceFragments(t *testing.T) {
 	if err := root.Execute(); err != nil {
 		t.Fatalf("execute generate source: %v", err)
 	}
-	for _, name := range []string{"spec.gen.go", "providers.gen.go", "bundle.gen.go"} {
+	for _, name := range []string{"runtime_plan.gen.go", "providers.gen.go", "bundle.gen.go"} {
 		if _, err := os.Stat(filepath.Join(outputDir, name)); err != nil {
 			t.Fatalf("expected source fragment %s: %v", name, err)
 		}

--- a/cmd/xgoja/v2_bridge_test.go
+++ b/cmd/xgoja/v2_bridge_test.go
@@ -25,7 +25,7 @@ func TestLoadV2PlanRejectsLegacySpec(t *testing.T) {
 	}
 }
 
-func TestV2PlanEmbeddedRuntimeSpecMarksArtifactSourcesEmbedded(t *testing.T) {
+func TestV2PlanEmbeddedRuntimePlanMarksArtifactSourcesEmbedded(t *testing.T) {
 	compiled := &plan.Plan{Config: specv2.Config{
 		Schema: specv2.Schema,
 		Name:   "embedded",
@@ -40,17 +40,21 @@ func TestV2PlanEmbeddedRuntimeSpecMarksArtifactSourcesEmbedded(t *testing.T) {
 		},
 	}}
 
-	runtimeSpec := app.RuntimeSpec{}
-	if err := json.Unmarshal([]byte(generate.RenderEmbeddedSpecFromPlan(compiled)), &runtimeSpec); err != nil {
+	runtimePlan := app.RuntimePlan{}
+	if err := json.Unmarshal([]byte(generate.RenderEmbeddedSpecFromPlan(compiled)), &runtimePlan); err != nil {
 		t.Fatalf("decode runtime spec: %v", err)
 	}
-	if len(runtimeSpec.JSVerbs) != 1 || !runtimeSpec.JSVerbs[0].Embed || runtimeSpec.JSVerbs[0].Path != "xgoja_embed/jsverbs/verbs" {
-		t.Fatalf("expected v2 binary source dependency to embed jsverbs, got %#v", runtimeSpec.JSVerbs)
+	assertEmbeddedSource(t, runtimePlan, app.SourceKindJSVerbs, "xgoja_embed/jsverbs/verbs")
+	assertEmbeddedSource(t, runtimePlan, app.SourceKindHelp, "xgoja_embed/help/docs")
+	assertEmbeddedSource(t, runtimePlan, app.SourceKindAssets, "xgoja_embed/assets/web")
+}
+
+func assertEmbeddedSource(t *testing.T, runtimePlan app.RuntimePlan, kind app.SourceKind, path string) {
+	t.Helper()
+	for _, source := range runtimePlan.Sources {
+		if source.Kind == kind && source.Path == path && source.Embed {
+			return
+		}
 	}
-	if len(runtimeSpec.Help.Sources) != 1 || !runtimeSpec.Help.Sources[0].Embed || runtimeSpec.Help.Sources[0].Path != "xgoja_embed/help/docs" {
-		t.Fatalf("expected v2 binary source dependency to embed help, got %#v", runtimeSpec.Help.Sources)
-	}
-	if len(runtimeSpec.Assets) != 1 || !runtimeSpec.Assets[0].Embed || runtimeSpec.Assets[0].Path != "xgoja_embed/assets/web" {
-		t.Fatalf("expected v2 embedded-assets artifact to embed assets, got %#v", runtimeSpec.Assets)
-	}
+	t.Fatalf("expected embedded source kind=%s path=%s, got %#v", kind, path, runtimePlan.Sources)
 }

--- a/cmd/xgoja/v2_bridge_test.go
+++ b/cmd/xgoja/v2_bridge_test.go
@@ -41,7 +41,7 @@ func TestV2PlanEmbeddedRuntimePlanMarksArtifactSourcesEmbedded(t *testing.T) {
 	}}
 
 	runtimePlan := app.RuntimePlan{}
-	if err := json.Unmarshal([]byte(generate.RenderEmbeddedSpecFromPlan(compiled)), &runtimePlan); err != nil {
+	if err := json.Unmarshal([]byte(generate.RenderRuntimePlanJSONFromPlan(compiled)), &runtimePlan); err != nil {
 		t.Fatalf("decode runtime spec: %v", err)
 	}
 	assertEmbeddedSource(t, runtimePlan, app.SourceKindJSVerbs, "xgoja_embed/jsverbs/verbs")

--- a/examples/xgoja/06-runtime-filesystem/README.md
+++ b/examples/xgoja/06-runtime-filesystem/README.md
@@ -13,7 +13,7 @@ make smoke
 The smoke target:
 
 1. validates `xgoja.yaml`,
-2. builds `dist/runtime-filesystem` with a local `go-go-goja` replace,
+2. builds `dist/runtime-filesystem` using v2 workspace module resolution,
 3. runs `eval` against the fixture provider module,
 4. runs `run scripts/run.js` through the generated runtime,
 5. runs the filesystem verb from `verbs/tools.js`.
@@ -39,19 +39,25 @@ make clean
 The important part of `xgoja.yaml` is:
 
 ```yaml
-jsverbs:
+sources:
   - id: local-dev
-    path: ./verbs
-    embed: false
+    kind: jsverbs
+    from:
+      dir: ./verbs
+commands:
+  - id: verbs
+    type: builtin.jsverbs
+    sources: [local-dev]
 ```
 
 If your runtime source root contains generated files or browser bundles, keep the root narrow or add filters:
 
 ```yaml
-jsverbs:
+sources:
   - id: local-dev
-    path: .
-    embed: false
+    kind: jsverbs
+    from:
+      dir: .
     include:
       - verbs/**/*.js
       - site.js
@@ -60,4 +66,4 @@ jsverbs:
       - dist/**
 ```
 
-`include` and `exclude` match slash-separated paths relative to `path`.
+`include` and `exclude` match slash-separated paths relative to the source root.

--- a/examples/xgoja/07-embedded-jsverbs/README.md
+++ b/examples/xgoja/07-embedded-jsverbs/README.md
@@ -13,7 +13,7 @@ make smoke
 The smoke target:
 
 1. validates `xgoja.yaml`,
-2. builds `dist/embedded-jsverbs` with a local `go-go-goja` replace,
+2. builds `dist/embedded-jsverbs` using v2 workspace module resolution,
 3. runs `eval` against the fixture provider module,
 4. runs `run scripts/run.js` through the generated runtime,
 5. runs the embedded verb from the generated binary.
@@ -38,19 +38,25 @@ That target copies the generated binary to a temporary directory and runs the ve
 The important part of `xgoja.yaml` is:
 
 ```yaml
-jsverbs:
+sources:
   - id: local
-    path: ./verbs
-    embed: true
+    kind: jsverbs
+    from:
+      dir: ./verbs
+artifacts:
+  - id: binary
+    type: binary
+    sources: [local]
 ```
 
 Embedded sources also support filters. This is useful when the embedded source root is an application directory rather than a dedicated `verbs/` directory:
 
 ```yaml
-jsverbs:
+sources:
   - id: local
-    path: .
-    embed: true
+    kind: jsverbs
+    from:
+      dir: .
     include:
       - site.js
       - jsverbs/**/*.js
@@ -58,6 +64,10 @@ jsverbs:
       - assets/**
       - dist/**
       - webapp/**
+artifacts:
+  - id: binary
+    type: binary
+    sources: [local]
 ```
 
-Filters are preserved in the generated runtime spec and are applied when the embedded filesystem is scanned.
+Filters are preserved in the generated runtime plan and are applied when the embedded filesystem is scanned.

--- a/examples/xgoja/08-provider-shipped-jsverbs/README.md
+++ b/examples/xgoja/08-provider-shipped-jsverbs/README.md
@@ -13,7 +13,7 @@ make smoke
 The smoke target:
 
 1. validates `xgoja.yaml`,
-2. builds `dist/provider-shipped-jsverbs` with a local `go-go-goja` replace,
+2. builds `dist/provider-shipped-jsverbs` using v2 workspace module resolution,
 3. runs `eval` against the fixture provider module,
 4. runs `run scripts/run.js` through the generated runtime,
 5. runs a provider-shipped verb,
@@ -32,19 +32,29 @@ pong
 The important part of `xgoja.yaml` is:
 
 ```yaml
-jsverbs:
+sources:
   - id: provider-defaults
-    package: fixture
-    source: verbs
+    kind: jsverbs
+    from:
+      provider:
+        provider: fixture
+        source: verbs
+commands:
+  - id: verbs
+    type: builtin.jsverbs
+    sources: [provider-defaults]
 ```
 
 Provider sources can also be filtered by paths relative to the provider source root:
 
 ```yaml
-jsverbs:
+sources:
   - id: provider-defaults
-    package: fixture
-    source: verbs
+    kind: jsverbs
+    from:
+      provider:
+        provider: fixture
+        source: verbs
     include:
       - tools.js
       - commands/**/*.js

--- a/examples/xgoja/10-embedded-assets-fs/README.md
+++ b/examples/xgoja/10-embedded-assets-fs/README.md
@@ -19,7 +19,7 @@ The smoke target:
 
 1. validates `xgoja.yaml`,
 2. lists selected modules,
-3. builds `dist/embedded-assets-fs` with a local `go-go-goja` replace,
+3. builds `dist/embedded-assets-fs` using v2 workspace module resolution,
 4. runs `scripts/read-assets.js`,
 5. verifies that embedded JSON was copied to `out.json` through `fs:host`.
 
@@ -60,29 +60,36 @@ make prove-self-contained
 
 That target copies the generated binary and script to a temporary directory and runs it away from the original `assets/` directory. The script still reads `/app/config/default.json` because the file is embedded into the binary.
 
-## Important buildspec fragment
+## Important xgoja/v2 fragment
 
 ```yaml
-assets:
+sources:
   - id: app-assets
-    path: ./assets
-    embed: true
+    kind: assets
+    from:
+      dir: ./assets
 
-modules:
-  - package: go-go-goja-host
-    name: fs
-    as: fs:assets
-    config:
-      embedded:
+runtime:
+  modules:
+    - provider: go-go-goja-host
+      name: fs
+      as: fs:assets
+      config:
+        embedded:
+          allow: true
+          mounts:
+            - asset: app-assets
+              mount: /app
+    - provider: go-go-goja-host
+      name: fs
+      as: fs:host
+      config:
         allow: true
-        mounts:
-          - asset: app-assets
-            mount: /app
-  - package: go-go-goja-host
-    name: fs
-    as: fs:host
-    config:
-      allow: true
-  - package: go-go-goja-http
-    name: express
+    - provider: go-go-goja-http
+      name: express
+
+artifacts:
+  - id: embedded-assets
+    type: embedded-assets
+    sources: [app-assets]
 ```

--- a/examples/xgoja/11-config-env/README.md
+++ b/examples/xgoja/11-config-env/README.md
@@ -9,8 +9,11 @@ This example demonstrates how a generated xgoja binary can read configuration fr
 ## Build
 
 ```bash
-xgoja build -f xgoja.yaml --xgoja-replace /path/to/go-go-goja
+xgoja doctor -f xgoja.yaml
+xgoja build -f xgoja.yaml
 ```
+
+The spec uses `workspace.mode: auto`, so local module replacements come from the repository workspace when available.
 
 ## Run with config file
 

--- a/examples/xgoja/14-generated-runtime-package/README.md
+++ b/examples/xgoja/14-generated-runtime-package/README.md
@@ -12,16 +12,20 @@ Generate the package and run the host smoke test:
 make -C examples/xgoja/14-generated-runtime-package smoke
 ```
 
-The generated package exposes:
+The generated package exposes a v2-native runtime-plan API:
 
-- `EmbeddedSpecJSON`
-- `DecodeSpec()`
+- `EmbeddedRuntimePlanJSON`
+- `DecodeRuntimePlan() (*app.RuntimePlan, error)`
 - `RegisterProviders(registry)`
 - `NewBundle(options)`
 - `Options.ConfigureServices func(*app.HostServices)` for host-owned service injection
+- `Bundle.RuntimePlan *app.RuntimePlan`
 - `Bundle.NewRuntime(ctx, ...)`
 - `Bundle.NewRuntimeFromSections(ctx, vals, ...)`
 - `Bundle.AttachDefaultCommands(root)`
+
+`NewBundle` remains the main ergonomic entry point: hosts do not need to decode
+metadata directly unless they want to inspect the generated runtime plan.
 
 The host program in `cmd/host/main.go` imports the generated package and runs:
 

--- a/examples/xgoja/14-generated-runtime-package/internal/xgojaruntime/xgoja_runtime.gen.go
+++ b/examples/xgoja/14-generated-runtime-package/internal/xgojaruntime/xgoja_runtime.gen.go
@@ -63,7 +63,7 @@ type Options struct {
 
 type Bundle struct {
 	Providers   *providerapi.ProviderRegistry
-	RuntimeSpec *app.RuntimeSpec
+	RuntimePlan *app.RuntimePlan
 	Host        *app.Host
 }
 
@@ -77,12 +77,12 @@ func RegisterProviders(registry *providerapi.ProviderRegistry) error {
 	return nil
 }
 
-func DecodeSpec() (*app.RuntimeSpec, error) {
-	runtimeSpec := &app.RuntimeSpec{}
-	if err := json.Unmarshal([]byte(EmbeddedSpecJSON), runtimeSpec); err != nil {
+func DecodeSpec() (*app.RuntimePlan, error) {
+	runtimePlan := &app.RuntimePlan{}
+	if err := json.Unmarshal([]byte(EmbeddedSpecJSON), runtimePlan); err != nil {
 		return nil, err
 	}
-	return runtimeSpec, nil
+	return runtimePlan, nil
 }
 
 func NewBundle(opts Options) (*Bundle, error) {
@@ -90,16 +90,16 @@ func NewBundle(opts Options) (*Bundle, error) {
 	if err := RegisterProviders(registry); err != nil {
 		return nil, err
 	}
-	runtimeSpec, err := DecodeSpec()
+	runtimePlan, err := DecodeSpec()
 	if err != nil {
 		return nil, err
 	}
-	host := app.NewHostWithOptions(registry, runtimeSpec, app.HostOptions{
+	host := app.NewHostWithOptions(registry, runtimePlan, app.HostOptions{
 		Out:               opts.Out,
 		MiddlewaresFunc:   opts.MiddlewaresFunc,
 		ConfigureServices: opts.ConfigureServices,
 	})
-	return &Bundle{Providers: registry, RuntimeSpec: runtimeSpec, Host: host}, nil
+	return &Bundle{Providers: registry, RuntimePlan: runtimePlan, Host: host}, nil
 }
 
 func (b *Bundle) TypeScriptDeclarations() (string, error) {

--- a/examples/xgoja/14-generated-runtime-package/internal/xgojaruntime/xgoja_runtime.gen.go
+++ b/examples/xgoja/14-generated-runtime-package/internal/xgojaruntime/xgoja_runtime.gen.go
@@ -18,40 +18,45 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const EmbeddedSpecJSON = `{
+const EmbeddedRuntimePlanJSON = `{
+  "schema": "xgoja/runtime/v2",
   "name": "generated-runtime-package",
-  "appName": "generated-runtime-package",
+  "app": {
+    "name": "generated-runtime-package"
+  },
   "target": {
     "kind": "package",
     "output": "internal/xgojaruntime"
   },
-  "packages": [
+  "providers": [
     {
       "id": "fixture"
     }
   ],
-  "modules": [
+  "runtime": {
+    "modules": [
+      {
+        "provider": "fixture",
+        "name": "hello",
+        "as": "hello"
+      }
+    ]
+  },
+  "commands": [
     {
-      "package": "fixture",
-      "name": "hello",
-      "as": "hello"
+      "id": "eval",
+      "type": "builtin.eval",
+      "name": "eval"
     }
   ],
-  "commands": {
-    "eval": {
-      "enabled": true,
-      "name": "eval"
-    },
-    "run": {
-      "enabled": false
-    },
-    "repl": {
-      "enabled": false
-    },
-    "jsverbs": {
-      "enabled": false
+  "artifacts": [
+    {
+      "id": "runtime-package",
+      "type": "runtime-package",
+      "output": "internal/xgojaruntime",
+      "package": "xgojaruntime"
     }
-  }
+  ]
 }
 `
 
@@ -77,9 +82,9 @@ func RegisterProviders(registry *providerapi.ProviderRegistry) error {
 	return nil
 }
 
-func DecodeSpec() (*app.RuntimePlan, error) {
+func DecodeRuntimePlan() (*app.RuntimePlan, error) {
 	runtimePlan := &app.RuntimePlan{}
-	if err := json.Unmarshal([]byte(EmbeddedSpecJSON), runtimePlan); err != nil {
+	if err := json.Unmarshal([]byte(EmbeddedRuntimePlanJSON), runtimePlan); err != nil {
 		return nil, err
 	}
 	return runtimePlan, nil
@@ -90,7 +95,7 @@ func NewBundle(opts Options) (*Bundle, error) {
 	if err := RegisterProviders(registry); err != nil {
 		return nil, err
 	}
-	runtimePlan, err := DecodeSpec()
+	runtimePlan, err := DecodeRuntimePlan()
 	if err != nil {
 		return nil, err
 	}

--- a/examples/xgoja/16-typescript-jsverbs/js/types/xgoja-modules.d.ts
+++ b/examples/xgoja/16-typescript-jsverbs/js/types/xgoja-modules.d.ts
@@ -9,9 +9,13 @@ declare module "express" {
   patch(pattern: string, handler: Handler): void;
   delete(pattern: string, handler: Handler): void;
   all(pattern: string, handler: Handler): void;
+  mount(prefix: string, handler: MountableHandler, options?: MountOptions): void;
+  mountHandler(prefix: string, handler: MountableHandler, options?: MountOptions): void;
   static(prefix: string, directory: string): void;
   staticFromAssetsModule(prefix: string, assetsModule: unknown, root: string): void;
   }
+  export interface MountableHandler {}
+  export interface MountOptions { stripPrefix?: boolean; excludePrefixes?: string[]; }
   export type Handler = (req: Request, res: Response) => unknown;
   export interface Request {
   method: string;

--- a/examples/xgoja/README.md
+++ b/examples/xgoja/README.md
@@ -79,10 +79,4 @@ done
 
 `11-config-env/` and `12-geppetto-host-services/` are intentionally omitted from the bulk loop. `11-config-env/` is a command/config fixture rather than a Makefile-based smoke, and `12-geppetto-host-services/` depends on a sibling checkout of `geppetto` plus optional live profile credentials for the full inference smoke.
 
-The Makefiles use:
-
-```bash
-GOWORK=off go run ./cmd/xgoja ... --xgoja-replace <repo-root>
-```
-
-`GOWORK=off` avoids the local workspace `goja` override while this repository's workspace dependency mismatch is unresolved. `--xgoja-replace` makes generated binaries use this checkout of `go-go-goja` instead of a released module version.
+The examples are v2-first. Their specs generally use `workspace.mode: auto`, so generated build workspaces derive local module replacements from the repository `go.work` plan. Some Makefiles still run the xgoja CLI itself with `GOWORK=off` to isolate the CLI process, but generated module replacement should come from workspace planning or an explicit example-specific provider replacement rather than legacy runtime metadata.

--- a/pkg/xgoja/app/assets.go
+++ b/pkg/xgoja/app/assets.go
@@ -24,14 +24,17 @@ type HostServices struct {
 }
 
 func NewAssetStore(fsys fs.FS, runtimePlan *RuntimePlan) *AssetStore {
+	registry := NewSourceRegistry(nil, nil, runtimePlan.allSources())
+	return NewAssetStoreFromSources(fsys, registry.ListSourcesByKind(providerapi.RuntimeSourceKindAssets))
+}
+
+func NewAssetStoreFromSources(fsys fs.FS, assets []providerapi.RuntimeSourceDescriptor) *AssetStore {
 	store := &AssetStore{
 		fsys:   fsys,
 		assets: map[string]SourcePlan{},
 	}
-	if runtimePlan == nil {
-		return store
-	}
-	for _, asset := range runtimePlan.sourcesByKind(SourceKindAssets) {
+	for _, descriptor := range assets {
+		asset := SourcePlan{ID: descriptor.ID, Kind: SourceKindAssets, Path: descriptor.Path, Embed: descriptor.Embed, Provider: descriptor.Provider, Source: descriptor.Source}
 		id := strings.TrimSpace(asset.ID)
 		if id == "" {
 			continue

--- a/pkg/xgoja/app/assets.go
+++ b/pkg/xgoja/app/assets.go
@@ -15,7 +15,7 @@ var _ providerapi.HostServiceLookup = HostServices{}
 
 type AssetStore struct {
 	fsys   fs.FS
-	assets map[string]AssetSourceSpec
+	assets map[string]SourcePlan
 }
 
 type HostServices struct {
@@ -23,15 +23,15 @@ type HostServices struct {
 	Services map[string][]any
 }
 
-func NewAssetStore(fsys fs.FS, runtimeSpec *RuntimeSpec) *AssetStore {
+func NewAssetStore(fsys fs.FS, runtimePlan *RuntimePlan) *AssetStore {
 	store := &AssetStore{
 		fsys:   fsys,
-		assets: map[string]AssetSourceSpec{},
+		assets: map[string]SourcePlan{},
 	}
-	if runtimeSpec == nil {
+	if runtimePlan == nil {
 		return store
 	}
-	for _, asset := range runtimeSpec.Assets {
+	for _, asset := range runtimePlan.sourcesByKind(SourceKindAssets) {
 		id := strings.TrimSpace(asset.ID)
 		if id == "" {
 			continue

--- a/pkg/xgoja/app/assets_test.go
+++ b/pkg/xgoja/app/assets_test.go
@@ -16,7 +16,7 @@ func TestAssetStoreResolveAsset(t *testing.T) {
 	assetFS := fstest.MapFS{
 		"xgoja_embed/assets/app/config.json": &fstest.MapFile{Data: []byte(`{"ok":true}`)},
 	}
-	store := NewAssetStore(assetFS, &RuntimeSpec{Assets: []AssetSourceSpec{{ID: "app", Path: "/xgoja_embed/assets/app", Embed: true}}})
+	store := NewAssetStore(assetFS, &RuntimePlan{Assets: []SourcePlan{{ID: "app", Path: "/xgoja_embed/assets/app", Embed: true}}})
 
 	fsys, root, ok := store.ResolveAsset("app")
 	if !ok {
@@ -35,8 +35,8 @@ func TestAssetStoreResolveAsset(t *testing.T) {
 }
 
 func TestRuntimeFactoryPassesRuntimeOwnerToModules(t *testing.T) {
-	runtimeSpec := &RuntimeSpec{
-		Modules: []ModuleInstanceSpec{{Package: "fixture", Name: "owner-check", As: "owner-check"}},
+	runtimePlan := &RuntimePlan{
+		Modules: []RuntimeModulePlan{{Package: "fixture", Name: "owner-check", As: "owner-check"}},
 	}
 	seen := false
 	registry := providerapi.NewProviderRegistry()
@@ -53,7 +53,7 @@ func TestRuntimeFactoryPassesRuntimeOwnerToModules(t *testing.T) {
 		t.Fatalf("register provider: %v", err)
 	}
 
-	rt, err := NewRuntimeFactory(registry, runtimeSpec).NewRuntime(context.Background())
+	rt, err := NewRuntimeFactory(registry, runtimePlan).NewRuntime(context.Background())
 	if err != nil {
 		t.Fatalf("new runtime: %v", err)
 	}
@@ -67,9 +67,9 @@ func TestRuntimeFactoryPassesHostServicesToModules(t *testing.T) {
 	assetFS := fstest.MapFS{
 		"xgoja_embed/assets/app/config.json": &fstest.MapFile{Data: []byte(`{"ok":true}`)},
 	}
-	runtimeSpec := &RuntimeSpec{
-		Assets:  []AssetSourceSpec{{ID: "app", Path: "xgoja_embed/assets/app", Embed: true}},
-		Modules: []ModuleInstanceSpec{{Package: "fixture", Name: "asset-check", As: "asset-check"}},
+	runtimePlan := &RuntimePlan{
+		Assets:  []SourcePlan{{ID: "app", Path: "xgoja_embed/assets/app", Embed: true}},
+		Modules: []RuntimeModulePlan{{Package: "fixture", Name: "asset-check", As: "asset-check"}},
 	}
 	seen := false
 	registry := providerapi.NewProviderRegistry()
@@ -91,7 +91,7 @@ func TestRuntimeFactoryPassesHostServicesToModules(t *testing.T) {
 		t.Fatalf("register provider: %v", err)
 	}
 
-	host := NewHostWithOptions(registry, runtimeSpec, HostOptions{EmbeddedAssets: assetFS})
+	host := NewHostWithOptions(registry, runtimePlan, HostOptions{EmbeddedAssets: assetFS})
 	rt, err := host.Factory.NewRuntime(context.Background())
 	if err != nil {
 		t.Fatalf("new runtime: %v", err)

--- a/pkg/xgoja/app/assets_test.go
+++ b/pkg/xgoja/app/assets_test.go
@@ -16,7 +16,7 @@ func TestAssetStoreResolveAsset(t *testing.T) {
 	assetFS := fstest.MapFS{
 		"xgoja_embed/assets/app/config.json": &fstest.MapFile{Data: []byte(`{"ok":true}`)},
 	}
-	store := NewAssetStore(assetFS, &RuntimePlan{Assets: []SourcePlan{{ID: "app", Path: "/xgoja_embed/assets/app", Embed: true}}})
+	store := NewAssetStore(assetFS, &RuntimePlan{Sources: []SourcePlan{{ID: "app", Kind: SourceKindAssets, Path: "/xgoja_embed/assets/app", Embed: true}}})
 
 	fsys, root, ok := store.ResolveAsset("app")
 	if !ok {
@@ -36,7 +36,7 @@ func TestAssetStoreResolveAsset(t *testing.T) {
 
 func TestRuntimeFactoryPassesRuntimeOwnerToModules(t *testing.T) {
 	runtimePlan := &RuntimePlan{
-		Modules: []RuntimeModulePlan{{Package: "fixture", Name: "owner-check", As: "owner-check"}},
+		Runtime: RuntimeSection{Modules: []RuntimeModulePlan{{Provider: "fixture", Name: "owner-check", As: "owner-check"}}},
 	}
 	seen := false
 	registry := providerapi.NewProviderRegistry()
@@ -68,8 +68,8 @@ func TestRuntimeFactoryPassesHostServicesToModules(t *testing.T) {
 		"xgoja_embed/assets/app/config.json": &fstest.MapFile{Data: []byte(`{"ok":true}`)},
 	}
 	runtimePlan := &RuntimePlan{
-		Assets:  []SourcePlan{{ID: "app", Path: "xgoja_embed/assets/app", Embed: true}},
-		Modules: []RuntimeModulePlan{{Package: "fixture", Name: "asset-check", As: "asset-check"}},
+		Sources: []SourcePlan{{ID: "app", Kind: SourceKindAssets, Path: "xgoja_embed/assets/app", Embed: true}},
+		Runtime: RuntimeSection{Modules: []RuntimeModulePlan{{Provider: "fixture", Name: "asset-check", As: "asset-check"}}},
 	}
 	seen := false
 	registry := providerapi.NewProviderRegistry()

--- a/pkg/xgoja/app/command_providers.go
+++ b/pkg/xgoja/app/command_providers.go
@@ -21,41 +21,47 @@ func (h *Host) AttachCommandProviders(root *cobra.Command) {
 		return
 	}
 	for _, instance := range h.RuntimePlan.runtimeCommands() {
-		if instance.Type != "provider.command-set" {
-			continue
+		if instance.Type == "provider.command-set" {
+			h.AttachCommandProvider(root, instance)
 		}
-		provider, ok := h.Providers.ResolveCommandSetProvider(instance.ProviderID(), instance.Name)
-		mount := strings.TrimSpace(instance.Mount)
-		if mount == "" {
-			mount = provider.DefaultMount
+	}
+}
+
+func (h *Host) AttachCommandProvider(root *cobra.Command, instance CommandPlan) {
+	if root == nil || h == nil || h.Providers == nil {
+		return
+	}
+	provider, ok := h.Providers.ResolveCommandSetProvider(instance.ProviderID(), instance.Name)
+	mount := strings.TrimSpace(instance.Mount)
+	if mount == "" {
+		mount = provider.DefaultMount
+	}
+	if !ok {
+		root.AddCommand(commandErrorStub(commandProviderUse(instance, mount), "Attach custom xgoja command provider", fmt.Errorf("unknown command provider %s.%s", instance.ProviderID(), instance.Name)))
+		return
+	}
+	set, err := h.newCommandSet(instance, provider, mount)
+	if err != nil {
+		root.AddCommand(commandErrorStub(commandProviderUse(instance, mount), "Attach custom xgoja command provider", err))
+		return
+	}
+	commands := applyMountToCommands(set.Commands, mount)
+	middlewaresFunc := h.MiddlewaresFunc
+	if middlewaresFunc == nil {
+		middlewaresFunc = glazedcli.CobraCommandDefaultMiddlewares
+	}
+	parserConfig := glazedcli.CobraParserConfig{
+		ShortHelpSections: []string{schema.DefaultSlug},
+		MiddlewaresFunc:   middlewaresFunc,
+	}
+	if set.ParserConfig != nil {
+		parserConfig = *set.ParserConfig
+		if parserConfig.MiddlewaresFunc == nil {
+			parserConfig.MiddlewaresFunc = middlewaresFunc
 		}
-		if !ok {
-			root.AddCommand(commandErrorStub(commandProviderUse(instance, mount), "Attach custom xgoja command provider", fmt.Errorf("unknown command provider %s.%s", instance.ProviderID(), instance.Name)))
-			continue
-		}
-		set, err := h.newCommandSet(instance, provider, mount)
-		if err != nil {
-			root.AddCommand(commandErrorStub(commandProviderUse(instance, mount), "Attach custom xgoja command provider", err))
-			continue
-		}
-		commands := applyMountToCommands(set.Commands, mount)
-		middlewaresFunc := h.MiddlewaresFunc
-		if middlewaresFunc == nil {
-			middlewaresFunc = glazedcli.CobraCommandDefaultMiddlewares
-		}
-		parserConfig := glazedcli.CobraParserConfig{
-			ShortHelpSections: []string{schema.DefaultSlug},
-			MiddlewaresFunc:   middlewaresFunc,
-		}
-		if set.ParserConfig != nil {
-			parserConfig = *set.ParserConfig
-			if parserConfig.MiddlewaresFunc == nil {
-				parserConfig.MiddlewaresFunc = middlewaresFunc
-			}
-		}
-		if err := glazedcli.AddCommandsToRootCommand(root, commands, nil, glazedcli.WithParserConfig(parserConfig)); err != nil {
-			root.AddCommand(commandErrorStub(commandProviderUse(instance, mount), "Attach custom xgoja command provider", err))
-		}
+	}
+	if err := glazedcli.AddCommandsToRootCommand(root, commands, nil, glazedcli.WithParserConfig(parserConfig)); err != nil {
+		root.AddCommand(commandErrorStub(commandProviderUse(instance, mount), "Attach custom xgoja command provider", err))
 	}
 }
 
@@ -68,7 +74,7 @@ func (h *Host) newCommandSet(instance CommandPlan, provider providerapi.CommandS
 	if err != nil {
 		return nil, err
 	}
-	sourceRegistry := NewSourceRegistry(h.Providers, h.EmbeddedJSVerbs, h.RuntimePlan.allSources()).Scoped(instance.Sources)
+	sourceRegistry := h.SourceRegistry.Scoped(instance.Sources)
 	set, err := provider.NewCommandSet(providerapi.CommandSetContext{
 		Context:         context.Background(),
 		PackageID:       instance.ProviderID(),

--- a/pkg/xgoja/app/command_providers.go
+++ b/pkg/xgoja/app/command_providers.go
@@ -17,17 +17,20 @@ import (
 )
 
 func (h *Host) AttachCommandProviders(root *cobra.Command) {
-	if root == nil || h == nil || h.RuntimeSpec == nil || h.Providers == nil {
+	if root == nil || h == nil || h.RuntimePlan == nil || h.Providers == nil {
 		return
 	}
-	for _, instance := range h.RuntimeSpec.CommandProviders {
-		provider, ok := h.Providers.ResolveCommandSetProvider(instance.Package, instance.Name)
+	for _, instance := range h.RuntimePlan.runtimeCommands() {
+		if instance.Type != "provider.command-set" {
+			continue
+		}
+		provider, ok := h.Providers.ResolveCommandSetProvider(instance.ProviderID(), instance.Name)
 		mount := strings.TrimSpace(instance.Mount)
 		if mount == "" {
 			mount = provider.DefaultMount
 		}
 		if !ok {
-			root.AddCommand(commandErrorStub(commandProviderUse(instance, mount), "Attach custom xgoja command provider", fmt.Errorf("unknown command provider %s.%s", instance.Package, instance.Name)))
+			root.AddCommand(commandErrorStub(commandProviderUse(instance, mount), "Attach custom xgoja command provider", fmt.Errorf("unknown command provider %s.%s", instance.ProviderID(), instance.Name)))
 			continue
 		}
 		set, err := h.newCommandSet(instance, provider, mount)
@@ -56,7 +59,7 @@ func (h *Host) AttachCommandProviders(root *cobra.Command) {
 	}
 }
 
-func (h *Host) newCommandSet(instance CommandProviderInstanceSpec, provider providerapi.CommandSetProvider, mount string) (*providerapi.CommandSet, error) {
+func (h *Host) newCommandSet(instance CommandPlan, provider providerapi.CommandSetProvider, mount string) (*providerapi.CommandSet, error) {
 	config, err := json.Marshal(instance.Config)
 	if err != nil {
 		return nil, fmt.Errorf("marshal command provider config %s: %w", instance.ID, err)
@@ -67,25 +70,25 @@ func (h *Host) newCommandSet(instance CommandProviderInstanceSpec, provider prov
 	}
 	set, err := provider.NewCommandSet(providerapi.CommandSetContext{
 		Context:         context.Background(),
-		PackageID:       instance.Package,
+		PackageID:       instance.ProviderID(),
 		Name:            instance.Name,
 		Mount:           mount,
 		Config:          config,
 		Providers:       h.Providers,
 		RuntimeFactory:  h.Factory,
 		SelectedModules: selected,
-		JSVerbs:         newScopedJSVerbSourceSet(h.Providers, h.EmbeddedJSVerbs, h.RuntimeSpec.JSVerbs, instance.Sources),
+		JSVerbs:         newScopedJSVerbSourceSet(h.Providers, h.EmbeddedJSVerbs, h.RuntimePlan.sourcesByKind(SourceKindJSVerbs), instance.Sources),
 	})
 	if err != nil {
-		return nil, fmt.Errorf("create command set %s.%s: %w", instance.Package, instance.Name, err)
+		return nil, fmt.Errorf("create command set %s.%s: %w", instance.ProviderID(), instance.Name, err)
 	}
 	if set == nil {
-		return nil, fmt.Errorf("command provider %s.%s returned nil command set", instance.Package, instance.Name)
+		return nil, fmt.Errorf("command provider %s.%s returned nil command set", instance.ProviderID(), instance.Name)
 	}
 	return set, nil
 }
 
-func (h *Host) selectedModulesForCommandProvider(instance CommandProviderInstanceSpec) ([]providerapi.ModuleDescriptor, error) {
+func (h *Host) selectedModulesForCommandProvider(instance CommandPlan) ([]providerapi.ModuleDescriptor, error) {
 	descriptors, err := h.Factory.selectedModuleDescriptors()
 	if err != nil {
 		return nil, err
@@ -187,7 +190,7 @@ func (c mountedGlazeCommand) RunIntoGlazeProcessor(ctx context.Context, vals *va
 	return c.command.(cmds.GlazeCommand).RunIntoGlazeProcessor(ctx, vals, gp)
 }
 
-func commandProviderUse(instance CommandProviderInstanceSpec, mount string) string {
+func commandProviderUse(instance CommandPlan, mount string) string {
 	if strings.TrimSpace(mount) != "" {
 		return strings.TrimSpace(mount)
 	}

--- a/pkg/xgoja/app/command_providers.go
+++ b/pkg/xgoja/app/command_providers.go
@@ -16,7 +16,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func (h *Host) AttachCommandProviders(root *cobra.Command) {
+func (h *Host) AttachProviderCommands(root *cobra.Command) {
 	if root == nil || h == nil || h.RuntimePlan == nil || h.Providers == nil {
 		return
 	}
@@ -85,7 +85,6 @@ func (h *Host) newCommandSet(instance CommandPlan, provider providerapi.CommandS
 		RuntimeFactory:  h.Factory,
 		SelectedModules: selected,
 		Sources:         sourceRegistry,
-		JSVerbs:         sourceRegistry.JSVerbs(),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create command set %s.%s: %w", instance.ProviderID(), instance.Name, err)

--- a/pkg/xgoja/app/command_providers.go
+++ b/pkg/xgoja/app/command_providers.go
@@ -68,6 +68,7 @@ func (h *Host) newCommandSet(instance CommandPlan, provider providerapi.CommandS
 	if err != nil {
 		return nil, err
 	}
+	sourceRegistry := NewSourceRegistry(h.Providers, h.EmbeddedJSVerbs, h.RuntimePlan.allSources()).Scoped(instance.Sources)
 	set, err := provider.NewCommandSet(providerapi.CommandSetContext{
 		Context:         context.Background(),
 		PackageID:       instance.ProviderID(),
@@ -77,7 +78,8 @@ func (h *Host) newCommandSet(instance CommandPlan, provider providerapi.CommandS
 		Providers:       h.Providers,
 		RuntimeFactory:  h.Factory,
 		SelectedModules: selected,
-		JSVerbs:         newScopedJSVerbSourceSet(h.Providers, h.EmbeddedJSVerbs, h.RuntimePlan.sourcesByKind(SourceKindJSVerbs), instance.Sources),
+		Sources:         sourceRegistry,
+		JSVerbs:         sourceRegistry.JSVerbs(),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create command set %s.%s: %w", instance.ProviderID(), instance.Name, err)

--- a/pkg/xgoja/app/command_providers.go
+++ b/pkg/xgoja/app/command_providers.go
@@ -74,7 +74,7 @@ func (h *Host) newCommandSet(instance CommandProviderInstanceSpec, provider prov
 		Providers:       h.Providers,
 		RuntimeFactory:  h.Factory,
 		SelectedModules: selected,
-		JSVerbs:         newJSVerbSourceSet(h.Providers, h.EmbeddedJSVerbs, h.RuntimeSpec.JSVerbs),
+		JSVerbs:         newScopedJSVerbSourceSet(h.Providers, h.EmbeddedJSVerbs, h.RuntimeSpec.JSVerbs, instance.Sources),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create command set %s.%s: %w", instance.Package, instance.Name, err)

--- a/pkg/xgoja/app/command_providers_test.go
+++ b/pkg/xgoja/app/command_providers_test.go
@@ -212,6 +212,46 @@ func TestHostAttachProviderCommandsScopesSourceRegistry(t *testing.T) {
 	NewHost(registry, runtimePlan).AttachDefaultCommands(root)
 }
 
+func TestHostAttachProviderCommandsKeepsEmptySourceScopeEmpty(t *testing.T) {
+	registry := providerapi.NewProviderRegistry()
+	if err := registry.Package("fixture",
+		providerapi.CommandSetProvider{
+			Name: "tools",
+			NewCommandSet: func(ctx providerapi.CommandSetContext) (*providerapi.CommandSet, error) {
+				if ctx.Sources == nil {
+					t.Fatal("expected source registry")
+				}
+				if sources := ctx.Sources.ListSources(); len(sources) != 0 {
+					t.Fatalf("sources = %#v, want empty command scope", sources)
+				}
+				if jsverbSources := ctx.Sources.JSVerbs().ListJSVerbSources(); len(jsverbSources) != 0 {
+					t.Fatalf("jsverb sources = %#v, want empty command scope", jsverbSources)
+				}
+				return &providerapi.CommandSet{Commands: []cmds.Command{&fixtureBareCommand{
+					CommandDescription: cmds.NewCommandDescription("ping", cmds.WithShort("Ping")),
+					run:                func(context.Context, *values.Values) error { return nil },
+				}}}, nil
+			},
+		},
+	); err != nil {
+		t.Fatalf("register provider: %v", err)
+	}
+	runtimePlan := &RuntimePlan{
+		Sources: []SourcePlan{
+			{ID: "site-a", Kind: SourceKindJSVerbs, Path: "a"},
+			{ID: "site-b", Kind: SourceKindJSVerbs, Path: "b"},
+		},
+		Commands: []CommandPlan{{
+			ID:       "fixture-tools",
+			Type:     "provider.command-set",
+			Provider: "fixture",
+			Name:     "tools",
+		}},
+	}
+	root := &cobra.Command{Use: "test"}
+	NewHost(registry, runtimePlan).AttachDefaultCommands(root)
+}
+
 func TestHostAttachProviderCommandsMountsGlazedCommand(t *testing.T) {
 	called := false
 	registry := providerapi.NewProviderRegistry()

--- a/pkg/xgoja/app/command_providers_test.go
+++ b/pkg/xgoja/app/command_providers_test.go
@@ -67,8 +67,8 @@ func TestHostAttachCommandProvidersPassesSelectedModules(t *testing.T) {
 	); err != nil {
 		t.Fatalf("register provider: %v", err)
 	}
-	runtimeSpec := &RuntimeSpec{
-		Modules: []ModuleInstanceSpec{{Package: "fixture", Name: "mod"}},
+	runtimePlan := &RuntimePlan{
+		Modules: []RuntimeModulePlan{{Package: "fixture", Name: "mod"}},
 		CommandProviders: []CommandProviderInstanceSpec{{
 			ID:      "fixture-tools",
 			Package: "fixture",
@@ -77,7 +77,7 @@ func TestHostAttachCommandProvidersPassesSelectedModules(t *testing.T) {
 		}},
 	}
 	root := &cobra.Command{Use: "test"}
-	NewHost(registry, runtimeSpec).AttachDefaultCommands(root)
+	NewHost(registry, runtimePlan).AttachDefaultCommands(root)
 	root.SetArgs([]string{"fixture", "ping"})
 	if err := root.ExecuteContext(context.Background()); err != nil {
 		t.Fatalf("execute command provider command: %v", err)
@@ -101,7 +101,7 @@ module.exports = { helper };
 		t.Fatalf("write helper module: %v", err)
 	}
 
-	registry, err := scanVerbSource(providerapi.NewProviderRegistry(), nil, JSVerbSourceSpec{ID: "local", Path: dir}, nil)
+	registry, err := scanVerbSource(providerapi.NewProviderRegistry(), nil, SourcePlan{ID: "local", Path: dir}, nil)
 	if err != nil {
 		t.Fatalf("scan source: %v", err)
 	}
@@ -151,8 +151,8 @@ function hello() { return "hello"; }
 	); err != nil {
 		t.Fatalf("register provider: %v", err)
 	}
-	runtimeSpec := &RuntimeSpec{
-		JSVerbs: []JSVerbSourceSpec{{ID: "local", Path: dir}},
+	runtimePlan := &RuntimePlan{
+		JSVerbs: []SourcePlan{{ID: "local", Path: dir}},
 		CommandProviders: []CommandProviderInstanceSpec{{
 			ID:      "fixture-tools",
 			Package: "fixture",
@@ -160,7 +160,7 @@ function hello() { return "hello"; }
 		}},
 	}
 	root := &cobra.Command{Use: "test"}
-	NewHost(registry, runtimeSpec).AttachDefaultCommands(root)
+	NewHost(registry, runtimePlan).AttachDefaultCommands(root)
 }
 
 func TestHostAttachCommandProvidersMountsGlazedCommand(t *testing.T) {
@@ -204,8 +204,8 @@ func TestHostAttachCommandProvidersMountsGlazedCommand(t *testing.T) {
 	); err != nil {
 		t.Fatalf("register provider: %v", err)
 	}
-	runtimeSpec := &RuntimeSpec{
-		Modules: []ModuleInstanceSpec{{Package: "fixture", Name: "mod"}},
+	runtimePlan := &RuntimePlan{
+		Modules: []RuntimeModulePlan{{Package: "fixture", Name: "mod"}},
 		CommandProviders: []CommandProviderInstanceSpec{{
 			ID:      "fixture-tools",
 			Package: "fixture",
@@ -214,7 +214,7 @@ func TestHostAttachCommandProvidersMountsGlazedCommand(t *testing.T) {
 		}},
 	}
 	root := &cobra.Command{Use: "test"}
-	NewHost(registry, runtimeSpec).AttachDefaultCommands(root)
+	NewHost(registry, runtimePlan).AttachDefaultCommands(root)
 	root.SetArgs([]string{"fixture", "ping", "--message", "hello"})
 	if err := root.ExecuteContext(context.Background()); err != nil {
 		t.Fatalf("execute command provider command: %v", err)

--- a/pkg/xgoja/app/command_providers_test.go
+++ b/pkg/xgoja/app/command_providers_test.go
@@ -163,6 +163,53 @@ function hello() { return "hello"; }
 	NewHost(registry, runtimePlan).AttachDefaultCommands(root)
 }
 
+func TestHostAttachCommandProvidersScopesSourceRegistry(t *testing.T) {
+	registry := providerapi.NewProviderRegistry()
+	if err := registry.Package("fixture",
+		providerapi.CommandSetProvider{
+			Name: "tools",
+			NewCommandSet: func(ctx providerapi.CommandSetContext) (*providerapi.CommandSet, error) {
+				if ctx.Sources == nil {
+					t.Fatal("expected source registry")
+				}
+				if _, ok := ctx.Sources.SourceByID("site-a"); !ok {
+					t.Fatal("expected selected source site-a")
+				}
+				if _, ok := ctx.Sources.SourceByID("site-b"); ok {
+					t.Fatal("did not expect unselected source site-b")
+				}
+				jsverbSources := ctx.Sources.ListSourcesByKind(providerapi.RuntimeSourceKindJSVerbs)
+				if len(jsverbSources) != 1 || jsverbSources[0].ID != "site-a" {
+					t.Fatalf("jsverb sources = %#v", jsverbSources)
+				}
+				if got := ctx.JSVerbs.ListJSVerbSources(); len(got) != 1 || got[0].ID != "site-a" {
+					t.Fatalf("jsverb adapter sources = %#v", got)
+				}
+				return &providerapi.CommandSet{Commands: []cmds.Command{&fixtureBareCommand{
+					CommandDescription: cmds.NewCommandDescription("ping", cmds.WithShort("Ping")),
+					run:                func(context.Context, *values.Values) error { return nil },
+				}}}, nil
+			},
+		},
+	); err != nil {
+		t.Fatalf("register provider: %v", err)
+	}
+	runtimePlan := &RuntimePlan{
+		Sources: []SourcePlan{
+			{ID: "site-a", Kind: SourceKindJSVerbs, Path: "a"},
+			{ID: "site-b", Kind: SourceKindJSVerbs, Path: "b"},
+		},
+		CommandProviders: []CommandPlan{{
+			ID:       "fixture-tools",
+			Provider: "fixture",
+			Name:     "tools",
+			Sources:  []string{"site-a"},
+		}},
+	}
+	root := &cobra.Command{Use: "test"}
+	NewHost(registry, runtimePlan).AttachDefaultCommands(root)
+}
+
 func TestHostAttachCommandProvidersMountsGlazedCommand(t *testing.T) {
 	called := false
 	registry := providerapi.NewProviderRegistry()

--- a/pkg/xgoja/app/command_providers_test.go
+++ b/pkg/xgoja/app/command_providers_test.go
@@ -37,7 +37,7 @@ func TestApplyMountToCommandsDoesNotMutateProviderDescriptions(t *testing.T) {
 	}
 }
 
-func TestHostAttachCommandProvidersPassesSelectedModules(t *testing.T) {
+func TestHostAttachProviderCommandsPassesSelectedModules(t *testing.T) {
 	registry := providerapi.NewProviderRegistry()
 	if err := registry.Package("fixture",
 		providerapi.Module{Name: "mod", NewModuleFactory: noopSectionModule},
@@ -68,12 +68,13 @@ func TestHostAttachCommandProvidersPassesSelectedModules(t *testing.T) {
 		t.Fatalf("register provider: %v", err)
 	}
 	runtimePlan := &RuntimePlan{
-		Modules: []RuntimeModulePlan{{Package: "fixture", Name: "mod"}},
-		CommandProviders: []CommandProviderInstanceSpec{{
-			ID:      "fixture-tools",
-			Package: "fixture",
-			Name:    "tools",
-			Mount:   "fixture",
+		Runtime: RuntimeSection{Modules: []RuntimeModulePlan{{Provider: "fixture", Name: "mod"}}},
+		Commands: []CommandPlan{{
+			ID:       "fixture-tools",
+			Type:     "provider.command-set",
+			Provider: "fixture",
+			Name:     "tools",
+			Mount:    "fixture",
 		}},
 	}
 	root := &cobra.Command{Use: "test"}
@@ -114,7 +115,7 @@ module.exports = { helper };
 	}
 }
 
-func TestHostAttachCommandProvidersProvidesJSVerbSources(t *testing.T) {
+func TestHostAttachProviderCommandsProvidesSourceRegistryJSVerbs(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "tools.js"), []byte(`
 __package__({ name: "tools" });
@@ -128,14 +129,15 @@ function hello() { return "hello"; }
 		providerapi.CommandSetProvider{
 			Name: "tools",
 			NewCommandSet: func(ctx providerapi.CommandSetContext) (*providerapi.CommandSet, error) {
-				if ctx.JSVerbs == nil {
-					t.Fatal("expected jsverb source set")
+				if ctx.Sources == nil {
+					t.Fatal("expected source registry")
 				}
-				sources := ctx.JSVerbs.ListJSVerbSources()
+				jsverbs := ctx.Sources.JSVerbs()
+				sources := jsverbs.ListJSVerbSources()
 				if len(sources) != 1 || sources[0].ID != "local" {
 					t.Fatalf("sources = %#v", sources)
 				}
-				registries, err := ctx.JSVerbs.ScanAllJSVerbSources()
+				registries, err := jsverbs.ScanAllJSVerbSources()
 				if err != nil {
 					t.Fatalf("scan all jsverb sources: %v", err)
 				}
@@ -152,18 +154,20 @@ function hello() { return "hello"; }
 		t.Fatalf("register provider: %v", err)
 	}
 	runtimePlan := &RuntimePlan{
-		JSVerbs: []SourcePlan{{ID: "local", Path: dir}},
-		CommandProviders: []CommandProviderInstanceSpec{{
-			ID:      "fixture-tools",
-			Package: "fixture",
-			Name:    "tools",
+		Sources: []SourcePlan{{ID: "local", Kind: SourceKindJSVerbs, Path: dir}},
+		Commands: []CommandPlan{{
+			ID:       "fixture-tools",
+			Type:     "provider.command-set",
+			Provider: "fixture",
+			Name:     "tools",
+			Sources:  []string{"local"},
 		}},
 	}
 	root := &cobra.Command{Use: "test"}
 	NewHost(registry, runtimePlan).AttachDefaultCommands(root)
 }
 
-func TestHostAttachCommandProvidersScopesSourceRegistry(t *testing.T) {
+func TestHostAttachProviderCommandsScopesSourceRegistry(t *testing.T) {
 	registry := providerapi.NewProviderRegistry()
 	if err := registry.Package("fixture",
 		providerapi.CommandSetProvider{
@@ -182,9 +186,6 @@ func TestHostAttachCommandProvidersScopesSourceRegistry(t *testing.T) {
 				if len(jsverbSources) != 1 || jsverbSources[0].ID != "site-a" {
 					t.Fatalf("jsverb sources = %#v", jsverbSources)
 				}
-				if got := ctx.JSVerbs.ListJSVerbSources(); len(got) != 1 || got[0].ID != "site-a" {
-					t.Fatalf("jsverb adapter sources = %#v", got)
-				}
 				return &providerapi.CommandSet{Commands: []cmds.Command{&fixtureBareCommand{
 					CommandDescription: cmds.NewCommandDescription("ping", cmds.WithShort("Ping")),
 					run:                func(context.Context, *values.Values) error { return nil },
@@ -199,8 +200,9 @@ func TestHostAttachCommandProvidersScopesSourceRegistry(t *testing.T) {
 			{ID: "site-a", Kind: SourceKindJSVerbs, Path: "a"},
 			{ID: "site-b", Kind: SourceKindJSVerbs, Path: "b"},
 		},
-		CommandProviders: []CommandPlan{{
+		Commands: []CommandPlan{{
 			ID:       "fixture-tools",
+			Type:     "provider.command-set",
 			Provider: "fixture",
 			Name:     "tools",
 			Sources:  []string{"site-a"},
@@ -210,7 +212,7 @@ func TestHostAttachCommandProvidersScopesSourceRegistry(t *testing.T) {
 	NewHost(registry, runtimePlan).AttachDefaultCommands(root)
 }
 
-func TestHostAttachCommandProvidersMountsGlazedCommand(t *testing.T) {
+func TestHostAttachProviderCommandsMountsGlazedCommand(t *testing.T) {
 	called := false
 	registry := providerapi.NewProviderRegistry()
 	if err := registry.Package("fixture",
@@ -252,12 +254,13 @@ func TestHostAttachCommandProvidersMountsGlazedCommand(t *testing.T) {
 		t.Fatalf("register provider: %v", err)
 	}
 	runtimePlan := &RuntimePlan{
-		Modules: []RuntimeModulePlan{{Package: "fixture", Name: "mod"}},
-		CommandProviders: []CommandProviderInstanceSpec{{
-			ID:      "fixture-tools",
-			Package: "fixture",
-			Name:    "tools",
-			Mount:   "fixture",
+		Runtime: RuntimeSection{Modules: []RuntimeModulePlan{{Provider: "fixture", Name: "mod"}}},
+		Commands: []CommandPlan{{
+			ID:       "fixture-tools",
+			Type:     "provider.command-set",
+			Provider: "fixture",
+			Name:     "tools",
+			Mount:    "fixture",
 		}},
 	}
 	root := &cobra.Command{Use: "test"}

--- a/pkg/xgoja/app/eval_module_sections_test.go
+++ b/pkg/xgoja/app/eval_module_sections_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestEvalCommandIncludesRuntimeModuleSections(t *testing.T) {
 	factory := newSectionTestFactory(t, providerapi.WithPackageCapability(runFixtureCapability{}))
-	cmd := newEvalCommand(factory, factory.runtimeSpec, nil)
+	cmd := newEvalCommand(factory, factory.runtimePlan, nil)
 	section, ok := cmd.Description().Schema.Get("fixture")
 	if !ok {
 		t.Fatal("expected fixture section on eval command")
@@ -23,7 +23,7 @@ func TestEvalCommandIncludesRuntimeModuleSections(t *testing.T) {
 func TestEvalCommandInitializesRuntimeFromModuleSections(t *testing.T) {
 	factory := newSectionTestFactory(t, providerapi.WithPackageCapability(runFixtureCapability{}))
 	out := &bytes.Buffer{}
-	cmd, err := buildGlazedCobraCommand(newEvalCommand(factory, factory.runtimeSpec, out))
+	cmd, err := buildGlazedCobraCommand(newEvalCommand(factory, factory.runtimePlan, out))
 	if err != nil {
 		t.Fatalf("build cobra command: %v", err)
 	}

--- a/pkg/xgoja/app/factory.go
+++ b/pkg/xgoja/app/factory.go
@@ -16,19 +16,19 @@ type JSRuntime = engine.Runtime
 
 type RuntimeFactory struct {
 	providers   *providerapi.ProviderRegistry
-	runtimeSpec *RuntimeSpec
+	runtimePlan *RuntimePlan
 	services    providerapi.HostServices
 }
 
 type providerRuntimeModuleRegistrar struct {
-	instance ModuleInstanceSpec
+	instance RuntimeModulePlan
 	module   providerapi.Module
 	config   json.RawMessage
 	services providerapi.HostServices
 }
 
 func (s providerRuntimeModuleRegistrar) ID() string {
-	return fmt.Sprintf("xgoja:%s.%s:%s", s.instance.Package, s.instance.Name, s.instance.Alias())
+	return fmt.Sprintf("xgoja:%s.%s:%s", s.instance.ProviderID(), s.instance.Name, s.instance.Alias())
 }
 
 func (s providerRuntimeModuleRegistrar) RegisterRuntimeModule(ctx *engine.RuntimeModuleRegistrationContext, reg *require.Registry) error {
@@ -40,7 +40,7 @@ func (s providerRuntimeModuleRegistrar) RegisterRuntimeModule(ctx *engine.Runtim
 		var err error
 		config, err = json.Marshal(s.instance.Config)
 		if err != nil {
-			return fmt.Errorf("marshal config for %s.%s: %w", s.instance.Package, s.instance.Name, err)
+			return fmt.Errorf("marshal config for %s.%s: %w", s.instance.ProviderID(), s.instance.Name, err)
 		}
 	}
 	loader, err := s.module.NewModuleFactory(providerapi.ModuleSetupContext{
@@ -53,18 +53,18 @@ func (s providerRuntimeModuleRegistrar) RegisterRuntimeModule(ctx *engine.Runtim
 		AddCloser:    ctx.AddCloser,
 	})
 	if err != nil {
-		return fmt.Errorf("create module %s.%s: %w", s.instance.Package, s.instance.Name, err)
+		return fmt.Errorf("create module %s.%s: %w", s.instance.ProviderID(), s.instance.Name, err)
 	}
 	reg.RegisterNativeModule(s.instance.Alias(), loader)
 	return nil
 }
 
-func NewRuntimeFactory(providers *providerapi.ProviderRegistry, runtimeSpec *RuntimeSpec, services ...providerapi.HostServices) *RuntimeFactory {
+func NewRuntimeFactory(providers *providerapi.ProviderRegistry, runtimePlan *RuntimePlan, services ...providerapi.HostServices) *RuntimeFactory {
 	var hostServices providerapi.HostServices
 	if len(services) > 0 {
 		hostServices = services[0]
 	}
-	return &RuntimeFactory{providers: providers, runtimeSpec: runtimeSpec, services: hostServices}
+	return &RuntimeFactory{providers: providers, runtimePlan: runtimePlan, services: hostServices}
 }
 
 func (f *RuntimeFactory) NewRuntime(ctx context.Context, opts ...require.Option) (*JSRuntime, error) {
@@ -76,7 +76,7 @@ func (f *RuntimeFactory) NewRuntimeFromSections(ctx context.Context, vals *value
 }
 
 func (f *RuntimeFactory) NewRuntimeFromSectionsWithHostServices(ctx context.Context, vals *values.Values, hostServices providerapi.HostServices, opts ...require.Option) (*JSRuntime, error) {
-	if f == nil || f.providers == nil || f.runtimeSpec == nil {
+	if f == nil || f.providers == nil || f.runtimePlan == nil {
 		return nil, fmt.Errorf("xgoja runtime factory is not initialized")
 	}
 	descriptors, err := f.selectedModuleDescriptors()
@@ -97,15 +97,15 @@ func (f *RuntimeFactory) NewRuntimeFromSectionsWithHostServices(ctx context.Cont
 	for _, descriptor := range descriptors {
 		descriptorsByInstance[moduleDescriptorKey(descriptor.PackageID, descriptor.ModuleID, descriptor.As)] = descriptor
 	}
-	modules := make([]engine.RuntimeModuleRegistrar, 0, len(f.runtimeSpec.Modules))
-	for _, instance := range f.runtimeSpec.Modules {
-		module, ok := f.providers.ResolveModule(instance.Package, instance.Name)
+	modules := make([]engine.RuntimeModuleRegistrar, 0, len(f.runtimePlan.runtimeModules()))
+	for _, instance := range f.runtimePlan.runtimeModules() {
+		module, ok := f.providers.ResolveModule(instance.ProviderID(), instance.Name)
 		if !ok {
-			return nil, fmt.Errorf("runtime references unknown provider module %s.%s", instance.Package, instance.Name)
+			return nil, fmt.Errorf("runtime references unknown provider module %s.%s", instance.ProviderID(), instance.Name)
 		}
-		descriptor := descriptorsByInstance[moduleDescriptorKey(instance.Package, instance.Name, instance.Alias())]
+		descriptor := descriptorsByInstance[moduleDescriptorKey(instance.ProviderID(), instance.Name, instance.Alias())]
 		if descriptor.Module.Name == "" {
-			descriptor = providerapi.ModuleDescriptor{PackageID: instance.Package, ModuleID: instance.Name, As: instance.Alias(), Module: module}
+			descriptor = providerapi.ModuleDescriptor{PackageID: instance.ProviderID(), ModuleID: instance.Name, As: instance.Alias(), Module: module}
 		}
 		config, err := f.configForModuleInstance(ctx, instance, descriptor, vals)
 		if err != nil {
@@ -181,10 +181,10 @@ func (f *RuntimeFactory) hostServicesForRuntime(ctx context.Context, vals *value
 	return collector.servicesForRuntime(), nil
 }
 
-func (f *RuntimeFactory) configForModuleInstance(ctx context.Context, instance ModuleInstanceSpec, descriptor providerapi.ModuleDescriptor, vals *values.Values) (json.RawMessage, error) {
+func (f *RuntimeFactory) configForModuleInstance(ctx context.Context, instance RuntimeModulePlan, descriptor providerapi.ModuleDescriptor, vals *values.Values) (json.RawMessage, error) {
 	config, err := json.Marshal(instance.Config)
 	if err != nil {
-		return nil, fmt.Errorf("marshal config for %s.%s: %w", instance.Package, instance.Name, err)
+		return nil, fmt.Errorf("marshal config for %s.%s: %w", instance.ProviderID(), instance.Name, err)
 	}
 	for _, capability := range descriptor.PackageCapabilities {
 		xgojaConfig, ok := capability.(providerapi.XGojaConfigSectionCapability)
@@ -194,11 +194,11 @@ func (f *RuntimeFactory) configForModuleInstance(ctx context.Context, instance M
 		sectionRequest := providerapi.SectionRequest{PackageID: descriptor.PackageID, ModuleID: descriptor.ModuleID}
 		section, err := xgojaConfig.XGojaConfigSection(sectionRequest, descriptor)
 		if err != nil {
-			return nil, fmt.Errorf("xgoja config section for %s.%s capability %s: %w", instance.Package, instance.Name, capability.CapabilityID(), err)
+			return nil, fmt.Errorf("xgoja config section for %s.%s capability %s: %w", instance.ProviderID(), instance.Name, capability.CapabilityID(), err)
 		}
 		staticValues, err := providerutil.ParseXGojaConfigMap(section, instance.Config)
 		if err != nil {
-			return nil, fmt.Errorf("parse xgoja config for %s.%s capability %s: %w", instance.Package, instance.Name, capability.CapabilityID(), err)
+			return nil, fmt.Errorf("parse xgoja config for %s.%s capability %s: %w", instance.ProviderID(), instance.Name, capability.CapabilityID(), err)
 		}
 		overrideValues, err := xgojaConfig.XGojaConfigFromGlazed(ctx, providerapi.XGojaConfigRequest{
 			SectionRequest: sectionRequest,
@@ -208,15 +208,15 @@ func (f *RuntimeFactory) configForModuleInstance(ctx context.Context, instance M
 			GlazedValues:   vals,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("map glazed config for %s.%s capability %s: %w", instance.Package, instance.Name, capability.CapabilityID(), err)
+			return nil, fmt.Errorf("map glazed config for %s.%s capability %s: %w", instance.ProviderID(), instance.Name, capability.CapabilityID(), err)
 		}
 		mergedValues, err := providerutil.MergeSectionValues(section, staticValues, overrideValues)
 		if err != nil {
-			return nil, fmt.Errorf("merge xgoja config for %s.%s capability %s: %w", instance.Package, instance.Name, capability.CapabilityID(), err)
+			return nil, fmt.Errorf("merge xgoja config for %s.%s capability %s: %w", instance.ProviderID(), instance.Name, capability.CapabilityID(), err)
 		}
 		config, err = providerutil.SectionValuesToRawJSON(mergedValues)
 		if err != nil {
-			return nil, fmt.Errorf("encode xgoja config for %s.%s capability %s: %w", instance.Package, instance.Name, capability.CapabilityID(), err)
+			return nil, fmt.Errorf("encode xgoja config for %s.%s capability %s: %w", instance.ProviderID(), instance.Name, capability.CapabilityID(), err)
 		}
 	}
 	return config, nil

--- a/pkg/xgoja/app/factory_config_sections_test.go
+++ b/pkg/xgoja/app/factory_config_sections_test.go
@@ -33,7 +33,7 @@ func TestRuntimeFactoryAppliesGlazedConfigBeforeModuleSetup(t *testing.T) {
 	); err != nil {
 		t.Fatalf("register package: %v", err)
 	}
-	factory := NewRuntimeFactory(registry, &RuntimeSpec{Modules: []ModuleInstanceSpec{{Package: "fixture", Name: "mod", As: "alias", Config: map[string]any{"message": "static"}}}})
+	factory := NewRuntimeFactory(registry, &RuntimePlan{Modules: []RuntimeModulePlan{{Package: "fixture", Name: "mod", As: "alias", Config: map[string]any{"message": "static"}}}})
 	vals := configPatchValues(t, "cli")
 	rt, err := factory.NewRuntimeFromSections(context.Background(), vals)
 	if err != nil {
@@ -68,7 +68,7 @@ func TestRuntimeFactoryKeepsIndependentConfigForRepeatedProvider(t *testing.T) {
 	); err != nil {
 		t.Fatalf("register package: %v", err)
 	}
-	factory := NewRuntimeFactory(registry, &RuntimeSpec{Modules: []ModuleInstanceSpec{
+	factory := NewRuntimeFactory(registry, &RuntimePlan{Modules: []RuntimeModulePlan{
 		{Package: "fixture", Name: "mod", As: "one", Config: map[string]any{"message": "static-one"}},
 		{Package: "fixture", Name: "mod", As: "two", Config: map[string]any{"message": "static-two"}},
 	}})

--- a/pkg/xgoja/app/factory_config_sections_test.go
+++ b/pkg/xgoja/app/factory_config_sections_test.go
@@ -33,7 +33,7 @@ func TestRuntimeFactoryAppliesGlazedConfigBeforeModuleSetup(t *testing.T) {
 	); err != nil {
 		t.Fatalf("register package: %v", err)
 	}
-	factory := NewRuntimeFactory(registry, &RuntimePlan{Modules: []RuntimeModulePlan{{Package: "fixture", Name: "mod", As: "alias", Config: map[string]any{"message": "static"}}}})
+	factory := NewRuntimeFactory(registry, &RuntimePlan{Runtime: RuntimeSection{Modules: []RuntimeModulePlan{{Provider: "fixture", Name: "mod", As: "alias", Config: map[string]any{"message": "static"}}}}})
 	vals := configPatchValues(t, "cli")
 	rt, err := factory.NewRuntimeFromSections(context.Background(), vals)
 	if err != nil {
@@ -68,10 +68,10 @@ func TestRuntimeFactoryKeepsIndependentConfigForRepeatedProvider(t *testing.T) {
 	); err != nil {
 		t.Fatalf("register package: %v", err)
 	}
-	factory := NewRuntimeFactory(registry, &RuntimePlan{Modules: []RuntimeModulePlan{
-		{Package: "fixture", Name: "mod", As: "one", Config: map[string]any{"message": "static-one"}},
-		{Package: "fixture", Name: "mod", As: "two", Config: map[string]any{"message": "static-two"}},
-	}})
+	factory := NewRuntimeFactory(registry, &RuntimePlan{Runtime: RuntimeSection{Modules: []RuntimeModulePlan{
+		{Provider: "fixture", Name: "mod", As: "one", Config: map[string]any{"message": "static-one"}},
+		{Provider: "fixture", Name: "mod", As: "two", Config: map[string]any{"message": "static-two"}},
+	}}})
 	vals := configPatchValues(t, "cli")
 	rt, err := factory.NewRuntimeFromSections(context.Background(), vals)
 	if err != nil {

--- a/pkg/xgoja/app/framework.go
+++ b/pkg/xgoja/app/framework.go
@@ -21,7 +21,7 @@ type frameworkOptions struct {
 	EmbeddedHelp fs.FS
 }
 
-func installRootFramework(root *cobra.Command, runtimeSpec *RuntimeSpec, opts frameworkOptions) error {
+func installRootFramework(root *cobra.Command, runtimePlan *RuntimePlan, opts frameworkOptions) error {
 	if root == nil {
 		return fmt.Errorf("root command is nil")
 	}
@@ -32,11 +32,11 @@ func installRootFramework(root *cobra.Command, runtimeSpec *RuntimeSpec, opts fr
 		return nil
 	}
 	appName := "xgoja"
-	if runtimeSpec != nil {
-		if strings.TrimSpace(runtimeSpec.AppName) != "" {
-			appName = strings.TrimSpace(runtimeSpec.AppName)
-		} else if strings.TrimSpace(runtimeSpec.Name) != "" {
-			appName = strings.TrimSpace(runtimeSpec.Name)
+	if runtimePlan != nil {
+		if strings.TrimSpace(runtimePlan.AppName()) != "" {
+			appName = strings.TrimSpace(runtimePlan.AppName())
+		} else if strings.TrimSpace(runtimePlan.Name) != "" {
+			appName = strings.TrimSpace(runtimePlan.Name)
 		}
 	}
 	if err := logging.AddLoggingSectionToRootCommand(root, appName); err != nil {
@@ -49,7 +49,7 @@ func installRootFramework(root *cobra.Command, runtimeSpec *RuntimeSpec, opts fr
 	if err := xgojadoc.AddDocToHelpSystem(helpSystem); err != nil {
 		return fmt.Errorf("load generated xgoja help docs: %w", err)
 	}
-	if err := loadConfiguredHelpSources(helpSystem, runtimeSpec, opts); err != nil {
+	if err := loadConfiguredHelpSources(helpSystem, runtimePlan, opts); err != nil {
 		return err
 	}
 	help_cmd.SetupCobraRootCommand(helpSystem, root)
@@ -57,12 +57,13 @@ func installRootFramework(root *cobra.Command, runtimeSpec *RuntimeSpec, opts fr
 	return nil
 }
 
-func loadConfiguredHelpSources(helpSystem *help.HelpSystem, runtimeSpec *RuntimeSpec, opts frameworkOptions) error {
-	if helpSystem == nil || runtimeSpec == nil || len(runtimeSpec.Help.Sources) == 0 {
+func loadConfiguredHelpSources(helpSystem *help.HelpSystem, runtimePlan *RuntimePlan, opts frameworkOptions) error {
+	helpSources := runtimePlan.sourcesByKind(SourceKindHelp)
+	if helpSystem == nil || runtimePlan == nil || len(helpSources) == 0 {
 		return nil
 	}
 	seen := map[string]struct{}{}
-	for _, source := range runtimeSpec.Help.Sources {
+	for _, source := range helpSources {
 		id := strings.TrimSpace(source.ID)
 		if id == "" {
 			return fmt.Errorf("help source id is required")
@@ -72,17 +73,17 @@ func loadConfiguredHelpSources(helpSystem *help.HelpSystem, runtimeSpec *Runtime
 		}
 		seen[id] = struct{}{}
 
-		hasProvider := strings.TrimSpace(source.Package) != "" || strings.TrimSpace(source.Source) != ""
+		hasProvider := strings.TrimSpace(source.ProviderID()) != "" || strings.TrimSpace(source.Source) != ""
 		if hasProvider {
 			if opts.Providers == nil {
 				return fmt.Errorf("load help source %s: providers registry is required", id)
 			}
-			providerSource, ok := opts.Providers.ResolveHelpSource(source.Package, source.Source)
+			providerSource, ok := opts.Providers.ResolveHelpSource(source.ProviderID(), source.Source)
 			if !ok {
-				return fmt.Errorf("load help source %s: unknown provider help source %s.%s", id, source.Package, source.Source)
+				return fmt.Errorf("load help source %s: unknown provider help source %s.%s", id, source.ProviderID(), source.Source)
 			}
 			if err := helpSystem.LoadSectionsFromFS(providerSource.FS, providerSource.Root); err != nil {
-				return fmt.Errorf("load provider help source %s (%s.%s): %w", id, source.Package, source.Source, err)
+				return fmt.Errorf("load provider help source %s (%s.%s): %w", id, source.ProviderID(), source.Source, err)
 			}
 			continue
 		}

--- a/pkg/xgoja/app/framework.go
+++ b/pkg/xgoja/app/framework.go
@@ -17,8 +17,9 @@ import (
 const rootFrameworkInstalledAnnotation = "xgoja/root-framework-installed"
 
 type frameworkOptions struct {
-	Providers    *providerapi.ProviderRegistry
-	EmbeddedHelp fs.FS
+	Providers      *providerapi.ProviderRegistry
+	SourceRegistry *SourceRegistry
+	EmbeddedHelp   fs.FS
 }
 
 func installRootFramework(root *cobra.Command, runtimePlan *RuntimePlan, opts frameworkOptions) error {
@@ -59,6 +60,9 @@ func installRootFramework(root *cobra.Command, runtimePlan *RuntimePlan, opts fr
 
 func loadConfiguredHelpSources(helpSystem *help.HelpSystem, runtimePlan *RuntimePlan, opts frameworkOptions) error {
 	helpSources := runtimePlan.sourcesByKind(SourceKindHelp)
+	if opts.SourceRegistry != nil {
+		helpSources = sourcePlansFromDescriptors(opts.SourceRegistry.ListSourcesByKind(providerapi.RuntimeSourceKindHelp))
+	}
 	if helpSystem == nil || runtimePlan == nil || len(helpSources) == 0 {
 		return nil
 	}

--- a/pkg/xgoja/app/host.go
+++ b/pkg/xgoja/app/host.go
@@ -86,7 +86,7 @@ func (h *Host) AttachCommandPlan(root *cobra.Command, command CommandPlan) {
 	case "builtin.repl":
 		h.AttachRepl(root)
 	case "builtin.jsverbs":
-		h.AttachVerbs(root)
+		h.attachVerbCommandPlan(root, command)
 	case "provider.command-set":
 		h.AttachCommandProvider(root, command)
 	}
@@ -164,8 +164,16 @@ func (h *Host) AttachVerbs(root *cobra.Command) {
 		return
 	}
 	jsverbsCommand, _ := h.RuntimePlan.commandByType("builtin.jsverbs")
+	h.attachVerbCommandPlan(root, jsverbsCommand)
+}
+
+func (h *Host) attachVerbCommandPlan(root *cobra.Command, jsverbsCommand CommandPlan) {
+	if root == nil || h == nil || h.RuntimePlan == nil {
+		return
+	}
+	sourceRegistry := h.SourceRegistry.Scoped(jsverbsCommand.Sources)
 	if commandMount(jsverbsCommand) == "root" {
-		cmds, err := buildVerbCommands(h.SourceRegistry, h.Factory, h.RuntimePlan)
+		cmds, err := buildVerbCommands(sourceRegistry, h.Factory, h.RuntimePlan)
 		if err != nil {
 			root.AddCommand(commandErrorStub(commandName(jsverbsCommand, "verbs"), "Run configured JavaScript verb commands", err))
 			return
@@ -179,5 +187,5 @@ func (h *Host) AttachVerbs(root *cobra.Command) {
 		}
 		return
 	}
-	root.AddCommand(newVerbsCommand(h.SourceRegistry, h.Factory, h.RuntimePlan, h.MiddlewaresFunc))
+	root.AddCommand(newVerbsCommand(sourceRegistry, h.Factory, h.RuntimePlan, jsverbsCommand, h.MiddlewaresFunc))
 }

--- a/pkg/xgoja/app/host.go
+++ b/pkg/xgoja/app/host.go
@@ -11,7 +11,7 @@ import (
 
 type Host struct {
 	Providers       *providerapi.ProviderRegistry
-	RuntimeSpec     *RuntimeSpec
+	RuntimePlan     *RuntimePlan
 	Factory         *RuntimeFactory
 	EmbeddedJSVerbs fs.FS
 	EmbeddedHelp    fs.FS
@@ -30,23 +30,23 @@ type HostOptions struct {
 	ConfigureServices func(*HostServices)
 }
 
-func NewHost(providers *providerapi.ProviderRegistry, runtimeSpec *RuntimeSpec) *Host {
-	return NewHostWithOptions(providers, runtimeSpec, HostOptions{})
+func NewHost(providers *providerapi.ProviderRegistry, runtimePlan *RuntimePlan) *Host {
+	return NewHostWithOptions(providers, runtimePlan, HostOptions{})
 }
 
-func NewHostWithOptions(providers *providerapi.ProviderRegistry, runtimeSpec *RuntimeSpec, opts HostOptions) *Host {
-	services := HostServices{Assets: NewAssetStore(opts.EmbeddedAssets, runtimeSpec)}
+func NewHostWithOptions(providers *providerapi.ProviderRegistry, runtimePlan *RuntimePlan, opts HostOptions) *Host {
+	services := HostServices{Assets: NewAssetStore(opts.EmbeddedAssets, runtimePlan)}
 	if opts.ConfigureServices != nil {
 		opts.ConfigureServices(&services)
 	}
 	middlewaresFunc := opts.MiddlewaresFunc
 	if middlewaresFunc == nil {
-		middlewaresFunc = MiddlewaresFromSpec(runtimeSpec)
+		middlewaresFunc = MiddlewaresFromSpec(runtimePlan)
 	}
 	return &Host{
 		Providers:       providers,
-		RuntimeSpec:     runtimeSpec,
-		Factory:         NewRuntimeFactory(providers, runtimeSpec, services),
+		RuntimePlan:     runtimePlan,
+		Factory:         NewRuntimeFactory(providers, runtimePlan, services),
 		EmbeddedJSVerbs: opts.EmbeddedJSVerbs,
 		EmbeddedHelp:    opts.EmbeddedHelp,
 		EmbeddedAssets:  opts.EmbeddedAssets,
@@ -57,25 +57,25 @@ func NewHostWithOptions(providers *providerapi.ProviderRegistry, runtimeSpec *Ru
 }
 
 func (h *Host) AttachDefaultCommands(root *cobra.Command) {
-	if root == nil || h == nil || h.RuntimeSpec == nil {
+	if root == nil || h == nil || h.RuntimePlan == nil {
 		return
 	}
-	if err := installRootFramework(root, h.RuntimeSpec, frameworkOptions{Providers: h.Providers, EmbeddedHelp: h.EmbeddedHelp}); err != nil {
+	if err := installRootFramework(root, h.RuntimePlan, frameworkOptions{Providers: h.Providers, EmbeddedHelp: h.EmbeddedHelp}); err != nil {
 		root.PersistentPreRunE = func(cmd *cobra.Command, args []string) error { return err }
 	}
-	if h.RuntimeSpec.Commands.Eval.Enabled {
+	if _, ok := h.RuntimePlan.commandByType("builtin.eval"); ok {
 		h.AttachEval(root)
 	}
-	if h.RuntimeSpec.Commands.Run.Enabled {
+	if _, ok := h.RuntimePlan.commandByType("builtin.run"); ok {
 		h.AttachRun(root)
 	}
-	if h.RuntimeSpec.Commands.Repl.Enabled {
+	if _, ok := h.RuntimePlan.commandByType("builtin.repl"); ok {
 		h.AttachRepl(root)
 	}
 	h.AttachModules(root)
 	h.AttachSelectedModules(root)
 	h.AttachTypes(root)
-	if h.RuntimeSpec.Commands.JSVerbs.Enabled {
+	if _, ok := h.RuntimePlan.commandByType("builtin.jsverbs"); ok {
 		h.AttachVerbs(root)
 	}
 	h.AttachCommandProviders(root)
@@ -89,9 +89,10 @@ func (h *Host) AttachEval(root *cobra.Command) {
 	if out == nil {
 		out = root.OutOrStdout()
 	}
-	cmd, err := buildGlazedCobraCommand(newEvalCommand(h.Factory, h.RuntimeSpec, out), h.MiddlewaresFunc)
+	cmd, err := buildGlazedCobraCommand(newEvalCommand(h.Factory, h.RuntimePlan, out), h.MiddlewaresFunc)
 	if err != nil {
-		root.AddCommand(commandErrorStub(commandName(h.RuntimeSpec.Commands.Eval, "eval"), "Evaluate JavaScript in a generated xgoja runtime", err))
+		command, _ := h.RuntimePlan.commandByType("builtin.eval")
+		root.AddCommand(commandErrorStub(commandName(command, "eval"), "Evaluate JavaScript in a generated xgoja runtime", err))
 		return
 	}
 	root.AddCommand(cmd)
@@ -101,9 +102,10 @@ func (h *Host) AttachRun(root *cobra.Command) {
 	if root == nil || h == nil {
 		return
 	}
-	cmd, err := buildGlazedCobraCommand(newRunCommand(h.Factory, h.RuntimeSpec), h.MiddlewaresFunc)
+	cmd, err := buildGlazedCobraCommand(newRunCommand(h.Factory, h.RuntimePlan), h.MiddlewaresFunc)
 	if err != nil {
-		root.AddCommand(commandErrorStub(commandName(h.RuntimeSpec.Commands.Run, "run"), "Execute a JavaScript file in a generated xgoja runtime", err))
+		command, _ := h.RuntimePlan.commandByType("builtin.run")
+		root.AddCommand(commandErrorStub(commandName(command, "run"), "Execute a JavaScript file in a generated xgoja runtime", err))
 		return
 	}
 	root.AddCommand(cmd)
@@ -113,9 +115,10 @@ func (h *Host) AttachRepl(root *cobra.Command) {
 	if root == nil || h == nil {
 		return
 	}
-	cmd, err := buildGlazedCobraCommand(newTUICommand(h.Factory, h.RuntimeSpec), h.MiddlewaresFunc)
+	cmd, err := buildGlazedCobraCommand(newTUICommand(h.Factory, h.RuntimePlan), h.MiddlewaresFunc)
 	if err != nil {
-		root.AddCommand(commandErrorStub(commandName(h.RuntimeSpec.Commands.Repl, "repl"), "Run an interactive TUI REPL for a generated xgoja runtime", err))
+		command, _ := h.RuntimePlan.commandByType("builtin.repl")
+		root.AddCommand(commandErrorStub(commandName(command, "repl"), "Run an interactive TUI REPL for a generated xgoja runtime", err))
 		return
 	}
 	root.AddCommand(cmd)
@@ -125,7 +128,7 @@ func (h *Host) AttachModules(root *cobra.Command) {
 	if root == nil || h == nil {
 		return
 	}
-	cmd, err := buildGlazedCobraCommand(newModulesCommand(h.Providers, h.RuntimeSpec), h.MiddlewaresFunc)
+	cmd, err := buildGlazedCobraCommand(newModulesCommand(h.Providers, h.RuntimePlan), h.MiddlewaresFunc)
 	if err != nil {
 		root.AddCommand(commandErrorStub("modules", "List provider modules compiled into this generated binary", err))
 		return
@@ -137,7 +140,7 @@ func (h *Host) AttachSelectedModules(root *cobra.Command) {
 	if root == nil || h == nil {
 		return
 	}
-	cmd, err := buildGlazedCobraCommand(newSelectedModulesCommand(h.RuntimeSpec), h.MiddlewaresFunc)
+	cmd, err := buildGlazedCobraCommand(newSelectedModulesCommand(h.RuntimePlan), h.MiddlewaresFunc)
 	if err != nil {
 		root.AddCommand(commandErrorStub("selected-modules", "List require() modules selected for this generated runtime", err))
 		return
@@ -146,13 +149,14 @@ func (h *Host) AttachSelectedModules(root *cobra.Command) {
 }
 
 func (h *Host) AttachVerbs(root *cobra.Command) {
-	if root == nil || h == nil || h.RuntimeSpec == nil {
+	if root == nil || h == nil || h.RuntimePlan == nil {
 		return
 	}
-	if commandMount(h.RuntimeSpec.Commands.JSVerbs) == "root" {
-		cmds, err := buildVerbCommands(h.Providers, h.Factory, h.RuntimeSpec, h.EmbeddedJSVerbs)
+	jsverbsCommand, _ := h.RuntimePlan.commandByType("builtin.jsverbs")
+	if commandMount(jsverbsCommand) == "root" {
+		cmds, err := buildVerbCommands(h.Providers, h.Factory, h.RuntimePlan, h.EmbeddedJSVerbs)
 		if err != nil {
-			root.AddCommand(commandErrorStub(commandName(h.RuntimeSpec.Commands.JSVerbs, "verbs"), "Run configured JavaScript verb commands", err))
+			root.AddCommand(commandErrorStub(commandName(jsverbsCommand, "verbs"), "Run configured JavaScript verb commands", err))
 			return
 		}
 		middlewaresFunc := h.MiddlewaresFunc
@@ -160,9 +164,9 @@ func (h *Host) AttachVerbs(root *cobra.Command) {
 			middlewaresFunc = cli.CobraCommandDefaultMiddlewares
 		}
 		if err := cli.AddCommandsToRootCommand(root, cmds, nil, cli.WithParserConfig(cli.CobraParserConfig{MiddlewaresFunc: middlewaresFunc})); err != nil {
-			root.AddCommand(commandErrorStub(commandName(h.RuntimeSpec.Commands.JSVerbs, "verbs"), "Run configured JavaScript verb commands", err))
+			root.AddCommand(commandErrorStub(commandName(jsverbsCommand, "verbs"), "Run configured JavaScript verb commands", err))
 		}
 		return
 	}
-	root.AddCommand(newVerbsCommand(h.Providers, h.Factory, h.RuntimeSpec, h.EmbeddedJSVerbs, h.MiddlewaresFunc))
+	root.AddCommand(newVerbsCommand(h.Providers, h.Factory, h.RuntimePlan, h.EmbeddedJSVerbs, h.MiddlewaresFunc))
 }

--- a/pkg/xgoja/app/host.go
+++ b/pkg/xgoja/app/host.go
@@ -17,6 +17,7 @@ type Host struct {
 	EmbeddedHelp    fs.FS
 	EmbeddedAssets  fs.FS
 	Services        HostServices
+	SourceRegistry  *SourceRegistry
 	Out             io.Writer
 	MiddlewaresFunc cli.CobraMiddlewaresFunc
 }
@@ -35,7 +36,8 @@ func NewHost(providers *providerapi.ProviderRegistry, runtimePlan *RuntimePlan) 
 }
 
 func NewHostWithOptions(providers *providerapi.ProviderRegistry, runtimePlan *RuntimePlan, opts HostOptions) *Host {
-	services := HostServices{Assets: NewAssetStore(opts.EmbeddedAssets, runtimePlan)}
+	sourceRegistry := NewSourceRegistry(providers, opts.EmbeddedJSVerbs, runtimePlan.allSources())
+	services := HostServices{Assets: NewAssetStoreFromSources(opts.EmbeddedAssets, sourceRegistry.ListSourcesByKind(providerapi.RuntimeSourceKindAssets))}
 	if opts.ConfigureServices != nil {
 		opts.ConfigureServices(&services)
 	}
@@ -51,6 +53,7 @@ func NewHostWithOptions(providers *providerapi.ProviderRegistry, runtimePlan *Ru
 		EmbeddedHelp:    opts.EmbeddedHelp,
 		EmbeddedAssets:  opts.EmbeddedAssets,
 		Services:        services,
+		SourceRegistry:  sourceRegistry,
 		Out:             opts.Out,
 		MiddlewaresFunc: middlewaresFunc,
 	}
@@ -60,25 +63,33 @@ func (h *Host) AttachDefaultCommands(root *cobra.Command) {
 	if root == nil || h == nil || h.RuntimePlan == nil {
 		return
 	}
-	if err := installRootFramework(root, h.RuntimePlan, frameworkOptions{Providers: h.Providers, EmbeddedHelp: h.EmbeddedHelp}); err != nil {
+	if err := installRootFramework(root, h.RuntimePlan, frameworkOptions{Providers: h.Providers, SourceRegistry: h.SourceRegistry, EmbeddedHelp: h.EmbeddedHelp}); err != nil {
 		root.PersistentPreRunE = func(cmd *cobra.Command, args []string) error { return err }
 	}
-	if _, ok := h.RuntimePlan.commandByType("builtin.eval"); ok {
-		h.AttachEval(root)
-	}
-	if _, ok := h.RuntimePlan.commandByType("builtin.run"); ok {
-		h.AttachRun(root)
-	}
-	if _, ok := h.RuntimePlan.commandByType("builtin.repl"); ok {
-		h.AttachRepl(root)
+	for _, command := range h.RuntimePlan.runtimeCommands() {
+		h.AttachCommandPlan(root, command)
 	}
 	h.AttachModules(root)
 	h.AttachSelectedModules(root)
 	h.AttachTypes(root)
-	if _, ok := h.RuntimePlan.commandByType("builtin.jsverbs"); ok {
-		h.AttachVerbs(root)
+}
+
+func (h *Host) AttachCommandPlan(root *cobra.Command, command CommandPlan) {
+	if root == nil || h == nil {
+		return
 	}
-	h.AttachCommandProviders(root)
+	switch command.Type {
+	case "builtin.eval":
+		h.AttachEval(root)
+	case "builtin.run":
+		h.AttachRun(root)
+	case "builtin.repl":
+		h.AttachRepl(root)
+	case "builtin.jsverbs":
+		h.AttachVerbs(root)
+	case "provider.command-set":
+		h.AttachCommandProvider(root, command)
+	}
 }
 
 func (h *Host) AttachEval(root *cobra.Command) {
@@ -154,7 +165,7 @@ func (h *Host) AttachVerbs(root *cobra.Command) {
 	}
 	jsverbsCommand, _ := h.RuntimePlan.commandByType("builtin.jsverbs")
 	if commandMount(jsverbsCommand) == "root" {
-		cmds, err := buildVerbCommands(h.Providers, h.Factory, h.RuntimePlan, h.EmbeddedJSVerbs)
+		cmds, err := buildVerbCommands(h.SourceRegistry, h.Factory, h.RuntimePlan)
 		if err != nil {
 			root.AddCommand(commandErrorStub(commandName(jsverbsCommand, "verbs"), "Run configured JavaScript verb commands", err))
 			return
@@ -168,5 +179,5 @@ func (h *Host) AttachVerbs(root *cobra.Command) {
 		}
 		return
 	}
-	root.AddCommand(newVerbsCommand(h.Providers, h.Factory, h.RuntimePlan, h.EmbeddedJSVerbs, h.MiddlewaresFunc))
+	root.AddCommand(newVerbsCommand(h.SourceRegistry, h.Factory, h.RuntimePlan, h.MiddlewaresFunc))
 }

--- a/pkg/xgoja/app/host_services_test.go
+++ b/pkg/xgoja/app/host_services_test.go
@@ -61,7 +61,7 @@ func TestHostOptionsConfigureServicesVisibleToModuleSetup(t *testing.T) {
 	); err != nil {
 		t.Fatalf("register package: %v", err)
 	}
-	runtimePlan := &RuntimePlan{Modules: []RuntimeModulePlan{{Package: "fixture", Name: "mod"}}}
+	runtimePlan := &RuntimePlan{Runtime: RuntimeSection{Modules: []RuntimeModulePlan{{Provider: "fixture", Name: "mod"}}}}
 	host := NewHostWithOptions(registry, runtimePlan, HostOptions{ConfigureServices: func(services *HostServices) {
 		if err := services.SetHostService("demo", "from-host-options"); err != nil {
 			t.Fatalf("SetHostService: %v", err)
@@ -97,7 +97,7 @@ func TestRuntimeFactoryPerRuntimeHostServicesVisibleToModuleSetup(t *testing.T) 
 	); err != nil {
 		t.Fatalf("register package: %v", err)
 	}
-	runtimePlan := &RuntimePlan{Modules: []RuntimeModulePlan{{Package: "fixture", Name: "mod"}}}
+	runtimePlan := &RuntimePlan{Runtime: RuntimeSection{Modules: []RuntimeModulePlan{{Provider: "fixture", Name: "mod"}}}}
 	factory := NewRuntimeFactory(registry, runtimePlan, HostServices{Services: map[string][]any{"demo": {"base"}}})
 	runtimeServices := HostServices{}
 	if err := runtimeServices.SetHostService("demo", "runtime"); err != nil {
@@ -138,7 +138,7 @@ func TestRuntimeFactoryCollectsHostServiceContributionsBeforeModuleSetup(t *test
 	); err != nil {
 		t.Fatalf("register package: %v", err)
 	}
-	runtimePlan := &RuntimePlan{Modules: []RuntimeModulePlan{{Package: "fixture", Name: "mod"}}}
+	runtimePlan := &RuntimePlan{Runtime: RuntimeSection{Modules: []RuntimeModulePlan{{Provider: "fixture", Name: "mod"}}}}
 	factory := NewRuntimeFactory(registry, runtimePlan, HostServices{})
 	rt, err := factory.NewRuntimeFromSections(context.Background(), values.New())
 	if err != nil {
@@ -168,7 +168,7 @@ func TestHostServiceContributionsDedupeSamePackageCapability(t *testing.T) {
 	); err != nil {
 		t.Fatalf("register package: %v", err)
 	}
-	runtimePlan := &RuntimePlan{Modules: []RuntimeModulePlan{{Package: "fixture", Name: "first"}, {Package: "fixture", Name: "second"}}}
+	runtimePlan := &RuntimePlan{Runtime: RuntimeSection{Modules: []RuntimeModulePlan{{Provider: "fixture", Name: "first"}, {Provider: "fixture", Name: "second"}}}}
 	factory := NewRuntimeFactory(registry, runtimePlan, HostServices{})
 	rt, err := factory.NewRuntimeFromSections(context.Background(), values.New())
 	if err != nil {
@@ -195,7 +195,7 @@ func TestHostServiceContributionClosersRunOnRuntimeClose(t *testing.T) {
 	); err != nil {
 		t.Fatalf("register package: %v", err)
 	}
-	runtimePlan := &RuntimePlan{Modules: []RuntimeModulePlan{{Package: "fixture", Name: "mod"}}}
+	runtimePlan := &RuntimePlan{Runtime: RuntimeSection{Modules: []RuntimeModulePlan{{Provider: "fixture", Name: "mod"}}}}
 	factory := NewRuntimeFactory(registry, runtimePlan, HostServices{})
 	rt, err := factory.NewRuntimeFromSections(context.Background(), values.New())
 	if err != nil {
@@ -227,7 +227,7 @@ func TestHostServiceContributionClosersRunOnRuntimeSetupFailure(t *testing.T) {
 	); err != nil {
 		t.Fatalf("register package: %v", err)
 	}
-	runtimePlan := &RuntimePlan{Modules: []RuntimeModulePlan{{Package: "fixture", Name: "mod"}}}
+	runtimePlan := &RuntimePlan{Runtime: RuntimeSection{Modules: []RuntimeModulePlan{{Provider: "fixture", Name: "mod"}}}}
 	factory := NewRuntimeFactory(registry, runtimePlan, HostServices{})
 	_, err := factory.NewRuntimeFromSections(context.Background(), values.New())
 	if err == nil || !strings.Contains(err.Error(), "setup failed") {
@@ -249,7 +249,7 @@ func TestHostServiceContributionErrorsAreWrapped(t *testing.T) {
 	); err != nil {
 		t.Fatalf("register package: %v", err)
 	}
-	runtimePlan := &RuntimePlan{Modules: []RuntimeModulePlan{{Package: "fixture", Name: "mod"}}}
+	runtimePlan := &RuntimePlan{Runtime: RuntimeSection{Modules: []RuntimeModulePlan{{Provider: "fixture", Name: "mod"}}}}
 	factory := NewRuntimeFactory(registry, runtimePlan, HostServices{})
 	_, err := factory.NewRuntimeFromSections(context.Background(), values.New())
 	if err == nil || !strings.Contains(err.Error(), "contribute host services for fixture capability host-service") || !strings.Contains(err.Error(), "boom") {

--- a/pkg/xgoja/app/host_services_test.go
+++ b/pkg/xgoja/app/host_services_test.go
@@ -61,8 +61,8 @@ func TestHostOptionsConfigureServicesVisibleToModuleSetup(t *testing.T) {
 	); err != nil {
 		t.Fatalf("register package: %v", err)
 	}
-	runtimeSpec := &RuntimeSpec{Modules: []ModuleInstanceSpec{{Package: "fixture", Name: "mod"}}}
-	host := NewHostWithOptions(registry, runtimeSpec, HostOptions{ConfigureServices: func(services *HostServices) {
+	runtimePlan := &RuntimePlan{Modules: []RuntimeModulePlan{{Package: "fixture", Name: "mod"}}}
+	host := NewHostWithOptions(registry, runtimePlan, HostOptions{ConfigureServices: func(services *HostServices) {
 		if err := services.SetHostService("demo", "from-host-options"); err != nil {
 			t.Fatalf("SetHostService: %v", err)
 		}
@@ -97,8 +97,8 @@ func TestRuntimeFactoryPerRuntimeHostServicesVisibleToModuleSetup(t *testing.T) 
 	); err != nil {
 		t.Fatalf("register package: %v", err)
 	}
-	runtimeSpec := &RuntimeSpec{Modules: []ModuleInstanceSpec{{Package: "fixture", Name: "mod"}}}
-	factory := NewRuntimeFactory(registry, runtimeSpec, HostServices{Services: map[string][]any{"demo": {"base"}}})
+	runtimePlan := &RuntimePlan{Modules: []RuntimeModulePlan{{Package: "fixture", Name: "mod"}}}
+	factory := NewRuntimeFactory(registry, runtimePlan, HostServices{Services: map[string][]any{"demo": {"base"}}})
 	runtimeServices := HostServices{}
 	if err := runtimeServices.SetHostService("demo", "runtime"); err != nil {
 		t.Fatalf("SetHostService: %v", err)
@@ -138,8 +138,8 @@ func TestRuntimeFactoryCollectsHostServiceContributionsBeforeModuleSetup(t *test
 	); err != nil {
 		t.Fatalf("register package: %v", err)
 	}
-	runtimeSpec := &RuntimeSpec{Modules: []ModuleInstanceSpec{{Package: "fixture", Name: "mod"}}}
-	factory := NewRuntimeFactory(registry, runtimeSpec, HostServices{})
+	runtimePlan := &RuntimePlan{Modules: []RuntimeModulePlan{{Package: "fixture", Name: "mod"}}}
+	factory := NewRuntimeFactory(registry, runtimePlan, HostServices{})
 	rt, err := factory.NewRuntimeFromSections(context.Background(), values.New())
 	if err != nil {
 		t.Fatalf("NewRuntimeFromSections: %v", err)
@@ -168,8 +168,8 @@ func TestHostServiceContributionsDedupeSamePackageCapability(t *testing.T) {
 	); err != nil {
 		t.Fatalf("register package: %v", err)
 	}
-	runtimeSpec := &RuntimeSpec{Modules: []ModuleInstanceSpec{{Package: "fixture", Name: "first"}, {Package: "fixture", Name: "second"}}}
-	factory := NewRuntimeFactory(registry, runtimeSpec, HostServices{})
+	runtimePlan := &RuntimePlan{Modules: []RuntimeModulePlan{{Package: "fixture", Name: "first"}, {Package: "fixture", Name: "second"}}}
+	factory := NewRuntimeFactory(registry, runtimePlan, HostServices{})
 	rt, err := factory.NewRuntimeFromSections(context.Background(), values.New())
 	if err != nil {
 		t.Fatalf("NewRuntimeFromSections: %v", err)
@@ -195,8 +195,8 @@ func TestHostServiceContributionClosersRunOnRuntimeClose(t *testing.T) {
 	); err != nil {
 		t.Fatalf("register package: %v", err)
 	}
-	runtimeSpec := &RuntimeSpec{Modules: []ModuleInstanceSpec{{Package: "fixture", Name: "mod"}}}
-	factory := NewRuntimeFactory(registry, runtimeSpec, HostServices{})
+	runtimePlan := &RuntimePlan{Modules: []RuntimeModulePlan{{Package: "fixture", Name: "mod"}}}
+	factory := NewRuntimeFactory(registry, runtimePlan, HostServices{})
 	rt, err := factory.NewRuntimeFromSections(context.Background(), values.New())
 	if err != nil {
 		t.Fatalf("NewRuntimeFromSections: %v", err)
@@ -227,8 +227,8 @@ func TestHostServiceContributionClosersRunOnRuntimeSetupFailure(t *testing.T) {
 	); err != nil {
 		t.Fatalf("register package: %v", err)
 	}
-	runtimeSpec := &RuntimeSpec{Modules: []ModuleInstanceSpec{{Package: "fixture", Name: "mod"}}}
-	factory := NewRuntimeFactory(registry, runtimeSpec, HostServices{})
+	runtimePlan := &RuntimePlan{Modules: []RuntimeModulePlan{{Package: "fixture", Name: "mod"}}}
+	factory := NewRuntimeFactory(registry, runtimePlan, HostServices{})
 	_, err := factory.NewRuntimeFromSections(context.Background(), values.New())
 	if err == nil || !strings.Contains(err.Error(), "setup failed") {
 		t.Fatalf("expected setup failure, got %v", err)
@@ -249,8 +249,8 @@ func TestHostServiceContributionErrorsAreWrapped(t *testing.T) {
 	); err != nil {
 		t.Fatalf("register package: %v", err)
 	}
-	runtimeSpec := &RuntimeSpec{Modules: []ModuleInstanceSpec{{Package: "fixture", Name: "mod"}}}
-	factory := NewRuntimeFactory(registry, runtimeSpec, HostServices{})
+	runtimePlan := &RuntimePlan{Modules: []RuntimeModulePlan{{Package: "fixture", Name: "mod"}}}
+	factory := NewRuntimeFactory(registry, runtimePlan, HostServices{})
 	_, err := factory.NewRuntimeFromSections(context.Background(), values.New())
 	if err == nil || !strings.Contains(err.Error(), "contribute host services for fixture capability host-service") || !strings.Contains(err.Error(), "boom") {
 		t.Fatalf("expected wrapped error, got %v", err)

--- a/pkg/xgoja/app/jsverb_sources.go
+++ b/pkg/xgoja/app/jsverb_sources.go
@@ -33,7 +33,7 @@ func (s *jsVerbSourceSet) ListJSVerbSources() []providerapi.JSVerbSourceDescript
 			ID:         source.ID,
 			Path:       source.Path,
 			Embed:      source.Embed,
-			Package:    source.ProviderID(),
+			Provider:   source.ProviderID(),
 			Source:     source.Source,
 			Include:    append([]string(nil), source.Include...),
 			Exclude:    append([]string(nil), source.Exclude...),

--- a/pkg/xgoja/app/jsverb_sources.go
+++ b/pkg/xgoja/app/jsverb_sources.go
@@ -12,18 +12,18 @@ import (
 type jsVerbSourceSet struct {
 	providers       *providerapi.ProviderRegistry
 	embeddedJSVerbs fs.FS
-	sources         []JSVerbSourceSpec
+	sources         []SourcePlan
 }
 
-func newJSVerbSourceSet(providers *providerapi.ProviderRegistry, embeddedJSVerbs fs.FS, sources []JSVerbSourceSpec) *jsVerbSourceSet {
+func newJSVerbSourceSet(providers *providerapi.ProviderRegistry, embeddedJSVerbs fs.FS, sources []SourcePlan) *jsVerbSourceSet {
 	return &jsVerbSourceSet{
 		providers:       providers,
 		embeddedJSVerbs: embeddedJSVerbs,
-		sources:         append([]JSVerbSourceSpec(nil), sources...),
+		sources:         append([]SourcePlan(nil), sources...),
 	}
 }
 
-func newScopedJSVerbSourceSet(providers *providerapi.ProviderRegistry, embeddedJSVerbs fs.FS, sources []JSVerbSourceSpec, selectedIDs []string) *jsVerbSourceSet {
+func newScopedJSVerbSourceSet(providers *providerapi.ProviderRegistry, embeddedJSVerbs fs.FS, sources []SourcePlan, selectedIDs []string) *jsVerbSourceSet {
 	if len(selectedIDs) == 0 {
 		return newJSVerbSourceSet(providers, embeddedJSVerbs, sources)
 	}
@@ -34,7 +34,7 @@ func newScopedJSVerbSourceSet(providers *providerapi.ProviderRegistry, embeddedJ
 			wanted[id] = struct{}{}
 		}
 	}
-	filtered := make([]JSVerbSourceSpec, 0, len(sources))
+	filtered := make([]SourcePlan, 0, len(sources))
 	for _, source := range sources {
 		if _, ok := wanted[source.ID]; ok {
 			filtered = append(filtered, source)
@@ -53,7 +53,7 @@ func (s *jsVerbSourceSet) ListJSVerbSources() []providerapi.JSVerbSourceDescript
 			ID:         source.ID,
 			Path:       source.Path,
 			Embed:      source.Embed,
-			Package:    source.Package,
+			Package:    source.ProviderID(),
 			Source:     source.Source,
 			Include:    append([]string(nil), source.Include...),
 			Exclude:    append([]string(nil), source.Exclude...),
@@ -64,7 +64,7 @@ func (s *jsVerbSourceSet) ListJSVerbSources() []providerapi.JSVerbSourceDescript
 	return out
 }
 
-func providerTypeScriptDescriptor(spec *TypeScriptSpec) *providerapi.TypeScriptDescriptor {
+func providerTypeScriptDescriptor(spec *TypeScriptPlan) *providerapi.TypeScriptDescriptor {
 	if spec == nil {
 		return nil
 	}

--- a/pkg/xgoja/app/jsverb_sources.go
+++ b/pkg/xgoja/app/jsverb_sources.go
@@ -23,26 +23,6 @@ func newJSVerbSourceSet(providers *providerapi.ProviderRegistry, embeddedJSVerbs
 	}
 }
 
-func newScopedJSVerbSourceSet(providers *providerapi.ProviderRegistry, embeddedJSVerbs fs.FS, sources []SourcePlan, selectedIDs []string) *jsVerbSourceSet {
-	if len(selectedIDs) == 0 {
-		return newJSVerbSourceSet(providers, embeddedJSVerbs, sources)
-	}
-	wanted := map[string]struct{}{}
-	for _, id := range selectedIDs {
-		id = strings.TrimSpace(id)
-		if id != "" {
-			wanted[id] = struct{}{}
-		}
-	}
-	filtered := make([]SourcePlan, 0, len(sources))
-	for _, source := range sources {
-		if _, ok := wanted[source.ID]; ok {
-			filtered = append(filtered, source)
-		}
-	}
-	return newJSVerbSourceSet(providers, embeddedJSVerbs, filtered)
-}
-
 func (s *jsVerbSourceSet) ListJSVerbSources() []providerapi.JSVerbSourceDescriptor {
 	if s == nil || len(s.sources) == 0 {
 		return nil

--- a/pkg/xgoja/app/jsverb_sources.go
+++ b/pkg/xgoja/app/jsverb_sources.go
@@ -23,6 +23,26 @@ func newJSVerbSourceSet(providers *providerapi.ProviderRegistry, embeddedJSVerbs
 	}
 }
 
+func newScopedJSVerbSourceSet(providers *providerapi.ProviderRegistry, embeddedJSVerbs fs.FS, sources []JSVerbSourceSpec, selectedIDs []string) *jsVerbSourceSet {
+	if len(selectedIDs) == 0 {
+		return newJSVerbSourceSet(providers, embeddedJSVerbs, sources)
+	}
+	wanted := map[string]struct{}{}
+	for _, id := range selectedIDs {
+		id = strings.TrimSpace(id)
+		if id != "" {
+			wanted[id] = struct{}{}
+		}
+	}
+	filtered := make([]JSVerbSourceSpec, 0, len(sources))
+	for _, source := range sources {
+		if _, ok := wanted[source.ID]; ok {
+			filtered = append(filtered, source)
+		}
+	}
+	return newJSVerbSourceSet(providers, embeddedJSVerbs, filtered)
+}
+
 func (s *jsVerbSourceSet) ListJSVerbSources() []providerapi.JSVerbSourceDescriptor {
 	if s == nil || len(s.sources) == 0 {
 		return nil

--- a/pkg/xgoja/app/jsverb_sources_test.go
+++ b/pkg/xgoja/app/jsverb_sources_test.go
@@ -3,11 +3,11 @@ package app
 import "testing"
 
 func TestJSVerbSourceSetListIncludesTypeScriptDescriptor(t *testing.T) {
-	set := newJSVerbSourceSet(nil, nil, []JSVerbSourceSpec{{
+	set := newJSVerbSourceSet(nil, nil, []SourcePlan{{
 		ID:         "local",
 		Path:       "verbs",
 		Extensions: []string{".ts"},
-		TypeScript: &TypeScriptSpec{
+		TypeScript: &TypeScriptPlan{
 			Enabled:      true,
 			Bundle:       true,
 			Target:       "es2015",

--- a/pkg/xgoja/app/jsverbs_module_sections_test.go
+++ b/pkg/xgoja/app/jsverbs_module_sections_test.go
@@ -12,9 +12,9 @@ import (
 
 func TestJSVerbsCommandsIncludeRuntimeModuleSections(t *testing.T) {
 	registry := newJSVerbsSectionRegistry(t)
-	runtimeSpec := jsverbsSectionSpec()
+	runtimePlan := jsverbsSectionSpec()
 	embedded := jsverbsSectionFS()
-	commands, err := buildVerbCommands(registry, NewRuntimeFactory(registry, runtimeSpec), runtimeSpec, embedded)
+	commands, err := buildVerbCommands(registry, NewRuntimeFactory(registry, runtimePlan), runtimePlan, embedded)
 	if err != nil {
 		t.Fatalf("build verb commands: %v", err)
 	}
@@ -64,11 +64,11 @@ func newJSVerbsSectionRegistry(t *testing.T) *providerapi.ProviderRegistry {
 	return registry
 }
 
-func jsverbsSectionSpec() *RuntimeSpec {
-	return &RuntimeSpec{
-		Modules:  []ModuleInstanceSpec{{Package: "fixture", Name: "mod", As: "mod"}},
-		Commands: CommandsSpec{JSVerbs: CommandSpec{Enabled: true, Name: "verbs"}},
-		JSVerbs:  []JSVerbSourceSpec{{ID: "local", Path: "xgoja_embed/jsverbs/local", Embed: true}},
+func jsverbsSectionSpec() *RuntimePlan {
+	return &RuntimePlan{
+		Runtime:  RuntimeSection{Modules: []RuntimeModulePlan{{Provider: "fixture", Name: "mod", As: "mod"}}},
+		Commands: []CommandPlan{{ID: "verbs", Type: "builtin.jsverbs", Name: "verbs"}},
+		Sources:  []SourcePlan{{ID: "local", Kind: SourceKindJSVerbs, Path: "xgoja_embed/jsverbs/local", Embed: true}},
 	}
 }
 

--- a/pkg/xgoja/app/jsverbs_module_sections_test.go
+++ b/pkg/xgoja/app/jsverbs_module_sections_test.go
@@ -14,7 +14,8 @@ func TestJSVerbsCommandsIncludeRuntimeModuleSections(t *testing.T) {
 	registry := newJSVerbsSectionRegistry(t)
 	runtimePlan := jsverbsSectionSpec()
 	embedded := jsverbsSectionFS()
-	commands, err := buildVerbCommands(registry, NewRuntimeFactory(registry, runtimePlan), runtimePlan, embedded)
+	sources := NewSourceRegistry(registry, embedded, runtimePlan.allSources())
+	commands, err := buildVerbCommands(sources, NewRuntimeFactory(registry, runtimePlan), runtimePlan)
 	if err != nil {
 		t.Fatalf("build verb commands: %v", err)
 	}

--- a/pkg/xgoja/app/jsverbs_module_sections_test.go
+++ b/pkg/xgoja/app/jsverbs_module_sections_test.go
@@ -34,14 +34,49 @@ func TestJSVerbsCommandsIncludeRuntimeModuleSections(t *testing.T) {
 func TestJSVerbsInitializeRuntimeFromModuleSections(t *testing.T) {
 	registry := newJSVerbsSectionRegistry(t)
 	specJSON := `{
+  "schema": "xgoja/runtime/v2",
   "name": "fixture",
-  "target": {"kind": "xgoja", "output": "dist/fixture"},
-  "packages": [{"id": "fixture"}],
-  "modules": [{"package": "fixture", "name": "mod", "as": "mod"}],
-  "commands": {"jsverbs": {"enabled": true, "name": "verbs"}},
-  "jsverbs": [{"id": "local", "path": "xgoja_embed/jsverbs/local", "embed": true}]
+  "app": {
+    "name": "fixture"
+  },
+  "target": {
+    "kind": "xgoja",
+    "output": "dist/fixture"
+  },
+  "providers": [
+    {
+      "id": "fixture"
+    }
+  ],
+  "runtime": {
+    "modules": [
+      {
+        "provider": "fixture",
+        "name": "mod",
+        "as": "mod"
+      }
+    ]
+  },
+  "sources": [
+    {
+      "id": "local",
+      "path": "xgoja_embed/jsverbs/local",
+      "embed": true,
+      "kind": "jsverbs"
+    }
+  ],
+  "commands": [
+    {
+      "id": "jsverbs",
+      "type": "builtin.jsverbs",
+      "name": "verbs",
+      "sources": [
+        "local"
+      ]
+    }
+  ]
 }`
-	root, err := NewRootCommand(Options{Providers: registry, SpecJSON: specJSON, EmbeddedJSVerbs: jsverbsSectionFS()})
+	root, err := NewRootCommand(Options{Providers: registry, RuntimePlanJSON: specJSON, EmbeddedJSVerbs: jsverbsSectionFS()})
 	if err != nil {
 		t.Fatalf("new root: %v", err)
 	}

--- a/pkg/xgoja/app/middlewares.go
+++ b/pkg/xgoja/app/middlewares.go
@@ -13,7 +13,7 @@ import (
 )
 
 // MiddlewaresFromSpec returns the Glazed parser middleware chain for generated
-// xgoja commands. If the runtime spec does not request an environment namespace or
+// xgoja commands. If the runtime plan does not request an environment namespace or
 // config file loading, it preserves the historical default chain: Cobra flags,
 // positional arguments, and field defaults only.
 func MiddlewaresFromSpec(runtimePlan *RuntimePlan) cli.CobraMiddlewaresFunc {
@@ -104,8 +104,8 @@ func buildConfigPlan(config *ConfigFilePlan, appName string, parsed *values.Valu
 }
 
 // EffectiveEnvPrefix returns the explicit envPrefix when present, otherwise a
-// shell-safe prefix derived from appName. The runtime spec name is intentionally not
-// used as an implicit env namespace; existing specs without appName/envPrefix
+// shell-safe prefix derived from appName. The runtime plan name is intentionally not
+// used as an implicit env namespace; existing plans without app.name/app.envPrefix
 // must keep their historical flag/argument/default-only parser behavior.
 func EffectiveEnvPrefix(runtimePlan *RuntimePlan) string {
 	if runtimePlan == nil {

--- a/pkg/xgoja/app/middlewares.go
+++ b/pkg/xgoja/app/middlewares.go
@@ -16,9 +16,9 @@ import (
 // xgoja commands. If the runtime spec does not request an environment namespace or
 // config file loading, it preserves the historical default chain: Cobra flags,
 // positional arguments, and field defaults only.
-func MiddlewaresFromSpec(runtimeSpec *RuntimeSpec) cli.CobraMiddlewaresFunc {
-	envPrefix := EffectiveEnvPrefix(runtimeSpec)
-	hasConfig := runtimeSpec != nil && runtimeSpec.ConfigFile != nil && runtimeSpec.ConfigFile.Enabled
+func MiddlewaresFromSpec(runtimePlan *RuntimePlan) cli.CobraMiddlewaresFunc {
+	envPrefix := EffectiveEnvPrefix(runtimePlan)
+	hasConfig := runtimePlan != nil && runtimePlan.App.ConfigFile != nil && runtimePlan.App.ConfigFile.Enabled
 
 	if envPrefix == "" && !hasConfig {
 		return cli.CobraCommandDefaultMiddlewares
@@ -41,7 +41,7 @@ func MiddlewaresFromSpec(runtimeSpec *RuntimeSpec) cli.CobraMiddlewaresFunc {
 			middlewares = append(middlewares,
 				cmdsources.FromConfigPlanBuilder(
 					func(_ context.Context, _ *values.Values) (*glazedconfig.Plan, error) {
-						return buildConfigPlan(runtimeSpec.ConfigFile, runtimeSpec.AppName, parsedCommandSections)
+						return buildConfigPlan(runtimePlan.App.ConfigFile, runtimePlan.AppName(), parsedCommandSections)
 					},
 					cmdsources.WithParseOptions(fields.WithSource("config")),
 				),
@@ -56,7 +56,7 @@ func MiddlewaresFromSpec(runtimeSpec *RuntimeSpec) cli.CobraMiddlewaresFunc {
 	}
 }
 
-func buildConfigPlan(config *ConfigFileSpec, appName string, parsed *values.Values) (*glazedconfig.Plan, error) {
+func buildConfigPlan(config *ConfigFilePlan, appName string, parsed *values.Values) (*glazedconfig.Plan, error) {
 	explicit := ""
 	if parsed != nil {
 		commandSettings := &cli.CommandSettings{}
@@ -107,14 +107,14 @@ func buildConfigPlan(config *ConfigFileSpec, appName string, parsed *values.Valu
 // shell-safe prefix derived from appName. The runtime spec name is intentionally not
 // used as an implicit env namespace; existing specs without appName/envPrefix
 // must keep their historical flag/argument/default-only parser behavior.
-func EffectiveEnvPrefix(runtimeSpec *RuntimeSpec) string {
-	if runtimeSpec == nil {
+func EffectiveEnvPrefix(runtimePlan *RuntimePlan) string {
+	if runtimePlan == nil {
 		return ""
 	}
-	if prefix := strings.TrimSpace(runtimeSpec.EnvPrefix); prefix != "" {
+	if prefix := strings.TrimSpace(runtimePlan.App.EnvPrefix); prefix != "" {
 		return strings.ToUpper(prefix)
 	}
-	return DefaultEnvPrefix(runtimeSpec.AppName)
+	return DefaultEnvPrefix(runtimePlan.App.Name)
 }
 
 // DefaultEnvPrefix converts an application name into a shell-safe environment

--- a/pkg/xgoja/app/middlewares_test.go
+++ b/pkg/xgoja/app/middlewares_test.go
@@ -39,18 +39,39 @@ func TestGeneratedRootReadsModuleSectionFromDerivedEnvPrefix(t *testing.T) {
 		t.Fatalf("register provider: %v", err)
 	}
 	specJSON := `{
+  "schema": "xgoja/runtime/v2",
   "name": "fixture",
-  "appName": "env-fixture",
-  "target": {"kind": "xgoja", "output": "dist/fixture"},
-  "packages": [{"id": "fixture"}],
-  "modules": [{"package": "fixture", "name": "hello", "as": "hello"}],
-  "commands": {
-    "eval": {"enabled": true, "name": "eval"},
-    "jsverbs": {"enabled": false}
-  }
+  "app": {
+    "name": "env-fixture"
+  },
+  "target": {
+    "kind": "xgoja",
+    "output": "dist/fixture"
+  },
+  "providers": [
+    {
+      "id": "fixture"
+    }
+  ],
+  "runtime": {
+    "modules": [
+      {
+        "provider": "fixture",
+        "name": "hello",
+        "as": "hello"
+      }
+    ]
+  },
+  "commands": [
+    {
+      "id": "eval",
+      "type": "builtin.eval",
+      "name": "eval"
+    }
+  ]
 }`
 	out := &bytes.Buffer{}
-	root, err := NewRootCommand(Options{Providers: registry, SpecJSON: specJSON, Out: out})
+	root, err := NewRootCommand(Options{Providers: registry, RuntimePlanJSON: specJSON, Out: out})
 	if err != nil {
 		t.Fatalf("new root: %v", err)
 	}
@@ -70,18 +91,40 @@ func TestGeneratedRootReadsModuleSectionFromExplicitEnvPrefix(t *testing.T) {
 		t.Fatalf("register provider: %v", err)
 	}
 	specJSON := `{
+  "schema": "xgoja/runtime/v2",
   "name": "fixture",
-  "envPrefix": "XGOJA_TEST",
-  "target": {"kind": "xgoja", "output": "dist/fixture"},
-  "packages": [{"id": "fixture"}],
-  "modules": [{"package": "fixture", "name": "hello", "as": "hello"}],
-  "commands": {
-    "eval": {"enabled": true, "name": "eval"},
-    "jsverbs": {"enabled": false}
-  }
+  "app": {
+    "name": "fixture",
+    "envPrefix": "XGOJA_TEST"
+  },
+  "target": {
+    "kind": "xgoja",
+    "output": "dist/fixture"
+  },
+  "providers": [
+    {
+      "id": "fixture"
+    }
+  ],
+  "runtime": {
+    "modules": [
+      {
+        "provider": "fixture",
+        "name": "hello",
+        "as": "hello"
+      }
+    ]
+  },
+  "commands": [
+    {
+      "id": "eval",
+      "type": "builtin.eval",
+      "name": "eval"
+    }
+  ]
 }`
 	out := &bytes.Buffer{}
-	root, err := NewRootCommand(Options{Providers: registry, SpecJSON: specJSON, Out: out})
+	root, err := NewRootCommand(Options{Providers: registry, RuntimePlanJSON: specJSON, Out: out})
 	if err != nil {
 		t.Fatalf("new root: %v", err)
 	}
@@ -101,7 +144,7 @@ func TestGeneratedRootKeepsDefaultMiddlewaresWithoutAppSettings(t *testing.T) {
 		t.Fatalf("register provider: %v", err)
 	}
 	out := &bytes.Buffer{}
-	root, err := NewRootCommand(Options{Providers: registry, SpecJSON: fixtureSpecJSON, Out: out})
+	root, err := NewRootCommand(Options{Providers: registry, RuntimePlanJSON: fixtureRuntimePlanJSON, Out: out})
 	if err != nil {
 		t.Fatalf("new root: %v", err)
 	}
@@ -127,19 +170,46 @@ func TestGeneratedRootReadsConfigFile(t *testing.T) {
 		t.Fatalf("register provider: %v", err)
 	}
 	specJSON := `{
+  "schema": "xgoja/runtime/v2",
   "name": "fixture",
-  "appName": "config-fixture",
-  "configFile": {"enabled": true, "layers": ["cwd"], "fileName": "config.yaml"},
-  "target": {"kind": "xgoja", "output": "dist/fixture"},
-  "packages": [{"id": "fixture"}],
-  "modules": [{"package": "fixture", "name": "hello", "as": "hello"}],
-  "commands": {
-    "eval": {"enabled": true, "name": "eval"},
-    "jsverbs": {"enabled": false}
-  }
+  "app": {
+    "name": "config-fixture",
+    "configFile": {
+      "enabled": true,
+      "layers": [
+        "cwd"
+      ],
+      "fileName": "config.yaml"
+    }
+  },
+  "target": {
+    "kind": "xgoja",
+    "output": "dist/fixture"
+  },
+  "providers": [
+    {
+      "id": "fixture"
+    }
+  ],
+  "runtime": {
+    "modules": [
+      {
+        "provider": "fixture",
+        "name": "hello",
+        "as": "hello"
+      }
+    ]
+  },
+  "commands": [
+    {
+      "id": "eval",
+      "type": "builtin.eval",
+      "name": "eval"
+    }
+  ]
 }`
 	out := &bytes.Buffer{}
-	root, err := NewRootCommand(Options{Providers: registry, SpecJSON: specJSON, Out: out})
+	root, err := NewRootCommand(Options{Providers: registry, RuntimePlanJSON: specJSON, Out: out})
 	if err != nil {
 		t.Fatalf("new root: %v", err)
 	}
@@ -166,20 +236,47 @@ func TestConfigPrecedenceEnvBeatsConfig(t *testing.T) {
 		t.Fatalf("register provider: %v", err)
 	}
 	specJSON := `{
+  "schema": "xgoja/runtime/v2",
   "name": "fixture",
-  "appName": "config-fixture",
-  "envPrefix": "CONFIG_FIXTURE",
-  "configFile": {"enabled": true, "layers": ["cwd"], "fileName": "config.yaml"},
-  "target": {"kind": "xgoja", "output": "dist/fixture"},
-  "packages": [{"id": "fixture"}],
-  "modules": [{"package": "fixture", "name": "hello", "as": "hello"}],
-  "commands": {
-    "eval": {"enabled": true, "name": "eval"},
-    "jsverbs": {"enabled": false}
-  }
+  "app": {
+    "name": "config-fixture",
+    "envPrefix": "CONFIG_FIXTURE",
+    "configFile": {
+      "enabled": true,
+      "layers": [
+        "cwd"
+      ],
+      "fileName": "config.yaml"
+    }
+  },
+  "target": {
+    "kind": "xgoja",
+    "output": "dist/fixture"
+  },
+  "providers": [
+    {
+      "id": "fixture"
+    }
+  ],
+  "runtime": {
+    "modules": [
+      {
+        "provider": "fixture",
+        "name": "hello",
+        "as": "hello"
+      }
+    ]
+  },
+  "commands": [
+    {
+      "id": "eval",
+      "type": "builtin.eval",
+      "name": "eval"
+    }
+  ]
 }`
 	out := &bytes.Buffer{}
-	root, err := NewRootCommand(Options{Providers: registry, SpecJSON: specJSON, Out: out})
+	root, err := NewRootCommand(Options{Providers: registry, RuntimePlanJSON: specJSON, Out: out})
 	if err != nil {
 		t.Fatalf("new root: %v", err)
 	}
@@ -206,20 +303,47 @@ func TestConfigPrecedenceFlagBeatsEnv(t *testing.T) {
 		t.Fatalf("register provider: %v", err)
 	}
 	specJSON := `{
+  "schema": "xgoja/runtime/v2",
   "name": "fixture",
-  "appName": "config-fixture",
-  "envPrefix": "CONFIG_FIXTURE",
-  "configFile": {"enabled": true, "layers": ["cwd"], "fileName": "config.yaml"},
-  "target": {"kind": "xgoja", "output": "dist/fixture"},
-  "packages": [{"id": "fixture"}],
-  "modules": [{"package": "fixture", "name": "hello", "as": "hello"}],
-  "commands": {
-    "eval": {"enabled": true, "name": "eval"},
-    "jsverbs": {"enabled": false}
-  }
+  "app": {
+    "name": "config-fixture",
+    "envPrefix": "CONFIG_FIXTURE",
+    "configFile": {
+      "enabled": true,
+      "layers": [
+        "cwd"
+      ],
+      "fileName": "config.yaml"
+    }
+  },
+  "target": {
+    "kind": "xgoja",
+    "output": "dist/fixture"
+  },
+  "providers": [
+    {
+      "id": "fixture"
+    }
+  ],
+  "runtime": {
+    "modules": [
+      {
+        "provider": "fixture",
+        "name": "hello",
+        "as": "hello"
+      }
+    ]
+  },
+  "commands": [
+    {
+      "id": "eval",
+      "type": "builtin.eval",
+      "name": "eval"
+    }
+  ]
 }`
 	out := &bytes.Buffer{}
-	root, err := NewRootCommand(Options{Providers: registry, SpecJSON: specJSON, Out: out})
+	root, err := NewRootCommand(Options{Providers: registry, RuntimePlanJSON: specJSON, Out: out})
 	if err != nil {
 		t.Fatalf("new root: %v", err)
 	}
@@ -244,19 +368,46 @@ func TestExplicitConfigFileRequiresExplicitLayer(t *testing.T) {
 		t.Fatalf("register provider: %v", err)
 	}
 	specJSON := `{
+  "schema": "xgoja/runtime/v2",
   "name": "fixture",
-  "appName": "config-fixture",
-  "configFile": {"enabled": true, "layers": ["cwd"], "fileName": "config.yaml"},
-  "target": {"kind": "xgoja", "output": "dist/fixture"},
-  "packages": [{"id": "fixture"}],
-  "modules": [{"package": "fixture", "name": "hello", "as": "hello"}],
-  "commands": {
-    "eval": {"enabled": true, "name": "eval"},
-    "jsverbs": {"enabled": false}
-  }
+  "app": {
+    "name": "config-fixture",
+    "configFile": {
+      "enabled": true,
+      "layers": [
+        "cwd"
+      ],
+      "fileName": "config.yaml"
+    }
+  },
+  "target": {
+    "kind": "xgoja",
+    "output": "dist/fixture"
+  },
+  "providers": [
+    {
+      "id": "fixture"
+    }
+  ],
+  "runtime": {
+    "modules": [
+      {
+        "provider": "fixture",
+        "name": "hello",
+        "as": "hello"
+      }
+    ]
+  },
+  "commands": [
+    {
+      "id": "eval",
+      "type": "builtin.eval",
+      "name": "eval"
+    }
+  ]
 }`
 	out := &bytes.Buffer{}
-	root, err := NewRootCommand(Options{Providers: registry, SpecJSON: specJSON, Out: out})
+	root, err := NewRootCommand(Options{Providers: registry, RuntimePlanJSON: specJSON, Out: out})
 	if err != nil {
 		t.Fatalf("new root: %v", err)
 	}
@@ -281,18 +432,46 @@ func TestExplicitConfigFileLoadsWithExplicitLayer(t *testing.T) {
 		t.Fatalf("register provider: %v", err)
 	}
 	specJSON := `{
+  "schema": "xgoja/runtime/v2",
   "name": "fixture",
-  "configFile": {"enabled": true, "layers": ["explicit"], "fileName": "config.yaml"},
-  "target": {"kind": "xgoja", "output": "dist/fixture"},
-  "packages": [{"id": "fixture"}],
-  "modules": [{"package": "fixture", "name": "hello", "as": "hello"}],
-  "commands": {
-    "eval": {"enabled": true, "name": "eval"},
-    "jsverbs": {"enabled": false}
-  }
+  "app": {
+    "name": "fixture",
+    "configFile": {
+      "enabled": true,
+      "layers": [
+        "explicit"
+      ],
+      "fileName": "config.yaml"
+    }
+  },
+  "target": {
+    "kind": "xgoja",
+    "output": "dist/fixture"
+  },
+  "providers": [
+    {
+      "id": "fixture"
+    }
+  ],
+  "runtime": {
+    "modules": [
+      {
+        "provider": "fixture",
+        "name": "hello",
+        "as": "hello"
+      }
+    ]
+  },
+  "commands": [
+    {
+      "id": "eval",
+      "type": "builtin.eval",
+      "name": "eval"
+    }
+  ]
 }`
 	out := &bytes.Buffer{}
-	root, err := NewRootCommand(Options{Providers: registry, SpecJSON: specJSON, Out: out})
+	root, err := NewRootCommand(Options{Providers: registry, RuntimePlanJSON: specJSON, Out: out})
 	if err != nil {
 		t.Fatalf("new root: %v", err)
 	}

--- a/pkg/xgoja/app/module_sections.go
+++ b/pkg/xgoja/app/module_sections.go
@@ -12,18 +12,18 @@ import (
 )
 
 func (f *RuntimeFactory) selectedModuleDescriptors() ([]providerapi.ModuleDescriptor, error) {
-	if f == nil || f.providers == nil || f.runtimeSpec == nil {
+	if f == nil || f.providers == nil || f.runtimePlan == nil {
 		return nil, fmt.Errorf("xgoja runtime factory is not initialized")
 	}
-	descriptors := make([]providerapi.ModuleDescriptor, 0, len(f.runtimeSpec.Modules))
-	for _, instance := range f.runtimeSpec.Modules {
-		module, ok := f.providers.ResolveModule(instance.Package, instance.Name)
+	descriptors := make([]providerapi.ModuleDescriptor, 0, len(f.runtimePlan.runtimeModules()))
+	for _, instance := range f.runtimePlan.runtimeModules() {
+		module, ok := f.providers.ResolveModule(instance.ProviderID(), instance.Name)
 		if !ok {
-			return nil, fmt.Errorf("runtime references unknown provider module %s.%s", instance.Package, instance.Name)
+			return nil, fmt.Errorf("runtime references unknown provider module %s.%s", instance.ProviderID(), instance.Name)
 		}
-		capabilities, _ := f.providers.ResolvePackageCapabilities(instance.Package)
+		capabilities, _ := f.providers.ResolvePackageCapabilities(instance.ProviderID())
 		descriptors = append(descriptors, providerapi.ModuleDescriptor{
-			PackageID:           instance.Package,
+			PackageID:           instance.ProviderID(),
 			ModuleID:            instance.Name,
 			As:                  instance.Alias(),
 			Module:              module,

--- a/pkg/xgoja/app/module_sections_test.go
+++ b/pkg/xgoja/app/module_sections_test.go
@@ -56,7 +56,7 @@ func TestRuntimeFactoryAttachesPackageCapabilitiesToEverySelectedModule(t *testi
 	); err != nil {
 		t.Fatalf("register fixture provider: %v", err)
 	}
-	factory := NewRuntimeFactory(registry, &RuntimeSpec{Modules: []ModuleInstanceSpec{
+	factory := NewRuntimeFactory(registry, &RuntimePlan{Modules: []RuntimeModulePlan{
 		{Package: "fixture", Name: "first", As: "first"},
 		{Package: "fixture", Name: "second", As: "second"},
 	}})
@@ -155,8 +155,8 @@ func newSectionTestFactory(t *testing.T, entries ...providerapi.Entry) *RuntimeF
 	if err := registry.Package("fixture", allEntries...); err != nil {
 		t.Fatalf("register fixture provider: %v", err)
 	}
-	return NewRuntimeFactory(registry, &RuntimeSpec{
-		Modules: []ModuleInstanceSpec{{Package: "fixture", Name: "mod", As: "alias"}},
+	return NewRuntimeFactory(registry, &RuntimePlan{
+		Modules: []RuntimeModulePlan{{Package: "fixture", Name: "mod", As: "alias"}},
 	})
 }
 

--- a/pkg/xgoja/app/module_sections_test.go
+++ b/pkg/xgoja/app/module_sections_test.go
@@ -56,10 +56,10 @@ func TestRuntimeFactoryAttachesPackageCapabilitiesToEverySelectedModule(t *testi
 	); err != nil {
 		t.Fatalf("register fixture provider: %v", err)
 	}
-	factory := NewRuntimeFactory(registry, &RuntimePlan{Modules: []RuntimeModulePlan{
-		{Package: "fixture", Name: "first", As: "first"},
-		{Package: "fixture", Name: "second", As: "second"},
-	}})
+	factory := NewRuntimeFactory(registry, &RuntimePlan{Runtime: RuntimeSection{Modules: []RuntimeModulePlan{
+		{Provider: "fixture", Name: "first", As: "first"},
+		{Provider: "fixture", Name: "second", As: "second"},
+	}}})
 	descriptors, err := factory.selectedModuleDescriptors()
 	if err != nil {
 		t.Fatalf("selected descriptors: %v", err)
@@ -156,7 +156,7 @@ func newSectionTestFactory(t *testing.T, entries ...providerapi.Entry) *RuntimeF
 		t.Fatalf("register fixture provider: %v", err)
 	}
 	return NewRuntimeFactory(registry, &RuntimePlan{
-		Modules: []RuntimeModulePlan{{Package: "fixture", Name: "mod", As: "alias"}},
+		Runtime: RuntimeSection{Modules: []RuntimeModulePlan{{Provider: "fixture", Name: "mod", As: "alias"}}},
 	})
 }
 

--- a/pkg/xgoja/app/root.go
+++ b/pkg/xgoja/app/root.go
@@ -239,8 +239,7 @@ func (c *selectedModulesCommand) RunIntoGlazeProcessor(ctx context.Context, vals
 	return nil
 }
 
-func newVerbsCommand(sourceRegistry *SourceRegistry, factory *RuntimeFactory, runtimePlan *RuntimePlan, middlewaresFunc glazedcli.CobraMiddlewaresFunc) *cobra.Command {
-	jsverbsCommand, _ := runtimePlan.commandByType("builtin.jsverbs")
+func newVerbsCommand(sourceRegistry *SourceRegistry, factory *RuntimeFactory, runtimePlan *RuntimePlan, jsverbsCommand CommandPlan, middlewaresFunc glazedcli.CobraMiddlewaresFunc) *cobra.Command {
 	root := &cobra.Command{
 		Use:   commandName(jsverbsCommand, "verbs"),
 		Short: "Run configured JavaScript verb commands",

--- a/pkg/xgoja/app/root.go
+++ b/pkg/xgoja/app/root.go
@@ -28,7 +28,7 @@ import (
 
 type Options struct {
 	Providers       *providerapi.ProviderRegistry
-	SpecJSON        string
+	RuntimePlanJSON string
 	Out             io.Writer
 	EmbeddedJSVerbs fs.FS
 	EmbeddedHelp    fs.FS
@@ -41,8 +41,8 @@ func NewRootCommand(opts Options) (*cobra.Command, error) {
 		return nil, fmt.Errorf("providers registry is required")
 	}
 	runtimePlan := &RuntimePlan{}
-	if err := json.Unmarshal([]byte(opts.SpecJSON), runtimePlan); err != nil {
-		return nil, fmt.Errorf("decode embedded xgoja runtime spec: %w", err)
+	if err := json.Unmarshal([]byte(opts.RuntimePlanJSON), runtimePlan); err != nil {
+		return nil, fmt.Errorf("decode embedded xgoja runtime plan: %w", err)
 	}
 	host := NewHostWithOptions(opts.Providers, runtimePlan, HostOptions{EmbeddedJSVerbs: opts.EmbeddedJSVerbs, EmbeddedHelp: opts.EmbeddedHelp, EmbeddedAssets: opts.EmbeddedAssets, Out: opts.Out, MiddlewaresFunc: opts.MiddlewaresFunc})
 	root := &cobra.Command{
@@ -215,7 +215,7 @@ func (c *modulesCommand) RunIntoGlazeProcessor(ctx context.Context, vals *values
 func (c *selectedModulesCommand) RunIntoGlazeProcessor(ctx context.Context, vals *values.Values, gp middlewares.Processor) error {
 	_ = vals
 	if c.runtimePlan == nil {
-		return fmt.Errorf("runtime spec is required")
+		return fmt.Errorf("runtime plan is required")
 	}
 	for _, mod := range c.runtimePlan.runtimeModules() {
 		config := "{}"

--- a/pkg/xgoja/app/root.go
+++ b/pkg/xgoja/app/root.go
@@ -40,13 +40,13 @@ func NewRootCommand(opts Options) (*cobra.Command, error) {
 	if opts.Providers == nil {
 		return nil, fmt.Errorf("providers registry is required")
 	}
-	runtimeSpec := &RuntimeSpec{}
-	if err := json.Unmarshal([]byte(opts.SpecJSON), runtimeSpec); err != nil {
+	runtimePlan := &RuntimePlan{}
+	if err := json.Unmarshal([]byte(opts.SpecJSON), runtimePlan); err != nil {
 		return nil, fmt.Errorf("decode embedded xgoja runtime spec: %w", err)
 	}
-	host := NewHostWithOptions(opts.Providers, runtimeSpec, HostOptions{EmbeddedJSVerbs: opts.EmbeddedJSVerbs, EmbeddedHelp: opts.EmbeddedHelp, EmbeddedAssets: opts.EmbeddedAssets, Out: opts.Out, MiddlewaresFunc: opts.MiddlewaresFunc})
+	host := NewHostWithOptions(opts.Providers, runtimePlan, HostOptions{EmbeddedJSVerbs: opts.EmbeddedJSVerbs, EmbeddedHelp: opts.EmbeddedHelp, EmbeddedAssets: opts.EmbeddedAssets, Out: opts.Out, MiddlewaresFunc: opts.MiddlewaresFunc})
 	root := &cobra.Command{
-		Use:   runtimeSpec.Name,
+		Use:   runtimePlan.Name,
 		Short: "Generated xgoja binary",
 	}
 	if opts.Out != nil {
@@ -69,7 +69,7 @@ type evalSettings struct {
 	Source string `glazed:"source"`
 }
 
-func newEvalCommand(factory *RuntimeFactory, runtimeSpec *RuntimeSpec, out io.Writer) cmds.Command {
+func newEvalCommand(factory *RuntimeFactory, runtimePlan *RuntimePlan, out io.Writer) cmds.Command {
 	moduleSections, _, sectionErr := factory.sectionsForRuntime("eval")
 	options := []cmds.CommandDescriptionOption{
 		cmds.WithShort("Evaluate JavaScript in a generated xgoja runtime"),
@@ -90,8 +90,9 @@ before evaluation and runtime initializers run before the JavaScript source.
 	if sectionErr == nil && len(moduleSections) > 0 {
 		options = append(options, cmds.WithSections(moduleSections...))
 	}
+	command, _ := runtimePlan.commandByType("builtin.eval")
 	return &evalCommand{
-		CommandDescription: cmds.NewCommandDescription(commandName(runtimeSpec.Commands.Eval, "eval"), options...),
+		CommandDescription: cmds.NewCommandDescription(commandName(command, "eval"), options...),
 		factory:            factory,
 		out:                out,
 		sectionErr:         sectionErr,
@@ -159,14 +160,14 @@ type modulesCommand struct {
 
 type selectedModulesCommand struct {
 	*cmds.CommandDescription
-	runtimeSpec *RuntimeSpec
+	runtimePlan *RuntimePlan
 }
 
 var _ cmds.GlazeCommand = (*modulesCommand)(nil)
 var _ cmds.GlazeCommand = (*selectedModulesCommand)(nil)
 
-func newModulesCommand(providers *providerapi.ProviderRegistry, runtimeSpec *RuntimeSpec) cmds.Command {
-	_ = runtimeSpec
+func newModulesCommand(providers *providerapi.ProviderRegistry, runtimePlan *RuntimePlan) cmds.Command {
+	_ = runtimePlan
 	return &modulesCommand{
 		CommandDescription: cmds.NewCommandDescription("modules",
 			cmds.WithShort("List provider modules compiled into this generated binary"),
@@ -176,13 +177,13 @@ func newModulesCommand(providers *providerapi.ProviderRegistry, runtimeSpec *Run
 	}
 }
 
-func newSelectedModulesCommand(runtimeSpec *RuntimeSpec) cmds.Command {
+func newSelectedModulesCommand(runtimePlan *RuntimePlan) cmds.Command {
 	return &selectedModulesCommand{
 		CommandDescription: cmds.NewCommandDescription("selected-modules",
 			cmds.WithShort("List require() modules selected for this generated runtime"),
 			cmds.WithLong("List the provider modules selected into this generated xgoja runtime, including the actual CommonJS require() alias and static module config."),
 		),
-		runtimeSpec: runtimeSpec,
+		runtimePlan: runtimePlan,
 	}
 }
 
@@ -213,23 +214,23 @@ func (c *modulesCommand) RunIntoGlazeProcessor(ctx context.Context, vals *values
 
 func (c *selectedModulesCommand) RunIntoGlazeProcessor(ctx context.Context, vals *values.Values, gp middlewares.Processor) error {
 	_ = vals
-	if c.runtimeSpec == nil {
+	if c.runtimePlan == nil {
 		return fmt.Errorf("runtime spec is required")
 	}
-	for _, mod := range c.runtimeSpec.Modules {
+	for _, mod := range c.runtimePlan.runtimeModules() {
 		config := "{}"
 		if len(mod.Config) > 0 {
 			data, err := json.Marshal(mod.Config)
 			if err != nil {
-				return fmt.Errorf("marshal config for %s.%s: %w", mod.Package, mod.Name, err)
+				return fmt.Errorf("marshal config for %s.%s: %w", mod.ProviderID(), mod.Name, err)
 			}
 			config = string(data)
 		}
 		if err := gp.AddRow(ctx, types.NewRow(
-			types.MRP("package", mod.Package),
+			types.MRP("package", mod.ProviderID()),
 			types.MRP("module", mod.Name),
 			types.MRP("alias", mod.Alias()),
-			types.MRP("provider_ref", fmt.Sprintf("%s.%s", mod.Package, mod.Name)),
+			types.MRP("provider_ref", fmt.Sprintf("%s.%s", mod.ProviderID(), mod.Name)),
 			types.MRP("config", config),
 		)); err != nil {
 			return err
@@ -238,12 +239,13 @@ func (c *selectedModulesCommand) RunIntoGlazeProcessor(ctx context.Context, vals
 	return nil
 }
 
-func newVerbsCommand(providers *providerapi.ProviderRegistry, factory *RuntimeFactory, runtimeSpec *RuntimeSpec, embeddedJSVerbs fs.FS, middlewaresFunc glazedcli.CobraMiddlewaresFunc) *cobra.Command {
+func newVerbsCommand(providers *providerapi.ProviderRegistry, factory *RuntimeFactory, runtimePlan *RuntimePlan, embeddedJSVerbs fs.FS, middlewaresFunc glazedcli.CobraMiddlewaresFunc) *cobra.Command {
+	jsverbsCommand, _ := runtimePlan.commandByType("builtin.jsverbs")
 	root := &cobra.Command{
-		Use:   commandName(runtimeSpec.Commands.JSVerbs, "verbs"),
+		Use:   commandName(jsverbsCommand, "verbs"),
 		Short: "Run configured JavaScript verb commands",
 	}
-	mounted, err := buildVerbCommands(providers, factory, runtimeSpec, embeddedJSVerbs)
+	mounted, err := buildVerbCommands(providers, factory, runtimePlan, embeddedJSVerbs)
 	if err != nil {
 		root.RunE = func(cmd *cobra.Command, args []string) error { return err }
 		return root
@@ -252,7 +254,7 @@ func newVerbsCommand(providers *providerapi.ProviderRegistry, factory *RuntimeFa
 		Use:   "sources",
 		Short: "List configured JavaScript verb sources",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			for _, source := range runtimeSpec.JSVerbs {
+			for _, source := range runtimePlan.sourcesByKind(SourceKindJSVerbs) {
 				fmt.Fprintf(cmd.OutOrStdout(), "%s\n", source.ID)
 			}
 			return nil
@@ -270,13 +272,13 @@ func newVerbsCommand(providers *providerapi.ProviderRegistry, factory *RuntimeFa
 	return root
 }
 
-func buildVerbCommands(providers *providerapi.ProviderRegistry, factory *RuntimeFactory, runtimeSpec *RuntimeSpec, embeddedJSVerbs fs.FS) ([]cmds.Command, error) {
+func buildVerbCommands(providers *providerapi.ProviderRegistry, factory *RuntimeFactory, runtimePlan *RuntimePlan, embeddedJSVerbs fs.FS) ([]cmds.Command, error) {
 	moduleSections, selectedModules, err := factory.sectionsForRuntime("jsverbs")
 	if err != nil {
 		return nil, err
 	}
 	commands := []cmds.Command{}
-	for _, source := range runtimeSpec.JSVerbs {
+	for _, source := range runtimePlan.sourcesByKind(SourceKindJSVerbs) {
 		registry, err := scanVerbSource(providers, embeddedJSVerbs, source, sourceGraphRuntimeAliases(moduleAliases(selectedModules)))
 		if err != nil {
 			return nil, err
@@ -314,7 +316,7 @@ func buildVerbCommands(providers *providerapi.ProviderRegistry, factory *Runtime
 	return commands, nil
 }
 
-func scanVerbSource(providers *providerapi.ProviderRegistry, embeddedJSVerbs fs.FS, source JSVerbSourceSpec, runtimeAliases []string) (*jsverbs.Registry, error) {
+func scanVerbSource(providers *providerapi.ProviderRegistry, embeddedJSVerbs fs.FS, source SourcePlan, runtimeAliases []string) (*jsverbs.Registry, error) {
 	scanOptions := jsVerbScanOptions(source, runtimeAliases)
 	sourceSet, err := sourceGraphSourceSet(providers, embeddedJSVerbs, source)
 	if err != nil {
@@ -341,7 +343,7 @@ func scanVerbSource(providers *providerapi.ProviderRegistry, embeddedJSVerbs fs.
 	return registry, nil
 }
 
-func sourceGraphSourceSet(providers *providerapi.ProviderRegistry, embeddedJSVerbs fs.FS, source JSVerbSourceSpec) (*sourcegraph.SourceSet, error) {
+func sourceGraphSourceSet(providers *providerapi.ProviderRegistry, embeddedJSVerbs fs.FS, source SourcePlan) (*sourcegraph.SourceSet, error) {
 	set := sourcegraph.SourceSet{
 		ID:         source.ID,
 		Kind:       sourcegraph.SourceKindJSVerbs,
@@ -349,18 +351,18 @@ func sourceGraphSourceSet(providers *providerapi.ProviderRegistry, embeddedJSVer
 		Exclude:    append([]string(nil), source.Exclude...),
 		Extensions: sourceGraphExtensions(source),
 	}
-	if source.Package != "" || source.Source != "" {
+	if source.ProviderID() != "" || source.Source != "" {
 		if providers == nil {
 			return nil, fmt.Errorf("scan jsverb source %s: providers registry is required", source.ID)
 		}
-		providerSource, ok := providers.ResolveVerbSource(source.Package, source.Source)
+		providerSource, ok := providers.ResolveVerbSource(source.ProviderID(), source.Source)
 		if !ok {
-			return nil, fmt.Errorf("scan jsverb source %s: unknown provider verb source %s.%s", source.ID, source.Package, source.Source)
+			return nil, fmt.Errorf("scan jsverb source %s: unknown provider verb source %s.%s", source.ID, source.ProviderID(), source.Source)
 		}
 		if providerSource.FS == nil {
-			return nil, fmt.Errorf("scan jsverb source %s: provider verb source %s.%s has no filesystem", source.ID, source.Package, source.Source)
+			return nil, fmt.Errorf("scan jsverb source %s: provider verb source %s.%s has no filesystem", source.ID, source.ProviderID(), source.Source)
 		}
-		set.Origin = sourcegraph.Origin{Kind: sourcegraph.OriginProvider, FS: providerSource.FS, Root: providerSource.Root, Provider: source.Package, Source: source.Source}
+		set.Origin = sourcegraph.Origin{Kind: sourcegraph.OriginProvider, FS: providerSource.FS, Root: providerSource.Root, Provider: source.ProviderID(), Source: source.Source}
 		return &set, nil
 	}
 	if source.Path == "" {
@@ -397,7 +399,7 @@ func allProviderRuntimeAliases(providers *providerapi.ProviderRegistry) []string
 	return appendUniqueStrings(nil, aliases...)
 }
 
-func sourceGraphExtensions(source JSVerbSourceSpec) []string {
+func sourceGraphExtensions(source SourcePlan) []string {
 	if len(source.Extensions) > 0 {
 		return append([]string(nil), source.Extensions...)
 	}
@@ -461,7 +463,7 @@ func sourceGraphResolveDir(file sourcegraph.File) string {
 	return filepath.Dir(file.AbsPath)
 }
 
-func jsVerbScanOptions(source JSVerbSourceSpec, runtimeAliases []string) jsverbs.ScanOptions {
+func jsVerbScanOptions(source SourcePlan, runtimeAliases []string) jsverbs.ScanOptions {
 	options := jsverbs.DefaultScanOptions()
 	if len(source.Extensions) > 0 {
 		options.Extensions = append([]string(nil), source.Extensions...)
@@ -472,14 +474,14 @@ func jsVerbScanOptions(source JSVerbSourceSpec, runtimeAliases []string) jsverbs
 	return options
 }
 
-func commandName(command CommandSpec, fallback string) string {
+func commandName(command CommandPlan, fallback string) string {
 	if command.Name != "" {
 		return command.Name
 	}
 	return fallback
 }
 
-func commandMount(command CommandSpec) string {
+func commandMount(command CommandPlan) string {
 	switch strings.ToLower(strings.TrimSpace(command.Mount)) {
 	case "root", "/", ".":
 		return "root"

--- a/pkg/xgoja/app/root.go
+++ b/pkg/xgoja/app/root.go
@@ -239,13 +239,13 @@ func (c *selectedModulesCommand) RunIntoGlazeProcessor(ctx context.Context, vals
 	return nil
 }
 
-func newVerbsCommand(providers *providerapi.ProviderRegistry, factory *RuntimeFactory, runtimePlan *RuntimePlan, embeddedJSVerbs fs.FS, middlewaresFunc glazedcli.CobraMiddlewaresFunc) *cobra.Command {
+func newVerbsCommand(sourceRegistry *SourceRegistry, factory *RuntimeFactory, runtimePlan *RuntimePlan, middlewaresFunc glazedcli.CobraMiddlewaresFunc) *cobra.Command {
 	jsverbsCommand, _ := runtimePlan.commandByType("builtin.jsverbs")
 	root := &cobra.Command{
 		Use:   commandName(jsverbsCommand, "verbs"),
 		Short: "Run configured JavaScript verb commands",
 	}
-	mounted, err := buildVerbCommands(providers, factory, runtimePlan, embeddedJSVerbs)
+	mounted, err := buildVerbCommands(sourceRegistry, factory, runtimePlan)
 	if err != nil {
 		root.RunE = func(cmd *cobra.Command, args []string) error { return err }
 		return root
@@ -254,7 +254,7 @@ func newVerbsCommand(providers *providerapi.ProviderRegistry, factory *RuntimeFa
 		Use:   "sources",
 		Short: "List configured JavaScript verb sources",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			for _, source := range runtimePlan.sourcesByKind(SourceKindJSVerbs) {
+			for _, source := range sourceRegistry.ListSourcesByKind(providerapi.RuntimeSourceKindJSVerbs) {
 				fmt.Fprintf(cmd.OutOrStdout(), "%s\n", source.ID)
 			}
 			return nil
@@ -272,14 +272,18 @@ func newVerbsCommand(providers *providerapi.ProviderRegistry, factory *RuntimeFa
 	return root
 }
 
-func buildVerbCommands(providers *providerapi.ProviderRegistry, factory *RuntimeFactory, runtimePlan *RuntimePlan, embeddedJSVerbs fs.FS) ([]cmds.Command, error) {
+func buildVerbCommands(sourceRegistry *SourceRegistry, factory *RuntimeFactory, runtimePlan *RuntimePlan) ([]cmds.Command, error) {
 	moduleSections, selectedModules, err := factory.sectionsForRuntime("jsverbs")
 	if err != nil {
 		return nil, err
 	}
 	commands := []cmds.Command{}
-	for _, source := range runtimePlan.sourcesByKind(SourceKindJSVerbs) {
-		registry, err := scanVerbSource(providers, embeddedJSVerbs, source, sourceGraphRuntimeAliases(moduleAliases(selectedModules)))
+	if sourceRegistry == nil {
+		return nil, fmt.Errorf("source registry is required")
+	}
+	jsverbSources := sourceRegistry.JSVerbs()
+	for _, source := range jsverbSources.ListJSVerbSources() {
+		registry, err := sourceRegistry.scanJSVerbSource(source.ID, sourceGraphRuntimeAliases(moduleAliases(selectedModules)))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/xgoja/app/root_test.go
+++ b/pkg/xgoja/app/root_test.go
@@ -17,15 +17,34 @@ import (
 	"github.com/go-go-golems/go-go-goja/pkg/xgoja/testprovider"
 )
 
-const fixtureSpecJSON = `{
+const fixtureRuntimePlanJSON = `{
+  "schema": "xgoja/runtime/v2",
   "name": "fixture",
-  "target": {"kind": "xgoja", "output": "dist/fixture"},
-  "packages": [{"id": "fixture"}],
-  "modules": [{"package": "fixture", "name": "hello", "as": "hello"}],
-  "commands": {
-    "eval": {"enabled": true, "name": "eval"},
-    "jsverbs": {"enabled": false}
-  }
+  "target": {
+    "kind": "xgoja",
+    "output": "dist/fixture"
+  },
+  "providers": [
+    {
+      "id": "fixture"
+    }
+  ],
+  "runtime": {
+    "modules": [
+      {
+        "provider": "fixture",
+        "name": "hello",
+        "as": "hello"
+      }
+    ]
+  },
+  "commands": [
+    {
+      "id": "eval",
+      "type": "builtin.eval",
+      "name": "eval"
+    }
+  ]
 }`
 
 func TestGeneratedRootEvalUsesProviderModule(t *testing.T) {
@@ -34,7 +53,7 @@ func TestGeneratedRootEvalUsesProviderModule(t *testing.T) {
 		t.Fatalf("register provider: %v", err)
 	}
 	out := &bytes.Buffer{}
-	root, err := NewRootCommand(Options{Providers: registry, SpecJSON: fixtureSpecJSON, Out: out})
+	root, err := NewRootCommand(Options{Providers: registry, RuntimePlanJSON: fixtureRuntimePlanJSON, Out: out})
 	if err != nil {
 		t.Fatalf("new root: %v", err)
 	}
@@ -53,17 +72,39 @@ func TestGeneratedRootRespectsConfiguredReplCommandName(t *testing.T) {
 		t.Fatalf("register provider: %v", err)
 	}
 	specJSON := `{
+  "schema": "xgoja/runtime/v2",
   "name": "fixture",
-  "target": {"kind": "xgoja", "output": "dist/fixture"},
-  "packages": [{"id": "fixture"}],
-  "modules": [{"package": "fixture", "name": "hello", "as": "hello"}],
-  "commands": {
-    "eval": {"enabled": true, "name": "runjs"},
-    "jsverbs": {"enabled": false}
-  }
+  "app": {
+    "name": "fixture"
+  },
+  "target": {
+    "kind": "xgoja",
+    "output": "dist/fixture"
+  },
+  "providers": [
+    {
+      "id": "fixture"
+    }
+  ],
+  "runtime": {
+    "modules": [
+      {
+        "provider": "fixture",
+        "name": "hello",
+        "as": "hello"
+      }
+    ]
+  },
+  "commands": [
+    {
+      "id": "eval",
+      "type": "builtin.eval",
+      "name": "runjs"
+    }
+  ]
 }`
 	out := &bytes.Buffer{}
-	root, err := NewRootCommand(Options{Providers: registry, SpecJSON: specJSON, Out: out})
+	root, err := NewRootCommand(Options{Providers: registry, RuntimePlanJSON: specJSON, Out: out})
 	if err != nil {
 		t.Fatalf("new root: %v", err)
 	}
@@ -82,16 +123,31 @@ func TestGeneratedRootRespectsDisabledReplCommand(t *testing.T) {
 		t.Fatalf("register provider: %v", err)
 	}
 	specJSON := `{
+  "schema": "xgoja/runtime/v2",
   "name": "fixture",
-  "target": {"kind": "xgoja", "output": "dist/fixture"},
-  "packages": [{"id": "fixture"}],
-  "modules": [{"package": "fixture", "name": "hello", "as": "hello"}],
-  "commands": {
-    "eval": {"enabled": false, "name": "runjs"},
-    "jsverbs": {"enabled": false}
+  "app": {
+    "name": "fixture"
+  },
+  "target": {
+    "kind": "xgoja",
+    "output": "dist/fixture"
+  },
+  "providers": [
+    {
+      "id": "fixture"
+    }
+  ],
+  "runtime": {
+    "modules": [
+      {
+        "provider": "fixture",
+        "name": "hello",
+        "as": "hello"
+      }
+    ]
   }
 }`
-	root, err := NewRootCommand(Options{Providers: registry, SpecJSON: specJSON})
+	root, err := NewRootCommand(Options{Providers: registry, RuntimePlanJSON: specJSON})
 	if err != nil {
 		t.Fatalf("new root: %v", err)
 	}
@@ -108,7 +164,7 @@ func TestGeneratedRootInstallsHelpAndLogging(t *testing.T) {
 		t.Fatalf("register provider: %v", err)
 	}
 	out := &bytes.Buffer{}
-	root, err := NewRootCommand(Options{Providers: registry, SpecJSON: fixtureSpecJSON, Out: out})
+	root, err := NewRootCommand(Options{Providers: registry, RuntimePlanJSON: fixtureRuntimePlanJSON, Out: out})
 	if err != nil {
 		t.Fatalf("new root: %v", err)
 	}
@@ -155,15 +211,40 @@ Fixture provider help body.
 		t.Fatalf("register provider: %v", err)
 	}
 	specJSON := `{
+  "schema": "xgoja/runtime/v2",
   "name": "fixture",
-  "target": {"kind": "xgoja", "output": "dist/fixture"},
-  "packages": [{"id": "fixture"}],
-  "modules": [{"package": "fixture", "name": "hello", "as": "hello"}],
-  "commands": {"eval": {"enabled": false}, "jsverbs": {"enabled": false}},
-  "help": {"sources": [{"id": "fixture-docs", "package": "fixture", "source": "docs"}]}
+  "app": {
+    "name": "fixture"
+  },
+  "target": {
+    "kind": "xgoja",
+    "output": "dist/fixture"
+  },
+  "providers": [
+    {
+      "id": "fixture"
+    }
+  ],
+  "runtime": {
+    "modules": [
+      {
+        "provider": "fixture",
+        "name": "hello",
+        "as": "hello"
+      }
+    ]
+  },
+  "sources": [
+    {
+      "id": "fixture-docs",
+      "source": "docs",
+      "kind": "help",
+      "provider": "fixture"
+    }
+  ]
 }`
 	out := &bytes.Buffer{}
-	root, err := NewRootCommand(Options{Providers: registry, SpecJSON: specJSON, Out: out})
+	root, err := NewRootCommand(Options{Providers: registry, RuntimePlanJSON: specJSON, Out: out})
 	if err != nil {
 		t.Fatalf("new root: %v", err)
 	}
@@ -200,15 +281,40 @@ Local generated help body.
 `)},
 	}
 	specJSON := `{
+  "schema": "xgoja/runtime/v2",
   "name": "fixture",
-  "target": {"kind": "xgoja", "output": "dist/fixture"},
-  "packages": [{"id": "fixture"}],
-  "modules": [{"package": "fixture", "name": "hello", "as": "hello"}],
-  "commands": {"eval": {"enabled": false}, "jsverbs": {"enabled": false}},
-  "help": {"sources": [{"id": "local", "path": "xgoja_embed/help/local", "embed": true}]}
+  "app": {
+    "name": "fixture"
+  },
+  "target": {
+    "kind": "xgoja",
+    "output": "dist/fixture"
+  },
+  "providers": [
+    {
+      "id": "fixture"
+    }
+  ],
+  "runtime": {
+    "modules": [
+      {
+        "provider": "fixture",
+        "name": "hello",
+        "as": "hello"
+      }
+    ]
+  },
+  "sources": [
+    {
+      "id": "local",
+      "path": "xgoja_embed/help/local",
+      "embed": true,
+      "kind": "help"
+    }
+  ]
 }`
 	out := &bytes.Buffer{}
-	root, err := NewRootCommand(Options{Providers: registry, SpecJSON: specJSON, Out: out, EmbeddedHelp: embeddedHelp})
+	root, err := NewRootCommand(Options{Providers: registry, RuntimePlanJSON: specJSON, Out: out, EmbeddedHelp: embeddedHelp})
 	if err != nil {
 		t.Fatalf("new root: %v", err)
 	}
@@ -227,14 +333,39 @@ func TestGeneratedRootReportsMissingProviderHelpSource(t *testing.T) {
 		t.Fatalf("register provider: %v", err)
 	}
 	specJSON := `{
+  "schema": "xgoja/runtime/v2",
   "name": "fixture",
-  "target": {"kind": "xgoja", "output": "dist/fixture"},
-  "packages": [{"id": "fixture"}],
-  "modules": [{"package": "fixture", "name": "hello", "as": "hello"}],
-  "commands": {"eval": {"enabled": false}, "jsverbs": {"enabled": false}},
-  "help": {"sources": [{"id": "missing", "package": "fixture", "source": "missing"}]}
+  "app": {
+    "name": "fixture"
+  },
+  "target": {
+    "kind": "xgoja",
+    "output": "dist/fixture"
+  },
+  "providers": [
+    {
+      "id": "fixture"
+    }
+  ],
+  "runtime": {
+    "modules": [
+      {
+        "provider": "fixture",
+        "name": "hello",
+        "as": "hello"
+      }
+    ]
+  },
+  "sources": [
+    {
+      "id": "missing",
+      "source": "missing",
+      "kind": "help",
+      "provider": "fixture"
+    }
+  ]
 }`
-	root, err := NewRootCommand(Options{Providers: registry, SpecJSON: specJSON})
+	root, err := NewRootCommand(Options{Providers: registry, RuntimePlanJSON: specJSON})
 	if err != nil {
 		t.Fatalf("new root should defer framework errors to execution, got %v", err)
 	}
@@ -251,17 +382,39 @@ func TestGeneratedRootTUIHelp(t *testing.T) {
 		t.Fatalf("register provider: %v", err)
 	}
 	specJSON := `{
+  "schema": "xgoja/runtime/v2",
   "name": "fixture",
-  "target": {"kind": "xgoja", "output": "dist/fixture"},
-  "packages": [{"id": "fixture"}],
-  "modules": [{"package": "fixture", "name": "hello", "as": "hello"}],
-  "commands": {
-    "repl": {"enabled": true, "name": "repl"},
-    "jsverbs": {"enabled": false}
-  }
+  "app": {
+    "name": "fixture"
+  },
+  "target": {
+    "kind": "xgoja",
+    "output": "dist/fixture"
+  },
+  "providers": [
+    {
+      "id": "fixture"
+    }
+  ],
+  "runtime": {
+    "modules": [
+      {
+        "provider": "fixture",
+        "name": "hello",
+        "as": "hello"
+      }
+    ]
+  },
+  "commands": [
+    {
+      "id": "repl",
+      "type": "builtin.repl",
+      "name": "repl"
+    }
+  ]
 }`
 	out := &bytes.Buffer{}
-	root, err := NewRootCommand(Options{Providers: registry, SpecJSON: specJSON, Out: out})
+	root, err := NewRootCommand(Options{Providers: registry, RuntimePlanJSON: specJSON, Out: out})
 	if err != nil {
 		t.Fatalf("new root: %v", err)
 	}
@@ -296,17 +449,43 @@ if (hello.greet(helper.name) !== "hello intern") {
 		t.Fatalf("write script: %v", err)
 	}
 	specJSON := `{
+  "schema": "xgoja/runtime/v2",
   "name": "fixture",
-  "target": {"kind": "xgoja", "output": "dist/fixture"},
-  "packages": [{"id": "fixture"}],
-  "modules": [{"package": "fixture", "name": "hello", "as": "hello"}],
-  "commands": {
-    "eval": {"enabled": true, "name": "eval"},
-    "run": {"enabled": true, "name": "run"},
-    "jsverbs": {"enabled": false}
-  }
+  "app": {
+    "name": "fixture"
+  },
+  "target": {
+    "kind": "xgoja",
+    "output": "dist/fixture"
+  },
+  "providers": [
+    {
+      "id": "fixture"
+    }
+  ],
+  "runtime": {
+    "modules": [
+      {
+        "provider": "fixture",
+        "name": "hello",
+        "as": "hello"
+      }
+    ]
+  },
+  "commands": [
+    {
+      "id": "eval",
+      "type": "builtin.eval",
+      "name": "eval"
+    },
+    {
+      "id": "run",
+      "type": "builtin.run",
+      "name": "run"
+    }
+  ]
 }`
-	root, err := NewRootCommand(Options{Providers: registry, SpecJSON: specJSON})
+	root, err := NewRootCommand(Options{Providers: registry, RuntimePlanJSON: specJSON})
 	if err != nil {
 		t.Fatalf("new root: %v", err)
 	}
@@ -321,7 +500,7 @@ func TestGeneratedRootModulesCommand(t *testing.T) {
 	if err := testprovider.Register(registry); err != nil {
 		t.Fatalf("register provider: %v", err)
 	}
-	root, err := NewRootCommand(Options{Providers: registry, SpecJSON: fixtureSpecJSON})
+	root, err := NewRootCommand(Options{Providers: registry, RuntimePlanJSON: fixtureRuntimePlanJSON})
 	if err != nil {
 		t.Fatalf("new root: %v", err)
 	}
@@ -344,16 +523,46 @@ func TestGeneratedRootSelectedModulesCommand(t *testing.T) {
 		t.Fatalf("register provider: %v", err)
 	}
 	specJSON := `{
+  "schema": "xgoja/runtime/v2",
   "name": "fixture",
-  "target": {"kind": "xgoja", "output": "dist/fixture"},
-  "packages": [{"id": "fixture"}],
-  "modules": [
-    {"package": "fixture", "name": "hello", "as": "hello"},
-    {"package": "fixture", "name": "hello", "as": "hello:custom", "config": {"message": "hi"}}
+  "app": {
+    "name": "fixture"
+  },
+  "target": {
+    "kind": "xgoja",
+    "output": "dist/fixture"
+  },
+  "providers": [
+    {
+      "id": "fixture"
+    }
   ],
-  "commands": {"eval": {"enabled": true, "name": "eval"}, "jsverbs": {"enabled": false}}
+  "runtime": {
+    "modules": [
+      {
+        "provider": "fixture",
+        "name": "hello",
+        "as": "hello"
+      },
+      {
+        "provider": "fixture",
+        "name": "hello",
+        "as": "hello:custom",
+        "config": {
+          "message": "hi"
+        }
+      }
+    ]
+  },
+  "commands": [
+    {
+      "id": "eval",
+      "type": "builtin.eval",
+      "name": "eval"
+    }
+  ]
 }`
-	root, err := NewRootCommand(Options{Providers: registry, SpecJSON: specJSON})
+	root, err := NewRootCommand(Options{Providers: registry, RuntimePlanJSON: specJSON})
 	if err != nil {
 		t.Fatalf("new root: %v", err)
 	}
@@ -376,8 +585,8 @@ func TestRuntimeFactoryDoesNotExposeImplicitEngineModules(t *testing.T) {
 		t.Fatalf("register provider: %v", err)
 	}
 	runtimePlan := &RuntimePlan{}
-	if err := json.Unmarshal([]byte(fixtureSpecJSON), runtimePlan); err != nil {
-		t.Fatalf("parse runtime spec: %v", err)
+	if err := json.Unmarshal([]byte(fixtureRuntimePlanJSON), runtimePlan); err != nil {
+		t.Fatalf("parse runtime plan: %v", err)
 	}
 	rt, err := NewRuntimeFactory(registry, runtimePlan).NewRuntime(context.Background())
 	if err != nil {
@@ -391,7 +600,7 @@ func TestRuntimeFactoryDoesNotExposeImplicitEngineModules(t *testing.T) {
 		t.Fatalf("require hello: %v", err)
 	}
 	if _, err := rt.Require.Require("path"); err == nil {
-		t.Fatalf("require path succeeded, want xgoja runtime spec-selected modules only")
+		t.Fatalf("require path succeeded, want xgoja runtime plan-selected modules only")
 	}
 }
 
@@ -401,15 +610,60 @@ func TestGeneratedRootMountsProviderJSVerbs(t *testing.T) {
 		t.Fatalf("register provider: %v", err)
 	}
 	specJSON := `{
+  "schema": "xgoja/runtime/v2",
   "name": "fixture",
-  "target": {"kind": "xgoja", "output": "dist/fixture"},
-  "packages": [{"id": "fixture"}],
-  "modules": [{"package": "fixture", "name": "hello", "as": "hello"}, {"package": "fixture", "name": "owner-check", "as": "owner-check"}],
-  "commands": {"eval": {"enabled": true, "name": "eval"}, "jsverbs": {"enabled": true, "name": "verbs"}},
-  "jsverbs": [{"id": "provider", "package": "fixture", "source": "verbs"}]
+  "app": {
+    "name": "fixture"
+  },
+  "target": {
+    "kind": "xgoja",
+    "output": "dist/fixture"
+  },
+  "providers": [
+    {
+      "id": "fixture"
+    }
+  ],
+  "runtime": {
+    "modules": [
+      {
+        "provider": "fixture",
+        "name": "hello",
+        "as": "hello"
+      },
+      {
+        "provider": "fixture",
+        "name": "owner-check",
+        "as": "owner-check"
+      }
+    ]
+  },
+  "sources": [
+    {
+      "id": "provider",
+      "source": "verbs",
+      "kind": "jsverbs",
+      "provider": "fixture"
+    }
+  ],
+  "commands": [
+    {
+      "id": "eval",
+      "type": "builtin.eval",
+      "name": "eval"
+    },
+    {
+      "id": "jsverbs",
+      "type": "builtin.jsverbs",
+      "name": "verbs",
+      "sources": [
+        "provider"
+      ]
+    }
+  ]
 }`
 	out := &bytes.Buffer{}
-	root, err := NewRootCommand(Options{Providers: registry, SpecJSON: specJSON, Out: out})
+	root, err := NewRootCommand(Options{Providers: registry, RuntimePlanJSON: specJSON, Out: out})
 	if err != nil {
 		t.Fatalf("new root: %v", err)
 	}
@@ -418,7 +672,7 @@ func TestGeneratedRootMountsProviderJSVerbs(t *testing.T) {
 		t.Fatalf("execute provider verb: %v", err)
 	}
 
-	root, err = NewRootCommand(Options{Providers: registry, SpecJSON: specJSON, Out: out})
+	root, err = NewRootCommand(Options{Providers: registry, RuntimePlanJSON: specJSON, Out: out})
 	if err != nil {
 		t.Fatalf("new root for owner verb: %v", err)
 	}
@@ -450,15 +704,55 @@ function embeddedGreet(name) {
 `)},
 	}
 	specJSON := `{
+  "schema": "xgoja/runtime/v2",
   "name": "fixture",
-  "target": {"kind": "xgoja", "output": "dist/fixture"},
-  "packages": [{"id": "fixture"}],
-  "modules": [{"package": "fixture", "name": "hello", "as": "hello"}],
-  "commands": {"eval": {"enabled": true, "name": "eval"}, "jsverbs": {"enabled": true, "name": "verbs"}},
-  "jsverbs": [{"id": "local", "path": "xgoja_embed/jsverbs/local", "embed": true}]
+  "app": {
+    "name": "fixture"
+  },
+  "target": {
+    "kind": "xgoja",
+    "output": "dist/fixture"
+  },
+  "providers": [
+    {
+      "id": "fixture"
+    }
+  ],
+  "runtime": {
+    "modules": [
+      {
+        "provider": "fixture",
+        "name": "hello",
+        "as": "hello"
+      }
+    ]
+  },
+  "sources": [
+    {
+      "id": "local",
+      "path": "xgoja_embed/jsverbs/local",
+      "embed": true,
+      "kind": "jsverbs"
+    }
+  ],
+  "commands": [
+    {
+      "id": "eval",
+      "type": "builtin.eval",
+      "name": "eval"
+    },
+    {
+      "id": "jsverbs",
+      "type": "builtin.jsverbs",
+      "name": "verbs",
+      "sources": [
+        "local"
+      ]
+    }
+  ]
 }`
 	out := &bytes.Buffer{}
-	root, err := NewRootCommand(Options{Providers: registry, SpecJSON: specJSON, Out: out, EmbeddedJSVerbs: embedded})
+	root, err := NewRootCommand(Options{Providers: registry, RuntimePlanJSON: specJSON, Out: out, EmbeddedJSVerbs: embedded})
 	if err != nil {
 		t.Fatalf("new root: %v", err)
 	}
@@ -490,15 +784,56 @@ function embeddedGreet(name) {
 `)},
 	}
 	specJSON := `{
+  "schema": "xgoja/runtime/v2",
   "name": "fixture",
-  "target": {"kind": "xgoja", "output": "dist/fixture"},
-  "packages": [{"id": "fixture"}],
-  "modules": [{"package": "fixture", "name": "hello", "as": "hello"}],
-  "commands": {"eval": {"enabled": true, "name": "eval"}, "jsverbs": {"enabled": true, "name": "verbs", "mount": "root"}},
-  "jsverbs": [{"id": "local", "path": "xgoja_embed/jsverbs/local", "embed": true}]
+  "app": {
+    "name": "fixture"
+  },
+  "target": {
+    "kind": "xgoja",
+    "output": "dist/fixture"
+  },
+  "providers": [
+    {
+      "id": "fixture"
+    }
+  ],
+  "runtime": {
+    "modules": [
+      {
+        "provider": "fixture",
+        "name": "hello",
+        "as": "hello"
+      }
+    ]
+  },
+  "sources": [
+    {
+      "id": "local",
+      "path": "xgoja_embed/jsverbs/local",
+      "embed": true,
+      "kind": "jsverbs"
+    }
+  ],
+  "commands": [
+    {
+      "id": "eval",
+      "type": "builtin.eval",
+      "name": "eval"
+    },
+    {
+      "id": "jsverbs",
+      "type": "builtin.jsverbs",
+      "name": "verbs",
+      "mount": "root",
+      "sources": [
+        "local"
+      ]
+    }
+  ]
 }`
 	out := &bytes.Buffer{}
-	root, err := NewRootCommand(Options{Providers: registry, SpecJSON: specJSON, Out: out, EmbeddedJSVerbs: embedded})
+	root, err := NewRootCommand(Options{Providers: registry, RuntimePlanJSON: specJSON, Out: out, EmbeddedJSVerbs: embedded})
 	if err != nil {
 		t.Fatalf("new root: %v", err)
 	}
@@ -531,15 +866,20 @@ function greet(name) {
 		t.Fatalf("write verb: %v", err)
 	}
 	specJSON := fmt.Sprintf(`{
+  "schema": "xgoja/runtime/v2",
   "name": "fixture",
+  "app": {"name": "fixture"},
   "target": {"kind": "xgoja", "output": "dist/fixture"},
-  "packages": [{"id": "fixture"}],
-  "modules": [{"package": "fixture", "name": "hello", "as": "hello"}],
-  "commands": {"eval": {"enabled": true, "name": "eval"}, "jsverbs": {"enabled": true, "name": "verbs"}},
-  "jsverbs": [{"id": "local", "path": %q, "embed": false}]
+  "providers": [{"id": "fixture"}],
+  "runtime": {"modules": [{"provider": "fixture", "name": "hello", "as": "hello"}]},
+  "sources": [{"id": "local", "kind": "jsverbs", "path": %q, "embed": false}],
+  "commands": [
+    {"id": "eval", "type": "builtin.eval", "name": "eval"},
+    {"id": "jsverbs", "type": "builtin.jsverbs", "name": "verbs", "sources": ["local"]}
+  ]
 }`, verbsDir)
 	out := &bytes.Buffer{}
-	root, err := NewRootCommand(Options{Providers: registry, SpecJSON: specJSON, Out: out})
+	root, err := NewRootCommand(Options{Providers: registry, RuntimePlanJSON: specJSON, Out: out})
 	if err != nil {
 		t.Fatalf("new root: %v", err)
 	}

--- a/pkg/xgoja/app/root_test.go
+++ b/pkg/xgoja/app/root_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/dop251/goja_nodejs/require"
 	"github.com/go-go-golems/go-go-goja/pkg/xgoja/providerapi"
 	"github.com/go-go-golems/go-go-goja/pkg/xgoja/testprovider"
+	"github.com/spf13/cobra"
 )
 
 const fixtureRuntimePlanJSON = `{
@@ -890,6 +891,74 @@ function greet(name) {
 	// The Glazed writer command currently writes through the framework output path
 	// rather than this root's bytes.Buffer. Successful execution proves the
 	// mounted command scanned, built, created an xgoja runtime, and invoked JS.
+}
+
+func TestGeneratedRootScopesBuiltinJSVerbCommandSources(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		mount      string
+		publicArgs []string
+		adminArgs  []string
+	}{
+		{name: "nested", publicArgs: []string{"verbs", "public", "start"}, adminArgs: []string{"verbs", "admin", "secret"}},
+		{name: "root", mount: "root", publicArgs: []string{"public", "start"}, adminArgs: []string{"admin", "secret"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			embedded := fstest.MapFS{
+				"xgoja_embed/jsverbs/public/public.js": &fstest.MapFile{Data: []byte(`
+__package__({ name: "public" })
+__verb__("start", { name: "start", output: "text" })
+function start() { return "public" }
+`)},
+				"xgoja_embed/jsverbs/admin/admin.js": &fstest.MapFile{Data: []byte(`
+__package__({ name: "admin" })
+__verb__("secret", { name: "secret", output: "text" })
+function secret() { return "admin" }
+`)},
+			}
+			specJSON := fmt.Sprintf(`{
+  "schema": "xgoja/runtime/v2",
+  "name": "fixture",
+  "app": {"name": "fixture"},
+  "target": {"kind": "xgoja", "output": "dist/fixture"},
+  "sources": [
+    {"id": "public", "path": "xgoja_embed/jsverbs/public", "embed": true, "kind": "jsverbs"},
+    {"id": "admin", "path": "xgoja_embed/jsverbs/admin", "embed": true, "kind": "jsverbs"}
+  ],
+  "commands": [
+    {"id": "jsverbs", "type": "builtin.jsverbs", "name": "verbs", "mount": %q, "sources": ["public"]}
+  ]
+}`, tt.mount)
+
+			root, err := NewRootCommand(Options{Providers: providerapi.NewProviderRegistry(), RuntimePlanJSON: specJSON, EmbeddedJSVerbs: embedded, Out: &bytes.Buffer{}})
+			if err != nil {
+				t.Fatalf("new root: %v", err)
+			}
+			if !cobraCommandPathExists(root, tt.publicArgs) {
+				t.Fatalf("expected selected public verb path %v to be mounted", tt.publicArgs)
+			}
+			if cobraCommandPathExists(root, tt.adminArgs) {
+				t.Fatalf("expected unselected admin verb path %v to be hidden", tt.adminArgs)
+			}
+			root.SetArgs(tt.publicArgs)
+			if err := root.ExecuteContext(context.Background()); err != nil {
+				t.Fatalf("execute selected public verb: %v", err)
+			}
+		})
+	}
+}
+
+func cobraCommandPathExists(root interface{ Commands() []*cobra.Command }, path []string) bool {
+	if len(path) == 0 {
+		return true
+	}
+	for _, child := range root.Commands() {
+		if child.Name() != path[0] {
+			continue
+		}
+		return cobraCommandPathExists(child, path[1:])
+	}
+	return false
 }
 
 func captureStdout(t *testing.T, fn func()) string {

--- a/pkg/xgoja/app/root_test.go
+++ b/pkg/xgoja/app/root_test.go
@@ -375,11 +375,11 @@ func TestRuntimeFactoryDoesNotExposeImplicitEngineModules(t *testing.T) {
 	if err := testprovider.Register(registry); err != nil {
 		t.Fatalf("register provider: %v", err)
 	}
-	runtimeSpec := &RuntimeSpec{}
-	if err := json.Unmarshal([]byte(fixtureSpecJSON), runtimeSpec); err != nil {
+	runtimePlan := &RuntimePlan{}
+	if err := json.Unmarshal([]byte(fixtureSpecJSON), runtimePlan); err != nil {
 		t.Fatalf("parse runtime spec: %v", err)
 	}
-	rt, err := NewRuntimeFactory(registry, runtimeSpec).NewRuntime(context.Background())
+	rt, err := NewRuntimeFactory(registry, runtimePlan).NewRuntime(context.Background())
 	if err != nil {
 		t.Fatalf("new runtime: %v", err)
 	}

--- a/pkg/xgoja/app/run.go
+++ b/pkg/xgoja/app/run.go
@@ -22,7 +22,7 @@ import (
 type runCommand struct {
 	*cmds.CommandDescription
 	factory     *RuntimeFactory
-	runtimeSpec *RuntimeSpec
+	runtimePlan *RuntimePlan
 	sectionErr  error
 }
 
@@ -33,7 +33,7 @@ type runSettings struct {
 	KeepAlive bool   `glazed:"keep-alive"`
 }
 
-func newRunCommand(factory *RuntimeFactory, runtimeSpec *RuntimeSpec) cmds.Command {
+func newRunCommand(factory *RuntimeFactory, runtimePlan *RuntimePlan) cmds.Command {
 	moduleSections, _, sectionErr := factory.sectionsForRuntime("run")
 	options := []cmds.CommandDescriptionOption{
 		cmds.WithShort("Execute a JavaScript file in a generated xgoja runtime"),
@@ -58,10 +58,11 @@ sibling JavaScript files can be required by relative path.
 	if sectionErr == nil && len(moduleSections) > 0 {
 		options = append(options, cmds.WithSections(moduleSections...))
 	}
+	command, _ := runtimePlan.commandByType("builtin.run")
 	return &runCommand{
-		CommandDescription: cmds.NewCommandDescription(commandName(runtimeSpec.Commands.Run, "run"), options...),
+		CommandDescription: cmds.NewCommandDescription(commandName(command, "run"), options...),
 		factory:            factory,
-		runtimeSpec:        runtimeSpec,
+		runtimePlan:        runtimePlan,
 		sectionErr:         sectionErr,
 	}
 }

--- a/pkg/xgoja/app/run_module_sections_test.go
+++ b/pkg/xgoja/app/run_module_sections_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestRunCommandIncludesRuntimeModuleSections(t *testing.T) {
 	factory := newSectionTestFactory(t, providerapi.WithPackageCapability(runFixtureCapability{}))
-	cmd := newRunCommand(factory, factory.runtimeSpec)
+	cmd := newRunCommand(factory, factory.runtimePlan)
 	section, ok := cmd.Description().Schema.Get("fixture")
 	if !ok {
 		t.Fatal("expected fixture section on run command")
@@ -27,7 +27,7 @@ func TestRunCommandIncludesRuntimeModuleSections(t *testing.T) {
 
 func TestRunCommandInitializesRuntimeFromModuleSections(t *testing.T) {
 	factory := newSectionTestFactory(t, providerapi.WithPackageCapability(runFixtureCapability{}))
-	cmd, err := buildGlazedCobraCommand(newRunCommand(factory, factory.runtimeSpec))
+	cmd, err := buildGlazedCobraCommand(newRunCommand(factory, factory.runtimePlan))
 	if err != nil {
 		t.Fatalf("build cobra command: %v", err)
 	}

--- a/pkg/xgoja/app/run_typescript_test.go
+++ b/pkg/xgoja/app/run_typescript_test.go
@@ -22,7 +22,7 @@ func TestRunScriptFileWithInitializersRunsTypeScriptEntry(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	factory := NewRuntimeFactory(providerapi.NewProviderRegistry(), &RuntimeSpec{})
+	factory := NewRuntimeFactory(providerapi.NewProviderRegistry(), &RuntimePlan{})
 	if err := runScriptFileWithInitializers(context.Background(), factory, entry, nil, nil, false); err != nil {
 		t.Fatalf("runScriptFileWithInitializers() error = %v", err)
 	}

--- a/pkg/xgoja/app/runtime_plan.go
+++ b/pkg/xgoja/app/runtime_plan.go
@@ -8,7 +8,10 @@
 // replace directives, and source BaseDir are intentionally omitted.
 package app
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 const RuntimePlanSchema = "xgoja/runtime/v2"
 
@@ -22,15 +25,6 @@ type RuntimePlan struct {
 	Sources   []SourcePlan   `json:"sources,omitempty"`
 	Commands  []CommandPlan  `json:"commands,omitempty"`
 	Artifacts []ArtifactPlan `json:"artifacts,omitempty"`
-
-	// Deprecated compatibility fields for old in-repository tests while the
-	// runtime implementation is being moved to the v2 plan shape. These fields are
-	// never emitted in generated runtime JSON.
-	Modules          []RuntimeModulePlan `json:"-"`
-	CommandProviders []CommandPlan       `json:"-"`
-	JSVerbs          []SourcePlan        `json:"-"`
-	Assets           []SourcePlan        `json:"-"`
-	LegacyCommands   CommandsSpec        `json:"-"`
 }
 
 type AppPlan struct {
@@ -61,33 +55,13 @@ type RuntimeSection struct {
 // RuntimeModulePlan selects one provider module for the generated xgoja runtime.
 type RuntimeModulePlan struct {
 	Provider string         `json:"provider"`
-	Package  string         `json:"-"`
 	Name     string         `json:"name"`
 	As       string         `json:"as,omitempty"`
 	Config   map[string]any `json:"config,omitempty"`
 }
 
-func (m *RuntimeModulePlan) UnmarshalJSON(data []byte) error {
-	type alias RuntimeModulePlan
-	var raw struct {
-		alias
-		Package string `json:"package,omitempty"`
-	}
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return err
-	}
-	*m = RuntimeModulePlan(raw.alias)
-	if m.Provider == "" {
-		m.Provider = raw.Package
-	}
-	return nil
-}
-
 func (m RuntimeModulePlan) ProviderID() string {
-	if m.Provider != "" {
-		return m.Provider
-	}
-	return m.Package
+	return m.Provider
 }
 
 func (m RuntimeModulePlan) Alias() string {
@@ -112,7 +86,6 @@ type SourcePlan struct {
 	Path       string          `json:"path,omitempty"`
 	Embed      bool            `json:"embed,omitempty"`
 	Provider   string          `json:"provider,omitempty"`
-	Package    string          `json:"-"`
 	Source     string          `json:"source,omitempty"`
 	Include    []string        `json:"include,omitempty"`
 	Exclude    []string        `json:"exclude,omitempty"`
@@ -120,27 +93,8 @@ type SourcePlan struct {
 	TypeScript *TypeScriptPlan `json:"typescript,omitempty"`
 }
 
-func (s *SourcePlan) UnmarshalJSON(data []byte) error {
-	type alias SourcePlan
-	var raw struct {
-		alias
-		Package string `json:"package,omitempty"`
-	}
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return err
-	}
-	*s = SourcePlan(raw.alias)
-	if s.Provider == "" {
-		s.Provider = raw.Package
-	}
-	return nil
-}
-
 func (s SourcePlan) ProviderID() string {
-	if s.Provider != "" {
-		return s.Provider
-	}
-	return s.Package
+	return s.Provider
 }
 
 type TypeScriptPlan struct {
@@ -156,55 +110,20 @@ type TypeScriptPlan struct {
 	CheckCommand []string          `json:"checkCommand,omitempty"`
 }
 
-type CommandSpec struct {
-	Enabled bool   `json:"enabled"`
-	Name    string `json:"name,omitempty"`
-	Mount   string `json:"mount,omitempty"`
-}
-
-type CommandsSpec struct {
-	Eval    CommandSpec `json:"eval"`
-	Run     CommandSpec `json:"run"`
-	Repl    CommandSpec `json:"repl"`
-	JSVerbs CommandSpec `json:"jsverbs"`
-}
-
-type CommandProviderInstanceSpec = CommandPlan
-
 type CommandPlan struct {
 	ID       string         `json:"id"`
 	Type     string         `json:"type"`
 	Name     string         `json:"name,omitempty"`
 	Mount    string         `json:"mount,omitempty"`
 	Provider string         `json:"provider,omitempty"`
-	Package  string         `json:"-"`
 	Sources  []string       `json:"sources,omitempty"`
 	Modules  []string       `json:"modules,omitempty"`
 	Config   map[string]any `json:"config,omitempty"`
 	Lazy     bool           `json:"lazy,omitempty"`
 }
 
-func (c *CommandPlan) UnmarshalJSON(data []byte) error {
-	type alias CommandPlan
-	var raw struct {
-		alias
-		Package string `json:"package,omitempty"`
-	}
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return err
-	}
-	*c = CommandPlan(raw.alias)
-	if c.Provider == "" {
-		c.Provider = raw.Package
-	}
-	return nil
-}
-
 func (c CommandPlan) ProviderID() string {
-	if c.Provider != "" {
-		return c.Provider
-	}
-	return c.Package
+	return c.Provider
 }
 
 type ArtifactPlan struct {
@@ -219,66 +138,21 @@ type ArtifactPlan struct {
 }
 
 func (p *RuntimePlan) UnmarshalJSON(data []byte) error {
-	type runtimePlanAlias RuntimePlan
-	var raw struct {
-		*runtimePlanAlias
-		AppName          string              `json:"appName,omitempty"`
-		EnvPrefix        string              `json:"envPrefix,omitempty"`
-		ConfigFile       *ConfigFilePlan     `json:"configFile,omitempty"`
-		Modules          []RuntimeModulePlan `json:"modules,omitempty"`
-		CommandsRaw      json.RawMessage     `json:"commands,omitempty"`
-		CommandProviders []CommandPlan       `json:"commandProviders,omitempty"`
-		JSVerbs          []SourcePlan        `json:"jsverbs,omitempty"`
-		Help             struct {
-			Sources []SourcePlan `json:"sources,omitempty"`
-		} `json:"help,omitempty"`
-		Assets []SourcePlan `json:"assets,omitempty"`
-	}
-	raw.runtimePlanAlias = (*runtimePlanAlias)(p)
-	if err := json.Unmarshal(data, &raw); err != nil {
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(data, &payload); err != nil {
 		return err
 	}
-	if p.App.Name == "" {
-		p.App.Name = raw.AppName
-	}
-	if p.App.EnvPrefix == "" {
-		p.App.EnvPrefix = raw.EnvPrefix
-	}
-	if p.App.ConfigFile == nil {
-		p.App.ConfigFile = raw.ConfigFile
-	}
-	if len(p.Runtime.Modules) == 0 {
-		p.Runtime.Modules = raw.Modules
-	}
-	if len(raw.CommandsRaw) > 0 {
-		var commandList []CommandPlan
-		if err := json.Unmarshal(raw.CommandsRaw, &commandList); err == nil {
-			p.Commands = commandList
-		} else {
-			var commandObject CommandsSpec
-			if err := json.Unmarshal(raw.CommandsRaw, &commandObject); err != nil {
-				return err
-			}
-			for typ, command := range map[string]CommandSpec{"builtin.eval": commandObject.Eval, "builtin.run": commandObject.Run, "builtin.repl": commandObject.Repl, "builtin.jsverbs": commandObject.JSVerbs} {
-				if command.Enabled {
-					p.Commands = append(p.Commands, CommandPlan{Type: typ, Name: command.Name, Mount: command.Mount})
-				}
-			}
+	for _, key := range []string{"appName", "envPrefix", "configFile", "packages", "modules", "commandProviders", "jsverbs", "help", "assets"} {
+		if _, ok := payload[key]; ok {
+			return fmt.Errorf("runtime plan uses removed legacy key %q", key)
 		}
 	}
-	p.Commands = append(p.Commands, raw.CommandProviders...)
-	for i := range raw.JSVerbs {
-		raw.JSVerbs[i].Kind = SourceKindJSVerbs
+	type alias RuntimePlan
+	var decoded alias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
 	}
-	for i := range raw.Help.Sources {
-		raw.Help.Sources[i].Kind = SourceKindHelp
-	}
-	for i := range raw.Assets {
-		raw.Assets[i].Kind = SourceKindAssets
-	}
-	p.Sources = append(p.Sources, raw.JSVerbs...)
-	p.Sources = append(p.Sources, raw.Help.Sources...)
-	p.Sources = append(p.Sources, raw.Assets...)
+	*p = RuntimePlan(decoded)
 	return nil
 }
 
@@ -296,34 +170,14 @@ func (p *RuntimePlan) runtimeModules() []RuntimeModulePlan {
 	if p == nil {
 		return nil
 	}
-	if len(p.Runtime.Modules) > 0 {
-		return p.Runtime.Modules
-	}
-	return p.Modules
+	return p.Runtime.Modules
 }
 
 func (p *RuntimePlan) runtimeCommands() []CommandPlan {
 	if p == nil {
 		return nil
 	}
-	out := append([]CommandPlan(nil), p.Commands...)
-	for _, command := range p.CommandProviders {
-		if command.Type == "" {
-			command.Type = "provider.command-set"
-		}
-		out = append(out, command)
-	}
-	for typ, command := range map[string]CommandSpec{
-		"builtin.eval":    p.LegacyCommands.Eval,
-		"builtin.run":     p.LegacyCommands.Run,
-		"builtin.repl":    p.LegacyCommands.Repl,
-		"builtin.jsverbs": p.LegacyCommands.JSVerbs,
-	} {
-		if command.Enabled {
-			out = append(out, CommandPlan{Type: typ, Name: command.Name, Mount: command.Mount})
-		}
-	}
-	return out
+	return append([]CommandPlan(nil), p.Commands...)
 }
 
 func (p *RuntimePlan) commandByType(commandType string) (CommandPlan, bool) {
@@ -339,20 +193,7 @@ func (p *RuntimePlan) allSources() []SourcePlan {
 	if p == nil {
 		return nil
 	}
-	out := append([]SourcePlan(nil), p.Sources...)
-	for _, source := range p.JSVerbs {
-		if source.Kind == "" {
-			source.Kind = SourceKindJSVerbs
-		}
-		out = append(out, source)
-	}
-	for _, source := range p.Assets {
-		if source.Kind == "" {
-			source.Kind = SourceKindAssets
-		}
-		out = append(out, source)
-	}
-	return out
+	return append([]SourcePlan(nil), p.Sources...)
 }
 
 func (p *RuntimePlan) sourcesByKind(kind SourceKind) []SourcePlan {

--- a/pkg/xgoja/app/runtime_plan_test.go
+++ b/pkg/xgoja/app/runtime_plan_test.go
@@ -1,0 +1,25 @@
+package app
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestRuntimePlanRejectsRemovedLegacyKeys(t *testing.T) {
+	for _, key := range []string{"appName", "envPrefix", "configFile", "packages", "modules", "commandProviders", "jsverbs", "help", "assets"} {
+		t.Run(key, func(t *testing.T) {
+			payload := `{"schema":"xgoja/runtime/v2","name":"fixture",` + jsonString(key) + `:null}`
+			var plan RuntimePlan
+			err := json.Unmarshal([]byte(payload), &plan)
+			if err == nil || !strings.Contains(err.Error(), key) {
+				t.Fatalf("expected removed-key error for %q, got %v", key, err)
+			}
+		})
+	}
+}
+
+func jsonString(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}

--- a/pkg/xgoja/app/runtime_spec.go
+++ b/pkg/xgoja/app/runtime_spec.go
@@ -81,6 +81,7 @@ type CommandProviderInstanceSpec struct {
 	Package string         `json:"package"`
 	Name    string         `json:"name"`
 	Mount   string         `json:"mount,omitempty"`
+	Sources []string       `json:"sources,omitempty"`
 	Modules []string       `json:"modules,omitempty"`
 	Config  map[string]any `json:"config,omitempty"`
 	Lazy    bool           `json:"lazy,omitempty"`

--- a/pkg/xgoja/app/runtime_spec.go
+++ b/pkg/xgoja/app/runtime_spec.go
@@ -1,105 +1,149 @@
-// Package app defines the runtime-side schema and wiring used by generated
+// Package app defines the v2-native runtime plan and wiring used by generated
 // xgoja binaries.
 //
-// The *Spec types in this file are declarative runtime DTOs decoded from the
-// embedded JSON produced by cmd/xgoja/internal/generate. They intentionally omit
-// build-only fields such as Go module versions, provider import paths, replace
-// directives, target build roots, and source BaseDir. They describe what the
-// generated binary should expose at runtime; concrete VM lifecycles live in
-// engine.Runtime and app.RuntimeFactory.
+// RuntimePlan is decoded from the embedded JSON produced by cmd/xgoja/internal/generate.
+// It mirrors the public xgoja/v2 concepts that are still relevant at runtime:
+// providers, selected runtime modules, sources, commands, artifacts, and app
+// settings. Build-only fields such as Go module versions, provider import paths,
+// replace directives, and source BaseDir are intentionally omitted.
 package app
 
-// RuntimeSpec is the normalized embedded runtime spec decoded by a generated xgoja
-// binary. It is derived from buildspec.BuildSpec during code generation and contains
-// only runtime-relevant command, module, config, help, jsverb, and asset data.
-type RuntimeSpec struct {
-	Name             string                        `json:"name"`
-	AppName          string                        `json:"appName,omitempty"`
-	EnvPrefix        string                        `json:"envPrefix,omitempty"`
-	ConfigFile       *ConfigFileSpec               `json:"configFile,omitempty"`
-	Target           TargetSpec                    `json:"target"`
-	Packages         []PackageSpec                 `json:"packages"`
-	Modules          []ModuleInstanceSpec          `json:"modules"`
-	Commands         CommandsSpec                  `json:"commands"`
-	CommandProviders []CommandProviderInstanceSpec `json:"commandProviders,omitempty"`
-	JSVerbs          []JSVerbSourceSpec            `json:"jsverbs,omitempty"`
-	Help             HelpSpec                      `json:"help,omitempty"`
-	Assets           []AssetSourceSpec             `json:"assets,omitempty"`
+import "encoding/json"
+
+const RuntimePlanSchema = "xgoja/runtime/v2"
+
+type RuntimePlan struct {
+	Schema    string         `json:"schema"`
+	Name      string         `json:"name"`
+	App       AppPlan        `json:"app,omitempty"`
+	Target    TargetPlan     `json:"target"`
+	Providers []ProviderPlan `json:"providers,omitempty"`
+	Runtime   RuntimeSection `json:"runtime,omitempty"`
+	Sources   []SourcePlan   `json:"sources,omitempty"`
+	Commands  []CommandPlan  `json:"commands,omitempty"`
+	Artifacts []ArtifactPlan `json:"artifacts,omitempty"`
+
+	// Deprecated compatibility fields for old in-repository tests while the
+	// runtime implementation is being moved to the v2 plan shape. These fields are
+	// never emitted in generated runtime JSON.
+	Modules          []RuntimeModulePlan `json:"-"`
+	CommandProviders []CommandPlan       `json:"-"`
+	JSVerbs          []SourcePlan        `json:"-"`
+	Assets           []SourcePlan        `json:"-"`
+	LegacyCommands   CommandsSpec        `json:"-"`
 }
 
-type ConfigFileSpec struct {
+type AppPlan struct {
+	Name       string          `json:"name,omitempty"`
+	EnvPrefix  string          `json:"envPrefix,omitempty"`
+	ConfigFile *ConfigFilePlan `json:"configFile,omitempty"`
+}
+
+type ConfigFilePlan struct {
 	Enabled  bool     `json:"enabled"`
 	Layers   []string `json:"layers,omitempty"`
 	FileName string   `json:"fileName,omitempty"`
 }
 
-type TargetSpec struct {
+type TargetPlan struct {
 	Kind   string `json:"kind"`
 	Output string `json:"output"`
 }
 
-type PackageSpec struct {
+type ProviderPlan struct {
 	ID string `json:"id"`
 }
 
-// ModuleInstanceSpec selects one provider module for the generated xgoja runtime.
-// The generated app resolves Package+Name through providerapi.ProviderRegistry and uses
-// As as the require() alias. Config is static module config carried from the
-// generated runtime spec.
-type ModuleInstanceSpec struct {
-	Package string         `json:"package"`
-	Name    string         `json:"name"`
-	As      string         `json:"as,omitempty"`
-	Config  map[string]any `json:"config,omitempty"`
+type RuntimeSection struct {
+	Modules []RuntimeModulePlan `json:"modules,omitempty"`
 }
 
-func (m ModuleInstanceSpec) Alias() string {
+// RuntimeModulePlan selects one provider module for the generated xgoja runtime.
+type RuntimeModulePlan struct {
+	Provider string         `json:"provider"`
+	Package  string         `json:"-"`
+	Name     string         `json:"name"`
+	As       string         `json:"as,omitempty"`
+	Config   map[string]any `json:"config,omitempty"`
+}
+
+func (m *RuntimeModulePlan) UnmarshalJSON(data []byte) error {
+	type alias RuntimeModulePlan
+	var raw struct {
+		alias
+		Package string `json:"package,omitempty"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	*m = RuntimeModulePlan(raw.alias)
+	if m.Provider == "" {
+		m.Provider = raw.Package
+	}
+	return nil
+}
+
+func (m RuntimeModulePlan) ProviderID() string {
+	if m.Provider != "" {
+		return m.Provider
+	}
+	return m.Package
+}
+
+func (m RuntimeModulePlan) Alias() string {
 	if m.As != "" {
 		return m.As
 	}
 	return m.Name
 }
 
-type CommandsSpec struct {
-	Eval    CommandSpec `json:"eval"`
-	Run     CommandSpec `json:"run"`
-	Repl    CommandSpec `json:"repl"`
-	JSVerbs CommandSpec `json:"jsverbs"`
-}
+type SourceKind string
 
-type CommandSpec struct {
-	Enabled bool   `json:"enabled"`
-	Name    string `json:"name,omitempty"`
-	Mount   string `json:"mount,omitempty"`
-}
+const (
+	SourceKindJSVerbs SourceKind = "jsverbs"
+	SourceKindScript  SourceKind = "script"
+	SourceKindAssets  SourceKind = "assets"
+	SourceKindHelp    SourceKind = "help"
+)
 
-// CommandProviderInstanceSpec selects one provider-owned command set to attach
-// to the generated Cobra root. It is the runtime DTO counterpart to the
-// providerapi.CommandSetProvider definition stored in providerapi.ProviderRegistry.
-type CommandProviderInstanceSpec struct {
-	ID      string         `json:"id"`
-	Package string         `json:"package"`
-	Name    string         `json:"name"`
-	Mount   string         `json:"mount,omitempty"`
-	Sources []string       `json:"sources,omitempty"`
-	Modules []string       `json:"modules,omitempty"`
-	Config  map[string]any `json:"config,omitempty"`
-	Lazy    bool           `json:"lazy,omitempty"`
-}
-
-type JSVerbSourceSpec struct {
+type SourcePlan struct {
 	ID         string          `json:"id"`
+	Kind       SourceKind      `json:"kind"`
 	Path       string          `json:"path,omitempty"`
-	Embed      bool            `json:"embed"`
-	Package    string          `json:"package,omitempty"`
+	Embed      bool            `json:"embed,omitempty"`
+	Provider   string          `json:"provider,omitempty"`
+	Package    string          `json:"-"`
 	Source     string          `json:"source,omitempty"`
 	Include    []string        `json:"include,omitempty"`
 	Exclude    []string        `json:"exclude,omitempty"`
 	Extensions []string        `json:"extensions,omitempty"`
-	TypeScript *TypeScriptSpec `json:"typescript,omitempty"`
+	TypeScript *TypeScriptPlan `json:"typescript,omitempty"`
 }
 
-type TypeScriptSpec struct {
+func (s *SourcePlan) UnmarshalJSON(data []byte) error {
+	type alias SourcePlan
+	var raw struct {
+		alias
+		Package string `json:"package,omitempty"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	*s = SourcePlan(raw.alias)
+	if s.Provider == "" {
+		s.Provider = raw.Package
+	}
+	return nil
+}
+
+func (s SourcePlan) ProviderID() string {
+	if s.Provider != "" {
+		return s.Provider
+	}
+	return s.Package
+}
+
+type TypeScriptPlan struct {
 	Enabled      bool              `json:"enabled"`
 	Bundle       bool              `json:"bundle"`
 	Target       string            `json:"target,omitempty"`
@@ -112,21 +156,200 @@ type TypeScriptSpec struct {
 	CheckCommand []string          `json:"checkCommand,omitempty"`
 }
 
-type HelpSpec struct {
-	Sources []HelpSourceSpec `json:"sources,omitempty"`
+type CommandSpec struct {
+	Enabled bool   `json:"enabled"`
+	Name    string `json:"name,omitempty"`
+	Mount   string `json:"mount,omitempty"`
 }
 
-type HelpSourceSpec struct {
-	ID      string `json:"id"`
-	Path    string `json:"path,omitempty"`
-	Embed   bool   `json:"embed"`
-	Package string `json:"package,omitempty"`
-	Source  string `json:"source,omitempty"`
+type CommandsSpec struct {
+	Eval    CommandSpec `json:"eval"`
+	Run     CommandSpec `json:"run"`
+	Repl    CommandSpec `json:"repl"`
+	JSVerbs CommandSpec `json:"jsverbs"`
 }
 
-type AssetSourceSpec struct {
-	ID          string `json:"id"`
-	Path        string `json:"path,omitempty"`
-	Embed       bool   `json:"embed"`
-	Description string `json:"description,omitempty"`
+type CommandProviderInstanceSpec = CommandPlan
+
+type CommandPlan struct {
+	ID       string         `json:"id"`
+	Type     string         `json:"type"`
+	Name     string         `json:"name,omitempty"`
+	Mount    string         `json:"mount,omitempty"`
+	Provider string         `json:"provider,omitempty"`
+	Package  string         `json:"-"`
+	Sources  []string       `json:"sources,omitempty"`
+	Modules  []string       `json:"modules,omitempty"`
+	Config   map[string]any `json:"config,omitempty"`
+	Lazy     bool           `json:"lazy,omitempty"`
+}
+
+func (c *CommandPlan) UnmarshalJSON(data []byte) error {
+	type alias CommandPlan
+	var raw struct {
+		alias
+		Package string `json:"package,omitempty"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	*c = CommandPlan(raw.alias)
+	if c.Provider == "" {
+		c.Provider = raw.Package
+	}
+	return nil
+}
+
+func (c CommandPlan) ProviderID() string {
+	if c.Provider != "" {
+		return c.Provider
+	}
+	return c.Package
+}
+
+type ArtifactPlan struct {
+	ID      string   `json:"id"`
+	Type    string   `json:"type"`
+	Output  string   `json:"output,omitempty"`
+	Package string   `json:"package,omitempty"`
+	Import  string   `json:"import,omitempty"`
+	Root    string   `json:"root,omitempty"`
+	Sources []string `json:"sources,omitempty"`
+	Strict  bool     `json:"strict,omitempty"`
+}
+
+func (p *RuntimePlan) UnmarshalJSON(data []byte) error {
+	type runtimePlanAlias RuntimePlan
+	var raw struct {
+		*runtimePlanAlias
+		AppName          string              `json:"appName,omitempty"`
+		EnvPrefix        string              `json:"envPrefix,omitempty"`
+		ConfigFile       *ConfigFilePlan     `json:"configFile,omitempty"`
+		Modules          []RuntimeModulePlan `json:"modules,omitempty"`
+		CommandsRaw      json.RawMessage     `json:"commands,omitempty"`
+		CommandProviders []CommandPlan       `json:"commandProviders,omitempty"`
+		JSVerbs          []SourcePlan        `json:"jsverbs,omitempty"`
+		Help             struct {
+			Sources []SourcePlan `json:"sources,omitempty"`
+		} `json:"help,omitempty"`
+		Assets []SourcePlan `json:"assets,omitempty"`
+	}
+	raw.runtimePlanAlias = (*runtimePlanAlias)(p)
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if p.App.Name == "" {
+		p.App.Name = raw.AppName
+	}
+	if p.App.EnvPrefix == "" {
+		p.App.EnvPrefix = raw.EnvPrefix
+	}
+	if p.App.ConfigFile == nil {
+		p.App.ConfigFile = raw.ConfigFile
+	}
+	if len(p.Runtime.Modules) == 0 {
+		p.Runtime.Modules = raw.Modules
+	}
+	if len(raw.CommandsRaw) > 0 {
+		var commandList []CommandPlan
+		if err := json.Unmarshal(raw.CommandsRaw, &commandList); err == nil {
+			p.Commands = commandList
+		} else {
+			var commandObject CommandsSpec
+			if err := json.Unmarshal(raw.CommandsRaw, &commandObject); err != nil {
+				return err
+			}
+			for typ, command := range map[string]CommandSpec{"builtin.eval": commandObject.Eval, "builtin.run": commandObject.Run, "builtin.repl": commandObject.Repl, "builtin.jsverbs": commandObject.JSVerbs} {
+				if command.Enabled {
+					p.Commands = append(p.Commands, CommandPlan{Type: typ, Name: command.Name, Mount: command.Mount})
+				}
+			}
+		}
+	}
+	p.Commands = append(p.Commands, raw.CommandProviders...)
+	for i := range raw.JSVerbs {
+		raw.JSVerbs[i].Kind = SourceKindJSVerbs
+	}
+	for i := range raw.Help.Sources {
+		raw.Help.Sources[i].Kind = SourceKindHelp
+	}
+	for i := range raw.Assets {
+		raw.Assets[i].Kind = SourceKindAssets
+	}
+	p.Sources = append(p.Sources, raw.JSVerbs...)
+	p.Sources = append(p.Sources, raw.Help.Sources...)
+	p.Sources = append(p.Sources, raw.Assets...)
+	return nil
+}
+
+func (p *RuntimePlan) AppName() string {
+	if p == nil {
+		return ""
+	}
+	if p.App.Name != "" {
+		return p.App.Name
+	}
+	return p.Name
+}
+
+func (p *RuntimePlan) runtimeModules() []RuntimeModulePlan {
+	if p == nil {
+		return nil
+	}
+	if len(p.Runtime.Modules) > 0 {
+		return p.Runtime.Modules
+	}
+	return p.Modules
+}
+
+func (p *RuntimePlan) runtimeCommands() []CommandPlan {
+	if p == nil {
+		return nil
+	}
+	out := append([]CommandPlan(nil), p.Commands...)
+	for _, command := range p.CommandProviders {
+		if command.Type == "" {
+			command.Type = "provider.command-set"
+		}
+		out = append(out, command)
+	}
+	for typ, command := range map[string]CommandSpec{
+		"builtin.eval":    p.LegacyCommands.Eval,
+		"builtin.run":     p.LegacyCommands.Run,
+		"builtin.repl":    p.LegacyCommands.Repl,
+		"builtin.jsverbs": p.LegacyCommands.JSVerbs,
+	} {
+		if command.Enabled {
+			out = append(out, CommandPlan{Type: typ, Name: command.Name, Mount: command.Mount})
+		}
+	}
+	return out
+}
+
+func (p *RuntimePlan) commandByType(commandType string) (CommandPlan, bool) {
+	for _, command := range p.runtimeCommands() {
+		if command.Type == commandType {
+			return command, true
+		}
+	}
+	return CommandPlan{}, false
+}
+
+func (p *RuntimePlan) sourcesByKind(kind SourceKind) []SourcePlan {
+	if p == nil {
+		return nil
+	}
+	out := make([]SourcePlan, 0)
+	for _, source := range p.Sources {
+		if source.Kind == kind {
+			out = append(out, source)
+		}
+	}
+	if kind == SourceKindJSVerbs {
+		out = append(out, p.JSVerbs...)
+	}
+	if kind == SourceKindAssets {
+		out = append(out, p.Assets...)
+	}
+	return out
 }

--- a/pkg/xgoja/app/runtime_spec.go
+++ b/pkg/xgoja/app/runtime_spec.go
@@ -335,21 +335,35 @@ func (p *RuntimePlan) commandByType(commandType string) (CommandPlan, bool) {
 	return CommandPlan{}, false
 }
 
+func (p *RuntimePlan) allSources() []SourcePlan {
+	if p == nil {
+		return nil
+	}
+	out := append([]SourcePlan(nil), p.Sources...)
+	for _, source := range p.JSVerbs {
+		if source.Kind == "" {
+			source.Kind = SourceKindJSVerbs
+		}
+		out = append(out, source)
+	}
+	for _, source := range p.Assets {
+		if source.Kind == "" {
+			source.Kind = SourceKindAssets
+		}
+		out = append(out, source)
+	}
+	return out
+}
+
 func (p *RuntimePlan) sourcesByKind(kind SourceKind) []SourcePlan {
 	if p == nil {
 		return nil
 	}
 	out := make([]SourcePlan, 0)
-	for _, source := range p.Sources {
+	for _, source := range p.allSources() {
 		if source.Kind == kind {
 			out = append(out, source)
 		}
-	}
-	if kind == SourceKindJSVerbs {
-		out = append(out, p.JSVerbs...)
-	}
-	if kind == SourceKindAssets {
-		out = append(out, p.Assets...)
 	}
 	return out
 }

--- a/pkg/xgoja/app/source_registry.go
+++ b/pkg/xgoja/app/source_registry.go
@@ -1,0 +1,127 @@
+package app
+
+import (
+	"io/fs"
+	"strings"
+
+	"github.com/go-go-golems/go-go-goja/pkg/xgoja/providerapi"
+)
+
+type SourceRegistry struct {
+	providers       *providerapi.ProviderRegistry
+	embeddedJSVerbs fs.FS
+	sources         []SourcePlan
+}
+
+var _ providerapi.SourceRegistry = (*SourceRegistry)(nil)
+
+func NewSourceRegistry(providers *providerapi.ProviderRegistry, embeddedJSVerbs fs.FS, sources []SourcePlan) *SourceRegistry {
+	return &SourceRegistry{providers: providers, embeddedJSVerbs: embeddedJSVerbs, sources: append([]SourcePlan(nil), sources...)}
+}
+
+func (r *SourceRegistry) ListSources() []providerapi.RuntimeSourceDescriptor {
+	if r == nil || len(r.sources) == 0 {
+		return nil
+	}
+	out := make([]providerapi.RuntimeSourceDescriptor, 0, len(r.sources))
+	for _, source := range r.sources {
+		out = append(out, runtimeSourceDescriptor(source))
+	}
+	return out
+}
+
+func (r *SourceRegistry) ListSourcesByKind(kind providerapi.RuntimeSourceKind) []providerapi.RuntimeSourceDescriptor {
+	if r == nil || len(r.sources) == 0 {
+		return nil
+	}
+	out := make([]providerapi.RuntimeSourceDescriptor, 0, len(r.sources))
+	for _, source := range r.sources {
+		if providerSourceKind(source.Kind) == kind {
+			out = append(out, runtimeSourceDescriptor(source))
+		}
+	}
+	return out
+}
+
+func (r *SourceRegistry) SourceByID(id string) (providerapi.RuntimeSourceDescriptor, bool) {
+	id = strings.TrimSpace(id)
+	if r == nil || id == "" {
+		return providerapi.RuntimeSourceDescriptor{}, false
+	}
+	for _, source := range r.sources {
+		if source.ID == id {
+			return runtimeSourceDescriptor(source), true
+		}
+	}
+	return providerapi.RuntimeSourceDescriptor{}, false
+}
+
+func (r *SourceRegistry) JSVerbs() providerapi.JSVerbSourceSet {
+	if r == nil {
+		return nil
+	}
+	return newJSVerbSourceSet(r.providers, r.embeddedJSVerbs, filterSourcesByKind(r.sources, SourceKindJSVerbs))
+}
+
+func (r *SourceRegistry) Scoped(sourceIDs []string) *SourceRegistry {
+	if r == nil {
+		return nil
+	}
+	if len(sourceIDs) == 0 {
+		return NewSourceRegistry(r.providers, r.embeddedJSVerbs, r.sources)
+	}
+	wanted := map[string]struct{}{}
+	for _, id := range sourceIDs {
+		id = strings.TrimSpace(id)
+		if id != "" {
+			wanted[id] = struct{}{}
+		}
+	}
+	filtered := make([]SourcePlan, 0, len(r.sources))
+	for _, source := range r.sources {
+		if _, ok := wanted[source.ID]; ok {
+			filtered = append(filtered, source)
+		}
+	}
+	return NewSourceRegistry(r.providers, r.embeddedJSVerbs, filtered)
+}
+
+func filterSourcesByKind(sources []SourcePlan, kind SourceKind) []SourcePlan {
+	out := make([]SourcePlan, 0, len(sources))
+	for _, source := range sources {
+		if source.Kind == kind {
+			out = append(out, source)
+		}
+	}
+	return out
+}
+
+func runtimeSourceDescriptor(source SourcePlan) providerapi.RuntimeSourceDescriptor {
+	return providerapi.RuntimeSourceDescriptor{
+		ID:         source.ID,
+		Kind:       providerSourceKind(source.Kind),
+		Path:       source.Path,
+		Embed:      source.Embed,
+		Provider:   source.ProviderID(),
+		Source:     source.Source,
+		Include:    append([]string(nil), source.Include...),
+		Exclude:    append([]string(nil), source.Exclude...),
+		Extensions: append([]string(nil), source.Extensions...),
+		TypeScript: providerTypeScriptDescriptor(source.TypeScript),
+	}
+}
+
+func providerSourceKind(kind SourceKind) providerapi.RuntimeSourceKind {
+	switch kind {
+	case SourceKindJSVerbs:
+		return providerapi.RuntimeSourceKindJSVerbs
+	case SourceKindScript:
+		return providerapi.RuntimeSourceKindScript
+	case SourceKindAssets:
+		return providerapi.RuntimeSourceKindAssets
+	case SourceKindHelp:
+		return providerapi.RuntimeSourceKindHelp
+	default:
+		return providerapi.RuntimeSourceKind(kind)
+	}
+}

--- a/pkg/xgoja/app/source_registry.go
+++ b/pkg/xgoja/app/source_registry.go
@@ -80,9 +80,6 @@ func (r *SourceRegistry) Scoped(sourceIDs []string) *SourceRegistry {
 	if r == nil {
 		return nil
 	}
-	if len(sourceIDs) == 0 {
-		return NewSourceRegistry(r.providers, r.embeddedJSVerbs, r.sources)
-	}
 	wanted := map[string]struct{}{}
 	for _, id := range sourceIDs {
 		id = strings.TrimSpace(id)

--- a/pkg/xgoja/app/source_registry.go
+++ b/pkg/xgoja/app/source_registry.go
@@ -4,6 +4,7 @@ import (
 	"io/fs"
 	"strings"
 
+	"github.com/go-go-golems/go-go-goja/pkg/jsverbs"
 	"github.com/go-go-golems/go-go-goja/pkg/xgoja/providerapi"
 )
 
@@ -63,6 +64,18 @@ func (r *SourceRegistry) JSVerbs() providerapi.JSVerbSourceSet {
 	return newJSVerbSourceSet(r.providers, r.embeddedJSVerbs, filterSourcesByKind(r.sources, SourceKindJSVerbs))
 }
 
+func (r *SourceRegistry) scanJSVerbSource(id string, runtimeAliases []string) (*jsverbs.Registry, error) {
+	if r == nil {
+		return nil, nil
+	}
+	for _, source := range r.sources {
+		if source.ID == id && source.Kind == SourceKindJSVerbs {
+			return scanVerbSource(r.providers, r.embeddedJSVerbs, source, runtimeAliases)
+		}
+	}
+	return nil, nil
+}
+
 func (r *SourceRegistry) Scoped(sourceIDs []string) *SourceRegistry {
 	if r == nil {
 		return nil
@@ -96,6 +109,14 @@ func filterSourcesByKind(sources []SourcePlan, kind SourceKind) []SourcePlan {
 	return out
 }
 
+func sourcePlansFromDescriptors(descriptors []providerapi.RuntimeSourceDescriptor) []SourcePlan {
+	out := make([]SourcePlan, 0, len(descriptors))
+	for _, descriptor := range descriptors {
+		out = append(out, SourcePlan{ID: descriptor.ID, Kind: appSourceKind(descriptor.Kind), Path: descriptor.Path, Embed: descriptor.Embed, Provider: descriptor.Provider, Source: descriptor.Source, Include: append([]string(nil), descriptor.Include...), Exclude: append([]string(nil), descriptor.Exclude...), Extensions: append([]string(nil), descriptor.Extensions...), TypeScript: appTypeScriptPlan(descriptor.TypeScript)})
+	}
+	return out
+}
+
 func runtimeSourceDescriptor(source SourcePlan) providerapi.RuntimeSourceDescriptor {
 	return providerapi.RuntimeSourceDescriptor{
 		ID:         source.ID,
@@ -108,6 +129,28 @@ func runtimeSourceDescriptor(source SourcePlan) providerapi.RuntimeSourceDescrip
 		Exclude:    append([]string(nil), source.Exclude...),
 		Extensions: append([]string(nil), source.Extensions...),
 		TypeScript: providerTypeScriptDescriptor(source.TypeScript),
+	}
+}
+
+func appTypeScriptPlan(spec *providerapi.TypeScriptDescriptor) *TypeScriptPlan {
+	if spec == nil {
+		return nil
+	}
+	return &TypeScriptPlan{Enabled: spec.Enabled, Bundle: spec.Bundle, Target: spec.Target, Format: spec.Format, Platform: spec.Platform, Tsconfig: spec.Tsconfig, Sourcemap: spec.Sourcemap, External: append([]string(nil), spec.External...), Define: cloneStringMap(spec.Define), CheckCommand: append([]string(nil), spec.CheckCommand...)}
+}
+
+func appSourceKind(kind providerapi.RuntimeSourceKind) SourceKind {
+	switch kind {
+	case providerapi.RuntimeSourceKindJSVerbs:
+		return SourceKindJSVerbs
+	case providerapi.RuntimeSourceKindScript:
+		return SourceKindScript
+	case providerapi.RuntimeSourceKindAssets:
+		return SourceKindAssets
+	case providerapi.RuntimeSourceKindHelp:
+		return SourceKindHelp
+	default:
+		return SourceKind(kind)
 	}
 }
 

--- a/pkg/xgoja/app/source_registry_test.go
+++ b/pkg/xgoja/app/source_registry_test.go
@@ -1,0 +1,47 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/go-go-golems/go-go-goja/pkg/xgoja/providerapi"
+)
+
+func TestSourceRegistryScopedEmptyReturnsEmptyRegistry(t *testing.T) {
+	registry := NewSourceRegistry(nil, nil, []SourcePlan{
+		{ID: "public", Kind: SourceKindJSVerbs, Path: "public"},
+		{ID: "admin", Kind: SourceKindJSVerbs, Path: "admin"},
+	})
+
+	scoped := registry.Scoped(nil)
+	if scoped == nil {
+		t.Fatal("expected scoped registry")
+	}
+	if got := scoped.ListSources(); len(got) != 0 {
+		t.Fatalf("empty scope sources = %#v, want none", got)
+	}
+	if got := scoped.ListSourcesByKind(providerapi.RuntimeSourceKindJSVerbs); len(got) != 0 {
+		t.Fatalf("empty scope jsverb sources = %#v, want none", got)
+	}
+	if got := scoped.JSVerbs().ListJSVerbSources(); len(got) != 0 {
+		t.Fatalf("empty scope JSVerbs() sources = %#v, want none", got)
+	}
+}
+
+func TestSourceRegistryScopedFiltersExplicitSourceIDs(t *testing.T) {
+	registry := NewSourceRegistry(nil, nil, []SourcePlan{
+		{ID: "public", Kind: SourceKindJSVerbs, Path: "public"},
+		{ID: "admin", Kind: SourceKindJSVerbs, Path: "admin"},
+	})
+
+	scoped := registry.Scoped([]string{"public"})
+	if _, ok := scoped.SourceByID("public"); !ok {
+		t.Fatal("expected selected public source")
+	}
+	if _, ok := scoped.SourceByID("admin"); ok {
+		t.Fatal("did not expect unselected admin source")
+	}
+	jsverbSources := scoped.JSVerbs().ListJSVerbSources()
+	if len(jsverbSources) != 1 || jsverbSources[0].ID != "public" {
+		t.Fatalf("jsverb sources = %#v, want only public", jsverbSources)
+	}
+}

--- a/pkg/xgoja/app/tui.go
+++ b/pkg/xgoja/app/tui.go
@@ -27,7 +27,7 @@ import (
 type tuiCommand struct {
 	*cmds.CommandDescription
 	factory     *RuntimeFactory
-	runtimeSpec *RuntimeSpec
+	runtimePlan *RuntimePlan
 	sectionErr  error
 }
 
@@ -37,8 +37,9 @@ type tuiSettings struct {
 	AltScreen bool `glazed:"alt-screen"`
 }
 
-func newTUICommand(factory *RuntimeFactory, runtimeSpec *RuntimeSpec) cmds.Command {
+func newTUICommand(factory *RuntimeFactory, runtimePlan *RuntimePlan) cmds.Command {
 	moduleSections, _, sectionErr := factory.sectionsForRuntime("repl")
+	command, _ := runtimePlan.commandByType("builtin.repl")
 	options := []cmds.CommandDescriptionOption{
 		cmds.WithShort("Run an interactive TUI REPL for a generated xgoja runtime"),
 		cmds.WithLong(`
@@ -56,9 +57,9 @@ require().
 		options = append(options, cmds.WithSections(moduleSections...))
 	}
 	return &tuiCommand{
-		CommandDescription: cmds.NewCommandDescription(commandName(runtimeSpec.Commands.Repl, "repl"), options...),
+		CommandDescription: cmds.NewCommandDescription(commandName(command, "repl"), options...),
 		factory:            factory,
-		runtimeSpec:        runtimeSpec,
+		runtimePlan:        runtimePlan,
 		sectionErr:         sectionErr,
 	}
 }
@@ -75,10 +76,10 @@ func (c *tuiCommand) Run(ctx context.Context, vals *values.Values) error {
 	if err != nil {
 		return err
 	}
-	return runTUI(ctx, c.factory, c.runtimeSpec, settings.AltScreen, vals, selectedModules)
+	return runTUI(ctx, c.factory, c.runtimePlan, settings.AltScreen, vals, selectedModules)
 }
 
-func runTUI(ctx context.Context, factory *RuntimeFactory, runtimeSpec *RuntimeSpec, altScreen bool, vals *values.Values, selectedModules []providerapi.ModuleDescriptor) error {
+func runTUI(ctx context.Context, factory *RuntimeFactory, runtimePlan *RuntimePlan, altScreen bool, vals *values.Values, selectedModules []providerapi.ModuleDescriptor) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -95,8 +96,8 @@ func runTUI(ctx context.Context, factory *RuntimeFactory, runtimeSpec *RuntimeSp
 
 	cfg := bobarepl.DefaultConfig()
 	name := "xgoja"
-	if runtimeSpec != nil && strings.TrimSpace(runtimeSpec.Name) != "" {
-		name = strings.TrimSpace(runtimeSpec.Name)
+	if runtimePlan != nil && strings.TrimSpace(runtimePlan.Name) != "" {
+		name = strings.TrimSpace(runtimePlan.Name)
 	}
 	cfg.Title = fmt.Sprintf("%s TUI", name)
 	cfg.Placeholder = "Generated xgoja runtime | Type JavaScript, then use alt+h for help"

--- a/pkg/xgoja/app/tui_module_sections_test.go
+++ b/pkg/xgoja/app/tui_module_sections_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestTUICommandIncludesRuntimeModuleSections(t *testing.T) {
 	factory := newSectionTestFactory(t, providerapi.WithPackageCapability(runFixtureCapability{}))
-	cmd := newTUICommand(factory, factory.runtimeSpec)
+	cmd := newTUICommand(factory, factory.runtimePlan)
 	section, ok := cmd.Description().Schema.Get("fixture")
 	if !ok {
 		t.Fatal("expected fixture section on repl command")

--- a/pkg/xgoja/app/types.go
+++ b/pkg/xgoja/app/types.go
@@ -19,16 +19,16 @@ func (h *Host) TypeScriptDeclarations(opts dtsgen.Options) (*dtsgen.Result, erro
 	if h == nil {
 		return nil, fmt.Errorf("xgoja host is nil")
 	}
-	return dtsgen.RenderModules(h.Providers, dtsgenModuleInstances(h.RuntimeSpec), opts)
+	return dtsgen.RenderModules(h.Providers, dtsgenModuleInstances(h.RuntimePlan), opts)
 }
 
-func dtsgenModuleInstances(runtimeSpec *RuntimeSpec) []dtsgen.ModuleInstance {
-	if runtimeSpec == nil || len(runtimeSpec.Modules) == 0 {
+func dtsgenModuleInstances(runtimePlan *RuntimePlan) []dtsgen.ModuleInstance {
+	if runtimePlan == nil || len(runtimePlan.runtimeModules()) == 0 {
 		return nil
 	}
-	out := make([]dtsgen.ModuleInstance, 0, len(runtimeSpec.Modules))
-	for _, mod := range runtimeSpec.Modules {
-		out = append(out, dtsgen.ModuleInstance{Package: mod.Package, Name: mod.Name, As: mod.As})
+	out := make([]dtsgen.ModuleInstance, 0, len(runtimePlan.runtimeModules()))
+	for _, mod := range runtimePlan.runtimeModules() {
+		out = append(out, dtsgen.ModuleInstance{Package: mod.ProviderID(), Name: mod.Name, As: mod.As})
 	}
 	return out
 }

--- a/pkg/xgoja/app/types_test.go
+++ b/pkg/xgoja/app/types_test.go
@@ -77,9 +77,9 @@ func typedTestHost(t *testing.T) *Host {
 	if err := core.Register(registry); err != nil {
 		t.Fatalf("register core provider: %v", err)
 	}
-	return NewHost(registry, &RuntimeSpec{
+	return NewHost(registry, &RuntimePlan{
 		Name: "typed-test",
-		Modules: []ModuleInstanceSpec{{
+		Modules: []RuntimeModulePlan{{
 			Package: core.PackageID,
 			Name:    "path",
 			As:      "path:runtime",

--- a/pkg/xgoja/app/types_test.go
+++ b/pkg/xgoja/app/types_test.go
@@ -79,10 +79,10 @@ func typedTestHost(t *testing.T) *Host {
 	}
 	return NewHost(registry, &RuntimePlan{
 		Name: "typed-test",
-		Modules: []RuntimeModulePlan{{
-			Package: core.PackageID,
-			Name:    "path",
-			As:      "path:runtime",
-		}},
+		Runtime: RuntimeSection{Modules: []RuntimeModulePlan{{
+			Provider: core.PackageID,
+			Name:     "path",
+			As:       "path:runtime",
+		}}},
 	})
 }

--- a/pkg/xgoja/app/typescript.go
+++ b/pkg/xgoja/app/typescript.go
@@ -12,11 +12,11 @@ import (
 
 const sourceLanguageTypeScript = "typescript"
 
-func applyTypeScriptScanOptions(source JSVerbSourceSpec, options *jsverbs.ScanOptions, runtimeAliases []string) {
+func applyTypeScriptScanOptions(source SourcePlan, options *jsverbs.ScanOptions, runtimeAliases []string) {
 	if options == nil || source.TypeScript == nil || !source.TypeScript.Enabled {
 		return
 	}
-	tsOptions := tsscriptOptionsFromRuntimeSpec(source.TypeScript)
+	tsOptions := tsscriptOptionsFromRuntimePlan(source.TypeScript)
 	tsOptions.External = appendUniqueStrings(tsOptions.External, runtimeAliases...)
 	options.SourceTransform = func(file jsverbs.SourceFile) (jsverbs.SourceFile, error) {
 		if !tsscript.IsTypeScriptPath(file.Path) {
@@ -96,7 +96,7 @@ func appendUniqueStrings(values []string, extra ...string) []string {
 	return out
 }
 
-func tsscriptOptionsFromRuntimeSpec(spec *TypeScriptSpec) tsscript.Options {
+func tsscriptOptionsFromRuntimePlan(spec *TypeScriptPlan) tsscript.Options {
 	if spec == nil {
 		return tsscript.Options{}
 	}

--- a/pkg/xgoja/app/typescript_jsverbs_test.go
+++ b/pkg/xgoja/app/typescript_jsverbs_test.go
@@ -29,11 +29,11 @@ func TestScanVerbSourceTypeScriptScansAndInvokesBundledVerb(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	registry, err := scanVerbSource(providerapi.NewProviderRegistry(), nil, JSVerbSourceSpec{
+	registry, err := scanVerbSource(providerapi.NewProviderRegistry(), nil, SourcePlan{
 		ID:         "local",
 		Path:       dir,
 		Extensions: []string{".ts"},
-		TypeScript: &TypeScriptSpec{Enabled: true, Bundle: true, Target: "es2015", Format: "cjs", Platform: "neutral"},
+		TypeScript: &TypeScriptPlan{Enabled: true, Bundle: true, Target: "es2015", Format: "cjs", Platform: "neutral"},
 	}, nil)
 	if err != nil {
 		t.Fatalf("scanVerbSource() error = %v", err)
@@ -72,10 +72,10 @@ func TestScanVerbSourceTypeScriptUsesTypeScriptExtensionsByDefault(t *testing.T)
 		t.Fatal(err)
 	}
 
-	registry, err := scanVerbSource(providerapi.NewProviderRegistry(), nil, JSVerbSourceSpec{
+	registry, err := scanVerbSource(providerapi.NewProviderRegistry(), nil, SourcePlan{
 		ID:         "local",
 		Path:       dir,
-		TypeScript: &TypeScriptSpec{Enabled: true, Bundle: true, Target: "es2015", Format: "cjs", Platform: "neutral"},
+		TypeScript: &TypeScriptPlan{Enabled: true, Bundle: true, Target: "es2015", Format: "cjs", Platform: "neutral"},
 	}, nil)
 	if err != nil {
 		t.Fatalf("scanVerbSource() error = %v", err)
@@ -132,12 +132,12 @@ func TestScanVerbSourceTypeScriptProviderFSBundlesHelperImport(t *testing.T) {
 		t.Fatalf("register provider: %v", err)
 	}
 
-	registry, err := scanVerbSource(providers, nil, JSVerbSourceSpec{
+	registry, err := scanVerbSource(providers, nil, SourcePlan{
 		ID:         "provider-sites",
 		Package:    "fixture",
 		Source:     "sites",
 		Extensions: []string{".ts"},
-		TypeScript: &TypeScriptSpec{Enabled: true, Bundle: true, Target: "es2015", Format: "cjs", Platform: "neutral"},
+		TypeScript: &TypeScriptPlan{Enabled: true, Bundle: true, Target: "es2015", Format: "cjs", Platform: "neutral"},
 	}, nil)
 	if err != nil {
 		t.Fatalf("scanVerbSource() error = %v", err)

--- a/pkg/xgoja/app/typescript_jsverbs_test.go
+++ b/pkg/xgoja/app/typescript_jsverbs_test.go
@@ -134,7 +134,7 @@ func TestScanVerbSourceTypeScriptProviderFSBundlesHelperImport(t *testing.T) {
 
 	registry, err := scanVerbSource(providers, nil, SourcePlan{
 		ID:         "provider-sites",
-		Package:    "fixture",
+		Provider:   "fixture",
 		Source:     "sites",
 		Extensions: []string{".ts"},
 		TypeScript: &TypeScriptPlan{Enabled: true, Bundle: true, Target: "es2015", Format: "cjs", Platform: "neutral"},

--- a/pkg/xgoja/app/xgoja_section_test.go
+++ b/pkg/xgoja/app/xgoja_section_test.go
@@ -23,16 +23,38 @@ func TestGeneratedRootExposesXGojaDebugPanicStackFlag(t *testing.T) {
 		t.Fatalf("register provider: %v", err)
 	}
 	specJSON := `{
+  "schema": "xgoja/runtime/v2",
   "name": "fixture",
-  "target": {"kind": "xgoja", "output": "dist/fixture"},
-  "packages": [{"id": "fixture"}],
-  "modules": [{"package": "fixture", "name": "mod", "as": "mod"}],
-  "commands": {
-    "eval": {"enabled": true, "name": "eval"},
-    "jsverbs": {"enabled": false}
-  }
+  "app": {
+    "name": "fixture"
+  },
+  "target": {
+    "kind": "xgoja",
+    "output": "dist/fixture"
+  },
+  "providers": [
+    {
+      "id": "fixture"
+    }
+  ],
+  "runtime": {
+    "modules": [
+      {
+        "provider": "fixture",
+        "name": "mod",
+        "as": "mod"
+      }
+    ]
+  },
+  "commands": [
+    {
+      "id": "eval",
+      "type": "builtin.eval",
+      "name": "eval"
+    }
+  ]
 }`
-	root, err := NewRootCommand(Options{Providers: registry, SpecJSON: specJSON})
+	root, err := NewRootCommand(Options{Providers: registry, RuntimePlanJSON: specJSON})
 	if err != nil {
 		t.Fatalf("new root: %v", err)
 	}
@@ -61,7 +83,7 @@ func TestRuntimeFactoryDebugPanicStackFieldControlsRecoveredPanicStack(t *testin
 	); err != nil {
 		t.Fatalf("register provider: %v", err)
 	}
-	factory := NewRuntimeFactory(registry, &RuntimePlan{Modules: []RuntimeModulePlan{{Package: "panic", Name: "panic", As: "panic"}}})
+	factory := NewRuntimeFactory(registry, &RuntimePlan{Runtime: RuntimeSection{Modules: []RuntimeModulePlan{{Provider: "panic", Name: "panic", As: "panic"}}}})
 
 	for _, tc := range []struct {
 		name      string

--- a/pkg/xgoja/app/xgoja_section_test.go
+++ b/pkg/xgoja/app/xgoja_section_test.go
@@ -61,7 +61,7 @@ func TestRuntimeFactoryDebugPanicStackFieldControlsRecoveredPanicStack(t *testin
 	); err != nil {
 		t.Fatalf("register provider: %v", err)
 	}
-	factory := NewRuntimeFactory(registry, &RuntimeSpec{Modules: []ModuleInstanceSpec{{Package: "panic", Name: "panic", As: "panic"}}})
+	factory := NewRuntimeFactory(registry, &RuntimePlan{Modules: []RuntimeModulePlan{{Package: "panic", Name: "panic", As: "panic"}}})
 
 	for _, tc := range []struct {
 		name      string

--- a/pkg/xgoja/providerapi/commands.go
+++ b/pkg/xgoja/providerapi/commands.go
@@ -29,12 +29,12 @@ type RuntimeFactoryWithHostServices interface {
 }
 
 // JSVerbSourceDescriptor describes one configured JavaScript verb source in the
-// generated binary's runtime spec.
+// generated binary's runtime plan.
 type JSVerbSourceDescriptor struct {
 	ID         string
 	Path       string
 	Embed      bool
-	Package    string
+	Provider   string
 	Source     string
 	Include    []string
 	Exclude    []string
@@ -79,7 +79,6 @@ type CommandSetContext struct {
 	RuntimeFactory  RuntimeFactory
 	SelectedModules []ModuleDescriptor
 	Sources         SourceRegistry
-	JSVerbs         JSVerbSourceSet
 }
 
 // CommandSetProvider registers a package-owned command factory.

--- a/pkg/xgoja/providerapi/commands.go
+++ b/pkg/xgoja/providerapi/commands.go
@@ -78,6 +78,7 @@ type CommandSetContext struct {
 	Providers       *ProviderRegistry
 	RuntimeFactory  RuntimeFactory
 	SelectedModules []ModuleDescriptor
+	Sources         SourceRegistry
 	JSVerbs         JSVerbSourceSet
 }
 

--- a/pkg/xgoja/providerapi/sources.go
+++ b/pkg/xgoja/providerapi/sources.go
@@ -1,0 +1,41 @@
+package providerapi
+
+import "github.com/go-go-golems/go-go-goja/pkg/jsverbs"
+
+// RuntimeSourceKind identifies a source kind in the generated xgoja runtime plan.
+type RuntimeSourceKind string
+
+const (
+	RuntimeSourceKindJSVerbs RuntimeSourceKind = "jsverbs"
+	RuntimeSourceKindScript  RuntimeSourceKind = "script"
+	RuntimeSourceKindAssets  RuntimeSourceKind = "assets"
+	RuntimeSourceKindHelp    RuntimeSourceKind = "help"
+)
+
+// RuntimeSourceDescriptor describes one configured runtime source in a provider-neutral shape.
+type RuntimeSourceDescriptor struct {
+	ID         string
+	Kind       RuntimeSourceKind
+	Path       string
+	Embed      bool
+	Provider   string
+	Source     string
+	Include    []string
+	Exclude    []string
+	Extensions []string
+	TypeScript *TypeScriptDescriptor
+}
+
+// SourceRegistry is the v2 runtime source lookup API passed to provider command sets.
+type SourceRegistry interface {
+	ListSources() []RuntimeSourceDescriptor
+	ListSourcesByKind(kind RuntimeSourceKind) []RuntimeSourceDescriptor
+	SourceByID(id string) (RuntimeSourceDescriptor, bool)
+	JSVerbs() JSVerbSourceSet
+}
+
+// JSVerbScanner is implemented by JS verb source adapters that can scan source descriptors.
+type JSVerbScanner interface {
+	ScanJSVerbSource(id string) (*jsverbs.Registry, error)
+	ScanAllJSVerbSources() ([]*jsverbs.Registry, error)
+}

--- a/pkg/xgoja/providers/host/host_test.go
+++ b/pkg/xgoja/providers/host/host_test.go
@@ -55,9 +55,9 @@ func TestFSHostAndEmbeddedAliases(t *testing.T) {
 	assetFS := fstest.MapFS{
 		"xgoja_embed/assets/app/config/default.json": &fstest.MapFile{Data: []byte(`{"ok":true}`)},
 	}
-	runtimeSpec := &app.RuntimeSpec{
-		Assets: []app.AssetSourceSpec{{ID: "app-assets", Path: "xgoja_embed/assets/app", Embed: true}},
-		Modules: []app.ModuleInstanceSpec{
+	runtimePlan := &app.RuntimePlan{
+		Assets: []app.SourcePlan{{ID: "app-assets", Path: "xgoja_embed/assets/app", Embed: true}},
+		Modules: []app.RuntimeModulePlan{
 			{
 				Package: PackageID,
 				Name:    "fs",
@@ -77,7 +77,7 @@ func TestFSHostAndEmbeddedAliases(t *testing.T) {
 			},
 		},
 	}
-	host := app.NewHostWithOptions(registry, runtimeSpec, app.HostOptions{EmbeddedAssets: assetFS})
+	host := app.NewHostWithOptions(registry, runtimePlan, app.HostOptions{EmbeddedAssets: assetFS})
 	rt, err := host.Factory.NewRuntime(context.Background())
 	if err != nil {
 		t.Fatalf("new runtime: %v", err)
@@ -118,9 +118,9 @@ func TestFSRootEmbeddedMount(t *testing.T) {
 	assetFS := fstest.MapFS{
 		"xgoja_embed/assets/app/config/default.json": &fstest.MapFile{Data: []byte(`{"ok":true}`)},
 	}
-	runtimeSpec := &app.RuntimeSpec{
-		Assets: []app.AssetSourceSpec{{ID: "app-assets", Path: "xgoja_embed/assets/app", Embed: true}},
-		Modules: []app.ModuleInstanceSpec{{
+	runtimePlan := &app.RuntimePlan{
+		Assets: []app.SourcePlan{{ID: "app-assets", Path: "xgoja_embed/assets/app", Embed: true}},
+		Modules: []app.RuntimeModulePlan{{
 			Package: PackageID,
 			Name:    "fs",
 			As:      "fs:assets",
@@ -132,7 +132,7 @@ func TestFSRootEmbeddedMount(t *testing.T) {
 			},
 		}},
 	}
-	host := app.NewHostWithOptions(registry, runtimeSpec, app.HostOptions{EmbeddedAssets: assetFS})
+	host := app.NewHostWithOptions(registry, runtimePlan, app.HostOptions{EmbeddedAssets: assetFS})
 	rt, err := host.Factory.NewRuntime(context.Background())
 	if err != nil {
 		t.Fatalf("new runtime: %v", err)
@@ -179,8 +179,8 @@ func TestDatabasePreconfiguredFromProviderConfig(t *testing.T) {
 		t.Fatalf("register host provider: %v", err)
 	}
 	dbPath := filepath.ToSlash(filepath.Join(t.TempDir(), "site.db"))
-	runtimeSpec := &app.RuntimeSpec{
-		Modules: []app.ModuleInstanceSpec{{
+	runtimePlan := &app.RuntimePlan{
+		Modules: []app.RuntimeModulePlan{{
 			Package: PackageID,
 			Name:    "db",
 			As:      "db",
@@ -190,7 +190,7 @@ func TestDatabasePreconfiguredFromProviderConfig(t *testing.T) {
 			},
 		}},
 	}
-	host := app.NewHostWithOptions(registry, runtimeSpec, app.HostOptions{})
+	host := app.NewHostWithOptions(registry, runtimePlan, app.HostOptions{})
 	rt, err := host.Factory.NewRuntime(context.Background())
 	if err != nil {
 		t.Fatalf("new runtime: %v", err)
@@ -250,15 +250,15 @@ func TestDatabaseAllowConfigureModeStillWorks(t *testing.T) {
 		t.Fatalf("register host provider: %v", err)
 	}
 	dbPath := filepath.ToSlash(filepath.Join(t.TempDir(), "configured-by-js.db"))
-	runtimeSpec := &app.RuntimeSpec{
-		Modules: []app.ModuleInstanceSpec{{
+	runtimePlan := &app.RuntimePlan{
+		Modules: []app.RuntimeModulePlan{{
 			Package: PackageID,
 			Name:    "db",
 			As:      "db",
 			Config:  map[string]any{"allowConfigure": true},
 		}},
 	}
-	host := app.NewHostWithOptions(registry, runtimeSpec, app.HostOptions{})
+	host := app.NewHostWithOptions(registry, runtimePlan, app.HostOptions{})
 	rt, err := host.Factory.NewRuntime(context.Background())
 	if err != nil {
 		t.Fatalf("new runtime: %v", err)

--- a/pkg/xgoja/providers/host/host_test.go
+++ b/pkg/xgoja/providers/host/host_test.go
@@ -56,12 +56,12 @@ func TestFSHostAndEmbeddedAliases(t *testing.T) {
 		"xgoja_embed/assets/app/config/default.json": &fstest.MapFile{Data: []byte(`{"ok":true}`)},
 	}
 	runtimePlan := &app.RuntimePlan{
-		Assets: []app.SourcePlan{{ID: "app-assets", Path: "xgoja_embed/assets/app", Embed: true}},
-		Modules: []app.RuntimeModulePlan{
+		Sources: []app.SourcePlan{{ID: "app-assets", Kind: app.SourceKindAssets, Path: "xgoja_embed/assets/app", Embed: true}},
+		Runtime: app.RuntimeSection{Modules: []app.RuntimeModulePlan{
 			{
-				Package: PackageID,
-				Name:    "fs",
-				As:      "fs:assets",
+				Provider: PackageID,
+				Name:     "fs",
+				As:       "fs:assets",
 				Config: map[string]any{
 					"embedded": map[string]any{
 						"allow":  true,
@@ -70,12 +70,12 @@ func TestFSHostAndEmbeddedAliases(t *testing.T) {
 				},
 			},
 			{
-				Package: PackageID,
-				Name:    "fs",
-				As:      "fs:host",
-				Config:  map[string]any{"allow": true},
+				Provider: PackageID,
+				Name:     "fs",
+				As:       "fs:host",
+				Config:   map[string]any{"allow": true},
 			},
-		},
+		}},
 	}
 	host := app.NewHostWithOptions(registry, runtimePlan, app.HostOptions{EmbeddedAssets: assetFS})
 	rt, err := host.Factory.NewRuntime(context.Background())
@@ -119,18 +119,18 @@ func TestFSRootEmbeddedMount(t *testing.T) {
 		"xgoja_embed/assets/app/config/default.json": &fstest.MapFile{Data: []byte(`{"ok":true}`)},
 	}
 	runtimePlan := &app.RuntimePlan{
-		Assets: []app.SourcePlan{{ID: "app-assets", Path: "xgoja_embed/assets/app", Embed: true}},
-		Modules: []app.RuntimeModulePlan{{
-			Package: PackageID,
-			Name:    "fs",
-			As:      "fs:assets",
+		Sources: []app.SourcePlan{{ID: "app-assets", Kind: app.SourceKindAssets, Path: "xgoja_embed/assets/app", Embed: true}},
+		Runtime: app.RuntimeSection{Modules: []app.RuntimeModulePlan{{
+			Provider: PackageID,
+			Name:     "fs",
+			As:       "fs:assets",
 			Config: map[string]any{
 				"embedded": map[string]any{
 					"allow":  true,
 					"mounts": []any{map[string]any{"asset": "app-assets", "mount": "/"}},
 				},
 			},
-		}},
+		}}},
 	}
 	host := app.NewHostWithOptions(registry, runtimePlan, app.HostOptions{EmbeddedAssets: assetFS})
 	rt, err := host.Factory.NewRuntime(context.Background())
@@ -180,15 +180,15 @@ func TestDatabasePreconfiguredFromProviderConfig(t *testing.T) {
 	}
 	dbPath := filepath.ToSlash(filepath.Join(t.TempDir(), "site.db"))
 	runtimePlan := &app.RuntimePlan{
-		Modules: []app.RuntimeModulePlan{{
-			Package: PackageID,
-			Name:    "db",
-			As:      "db",
+		Runtime: app.RuntimeSection{Modules: []app.RuntimeModulePlan{{
+			Provider: PackageID,
+			Name:     "db",
+			As:       "db",
 			Config: map[string]any{
 				"driverName":     "sqlite3",
 				"dataSourceName": dbPath,
 			},
-		}},
+		}}},
 	}
 	host := app.NewHostWithOptions(registry, runtimePlan, app.HostOptions{})
 	rt, err := host.Factory.NewRuntime(context.Background())
@@ -251,12 +251,12 @@ func TestDatabaseAllowConfigureModeStillWorks(t *testing.T) {
 	}
 	dbPath := filepath.ToSlash(filepath.Join(t.TempDir(), "configured-by-js.db"))
 	runtimePlan := &app.RuntimePlan{
-		Modules: []app.RuntimeModulePlan{{
-			Package: PackageID,
-			Name:    "db",
-			As:      "db",
-			Config:  map[string]any{"allowConfigure": true},
-		}},
+		Runtime: app.RuntimeSection{Modules: []app.RuntimeModulePlan{{
+			Provider: PackageID,
+			Name:     "db",
+			As:       "db",
+			Config:   map[string]any{"allowConfigure": true},
+		}}},
 	}
 	host := app.NewHostWithOptions(registry, runtimePlan, app.HostOptions{})
 	rt, err := host.Factory.NewRuntime(context.Background())

--- a/pkg/xgoja/providers/http/http_test.go
+++ b/pkg/xgoja/providers/http/http_test.go
@@ -119,7 +119,7 @@ func TestExpressProviderRegistersIntoExternalHost(t *testing.T) {
 	if err := Register(registry); err != nil {
 		t.Fatalf("register provider: %v", err)
 	}
-	runtimePlan := &app.RuntimePlan{Modules: []app.RuntimeModulePlan{{Package: PackageID, Name: "express", As: "express"}}}
+	runtimePlan := &app.RuntimePlan{Runtime: app.RuntimeSection{Modules: []app.RuntimeModulePlan{{Provider: PackageID, Name: "express", As: "express"}}}}
 	host := app.NewHostWithOptions(registry, runtimePlan, app.HostOptions{ConfigureServices: func(services *app.HostServices) {
 		if err := services.SetHostService(HostServiceKey, ExternalHostService{Host: jsHost, OwnsListen: false}); err != nil {
 			t.Fatalf("SetHostService: %v", err)

--- a/pkg/xgoja/providers/http/http_test.go
+++ b/pkg/xgoja/providers/http/http_test.go
@@ -119,8 +119,8 @@ func TestExpressProviderRegistersIntoExternalHost(t *testing.T) {
 	if err := Register(registry); err != nil {
 		t.Fatalf("register provider: %v", err)
 	}
-	runtimeSpec := &app.RuntimeSpec{Modules: []app.ModuleInstanceSpec{{Package: PackageID, Name: "express", As: "express"}}}
-	host := app.NewHostWithOptions(registry, runtimeSpec, app.HostOptions{ConfigureServices: func(services *app.HostServices) {
+	runtimePlan := &app.RuntimePlan{Modules: []app.RuntimeModulePlan{{Package: PackageID, Name: "express", As: "express"}}}
+	host := app.NewHostWithOptions(registry, runtimePlan, app.HostOptions{ConfigureServices: func(services *app.HostServices) {
 		if err := services.SetHostService(HostServiceKey, ExternalHostService{Host: jsHost, OwnsListen: false}); err != nil {
 			t.Fatalf("SetHostService: %v", err)
 		}

--- a/pkg/xgoja/providers/http/serve.go
+++ b/pkg/xgoja/providers/http/serve.go
@@ -399,7 +399,7 @@ func defaultServeHotReloadWatchRoots(sources providerapi.JSVerbSourceSet) []stri
 	seen := map[string]struct{}{}
 	for _, source := range sources.ListJSVerbSources() {
 		path := strings.TrimSpace(source.Path)
-		if path == "" || source.Embed || source.Package != "" || source.Source != "" {
+		if path == "" || source.Embed || source.Provider != "" || source.Source != "" {
 			continue
 		}
 		if _, ok := seen[path]; ok {

--- a/pkg/xgoja/providers/http/serve.go
+++ b/pkg/xgoja/providers/http/serve.go
@@ -41,9 +41,21 @@ type serveHotReloadSettings struct {
 
 const serveHotReloadSectionSlug = "http-serve"
 
-func newServeCommandSet(ctx providerapi.CommandSetContext) (*providerapi.CommandSet, error) {
-	if ctx.JSVerbs == nil {
+func serveCommandJSVerbSources(ctx providerapi.CommandSetContext) (providerapi.JSVerbSourceSet, error) {
+	if ctx.Sources == nil {
+		return nil, fmt.Errorf("http serve command requires command-scoped runtime sources")
+	}
+	jsverbSources := ctx.Sources.JSVerbs()
+	if jsverbSources == nil || len(jsverbSources.ListJSVerbSources()) == 0 {
 		return nil, fmt.Errorf("http serve command requires configured jsverb sources")
+	}
+	return jsverbSources, nil
+}
+
+func newServeCommandSet(ctx providerapi.CommandSetContext) (*providerapi.CommandSet, error) {
+	jsverbSources, err := serveCommandJSVerbSources(ctx)
+	if err != nil {
+		return nil, err
 	}
 	if ctx.RuntimeFactory == nil {
 		return nil, fmt.Errorf("http serve command requires runtime factory")
@@ -61,7 +73,7 @@ func newServeCommandSet(ctx providerapi.CommandSetContext) (*providerapi.Command
 	}
 	sections = append(sections, hotReloadSection)
 
-	registries, err := ctx.JSVerbs.ScanAllJSVerbSources()
+	registries, err := jsverbSources.ScanAllJSVerbSources()
 	if err != nil {
 		return nil, err
 	}
@@ -148,11 +160,15 @@ func serveVerbHotReload(ctx context.Context, commandCtx providerapi.CommandSetCo
 		return nil, err
 	}
 
+	jsverbSources, err := serveCommandJSVerbSources(commandCtx)
+	if err != nil {
+		return nil, err
+	}
 	verbPath := verb.FullPath()
 	manager, err := hotreload.NewManager(hotreload.Options{
 		CloseGrace: closeGrace,
 		Load: func(ctx context.Context, candidate hotreload.Candidate) (hotreload.Runtime, error) {
-			activeRegistry, activeVerb, err := resolveServeHotReloadVerb(commandCtx.JSVerbs, registry, verb, verbPath)
+			activeRegistry, activeVerb, err := resolveServeHotReloadVerb(jsverbSources, registry, verb, verbPath)
 			if err != nil {
 				return nil, err
 			}
@@ -187,9 +203,9 @@ func serveVerbHotReload(ctx context.Context, commandCtx providerapi.CommandSetCo
 	defer stop()
 	watchRoots := hotReloadSettings.WatchRoots
 	if len(watchRoots) == 0 {
-		watchRoots = defaultServeHotReloadWatchRoots(commandCtx.JSVerbs)
+		watchRoots = defaultServeHotReloadWatchRoots(jsverbSources)
 	}
-	if sourceSetHasTypeScript(commandCtx.JSVerbs) {
+	if sourceSetHasTypeScript(jsverbSources) {
 		hotReloadSettings.WatchExts = appendTypeScriptWatchExtensions(hotReloadSettings.WatchExts)
 	}
 	if len(watchRoots) > 0 {

--- a/pkg/xgoja/providers/http/serve_test.go
+++ b/pkg/xgoja/providers/http/serve_test.go
@@ -128,8 +128,8 @@ module.exports = { register };
 	if !ok || len(capabilities) != 1 {
 		t.Fatalf("http capabilities = %#v", capabilities)
 	}
-	runtimeSpec := &app.RuntimeSpec{Modules: []app.ModuleInstanceSpec{{Package: PackageID, Name: "express", As: "express"}}}
-	factory := app.NewRuntimeFactory(providers, runtimeSpec, app.HostServices{})
+	runtimePlan := &app.RuntimePlan{Modules: []app.RuntimeModulePlan{{Package: PackageID, Name: "express", As: "express"}}}
+	factory := app.NewRuntimeFactory(providers, runtimePlan, app.HostServices{})
 	addr := freeServeTestAddr(t)
 	parsedValues := serveHotReloadTestValues(t, addr, map[string]any{})
 	ctx, cancel := context.WithCancel(context.Background())
@@ -180,8 +180,8 @@ func TestServeVerbHotReloadServesStatusAndReloadsChangedSource(t *testing.T) {
 	if err := Register(providers); err != nil {
 		t.Fatalf("register http provider: %v", err)
 	}
-	runtimeSpec := &app.RuntimeSpec{Modules: []app.ModuleInstanceSpec{{Package: PackageID, Name: "express", As: "express"}}}
-	factory := app.NewRuntimeFactory(providers, runtimeSpec, app.HostServices{})
+	runtimePlan := &app.RuntimePlan{Modules: []app.RuntimeModulePlan{{Package: PackageID, Name: "express", As: "express"}}}
+	factory := app.NewRuntimeFactory(providers, runtimePlan, app.HostServices{})
 	addr := freeServeTestAddr(t)
 	parsedValues := serveHotReloadTestValues(t, addr, map[string]any{
 		"hot-reload":             true,

--- a/pkg/xgoja/providers/http/serve_test.go
+++ b/pkg/xgoja/providers/http/serve_test.go
@@ -47,7 +47,7 @@ func TestNewServeCommandSetBuildsVerbCommandsWithHTTPSection(t *testing.T) {
 			As:                  "express",
 			PackageCapabilities: []providerapi.PackageCapability{capability},
 		}},
-		JSVerbs: fakeJSVerbSourceSet{registries: []*jsverbs.Registry{registry}},
+		Sources: fakeSourceRegistry{jsverbs: fakeJSVerbSourceSet{registries: []*jsverbs.Registry{registry}}},
 	})
 	if err != nil {
 		t.Fatalf("new serve command set: %v", err)
@@ -111,7 +111,7 @@ module.exports = { register };
 	set, err := newServeCommandSet(providerapi.CommandSetContext{
 		Name:           "serve",
 		RuntimeFactory: fakeRuntimeFactory{},
-		JSVerbs:        fakeJSVerbSourceSet{registries: []*jsverbs.Registry{registry}},
+		Sources:        fakeSourceRegistry{jsverbs: fakeJSVerbSourceSet{registries: []*jsverbs.Registry{registry}}},
 	})
 	if err != nil {
 		t.Fatalf("new serve command set: %v", err)
@@ -197,7 +197,7 @@ func TestServeVerbHotReloadServesStatusAndReloadsChangedSource(t *testing.T) {
 	go func() {
 		_, err := serveVerb(ctx, providerapi.CommandSetContext{
 			RuntimeFactory: factory,
-			JSVerbs:        fakeJSVerbSourceSet{path: dir},
+			Sources:        fakeSourceRegistry{jsverbs: fakeJSVerbSourceSet{path: dir}},
 		}, registry, verb, parsedValues)
 		done <- err
 	}()
@@ -431,6 +431,38 @@ func TestSourceSetHasTypeScript(t *testing.T) {
 	if !sourceSetHasTypeScript(fakeJSVerbSourceSet{typescript: true}) {
 		t.Fatalf("TypeScript-enabled fake source set was not detected")
 	}
+}
+
+type fakeSourceRegistry struct {
+	jsverbs fakeJSVerbSourceSet
+}
+
+func (r fakeSourceRegistry) ListSources() []providerapi.RuntimeSourceDescriptor {
+	return r.ListSourcesByKind(providerapi.RuntimeSourceKindJSVerbs)
+}
+
+func (r fakeSourceRegistry) ListSourcesByKind(kind providerapi.RuntimeSourceKind) []providerapi.RuntimeSourceDescriptor {
+	if kind != providerapi.RuntimeSourceKindJSVerbs {
+		return nil
+	}
+	out := make([]providerapi.RuntimeSourceDescriptor, 0, len(r.jsverbs.ListJSVerbSources()))
+	for _, source := range r.jsverbs.ListJSVerbSources() {
+		out = append(out, providerapi.RuntimeSourceDescriptor{ID: source.ID, Kind: providerapi.RuntimeSourceKindJSVerbs, Path: source.Path, Embed: source.Embed, Provider: source.Package, Source: source.Source, TypeScript: source.TypeScript})
+	}
+	return out
+}
+
+func (r fakeSourceRegistry) SourceByID(id string) (providerapi.RuntimeSourceDescriptor, bool) {
+	for _, source := range r.ListSources() {
+		if source.ID == id {
+			return source, true
+		}
+	}
+	return providerapi.RuntimeSourceDescriptor{}, false
+}
+
+func (r fakeSourceRegistry) JSVerbs() providerapi.JSVerbSourceSet {
+	return r.jsverbs
 }
 
 type fakeJSVerbSourceSet struct {

--- a/pkg/xgoja/providers/http/serve_test.go
+++ b/pkg/xgoja/providers/http/serve_test.go
@@ -128,7 +128,7 @@ module.exports = { register };
 	if !ok || len(capabilities) != 1 {
 		t.Fatalf("http capabilities = %#v", capabilities)
 	}
-	runtimePlan := &app.RuntimePlan{Modules: []app.RuntimeModulePlan{{Package: PackageID, Name: "express", As: "express"}}}
+	runtimePlan := &app.RuntimePlan{Runtime: app.RuntimeSection{Modules: []app.RuntimeModulePlan{{Provider: PackageID, Name: "express", As: "express"}}}}
 	factory := app.NewRuntimeFactory(providers, runtimePlan, app.HostServices{})
 	addr := freeServeTestAddr(t)
 	parsedValues := serveHotReloadTestValues(t, addr, map[string]any{})
@@ -180,7 +180,7 @@ func TestServeVerbHotReloadServesStatusAndReloadsChangedSource(t *testing.T) {
 	if err := Register(providers); err != nil {
 		t.Fatalf("register http provider: %v", err)
 	}
-	runtimePlan := &app.RuntimePlan{Modules: []app.RuntimeModulePlan{{Package: PackageID, Name: "express", As: "express"}}}
+	runtimePlan := &app.RuntimePlan{Runtime: app.RuntimeSection{Modules: []app.RuntimeModulePlan{{Provider: PackageID, Name: "express", As: "express"}}}}
 	factory := app.NewRuntimeFactory(providers, runtimePlan, app.HostServices{})
 	addr := freeServeTestAddr(t)
 	parsedValues := serveHotReloadTestValues(t, addr, map[string]any{
@@ -447,7 +447,7 @@ func (r fakeSourceRegistry) ListSourcesByKind(kind providerapi.RuntimeSourceKind
 	}
 	out := make([]providerapi.RuntimeSourceDescriptor, 0, len(r.jsverbs.ListJSVerbSources()))
 	for _, source := range r.jsverbs.ListJSVerbSources() {
-		out = append(out, providerapi.RuntimeSourceDescriptor{ID: source.ID, Kind: providerapi.RuntimeSourceKindJSVerbs, Path: source.Path, Embed: source.Embed, Provider: source.Package, Source: source.Source, TypeScript: source.TypeScript})
+		out = append(out, providerapi.RuntimeSourceDescriptor{ID: source.ID, Kind: providerapi.RuntimeSourceKindJSVerbs, Path: source.Path, Embed: source.Embed, Provider: source.Provider, Source: source.Source, TypeScript: source.TypeScript})
 	}
 	return out
 }

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/README.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/README.md
@@ -1,0 +1,21 @@
+# Replace legacy xgoja runtime metadata bridge with v2-native runtime plan
+
+This is the document workspace for ticket GOJA-XGOJA-V2-RUNTIME-001.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr doc add --ticket GOJA-XGOJA-V2-RUNTIME-001 --doc-type design-doc --title "My Design"`
+- Import sources: `docmgr import file --ticket GOJA-XGOJA-V2-RUNTIME-001 --file /path/to/doc.md`
+- Update metadata: `docmgr meta update --ticket GOJA-XGOJA-V2-RUNTIME-001 --field Status --value review`

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/changelog.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/changelog.md
@@ -115,3 +115,16 @@ Completed generator-remnant and HTTP serve cleanup: verified no old generator co
 - /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/pkg/xgoja/providers/http/serve.go — HTTP serve now consumes command-scoped SourceRegistry JS verb adapter and hot reload rescans/watches that scoped set
 - /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/pkg/xgoja/providers/http/serve_test.go — HTTP serve tests now provide SourceRegistry contexts
 
+
+## 2026-06-13
+
+Completed Phase 7 runtime-package cleanup: generated runtime package/source-fragment APIs now expose EmbeddedRuntimePlanJSON and DecodeRuntimePlan, the checked-in runtime-package example embeds v2 RuntimePlan JSON, and smoke validation passes while NewBundle/NewRuntime stay stable.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/cmd/xgoja/internal/generate/generate_test.go — Regression guards generated runtime package against legacy API names
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/cmd/xgoja/internal/generate/templates/bundle_fragment.go.tmpl — Bundle fragment decodes RuntimePlan
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/cmd/xgoja/internal/generate/templates/runtime_package.go.tmpl — Runtime package template exposes RuntimePlan JSON/API
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/cmd/xgoja/internal/generate/templates/spec_fragment.go.tmpl — Source fragment template exposes RuntimePlan JSON/API
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/examples/xgoja/14-generated-runtime-package — Checked-in runtime-package example regenerated and documented
+

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/changelog.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/changelog.md
@@ -199,3 +199,14 @@ Updated generated TypeScript declaration fixture for examples/xgoja/16-typescrip
 
 - /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/examples/xgoja/16-typescript-jsverbs/js/types/xgoja-modules.d.ts — Regenerated declaration fixture during task 55 smoke validation
 
+
+## 2026-06-14
+
+Addressed PR #76 source-scope review comments: empty command source scopes now remain empty, and builtin jsverb commands use command-scoped registries for nested and root-mounted command layouts (commit bf81e9f).
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/pkg/xgoja/app/host.go — Builtin jsverb command attachment uses the current CommandPlan sources
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/pkg/xgoja/app/root_test.go — Regression for nested and root-mounted builtin jsverb source isolation
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/pkg/xgoja/app/source_registry.go — Empty scoped registries no longer fall back to all sources
+

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/changelog.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/changelog.md
@@ -50,3 +50,16 @@ Phase 0 task 8: added and ran scripts/01-reproduce-provider-command-source-loss.
 
 - /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/scripts/01-reproduce-provider-command-source-loss.sh — Reproduces provider command-set source loss
 
+
+## 2026-06-13
+
+Phase 0: added and passed an xgoja build regression proving provider.command-set sources scope HTTP serve jsverb commands while preserving serve flags.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/cmd/xgoja/internal/generate/templates.go — Carries v2 command sources into generated runtime metadata during the interim bridge
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/cmd/xgoja/root_test.go — Generated binary regression for command-scoped HTTP serve jsverb sources
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/pkg/xgoja/app/command_providers.go — Passes command-scoped JS verb sources into provider command contexts
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/pkg/xgoja/app/jsverb_sources.go — Filters JS verb sources by command source IDs
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/pkg/xgoja/app/runtime_spec.go — Adds source IDs to command provider runtime metadata for the regression fix
+

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/changelog.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/changelog.md
@@ -151,3 +151,13 @@ Removed active xgoja runtime legacy compatibility: RuntimePlan no longer carries
 - /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/pkg/xgoja/app/runtime_plan_test.go — RuntimePlan rejects removed top-level legacy keys
 - /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/pkg/xgoja/providerapi/commands.go — CommandSetContext now exposes Sources without JSVerbs adapter field
 
+
+## 2026-06-13
+
+Validated runtime legacy removal with pre-commit lint, go generate ./..., and go test ./... on commit 207bead; focused xgoja/internal and pkg/xgoja test suites also pass.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/cmd/xgoja/internal/generate — Validated RuntimePlan-named generated outputs (commit 207bead)
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/pkg/xgoja/app/runtime_plan.go — Validated RuntimePlan-only runtime DTO (commit 207bead)
+

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/changelog.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/changelog.md
@@ -180,3 +180,13 @@ Final diary updated with example smoke/help validation evidence, including the l
 
 - /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/reference/01-investigation-diary.md — Final validation diary entry
 
+
+## 2026-06-13
+
+Uploaded final RuntimePlan cutover bundle to reMarkable at /ai/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001/GOJA XGOJA V2 Runtime Cutover Final.pdf. Used a sanitized temporary diary copy for PDF rendering because pandoc treated literal backslash-n sequences in a verbatim prompt line as TeX control sequences.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/design-doc/01-xgoja-v2-native-runtime-plan-design-and-implementation-guide.md — Included in final upload
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/reference/01-investigation-diary.md — Included in final upload via sanitized temporary copy
+

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/changelog.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/changelog.md
@@ -75,3 +75,16 @@ Started hard cutover: generated runtime metadata now emits xgoja/runtime/v2 Runt
 - /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/cmd/xgoja/internal/generate/templates/main.go.tmpl — Generated main decodes RuntimePlan
 - /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/pkg/xgoja/app/runtime_spec.go — Defines v2-native RuntimePlan and runtime app compatibility during transition
 
+
+## 2026-06-13
+
+Added v2 runtime SourceRegistry and passed command-scoped source registry through provider CommandSetContext with JSVerbSourceSet adapter coverage.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/pkg/xgoja/app/command_providers.go — Builds command-scoped SourceRegistry for provider command sets
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/pkg/xgoja/app/command_providers_test.go — Regression coverage for command-scoped SourceRegistry and JS verb adapter
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/pkg/xgoja/app/source_registry.go — Runtime SourceRegistry implementation and scoped source filtering
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/pkg/xgoja/providerapi/commands.go — CommandSetContext now carries v2 SourceRegistry
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/pkg/xgoja/providerapi/sources.go — Provider-facing source registry interfaces and descriptors
+

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/changelog.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/changelog.md
@@ -63,3 +63,15 @@ Phase 0: added and passed an xgoja build regression proving provider.command-set
 - /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/pkg/xgoja/app/jsverb_sources.go — Filters JS verb sources by command source IDs
 - /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/pkg/xgoja/app/runtime_spec.go — Adds source IDs to command provider runtime metadata for the regression fix
 
+
+## 2026-06-13
+
+Started hard cutover: generated runtime metadata now emits xgoja/runtime/v2 RuntimePlan shape, tests assert no legacy packages/modules/commandProviders/jsverbs/help/assets top-level keys, and generated app/templates decode RuntimePlan.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/cmd/xgoja/internal/generate/generate_test.go — Asserts v2 runtime JSON shape and absence of legacy top-level keys
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/cmd/xgoja/internal/generate/templates.go — Emits v2 runtime plan JSON instead of legacy generated metadata
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/cmd/xgoja/internal/generate/templates/main.go.tmpl — Generated main decodes RuntimePlan
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/pkg/xgoja/app/runtime_spec.go — Defines v2-native RuntimePlan and runtime app compatibility during transition
+

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/changelog.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/changelog.md
@@ -102,3 +102,16 @@ Completed requested phase 2-4 cleanup: workspace auto replacement guard, SourceR
 - /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/pkg/xgoja/app/root.go — JS verb command scanning now uses SourceRegistry handles
 - /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/pkg/xgoja/app/source_registry.go — SourceRegistry descriptor conversion supports help/assets/jsverbs consumers
 
+
+## 2026-06-13
+
+Completed generator-remnant and HTTP serve cleanup: verified no old generator conversion helpers remain, HTTP serve now requires CommandSetContext.Sources, hot reload uses command-scoped sources, and example/app.mount smoke validations pass.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/examples/xgoja/13-http-serve-jsverbs/Makefile — Smoke target validated provider.command-set sources and --http-listen
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/modules/express — app.mount behavior validated with go test ./modules/express
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/pkg/gojahttp — mountable handler behavior validated with go test ./pkg/gojahttp
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/pkg/xgoja/providers/http/serve.go — HTTP serve now consumes command-scoped SourceRegistry JS verb adapter and hot reload rescans/watches that scoped set
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/pkg/xgoja/providers/http/serve_test.go — HTTP serve tests now provide SourceRegistry contexts
+

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/changelog.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/changelog.md
@@ -128,3 +128,13 @@ Completed Phase 7 runtime-package cleanup: generated runtime package/source-frag
 - /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/cmd/xgoja/internal/generate/templates/spec_fragment.go.tmpl — Source fragment template exposes RuntimePlan JSON/API
 - /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/examples/xgoja/14-generated-runtime-package — Checked-in runtime-package example regenerated and documented
 
+
+## 2026-06-13
+
+Completed Phase 8 docs: user guide, v2 reference, migration/provider docs, protobuf tutorial, troubleshooting, and affected example READMEs now describe RuntimePlan, command-scoped SourceRegistry, workspace.mode:auto, and generated runtime package APIs.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/cmd/xgoja/doc — Phase 8 xgoja help docs updated for RuntimePlan hard cutover
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/examples/xgoja — Phase 8 example README updates for v2 source/artifact/workspace patterns
+

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/changelog.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/changelog.md
@@ -23,3 +23,12 @@ Validated ticket docs and uploaded GOJA XGOJA V2 Runtime Cutover Guide bundle to
 
 - /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/design-doc/01-xgoja-v2-native-runtime-plan-design-and-implementation-guide.md — Uploaded in reMarkable bundle
 
+
+## 2026-06-13
+
+Expanded the ticket with a detailed 52-task phased implementation backlog covering hard cutover prep, RuntimePlan types, generator rewrite, SourceRegistry, app runtime rewrite, provider API/HTTP serve updates, runtime-package migration, docs/migration guide updates, sessionstream chatbot smoke, legacy removal sweep, validation, and final reMarkable upload.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/tasks.md — Detailed phased implementation backlog
+

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/changelog.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/changelog.md
@@ -161,3 +161,22 @@ Validated runtime legacy removal with pre-commit lint, go generate ./..., and go
 - /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/cmd/xgoja/internal/generate — Validated RuntimePlan-named generated outputs (commit 207bead)
 - /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/pkg/xgoja/app/runtime_plan.go — Validated RuntimePlan-only runtime DTO (commit 207bead)
 
+
+## 2026-06-13
+
+Ran final xgoja example smoke sweep and help validation: examples 01-08, 10, 13-16 passed; example 09 failed for missing sibling loupedeck checkout/go.mod rather than RuntimePlan code; help pages overview/user-guide/v2-reference/migration/provider/protobuf/buildspec render and top-level help discovers key v2 pages.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/cmd/xgoja/doc — Help pages rendered and discoverability checked
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/examples/xgoja — Example smoke sweep results for Phase 10 validation
+
+
+## 2026-06-13
+
+Final diary updated with example smoke/help validation evidence, including the loupedeck-dependent example precondition failure.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/reference/01-investigation-diary.md — Final validation diary entry
+

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/changelog.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/changelog.md
@@ -32,3 +32,21 @@ Expanded the ticket with a detailed 52-task phased implementation backlog coveri
 
 - /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/tasks.md — Detailed phased implementation backlog
 
+
+## 2026-06-13
+
+Phase 0 task 7: created dedicated local branch task/xgoja-v2-runtime-cutover from merged go-go-goja main plus ticket docs; baseline head is 70e98b3.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/tasks.md — Tracks cutover implementation tasks
+
+
+## 2026-06-13
+
+Phase 0 task 8: added and ran scripts/01-reproduce-provider-command-source-loss.sh, which proves v2 commands[].sources is dropped in generated legacy commandProviders metadata while all jsverb sources remain global.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/scripts/01-reproduce-provider-command-source-loss.sh — Reproduces provider command-set source loss
+

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/changelog.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/changelog.md
@@ -190,3 +190,12 @@ Uploaded final RuntimePlan cutover bundle to reMarkable at /ai/2026/06/13/GOJA-X
 - /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/design-doc/01-xgoja-v2-native-runtime-plan-design-and-implementation-guide.md — Included in final upload
 - /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/reference/01-investigation-diary.md — Included in final upload via sanitized temporary copy
 
+
+## 2026-06-13
+
+Updated generated TypeScript declaration fixture for examples/xgoja/16-typescript-jsverbs after final smoke; express declarations now include mount/mountHandler APIs from the current provider.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/examples/xgoja/16-typescript-jsverbs/js/types/xgoja-modules.d.ts — Regenerated declaration fixture during task 55 smoke validation
+

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/changelog.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/changelog.md
@@ -1,0 +1,25 @@
+# Changelog
+
+## 2026-06-13
+
+- Initial workspace created
+
+
+## 2026-06-13
+
+Created hard-cutover xgoja v2 runtime plan design guide and investigation diary; documented removal of legacy runtime metadata bridge plus docs/migration update requirements.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/design-doc/01-xgoja-v2-native-runtime-plan-design-and-implementation-guide.md — Primary implementation guide
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/reference/01-investigation-diary.md — Investigation diary
+
+
+## 2026-06-13
+
+Validated ticket docs and uploaded GOJA XGOJA V2 Runtime Cutover Guide bundle to reMarkable at /ai/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/design-doc/01-xgoja-v2-native-runtime-plan-design-and-implementation-guide.md — Uploaded in reMarkable bundle
+

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/changelog.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/changelog.md
@@ -88,3 +88,17 @@ Added v2 runtime SourceRegistry and passed command-scoped source registry throug
 - /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/pkg/xgoja/providerapi/commands.go — CommandSetContext now carries v2 SourceRegistry
 - /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/pkg/xgoja/providerapi/sources.go — Provider-facing source registry interfaces and descriptors
 
+
+## 2026-06-13
+
+Completed requested phase 2-4 cleanup: workspace auto replacement guard, SourceRegistry-backed JS verb/help/assets consumers, RuntimePlan host/factory path, and unified command attachment loop.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/cmd/xgoja/internal/generate/generate_test.go — Workspace module plan replacement regression for workspace.mode:auto behavior
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/pkg/xgoja/app/assets.go — AssetStore setup now uses SourceRegistry kind=assets
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/pkg/xgoja/app/framework.go — Help source loading now uses SourceRegistry kind=help
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/pkg/xgoja/app/host.go — Host owns SourceRegistry and attaches runtime commands through one CommandPlan loop
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/pkg/xgoja/app/root.go — JS verb command scanning now uses SourceRegistry handles
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/pkg/xgoja/app/source_registry.go — SourceRegistry descriptor conversion supports help/assets/jsverbs consumers
+

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/changelog.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/changelog.md
@@ -138,3 +138,16 @@ Completed Phase 8 docs: user guide, v2 reference, migration/provider docs, proto
 - /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/cmd/xgoja/doc — Phase 8 xgoja help docs updated for RuntimePlan hard cutover
 - /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/examples/xgoja — Phase 8 example README updates for v2 source/artifact/workspace patterns
 
+
+## 2026-06-13
+
+Removed active xgoja runtime legacy compatibility: RuntimePlan no longer carries legacy DTO fields or conversion decode paths, runtime-package/generated binary APIs use RuntimePlan naming, provider command contexts no longer expose ctx.JSVerbs, active tests use v2 RuntimePlan JSON, and grep sweep only finds allowed migration/guard references.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/cmd/xgoja/internal/generate — Generated outputs renamed from spec metadata to runtime-plan metadata
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/pkg/xgoja/app/root_test.go — Active root tests now use v2 RuntimePlan JSON
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/pkg/xgoja/app/runtime_plan.go — RuntimePlan hard-cutover DTO with removed-key rejection and no legacy compatibility fields
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/pkg/xgoja/app/runtime_plan_test.go — RuntimePlan rejects removed top-level legacy keys
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/pkg/xgoja/providerapi/commands.go — CommandSetContext now exposes Sources without JSVerbs adapter field
+

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/design-doc/01-xgoja-v2-native-runtime-plan-design-and-implementation-guide.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/design-doc/01-xgoja-v2-native-runtime-plan-design-and-implementation-guide.md
@@ -5,7 +5,7 @@ Status: active
 Topics:
     - xgoja
     - architecture
-    - codegen
+    - code-generation
 DocType: design-doc
 Intent: ""
 Owners: []

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/design-doc/01-xgoja-v2-native-runtime-plan-design-and-implementation-guide.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/design-doc/01-xgoja-v2-native-runtime-plan-design-and-implementation-guide.md
@@ -1,0 +1,995 @@
+---
+Title: xgoja v2-native runtime plan design and implementation guide
+Ticket: GOJA-XGOJA-V2-RUNTIME-001
+Status: active
+Topics:
+    - xgoja
+    - architecture
+    - codegen
+DocType: design-doc
+Intent: ""
+Owners: []
+RelatedFiles:
+    - Path: go-go-goja/cmd/xgoja/doc/16-migrating-to-xgoja-v2.md
+      Note: migration guide that must be updated during implementation
+    - Path: go-go-goja/cmd/xgoja/doc/17-xgoja-v2-reference.md
+      Note: v2 reference documentation that must become authoritative for runtime plan semantics
+    - Path: go-go-goja/cmd/xgoja/internal/generate/templates.go
+      Note: current lossy v2-to-legacy runtime metadata conversion
+    - Path: go-go-goja/cmd/xgoja/internal/plan/plan.go
+      Note: v2 planner output with provider/source/module/command graphs
+    - Path: go-go-goja/cmd/xgoja/internal/specv2/types.go
+      Note: v2 YAML schema and command/source/provider model
+    - Path: go-go-goja/pkg/xgoja/app/command_providers.go
+      Note: current provider command-set runtime attachment
+    - Path: go-go-goja/pkg/xgoja/app/runtime_spec.go
+      Note: legacy generated runtime DTO to replace
+    - Path: go-go-goja/pkg/xgoja/providers/http/serve.go
+      Note: HTTP serve provider requiring command-scoped jsverb sources
+ExternalSources: []
+Summary: ""
+LastUpdated: 0001-01-01T00:00:00Z
+WhatFor: ""
+WhenToUse: ""
+---
+
+
+# xgoja v2-native runtime plan design and implementation guide
+
+## Executive summary
+
+xgoja already has a native `schema: xgoja/v2` configuration language, a v2 validator, a v2 planner, workspace-aware Go module resolution, provider graph resolution, and source graph resolution. The remaining problem is that generated xgoja binaries still pass through a legacy-shaped runtime metadata DTO before constructing the runtime application. That bridge flattens v2 concepts into older names such as `packages`, `modules`, `commandProviders`, `jsverbs`, `help`, and `assets`.
+
+This ticket proposes a hard cutover: remove the legacy runtime metadata bridge entirely and make generated binaries consume a v2-native runtime plan end-to-end. The target implementation must not keep a legacy execution path, must not generate both legacy and v2 metadata for comparison, and must not add backward-compatibility shims around the old DTO. The public user-facing schema remains `xgoja/v2`; the internal generated runtime plan should finally match that schema.
+
+The immediate symptom that exposed the design debt was a provider command-set example using this v2 configuration:
+
+```yaml
+commands:
+  - id: serve
+    type: provider.command-set
+    provider: http
+    name: serve
+    mount: serve
+    sources: [sites]
+```
+
+The v2 schema has `commands[].sources`, but the legacy bridge currently drops it while converting to `app.CommandProviderInstanceSpec`. The generated binary therefore creates a top-level `serve` command but does not mount the expected jsverb subcommands or HTTP flags. The correct fix is not another one-field patch to the bridge. The correct fix is to remove the bridge so v2 command, source, provider, module, and artifact concepts survive unchanged until command/runtime construction.
+
+## Problem statement and scope
+
+The problem is architectural drift between the current xgoja front door and the generated runtime back end.
+
+The front door is v2-native. `cmd/xgoja/internal/specv2/types.go` defines `Config` with first-class `providers`, `runtime.modules`, `sources`, `commands`, and `artifacts`. The file explicitly states that the package defines the native xgoja/v2 configuration schema and that the schema is an intent-level planner input for providers, modules, sources, command surfaces, and artifacts (`cmd/xgoja/internal/specv2/types.go:1-25`).
+
+The back end is still legacy-shaped. `pkg/xgoja/app/runtime_spec.go` defines `RuntimeSpec` with fields named `Packages`, `Modules`, `Commands`, `CommandProviders`, `JSVerbs`, `Help`, and `Assets` (`pkg/xgoja/app/runtime_spec.go:12-28`). That DTO is decoded by generated binaries and drives `pkg/xgoja/app.Host` command/runtime construction.
+
+The scope of this ticket is to replace that runtime bridge with a v2-native runtime plan and update every affected layer:
+
+- xgoja generated metadata.
+- generated `main.go` and generated runtime-package output.
+- runtime application builder.
+- source registry APIs.
+- provider command-set setup APIs.
+- HTTP serve provider integration.
+- docs, migration guide, examples, tests, and help pages.
+
+The scope explicitly includes deleting or superseding legacy terminology in generated runtime internals. It does not require changing the public YAML schema to a hypothetical `xgoja/v3`; the intended user-facing schema remains `xgoja/v2`.
+
+## Current-state architecture
+
+### Current high-level flow
+
+The current system has two different models in one pipeline:
+
+```text
+xgoja/v2 YAML
+  -> specv2.ApplyDefaults / specv2.Validate
+  -> plan.Compile
+  -> generate.RenderRuntimeSpecJSON   (legacy-shaped bridge)
+  -> embedded xgoja.gen.json
+  -> pkg/xgoja/app.RuntimeSpec
+  -> app.NewHost / app.NewRootCommand / app.RuntimeFactory
+```
+
+The cutover target is:
+
+```text
+xgoja/v2 YAML
+  -> specv2.ApplyDefaults / specv2.Validate
+  -> plan.Compile
+  -> generated v2 runtime plan
+  -> app.NewHostV2 / app.NewRootCommandV2 / app.RuntimeFactoryV2
+```
+
+After cutover, there should be no generated `packages/modules/commandProviders/jsverbs` bridge for v2 builds. Generated runtime code should use v2 concepts directly.
+
+### The v2 schema already has the right conceptual model
+
+`specv2.Config` already preserves the core concepts we want runtime code to see:
+
+- `Providers []ProviderSpec` (`cmd/xgoja/internal/specv2/types.go:19`).
+- `Runtime RuntimeSpec` with `Modules []RuntimeModuleSpec` (`cmd/xgoja/internal/specv2/types.go:20,73-82`).
+- `Sources []SourceSpec` (`cmd/xgoja/internal/specv2/types.go:21,100-109`).
+- `Commands []CommandSurfaceSpec` (`cmd/xgoja/internal/specv2/types.go:22,138-148`).
+- `Artifacts []ArtifactSpec` (`cmd/xgoja/internal/specv2/types.go:23,150-159`).
+
+The v2 command model already includes the information that provider command sets need:
+
+```go
+type CommandSurfaceSpec struct {
+    ID       string
+    Type     string
+    Name     string
+    Mount    string
+    Provider string
+    Sources  []string
+    Modules  []string
+    Config   map[string]any
+    Lazy     bool
+}
+```
+
+The important fields for the HTTP serve use case are `Type`, `Provider`, `Name`, `Mount`, and `Sources`. The current bridge loses `Sources`; a v2-native runtime builder must not.
+
+### Defaults already make v2 practical for users
+
+`specv2.ApplyDefaults` defaults missing schema to `xgoja/v2`, missing app name from `name`, Go version to `1.26`, Go module to `xgoja.generated/<name>`, and workspace mode to `auto` (`cmd/xgoja/internal/specv2/defaults.go:8-36`). This means examples should not need explicit `replace:` entries when a parent `go.work` covers local modules. The v2 design goal should preserve that user experience.
+
+An idiomatic v2 example should look like this:
+
+```yaml
+schema: xgoja/v2
+name: goja-chatdemo-server
+workspace:
+  mode: auto
+providers:
+  - id: http
+    import: github.com/go-go-golems/go-go-goja/pkg/xgoja/providers/http
+  - id: sessionstream
+    import: github.com/go-go-golems/sessionstream/pkg/js/modules/sessionstream/provider
+runtime:
+  modules:
+    - provider: http
+      name: express
+    - provider: sessionstream
+      name: sessionstream
+sources:
+  - id: sites
+    kind: jsverbs
+    from:
+      dir: ./verbs
+commands:
+  - id: serve
+    type: provider.command-set
+    provider: http
+    name: serve
+    mount: serve
+    sources: [sites]
+```
+
+No `provider.module.replace` should be needed when `workspace.mode: auto` resolves the modules from `go.work`.
+
+### The v2 planner already builds the needed graphs
+
+`plan.Plan` already stores v2 `Config`, Go module plan, provider graph, source graph, command plans, artifact plans, and runtime aliases (`cmd/xgoja/internal/plan/plan.go:18-29`). `plan.Compile` validates the spec, builds provider graph, resolves Go modules, builds source graph, resolves imports, and returns command/artifact plans (`cmd/xgoja/internal/plan/plan.go:46-82`).
+
+The planner is not the main problem. The main problem begins after the planner, when code generation reshapes the v2 plan into legacy runtime metadata.
+
+### The generator currently converts v2 into legacy runtime fields
+
+The generator currently populates `runtimeSpec.Packages`, `runtimeSpec.Modules`, `runtimeSpec.Commands`, `runtimeSpec.CommandProviders`, `runtimeSpec.JSVerbs`, `runtimeSpec.Assets`, and help sources from v2 config (`cmd/xgoja/internal/generate/templates.go:360-405`). This conversion is the bridge that must be removed.
+
+The clearest lossy point is `applyPlanRuntimeCommand`:
+
+```go
+func applyPlanRuntimeCommand(commands *app.CommandsSpec, providers *[]app.CommandProviderInstanceSpec, command specv2.CommandSurfaceSpec) {
+    spec := app.CommandSpec{Enabled: true, Name: command.Name, Mount: command.Mount}
+    switch command.Type {
+    case "builtin.eval":
+        commands.Eval = spec
+    case "builtin.run":
+        commands.Run = spec
+    case "builtin.repl":
+        commands.Repl = spec
+    case "builtin.jsverbs":
+        commands.JSVerbs = spec
+    case "provider.command-set":
+        *providers = append(*providers, app.CommandProviderInstanceSpec{
+            ID: command.ID,
+            Package: command.Provider,
+            Name: command.Name,
+            Mount: command.Mount,
+            Modules: append([]string(nil), command.Modules...),
+            Config: command.Config,
+            Lazy: command.Lazy,
+        })
+    }
+}
+```
+
+The original command has `Sources []string` (`cmd/xgoja/internal/specv2/types.go:144`), but the legacy `CommandProviderInstanceSpec` has no `Sources` field (`pkg/xgoja/app/runtime_spec.go:79-87`), and this conversion cannot carry the source binding. That is the observed bug. More importantly, it demonstrates that the legacy DTO is not expressive enough for v2.
+
+### The runtime app builder consumes the legacy DTO everywhere
+
+The current `pkg/xgoja/app` runtime builder takes `*RuntimeSpec`. `Host` stores `RuntimeSpec`, embedded JS verbs, help, and assets (`pkg/xgoja/app/host.go`, evidence search lines show `RuntimeSpec` used throughout). `NewRootCommand` decodes `SpecJSON` into `RuntimeSpec` and constructs commands from it. Built-in jsverb commands scan `runtimeSpec.JSVerbs`; command providers receive a source set built from `runtimeSpec.JSVerbs`.
+
+This means a proper cutover cannot be completed only inside `cmd/xgoja/internal/generate`. The application runtime package must also stop depending on the legacy DTO.
+
+### Provider command sets need v2 command-scoped sources
+
+The HTTP provider serve command is the best concrete example. `newServeCommandSet` requires `ctx.JSVerbs` and calls `ctx.JSVerbs.ScanAllJSVerbSources()` (`pkg/xgoja/providers/http/serve.go:44-65`). It then creates a command for each jsverb (`pkg/xgoja/providers/http/serve.go:68-90`).
+
+That is the right behavior, but the source set passed into the command should be the command's declared sources, not every runtime jsverb source and not an accidentally empty global list. In v2 terms:
+
+```yaml
+commands:
+  - id: serve
+    type: provider.command-set
+    provider: http
+    name: serve
+    sources: [sites]
+```
+
+The provider command-set setup request should receive exactly the resolved source sets for `sites`.
+
+## Gap analysis
+
+### Gap 1: v2 command sources are not preserved
+
+Evidence:
+
+- V2 command has `Sources []string` (`cmd/xgoja/internal/specv2/types.go:144`).
+- Legacy command-provider DTO does not (`pkg/xgoja/app/runtime_spec.go:79-87`).
+- Conversion omits sources (`cmd/xgoja/internal/generate/templates.go:425-438`).
+
+Impact:
+
+- A generated `serve` command may exist without its jsverb subcommands.
+- HTTP provider command flags may not appear because no jsverb commands were mounted.
+- Users correctly writing v2 YAML see behavior that contradicts the v2 docs.
+
+### Gap 2: Source model is split by legacy buckets
+
+V2 has one `sources` list with `kind`, `from`, `include`, `exclude`, `extensions`, `language`, and `compile`. Runtime metadata splits sources into `jsverbs`, `help`, and `assets` fields (`pkg/xgoja/app/runtime_spec.go:25-27`). This makes each consumer handle a slightly different shape and forces conversion functions like `runtimeJSVerbSourceFromPlan`, `runtimeHelpSourceFromPlan`, and `runtimeAssetSourceFromPlan` (`cmd/xgoja/internal/generate/templates.go:441-480`).
+
+Impact:
+
+- Source-related behavior is duplicated.
+- Command-scoped source selection is harder than it should be.
+- Adding a new source kind requires another legacy bucket or special case.
+
+### Gap 3: Provider terminology is inconsistent
+
+V2 uses `providers`. The legacy runtime DTO uses `packages`. V2 runtime modules refer to `provider`; legacy module instances refer to `package` (`pkg/xgoja/app/runtime_spec.go:41-54`). This matters because docs, generated JSON, runtime code, and errors use different terms for the same thing.
+
+Impact:
+
+- New contributors must learn two vocabularies.
+- Generated debugging artifacts are harder to map back to YAML.
+- Migration docs must explain internal legacy names that should not exist.
+
+### Gap 4: Built-in commands are hardcoded as separate fields
+
+V2 commands are a list. Legacy `CommandsSpec` has fields for `Eval`, `Run`, `Repl`, and `JSVerbs` (`pkg/xgoja/app/runtime_spec.go:63-68`). This prevents a single runtime command loop from handling all command surfaces uniformly.
+
+Impact:
+
+- Built-in command handling and provider command handling diverge.
+- Adding a new built-in command requires a DTO field rather than another command plan entry.
+- Command ordering, mounting, and source/module binding are harder to reason about.
+
+### Gap 5: Generated-runtime-package support inherits legacy assumptions
+
+Generated runtime packages currently expose an API over generated runtime metadata and host construction. That path must also cut over. Otherwise a binary generated by `xgoja build` could be v2-native while a `runtime-package` artifact still embeds/loads legacy metadata.
+
+Impact:
+
+- Two generated artifact types would behave differently.
+- Docs would remain ambiguous.
+- The legacy DTO would survive through the runtime-package path.
+
+## Proposed architecture
+
+### Design goals
+
+1. **Hard cutover:** remove the legacy runtime metadata path. Do not keep both runtime plans. Do not compare generated legacy and v2 plans in production code.
+2. **V2 terminology end-to-end:** generated runtime data uses `providers`, `runtime.modules`, `sources`, `commands`, and `artifacts` concepts.
+3. **Command-scoped dependencies:** commands receive their declared sources/modules/config directly.
+4. **One source registry:** jsverbs, help, assets, and future source kinds are resolved through one source registry keyed by v2 source ID and kind.
+5. **Workspace-first examples:** examples use `workspace.mode: auto` and avoid explicit `replace:` when a parent `go.work` already covers local modules.
+6. **Docs updated in same PR:** no implementation is complete until the migration guide, v2 reference, user guide, tutorials, and examples reflect the cutover.
+7. **No legacy left:** old runtime DTOs, generated JSON names, and docs referring to runtime `packages`/`commandProviders` as active internals must be removed or explicitly marked historical in archival notes only.
+
+### New package-level structure
+
+The implementation can keep package names stable if desired, but the conceptual split should be:
+
+```text
+cmd/xgoja/internal/specv2     YAML schema, defaults, validation
+cmd/xgoja/internal/plan       v2 compile-time graph plan
+cmd/xgoja/internal/generate   v2 code generation only
+pkg/xgoja/app                 v2 runtime app builder
+pkg/xgoja/providerapi         v2 provider/module/command APIs
+pkg/xgoja/sourcegraph         source scanning/resolution primitives
+```
+
+Do not create `appv2` as a permanent parallel package unless it is immediately renamed into `app` before merge. A hard cutover means the public internal package should end in the v2-native state.
+
+### V2 runtime plan DTO
+
+Introduce a runtime plan that mirrors the v2 model but contains only runtime-safe data. It should not include build-only fields such as provider Go import paths, module versions, replace directives, or artifact output paths unrelated to runtime execution.
+
+API sketch:
+
+```go
+package app
+
+type RuntimePlan struct {
+    Schema     string          `json:"schema"`
+    Name       string          `json:"name"`
+    App        AppPlan         `json:"app,omitempty"`
+    Runtime    RuntimeSection  `json:"runtime,omitempty"`
+    Sources    []SourcePlan    `json:"sources,omitempty"`
+    Commands   []CommandPlan   `json:"commands,omitempty"`
+    Assets     []SourcePlan    `json:"-"` // derived through SourceRegistry, not a top-level legacy field
+    Help       []SourcePlan    `json:"-"` // derived through SourceRegistry, not a top-level legacy field
+}
+
+type AppPlan struct {
+    Name       string          `json:"name,omitempty"`
+    EnvPrefix  string          `json:"envPrefix,omitempty"`
+    ConfigFile *ConfigFilePlan `json:"configFile,omitempty"`
+}
+
+type RuntimeSection struct {
+    Modules []RuntimeModulePlan `json:"modules,omitempty"`
+}
+
+type RuntimeModulePlan struct {
+    Provider string          `json:"provider"`
+    Name     string          `json:"name"`
+    As       string          `json:"as,omitempty"`
+    Config   json.RawMessage `json:"config,omitempty"`
+}
+
+type SourcePlan struct {
+    ID         string              `json:"id"`
+    Kind       string              `json:"kind"`
+    Origin     SourceOriginPlan    `json:"origin"`
+    Include    []string            `json:"include,omitempty"`
+    Exclude    []string            `json:"exclude,omitempty"`
+    Extensions []string            `json:"extensions,omitempty"`
+    Language   string              `json:"language,omitempty"`
+    Compile    *CompilePlan        `json:"compile,omitempty"`
+}
+
+type SourceOriginPlan struct {
+    Kind     string `json:"kind"` // embedded, disk, provider, workspace-resolved
+    Path     string `json:"path,omitempty"`
+    Provider string `json:"provider,omitempty"`
+    Source   string `json:"source,omitempty"`
+    Root     string `json:"root,omitempty"`
+}
+
+type CommandPlan struct {
+    ID       string          `json:"id"`
+    Type     string          `json:"type"`
+    Name     string          `json:"name,omitempty"`
+    Mount    string          `json:"mount,omitempty"`
+    Provider string          `json:"provider,omitempty"`
+    Sources  []string        `json:"sources,omitempty"`
+    Modules  []string        `json:"modules,omitempty"`
+    Config   json.RawMessage `json:"config,omitempty"`
+    Lazy     bool            `json:"lazy,omitempty"`
+}
+```
+
+The exact Go type names can change, but the invariant must not: the runtime plan keeps commands as commands and sources as sources.
+
+### Source registry API
+
+Runtime code should expose one source registry to command builders, help loaders, asset modules, and jsverb commands.
+
+API sketch:
+
+```go
+type SourceRegistry interface {
+    Source(id string) (SourceHandle, bool)
+    Sources(ids []string, kinds ...SourceKind) ([]SourceHandle, error)
+    SourcesByKind(kind SourceKind) []SourceHandle
+}
+
+type SourceHandle struct {
+    ID         string
+    Kind       SourceKind
+    Origin     SourceOrigin
+    Include    []string
+    Exclude    []string
+    Extensions []string
+    Language   string
+    Compile    CompileOptions
+}
+```
+
+For JS verbs, keep an adapter that implements the existing provider-facing `JSVerbSourceSet` while internally selecting from the new source registry:
+
+```go
+func (r *sourceRegistry) JSVerbSourceSet(ids []string) (providerapi.JSVerbSourceSet, error) {
+    sources, err := r.Sources(ids, SourceKindJSVerbs)
+    if err != nil {
+        return nil, err
+    }
+    return newJSVerbSourceSetFromHandles(r.providers, r.embedded, sources), nil
+}
+```
+
+### Provider command-set setup API
+
+Provider command sets need to receive a v2 command-scoped setup request.
+
+Current HTTP provider code expects `providerapi.CommandSetContext` with `JSVerbs`, `RuntimeFactory`, and selected modules. The new context should make the command's declared dependencies explicit.
+
+API sketch:
+
+```go
+type CommandSetContext struct {
+    Context        context.Context
+    ID             string
+    Provider       string
+    Name           string
+    Mount          string
+    Config         json.RawMessage
+    RuntimeFactory RuntimeFactory
+    Host           HostServices
+
+    SelectedModules []ModuleDescriptor
+
+    // Source access is scoped to the command's sources field.
+    Sources SourceRegistry
+    JSVerbs JSVerbSourceSet // convenience view over Sources filtered to jsverbs
+}
+```
+
+For a command:
+
+```yaml
+commands:
+  - id: serve
+    type: provider.command-set
+    provider: http
+    name: serve
+    sources: [sites]
+```
+
+`CommandSetContext.JSVerbs` should scan only `sites`. It should not scan unrelated jsverb sources and should never be empty because of a conversion loss.
+
+### Runtime host construction
+
+The runtime app builder should construct root commands from the `[]CommandPlan` list.
+
+Pseudocode:
+
+```go
+func (h *Host) AttachCommands(root *cobra.Command) error {
+    for _, cmd := range h.Plan.Commands {
+        switch cmd.Type {
+        case "builtin.eval":
+            rootOrMount(root, cmd).AddCommand(newEvalCommand(h.Factory, h.Plan, cmd))
+        case "builtin.run":
+            rootOrMount(root, cmd).AddCommand(newRunCommand(h.Factory, h.Plan, cmd))
+        case "builtin.repl":
+            rootOrMount(root, cmd).AddCommand(newReplCommand(h.Factory, h.Plan, cmd))
+        case "builtin.jsverbs":
+            sourceSet := h.Sources.JSVerbSourceSet(cmd.Sources)
+            rootOrMount(root, cmd).AddCommand(newJSVerbCommands(h.Factory, sourceSet, cmd))
+        case "provider.command-set":
+            provider := h.Providers.ResolveCommandSetProvider(cmd.Provider, cmd.Name)
+            sourceView := h.Sources.CommandScoped(cmd.Sources)
+            selectedModules := h.selectModules(cmd.Modules)
+            commandSet := provider.NewCommandSet(providerapi.CommandSetContext{
+                ID: cmd.ID,
+                Provider: cmd.Provider,
+                Name: cmd.Name,
+                Mount: cmd.Mount,
+                Config: cmd.Config,
+                RuntimeFactory: h.Factory,
+                Host: h.Services,
+                Sources: sourceView,
+                JSVerbs: sourceView.JSVerbs(),
+                SelectedModules: selectedModules,
+            })
+            rootOrMount(root, cmd).AddCommand(commandSet.Commands...)
+        default:
+            return fmt.Errorf("unsupported command type %q", cmd.Type)
+        }
+    }
+}
+```
+
+The key difference is that there is no `CommandsSpec` and no `CommandProviders` list. There is one command loop.
+
+### Generated files after cutover
+
+Generated builds should embed something named after the v2 model, not `xgoja.gen.json` if that name implies the old runtime DTO.
+
+Recommended generated files:
+
+```text
+main.go
+xgoja.v2.runtime.json
+xgoja_embed/jsverbs/<source-id>/...
+xgoja_embed/help/<source-id>/...
+xgoja_embed/assets/<source-id>/...
+```
+
+Generated `main.go` sketch:
+
+```go
+package main
+
+import (
+    "embed"
+    "os"
+
+    "github.com/go-go-golems/go-go-goja/pkg/xgoja/app"
+    "github.com/go-go-golems/go-go-goja/pkg/xgoja/providerapi"
+    httpprovider "github.com/go-go-golems/go-go-goja/pkg/xgoja/providers/http"
+)
+
+//go:embed xgoja.v2.runtime.json
+var runtimePlanJSON []byte
+
+//go:embed xgoja_embed/jsverbs/**
+var embeddedJSVerbs embed.FS
+
+func main() {
+    providers := providerapi.NewProviderRegistry()
+    if err := httpprovider.Register(providers); err != nil {
+        panic(err)
+    }
+    root, err := app.NewRootCommand(app.Options{
+        Providers: providers,
+        PlanJSON: runtimePlanJSON,
+        EmbeddedSources: app.EmbeddedSources{
+            JSVerbs: embeddedJSVerbs,
+        },
+        Out: os.Stdout,
+    })
+    if err != nil {
+        panic(err)
+    }
+    if err := root.Execute(); err != nil {
+        os.Exit(1)
+    }
+}
+```
+
+The names are illustrative. The requirement is that the generated plan is v2-native and the generated host calls a v2-native app constructor.
+
+### Generated runtime package after cutover
+
+Runtime-package artifacts should use the same `RuntimePlan` and app builder as generated binaries. Do not leave runtime-package artifacts on the old DTO.
+
+API sketch:
+
+```go
+package xgojaruntime
+
+type Bundle struct {
+    providers *providerapi.ProviderRegistry
+    plan      *app.RuntimePlan
+    embedded  app.EmbeddedSources
+    options   Options
+}
+
+func NewBundle(opts Options) (*Bundle, error) {
+    providers := providerapi.NewProviderRegistry()
+    registerGeneratedProviders(providers)
+    plan, err := app.DecodeRuntimePlan(runtimePlanJSON)
+    if err != nil { return nil, err }
+    return &Bundle{providers: providers, plan: plan, embedded: generatedEmbeddedSources(), options: opts}, nil
+}
+
+func (b *Bundle) NewRuntime(ctx context.Context) (*engine.Runtime, error) {
+    host := app.NewHostWithOptions(b.providers, b.plan, app.HostOptions{EmbeddedSources: b.embedded})
+    return host.NewRuntime(ctx)
+}
+```
+
+## Required hard-cutover removals
+
+The implementation must remove or replace these active runtime concepts:
+
+- `pkg/xgoja/app.RuntimeSpec` as the generated binary runtime DTO.
+- `PackageSpec` as active runtime terminology; use provider terminology.
+- `ModuleInstanceSpec.Package`; use `Provider`.
+- `CommandsSpec` as separate `Eval/Run/Repl/JSVerbs` fields.
+- `CommandProviderInstanceSpec` as a separate command-provider bucket.
+- `JSVerbSourceSpec`, `HelpSourceSpec`, and `AssetSourceSpec` as independent top-level runtime buckets when used only to avoid a unified source registry.
+- `RenderRuntimeSpecJSON` or equivalent functions that reshape v2 plans into legacy runtime metadata.
+- Generated `xgoja.gen.json` if it stores the legacy shape.
+
+If any of these names remain, they must either be:
+
+1. deleted,
+2. renamed/reworked into v2-native types, or
+3. moved into test fixtures explicitly labeled as historical migration inputs.
+
+No production code should need to understand the legacy runtime DTO after the cutover.
+
+## Documentation update requirements
+
+The implementation is not done until documentation is updated. The PR must update these documents:
+
+1. `cmd/xgoja/doc/02-user-guide.md`
+   - Explain the v2-native runtime flow.
+   - Show provider command sets with `sources` and `modules`.
+   - Remove language implying that v2 specs are converted into legacy runtime metadata.
+
+2. `cmd/xgoja/doc/16-migrating-to-xgoja-v2.md`
+   - Add a section explaining the hard runtime cutover.
+   - State that generated binaries now preserve v2 concepts end-to-end.
+   - Explain that `workspace.mode: auto` is preferred over explicit `replace` when a parent `go.work` covers local modules.
+   - Add a troubleshooting section for provider command-set `sources` and runtime module aliases.
+
+3. `cmd/xgoja/doc/17-xgoja-v2-reference.md`
+   - Make the runtime plan model authoritative.
+   - Document command-scoped `sources` for `provider.command-set`.
+   - Clarify that `mount` is a CLI mount, not an HTTP mount.
+   - Document source kinds through the unified source registry model.
+
+4. `cmd/xgoja/doc/11-provider-runtime-config-and-host-services.md`
+   - Update provider author guidance for the new `CommandSetContext`.
+   - Explain how command providers receive command-scoped sources and selected modules.
+   - Keep host-service guidance current.
+
+5. `cmd/xgoja/doc/15-tutorial-protobuf-builder-provider.md`
+   - Ensure provider examples use v2-native terminology and workspace resolution.
+
+6. `examples/xgoja/*/README.md` and `examples/xgoja/*/xgoja.yaml`
+   - Update examples to remove unnecessary explicit replaces where `workspace.mode: auto` works.
+   - Ensure provider command-set examples work with `sources`.
+   - Update the HTTP serve example command syntax to match the new runtime behavior.
+
+7. Any generated-runtime-package documentation and examples.
+   - Replace references to legacy embedded runtime spec with the v2 runtime plan.
+
+Docs must be validated through existing help/doc tests. The migration guide is a first-class deliverable, not an optional follow-up.
+
+## Decision records
+
+### Decision: hard cutover instead of dual runtime paths
+
+- **Context:** The legacy bridge is already causing lossy conversion from v2 commands to runtime command-provider setup. A dual path would preserve ambiguity and require future contributors to understand both models.
+- **Options considered:** Patch the bridge; generate both legacy and v2 plans temporarily; hard cutover to v2-native runtime plan.
+- **Decision:** Perform a hard cutover. Generated binaries and runtime packages should use only the v2-native runtime plan.
+- **Rationale:** The user explicitly requested no legacy leftovers. The codebase already has a v2 planner; keeping the old DTO would continue to invite mismatches.
+- **Consequences:** The implementation must update more tests/examples/docs in one PR. It reduces migration ambiguity and makes failures easier to diagnose.
+- **Status:** accepted.
+
+### Decision: preserve v2 command list at runtime
+
+- **Context:** Legacy `CommandsSpec` splits built-ins into fields and provider commands into a separate list, losing common command semantics.
+- **Options considered:** Add missing fields to `CommandProviderInstanceSpec`; keep built-ins as special fields; represent every command as a `CommandPlan`.
+- **Decision:** Use one runtime `[]CommandPlan` list.
+- **Rationale:** This matches the YAML and lets all commands share `id`, `type`, `name`, `mount`, `sources`, `modules`, `config`, and `lazy` behavior.
+- **Consequences:** Command installation becomes a switch over `CommandPlan.Type`; tests should assert built-ins and providers both use the same command path.
+- **Status:** accepted.
+
+### Decision: unified source registry
+
+- **Context:** V2 sources have one schema with `kind`; legacy runtime metadata has separate source buckets.
+- **Options considered:** Keep separate `JSVerbs`, `Help`, and `Assets`; add per-kind slices under a new DTO; use one source registry with kind filters.
+- **Decision:** Use one source registry and derive kind-specific views from it.
+- **Rationale:** Command providers need command-scoped source selection, and future source kinds should not require new top-level runtime fields.
+- **Consequences:** Source scanning adapters must be rewritten, but command/help/asset behavior becomes more regular.
+- **Status:** accepted.
+
+### Decision: provider command contexts receive resolved command-scoped sources
+
+- **Context:** HTTP serve must scan only the jsverb sources attached to the serve command.
+- **Options considered:** Let providers scan all runtime sources; add source IDs only; pass resolved source handles/views.
+- **Decision:** Pass a source registry view scoped to `commands[].sources`, with a JS verb convenience adapter.
+- **Rationale:** Providers should not duplicate source ID resolution or accidentally scan unrelated sources.
+- **Consequences:** Provider API changes are required. HTTP serve tests must assert source scoping.
+- **Status:** accepted.
+
+### Decision: docs and migration guide are part of definition of done
+
+- **Context:** This refactor changes internal architecture and the mental model for provider authors and users.
+- **Options considered:** Update docs later; update only v2 reference; update all relevant docs in the same implementation.
+- **Decision:** Update all relevant docs and examples in the same PR.
+- **Rationale:** Leaving docs behind would preserve the old terminology and make the hard cutover incomplete.
+- **Consequences:** The implementation PR is larger, but the feature is reviewable as a complete migration.
+- **Status:** accepted.
+
+## Implementation plan
+
+### Phase 1: Inventory and failing tests
+
+1. Add tests that demonstrate current breakage:
+   - A v2 spec with `provider.command-set` and `sources: [sites]` must generate a binary whose `serve` command exposes the jsverb commands.
+   - The generated runtime metadata must contain `commands[].sources` in v2-native form.
+   - No generated `commandProviders` field should exist.
+2. Add grep-style test or CI check for active legacy runtime markers in generated output:
+   - `"packages"` as provider list.
+   - `"commandProviders"`.
+   - top-level `"jsverbs"` instead of `sources`.
+   - `xgoja.gen.json` if it contains legacy shape.
+3. Run the existing xgoja example suite to establish the failing baseline.
+
+### Phase 2: Define v2 runtime plan types
+
+1. Replace `pkg/xgoja/app.RuntimeSpec` with `RuntimePlan` or rename/rework it in place.
+2. Replace `PackageSpec` with `ProviderPlan` if provider identity is still needed at runtime.
+3. Replace `ModuleInstanceSpec.Package` with `RuntimeModulePlan.Provider`.
+4. Replace `CommandsSpec` and `CommandProviderInstanceSpec` with `[]CommandPlan`.
+5. Replace per-kind top-level source specs with `[]SourcePlan` plus `SourceRegistry`.
+
+Pseudocode for type migration:
+
+```go
+// Before
+type RuntimeSpec struct {
+    Packages []PackageSpec
+    Modules []ModuleInstanceSpec
+    Commands CommandsSpec
+    CommandProviders []CommandProviderInstanceSpec
+    JSVerbs []JSVerbSourceSpec
+    Help HelpSpec
+    Assets []AssetSourceSpec
+}
+
+// After
+type RuntimePlan struct {
+    Schema string
+    Name string
+    App AppPlan
+    Runtime RuntimeSection
+    Sources []SourcePlan
+    Commands []CommandPlan
+}
+```
+
+### Phase 3: Rewrite generator output
+
+1. Replace `RenderRuntimeSpecJSON` with `RenderRuntimePlanJSON`.
+2. Generate `xgoja.v2.runtime.json` or an equivalently named v2-native artifact.
+3. Remove `applyPlanRuntimeCommand`, `runtimeJSVerbSourceFromPlan`, `runtimeHelpSourceFromPlan`, and `runtimeAssetSourceFromPlan` if their only purpose is legacy reshaping.
+4. Generate runtime source origins from `plan.SourceGraph` rather than reconstructing sources from raw config alone.
+5. Ensure generated `go.mod` still uses workspace resolution from `plan.GoModules`; `RenderGoModPlan` already resolves workspace replacements from `plannedGoModules` (`cmd/xgoja/internal/generate/gomod.go:55-80`).
+
+### Phase 4: Rewrite runtime app builder
+
+1. Change `NewRootCommand` to decode `RuntimePlan`.
+2. Change `NewHost` / `NewHostWithOptions` to store `*RuntimePlan`.
+3. Change `RuntimeFactory` module setup to read `plan.Runtime.Modules`.
+4. Replace built-in command attachment logic with a loop over `plan.Commands`.
+5. Replace old jsverb command builder with a command-scoped source lookup.
+6. Replace help loading and asset store setup to query sources by kind.
+
+Pseudocode:
+
+```go
+func NewRootCommand(opts Options) (*cobra.Command, error) {
+    plan, err := DecodeRuntimePlan(opts.PlanJSON)
+    if err != nil { return nil, err }
+    host := NewHostWithOptions(opts.Providers, plan, HostOptions{EmbeddedSources: opts.EmbeddedSources})
+    root := newRoot(plan.App.Name)
+    if err := host.InstallFramework(root); err != nil { return nil, err }
+    if err := host.AttachCommands(root); err != nil { return nil, err }
+    return root, nil
+}
+```
+
+### Phase 5: Update provider API and providers
+
+1. Update `providerapi.CommandSetContext` to include command ID, provider, command config, scoped source registry, and selected modules.
+2. Update `pkg/xgoja/providers/http/serve.go` so `newServeCommandSet` uses the command-scoped JS verb source set.
+3. Ensure hot reload uses the same scoped source set for re-scan and watch-root calculation.
+4. Update tests in `pkg/xgoja/providers/http` and `pkg/xgoja/app`.
+
+Important HTTP serve assertions:
+
+- `ctx.JSVerbs == nil` remains an error for serve.
+- `ctx.JSVerbs.ScanAllJSVerbSources()` sees only command-attached sources.
+- A serve command with no `sources` should fail clearly unless provider-shipped default sources are explicitly supported.
+
+### Phase 6: Runtime package artifacts
+
+1. Update runtime-package generation to embed the v2 runtime plan.
+2. Update generated `NewBundle` and `NewRuntime` to use the v2 app builder.
+3. Update `examples/xgoja/14-generated-runtime-package` and its tests/docs.
+4. Remove any legacy runtime DTO references from generated package output.
+
+### Phase 7: Documentation and examples
+
+1. Update all docs listed in “Documentation update requirements”.
+2. Update examples to use idiomatic v2.
+3. Ensure `examples/xgoja/13-http-serve-jsverbs` passes with provider command-set `sources`.
+4. Finish `sessionstream/examples/goja-chatdemo-server` once the v2 command path works.
+5. Update migration guide to say there is no legacy runtime bridge.
+
+### Phase 8: Removal sweep
+
+Run repository searches and remove active legacy terms from implementation paths:
+
+```bash
+rg -n "CommandProviderInstanceSpec|CommandsSpec|PackageSpec|JSVerbSourceSpec|xgoja.gen.json|commandProviders|packages" cmd/xgoja pkg/xgoja examples/xgoja
+```
+
+Allowed matches after cutover:
+
+- Historical changelog or ticket docs.
+- Tests explicitly verifying old input migration if such tests are still useful.
+- User-facing docs only when describing old versions in the migration guide.
+
+Everything else should be renamed or removed.
+
+## Testing strategy
+
+### Unit tests
+
+- `cmd/xgoja/internal/specv2`: v2 schema defaults and validation still pass.
+- `cmd/xgoja/internal/plan`: command plans preserve `sources`, `modules`, `config`, and `lazy`.
+- `cmd/xgoja/internal/generate`: generated runtime plan JSON contains `commands` list and `sources` list; it does not contain `commandProviders` or top-level `jsverbs`.
+- `pkg/xgoja/app`: root command construction from v2 plan attaches built-ins and provider command sets.
+- `pkg/xgoja/providers/http`: HTTP serve command receives command-scoped jsverb sources.
+
+### Golden tests
+
+Add or update golden output for generated `main.go` and runtime plan JSON. The golden should show:
+
+```json
+{
+  "schema": "xgoja/runtime/v2",
+  "commands": [
+    {
+      "id": "serve",
+      "type": "provider.command-set",
+      "provider": "http",
+      "name": "serve",
+      "mount": "serve",
+      "sources": ["sites"]
+    }
+  ],
+  "sources": [
+    {
+      "id": "sites",
+      "kind": "jsverbs"
+    }
+  ]
+}
+```
+
+It should not show:
+
+```json
+{
+  "commandProviders": [],
+  "jsverbs": [],
+  "packages": []
+}
+```
+
+### Example smoke tests
+
+Required examples:
+
+```bash
+make -C examples/xgoja/13-http-serve-jsverbs smoke
+make -C examples/xgoja/14-generated-runtime-package smoke
+make -C examples/xgoja/15-protobuf-builder-provider smoke
+```
+
+After the sessionstream example is committed:
+
+```bash
+make -C ../sessionstream/examples/goja-chatdemo-server smoke
+```
+
+### Full validation
+
+Run:
+
+```bash
+go test ./cmd/xgoja/... ./pkg/xgoja/... ./pkg/gojahttp ./modules/express -count=1
+go test ./... -count=1
+```
+
+Also run docs/help validation tests that load xgoja help pages.
+
+## Risks and open questions
+
+### Risk: large PR surface
+
+A hard cutover touches generation, runtime app, provider APIs, docs, and examples. The mitigation is to phase internally but merge as one coherent cutover PR with strong tests.
+
+### Risk: generated runtime packages may have hidden users
+
+Runtime packages are a public-ish integration surface. The cutover should keep the high-level generated package API stable where possible (`NewBundle`, `NewRuntime`), while replacing internals.
+
+### Risk: provider API changes affect all providers
+
+Built-in providers and examples must be updated in the same PR. Custom external providers may need migration guidance. Since this is internal project work and the user requested a hard cutover, do not keep old provider command-set APIs as compatibility shims.
+
+### Open question: runtime plan JSON schema name
+
+Options:
+
+- `xgoja/runtime/v2`
+- `xgoja/v2-runtime`
+- no separate schema marker, relying on generated code version
+
+Recommendation: include `schema: xgoja/runtime/v2` in generated runtime JSON so tests can fail clearly if old JSON is embedded.
+
+### Open question: naming of app package types
+
+Options:
+
+- Rename `RuntimeSpec` to `RuntimePlan`.
+- Keep `RuntimeSpec` name but change its shape completely.
+
+Recommendation: use `RuntimePlan` because it distinguishes v2 runtime data from the historical DTO and communicates that the data is already planned/resolved.
+
+## Implementation checklist
+
+- [ ] Add failing tests for provider command-set `sources`.
+- [ ] Define v2 runtime plan types.
+- [ ] Replace generated runtime metadata with v2 runtime plan JSON.
+- [ ] Rewrite app host/root/factory to consume v2 runtime plan.
+- [ ] Replace runtime source buckets with source registry.
+- [ ] Update provider command-set context to receive scoped sources.
+- [ ] Update HTTP serve provider.
+- [ ] Update generated runtime-package path.
+- [ ] Remove active legacy DTO/types/conversion functions.
+- [ ] Update `cmd/xgoja/doc/02-user-guide.md`.
+- [ ] Update `cmd/xgoja/doc/16-migrating-to-xgoja-v2.md`.
+- [ ] Update `cmd/xgoja/doc/17-xgoja-v2-reference.md`.
+- [ ] Update provider author docs and tutorials.
+- [ ] Update examples and READMEs.
+- [ ] Add grep/test guard against legacy generated metadata returning.
+- [ ] Run full test and example smoke suite.
+
+## File reference map
+
+Start reading here:
+
+- `cmd/xgoja/internal/specv2/types.go`: v2 user-facing schema.
+- `cmd/xgoja/internal/specv2/defaults.go`: v2 defaults, including `workspace.mode: auto`.
+- `cmd/xgoja/internal/plan/plan.go`: planner output and provider/source/module graph resolution.
+- `cmd/xgoja/internal/generate/templates.go`: current lossy conversion into legacy runtime metadata; primary deletion target.
+- `cmd/xgoja/internal/generate/gomod.go`: Go module/workspace replacement generation; mostly reusable.
+- `pkg/xgoja/app/runtime_spec.go`: current legacy runtime DTO; primary replacement target.
+- `pkg/xgoja/app/host.go`: root command attachment and command-provider mounting.
+- `pkg/xgoja/app/root.go`: generated root command construction and built-in commands.
+- `pkg/xgoja/app/command_providers.go`: current provider command-set construction.
+- `pkg/xgoja/app/jsverb_sources.go`: current JS verb source set adapter.
+- `pkg/xgoja/providerapi/module.go`: module setup API.
+- `pkg/xgoja/providerapi/capabilities.go`: host services and runtime initializer capabilities.
+- `pkg/xgoja/providers/http/serve.go`: provider command-set consumer that exposed the source-scoping bug.
+- `cmd/xgoja/doc/16-migrating-to-xgoja-v2.md`: must be updated for the hard runtime cutover.
+- `cmd/xgoja/doc/17-xgoja-v2-reference.md`: must become authoritative for runtime plan semantics.
+
+## Appendix: mental model for interns
+
+Think of xgoja as a compiler and runtime host generator.
+
+At compile time, xgoja reads a YAML file that says:
+
+- Which Go provider packages are available.
+- Which provider modules JavaScript can import.
+- Which local/provider/workspace source files exist.
+- Which CLI commands the generated binary should expose.
+- Which artifacts should be built.
+
+At runtime, the generated binary should not care about Go module replacements or YAML parsing. It should care about:
+
+- Which modules are selected.
+- Which commands exist.
+- Which source sets those commands can read.
+- Which embedded files are available.
+- Which provider command/module factories should be called.
+
+The legacy bridge mixed those concerns by reshaping v2 concepts into older runtime fields. The v2-native cutover keeps the compile-time and runtime data models aligned: a v2 command remains a command, a v2 source remains a source, and a provider remains a provider all the way through the generated binary.

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/index.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/index.md
@@ -5,7 +5,7 @@ Status: active
 Topics:
     - xgoja
     - architecture
-    - codegen
+    - code-generation
 DocType: index
 Intent: long-term
 Owners: []

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/index.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/index.md
@@ -1,0 +1,57 @@
+---
+Title: Replace legacy xgoja runtime metadata bridge with v2-native runtime plan
+Ticket: GOJA-XGOJA-V2-RUNTIME-001
+Status: active
+Topics:
+    - xgoja
+    - architecture
+    - codegen
+DocType: index
+Intent: long-term
+Owners: []
+RelatedFiles: []
+ExternalSources: []
+Summary: ""
+LastUpdated: 2026-06-13T12:05:29.939356899-04:00
+WhatFor: ""
+WhenToUse: ""
+---
+
+# Replace legacy xgoja runtime metadata bridge with v2-native runtime plan
+
+## Overview
+
+<!-- Provide a brief overview of the ticket, its goals, and current status -->
+
+## Key Links
+
+- **Related Files**: See frontmatter RelatedFiles field
+- **External Sources**: See frontmatter ExternalSources field
+
+## Status
+
+Current status: **active**
+
+## Topics
+
+- xgoja
+- runtime
+- architecture
+- code-generation
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/reference/01-investigation-diary.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/reference/01-investigation-diary.md
@@ -10,22 +10,33 @@ DocType: reference
 Intent: ""
 Owners: []
 RelatedFiles:
+    - Path: cmd/xgoja/internal/generate/generate_test.go
+      Note: Step 4 metadata guard against legacy top-level generated keys (commit 617b977)
     - Path: cmd/xgoja/internal/generate/templates.go
-      Note: Step 3 preserves command sources during current generator bridge (commit 556ed5c)
+      Note: |-
+        Step 3 preserves command sources during current generator bridge (commit 556ed5c)
+        Step 4 emits v2-native runtime plan JSON (commit 617b977)
+    - Path: cmd/xgoja/internal/generate/templates/main.go.tmpl
+      Note: Step 4 generated main decodes RuntimePlan (commit 617b977)
     - Path: cmd/xgoja/root_test.go
       Note: Step 3 generated-binary regression and temporary fixture helper (commit 556ed5c)
+    - Path: examples/xgoja/14-generated-runtime-package/internal/xgojaruntime/xgoja_runtime.gen.go
+      Note: Step 4 checked-in runtime package fixture updated for RuntimePlan (commit 617b977)
     - Path: pkg/xgoja/app/command_providers.go
       Note: Step 3 passes filtered source set to provider command contexts (commit 556ed5c)
     - Path: pkg/xgoja/app/jsverb_sources.go
       Note: Step 3 command-scoped JS verb source filtering (commit 556ed5c)
     - Path: pkg/xgoja/app/runtime_spec.go
-      Note: Step 3 interim source IDs on command-provider metadata (commit 556ed5c)
+      Note: |-
+        Step 3 interim source IDs on command-provider metadata (commit 556ed5c)
+        Step 4 v2 RuntimePlan DTO and transitional decode path (commit 617b977)
 ExternalSources: []
 Summary: ""
 LastUpdated: 0001-01-01T00:00:00Z
 WhatFor: ""
 WhenToUse: ""
 ---
+
 
 
 # Diary
@@ -448,4 +459,133 @@ and must not expose `siteb` through:
 
 ```text
 scoped-serve serve --help
+```
+
+## Step 4: Cut generated runtime metadata over to RuntimePlan
+
+I started the hard cutover by moving generated xgoja metadata to a v2-native `RuntimePlan` JSON shape. Generated metadata now emits `schema: "xgoja/runtime/v2"`, `providers`, `runtime.modules`, unified `sources`, and `commands[]`; the generator test now fails if legacy top-level keys such as `packages`, `modules`, `commandProviders`, `jsverbs`, `help`, or `assets` reappear in generated v2 output.
+
+I also moved the generated main/runtime-package templates and the runtime app wiring to decode and consume `app.RuntimePlan`. To keep the repository buildable while migrating older in-repo tests and checked-in generated fixtures, `RuntimePlan` currently has non-emitted compatibility decode paths for old JSON/test literals; these are not produced by the generator and must be removed in the later legacy-removal sweep.
+
+### Prompt Context
+
+**User prompt (verbatim):** "let's do the full cutover. continue. We'll do sessionstream later on, you can break it"
+
+**Assistant interpretation:** Continue with the hard xgoja v2 runtime cutover now, prioritizing go-go-goja and deferring sessionstream compatibility until later.
+
+**Inferred user intent:** Remove the legacy generated runtime metadata bridge even if downstream/sessionstream work has to wait.
+
+**Commit (code):** 617b977 — "Cut over generated xgoja metadata to RuntimePlan"
+
+### What I did
+
+- Replaced generated runtime metadata rendering in `cmd/xgoja/internal/generate/templates.go` with v2-native `app.RuntimePlan` output.
+- Added a generated metadata guard in `cmd/xgoja/internal/generate/generate_test.go` that rejects legacy top-level keys: `packages`, `modules`, `commandProviders`, `jsverbs`, `help`, and `assets`.
+- Added `app.RuntimePlan`, `AppPlan`, `RuntimeSection`, `RuntimeModulePlan`, `SourcePlan`, `CommandPlan`, and `ArtifactPlan` in `pkg/xgoja/app/runtime_spec.go`.
+- Updated generated templates to decode `*app.RuntimePlan`.
+- Updated app runtime wiring, source resolution, command providers, asset/help loading, dts generation, HTTP provider tests, host provider tests, and the generated runtime-package fixture to use RuntimePlan-shaped concepts.
+- Marked tasks 10, 12, 16, 17, 19, and 21 complete.
+
+### Why
+
+- The source-scoping bug was a symptom of generated v2 specs being flattened into a legacy runtime DTO.
+- The hard cutover requires generated output to stop emitting old top-level concepts and preserve v2 concepts directly.
+- Starting at the generated metadata boundary gives every later runtime cleanup task a concrete v2 payload to consume.
+
+### What worked
+
+- The focused validation passed before commit:
+
+```text
+go test ./cmd/xgoja ./cmd/xgoja/internal/generate ./pkg/xgoja/app ./pkg/xgoja/providers/http -count=1
+ok  	github.com/go-go-golems/go-go-goja/cmd/xgoja	9.322s
+ok  	github.com/go-go-golems/go-go-goja/cmd/xgoja/internal/generate	0.038s
+ok  	github.com/go-go-golems/go-go-goja/pkg/xgoja/app	0.177s
+ok  	github.com/go-go-golems/go-go-goja/pkg/xgoja/providers/http	0.288s
+```
+
+- The pre-commit hook then passed lint, `go generate ./...`, and `go test ./...`.
+- The generated runtime-package example was updated enough to compile against `RuntimePlan`.
+
+### What didn't work
+
+The first commit attempt failed because checked-in generated runtime-package code still referenced removed names:
+
+```text
+examples/xgoja/14-generated-runtime-package/internal/xgojaruntime/xgoja_runtime.gen.go:66:19: undefined: app.RuntimeSpec
+examples/xgoja/14-generated-runtime-package/internal/xgojaruntime/xgoja_runtime.gen.go:80:25: undefined: app.RuntimeSpec
+examples/xgoja/14-generated-runtime-package/internal/xgojaruntime/xgoja_runtime.gen.go:81:22: undefined: app.RuntimeSpec
+```
+
+The full pre-commit test pass then also exposed host provider tests still using the old names:
+
+```text
+pkg/xgoja/providers/host/host_test.go:58:22: undefined: app.RuntimeSpec
+pkg/xgoja/providers/host/host_test.go:59:17: undefined: app.AssetSourceSpec
+pkg/xgoja/providers/host/host_test.go:60:18: undefined: app.ModuleInstanceSpec
+```
+
+I updated those files to use `RuntimePlan`, `SourcePlan`, and `RuntimeModulePlan` and reran the commit hook successfully.
+
+### What I learned
+
+- The generator boundary can now enforce the most important guarantee: v2-generated runtime JSON no longer emits the legacy top-level metadata shape.
+- Some older tests and fixtures still used legacy JSON or struct literals directly. Keeping them buildable required a temporary non-emitted decode/struct compatibility layer inside `RuntimePlan`.
+- The generated DTS sidecar template also needed a RuntimePlan update; otherwise v2 generated binaries worked but generated declaration sidecars were empty.
+
+### What was tricky to build
+
+- Go's default JSON unmarshalling made mixed old/new tests fail in both directions: old `commands` objects could not unmarshal into `[]CommandPlan`, and new `commands[]` arrays could not unmarshal into `CommandsSpec`. I added custom decode logic while keeping generated output strictly v2-shaped.
+- Runtime module provider identity changed from old `package` terminology to v2 `provider`; test literals and generated code needed to preserve provider IDs through module resolution, dts generation, and provider command setup.
+- `go generate ./...` in the pre-commit hook catches checked-in generated examples, so template changes must be reflected in the generated runtime-package fixture before the commit can land.
+
+### What warrants a second pair of eyes
+
+- `pkg/xgoja/app/runtime_spec.go` still contains temporary compatibility fields and decode paths for old in-repo tests/fixtures. These are not emitted in generated JSON, but they must be removed in the later legacy-removal phase.
+- The task checklist now has the generated metadata cutover tasks checked, but follow-up work is still needed to replace compatibility decode paths with purely v2 test fixtures.
+- Reviewers should verify that `assertNoLegacyRuntimeKeys` is strict enough for the generated v2 JSON contract.
+
+### What should be done in the future
+
+- Remove compatibility fields/decode paths from `RuntimePlan` after all tests and historical fixtures are migrated to v2 JSON/literals.
+- Continue with the unified source registry and provider `CommandSetContext` cleanup so command-scoped source handling no longer depends on a JSVerb-only adapter.
+- Run a grep guard in CI for active legacy runtime DTO names after the final removal sweep.
+
+### Code review instructions
+
+- Start with `cmd/xgoja/internal/generate/templates.go` and `cmd/xgoja/internal/generate/generate_test.go` to verify the generated metadata contract.
+- Then review `pkg/xgoja/app/runtime_spec.go` and the app wiring changes in `host.go`, `root.go`, `factory.go`, `command_providers.go`, `framework.go`, and `assets.go`.
+- Validate with:
+
+```bash
+go test ./cmd/xgoja ./cmd/xgoja/internal/generate ./pkg/xgoja/app ./pkg/xgoja/providers/http -count=1
+go test ./... -count=1
+```
+
+### Technical details
+
+Generated runtime JSON now uses this top-level shape:
+
+```json
+{
+  "schema": "xgoja/runtime/v2",
+  "name": "fixture",
+  "app": { "name": "fixture" },
+  "target": { "kind": "xgoja", "output": "dist/fixture" },
+  "providers": [{ "id": "fixture" }],
+  "runtime": { "modules": [{ "provider": "fixture", "name": "hello", "as": "hello" }] },
+  "sources": [{ "id": "verbs", "kind": "jsverbs", "path": "xgoja_embed/jsverbs/verbs", "embed": true }],
+  "commands": [{ "id": "eval", "type": "builtin.eval", "name": "eval" }]
+}
+```
+
+The generator test rejects these old top-level keys in v2 output:
+
+```text
+packages
+modules
+commandProviders
+jsverbs
+help
+assets
 ```

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/reference/01-investigation-diary.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/reference/01-investigation-diary.md
@@ -1,0 +1,164 @@
+---
+Title: Investigation diary
+DocType: reference
+Ticket: GOJA-XGOJA-V2-RUNTIME-001
+Status: active
+Topics: [xgoja, architecture, codegen]
+---
+
+# Diary
+
+## Goal
+
+This diary records the investigation and documentation work for replacing the legacy xgoja generated runtime metadata bridge with a v2-native runtime plan.
+
+## Step 1: Create ticket and write the hard-cutover design guide
+
+I created a dedicated docmgr ticket under `go-go-goja/ttmp` to capture the architecture analysis and implementation guide for an xgoja v2-native runtime cutover. The design focuses on removing the legacy runtime metadata bridge entirely rather than patching it or keeping a parallel compatibility path.
+
+The investigation started from a concrete failure in the sessionstream xgoja chatbot demo: v2 YAML allowed `commands[].sources`, but generated runtime metadata dropped that field while converting the v2 command into legacy `commandProviders`. I used that symptom to map the current pipeline from `specv2` through the planner, generator, `pkg/xgoja/app`, provider command-set setup, and the HTTP serve provider.
+
+### Prompt Context
+
+**User prompt (verbatim):** "create a new docmgr ticket in go-go-goja/ttmp with `docmgr --root go-go-goja/ttmp ...` and Create  a detailed analysis / design / implementation guide that is for a new intern, explaining all the parts of the system needed to understand what it is, with prose paragraphs and bullet point sand pseudocode and diagrams and api references and file references. It should be very clear and technical. Store in the ticket and the nupload to remarkable."
+
+**Assistant interpretation:** Create a go-go-goja ticket, investigate the xgoja v2 runtime bridge architecture deeply, write an intern-facing design/implementation guide with evidence, diagrams, pseudocode, API references, file references, and upload the final bundle to reMarkable.
+
+**Inferred user intent:** Preserve the architectural reasoning in a structured ticket so a new engineer can implement the xgoja v2-native runtime cutover without rediscovering the system from scratch.
+
+**User prompt (verbatim):** "make sure there is no legacy left and that all docs will be updated and the migration guide also gets updated."
+
+**Assistant interpretation:** Strengthen the guide so the target is a hard cutover with no legacy runtime path left behind and with documentation/migration updates as part of the definition of done.
+
+**Inferred user intent:** Avoid an incremental compatibility shim that leaves the confusing v2-to-legacy bridge in place; require a clean implementation and complete documentation refresh.
+
+**User prompt (verbatim):** "we can do a hard cutover, no need to keep a legacy path and compare"
+
+**Assistant interpretation:** Remove earlier dual-plan/compare migration language and document a direct replacement strategy.
+
+**Inferred user intent:** Keep the implementation simpler and more decisive by deleting the obsolete bridge instead of maintaining a temporary parallel runtime pipeline.
+
+### What I did
+
+- Created ticket `GOJA-XGOJA-V2-RUNTIME-001` with docmgr under `go-go-goja/ttmp`.
+- Added the primary design document:
+  - `design-doc/01-xgoja-v2-native-runtime-plan-design-and-implementation-guide.md`
+- Added this investigation diary.
+- Gathered evidence from:
+  - `cmd/xgoja/internal/specv2/types.go`
+  - `cmd/xgoja/internal/specv2/defaults.go`
+  - `cmd/xgoja/internal/plan/plan.go`
+  - `cmd/xgoja/internal/generate/templates.go`
+  - `cmd/xgoja/internal/generate/gomod.go`
+  - `pkg/xgoja/app/runtime_spec.go`
+  - `pkg/xgoja/app/host.go`
+  - `pkg/xgoja/app/root.go`
+  - `pkg/xgoja/app/command_providers.go`
+  - `pkg/xgoja/app/jsverb_sources.go`
+  - `pkg/xgoja/providerapi/module.go`
+  - `pkg/xgoja/providers/http/serve.go`
+  - `cmd/xgoja/doc/*`
+  - `examples/xgoja/*`
+- Wrote a long-form intern-facing guide covering:
+  - current architecture;
+  - current v2 schema/planner/generator/app-runtime split;
+  - exact gap analysis;
+  - hard-cutover architecture;
+  - proposed runtime plan DTOs;
+  - source registry API;
+  - provider command-set API;
+  - generated binary/runtime-package shape;
+  - hard removal targets;
+  - documentation update requirements;
+  - decision records;
+  - phased implementation plan;
+  - testing strategy;
+  - file reference map.
+- Added docmgr tasks for setup, evidence gathering, guide writing, bookkeeping, validation, and reMarkable upload.
+
+### Why
+
+- The existing xgoja v2 YAML schema is already conceptually correct, but the generated runtime still speaks an older DTO shape.
+- The bridge has now caused a real behavior bug: provider command-set `sources` are present in v2 YAML but dropped before runtime command construction.
+- A new intern needs a coherent map of all relevant code paths before attempting a hard cutover, because the work spans spec parsing, planning, generation, app runtime construction, provider APIs, examples, and docs.
+
+### What worked
+
+- `docmgr --root go-go-goja/ttmp ticket create-ticket` created the ticket workspace successfully.
+- `docmgr --root go-go-goja/ttmp doc add` created the design doc and diary.
+- Evidence gathering with `nl -ba` and `rg` produced concrete line references showing:
+  - v2 schema fields already exist;
+  - planner keeps command plans;
+  - generator reshapes v2 into legacy fields;
+  - legacy runtime DTO lacks command-provider source bindings;
+  - HTTP serve provider requires configured jsverb sources.
+- The final guide explicitly treats documentation and migration-guide updates as part of implementation completion.
+
+### What didn't work
+
+- The current generated xgoja runtime path cannot support the desired sessionstream chatbot server through the provider command-set `serve` flow without either patching the bridge or replacing it. The design therefore documents the replacement path rather than pretending the current path is sufficient.
+- I initially considered a dual-plan transition strategy, but the user clarified that a hard cutover is preferred. I updated the design to reject dual runtime paths and comparison-mode migration.
+
+### What I learned
+
+- The xgoja v2 planner is much closer to the desired architecture than the generated runtime layer is.
+- The lossy part is concentrated around the conversion from `plan.Plan` / `specv2.Config` into `pkg/xgoja/app.RuntimeSpec` and then the runtime app builder's dependence on that legacy DTO.
+- The codebase already has enough abstractions to make a clean cutover practical: provider graph, source graph, workspace resolution, runtime factory, host services, and provider command sets are all present.
+
+### What was tricky to build
+
+- The tricky part was distinguishing "legacy user config" from "legacy generated runtime metadata." The user-facing schema is already v2; the legacy part is the internal generated runtime DTO and app builder path.
+- Another tricky part was avoiding a small tactical fix. Adding `Sources []string` to `CommandProviderInstanceSpec` would fix the immediate bug, but it would leave the confusing architecture intact. The final design explicitly documents that this ticket should remove the bridge rather than extend it.
+- The documentation plan also needed to be strict: if the implementation changes internals but leaves the migration guide and examples using old terms, future contributors will continue learning the wrong model.
+
+### What warrants a second pair of eyes
+
+- Whether the new runtime plan should live in `pkg/xgoja/app` directly or in a temporary internal package during implementation. The design recommends ending in `pkg/xgoja/app` with no permanent `appv2` parallel path.
+- Whether the generated runtime JSON schema marker should be `xgoja/runtime/v2` or another name.
+- Whether any external provider command-set users need a short migration notice beyond the in-repo docs.
+
+### What should be done in the future
+
+- Implement the hard cutover in go-go-goja.
+- Finish the real sessionstream xgoja chatbot server once provider command-set `sources` survive to runtime.
+- Add tests that fail if generated v2 runtime metadata reintroduces legacy fields such as `commandProviders`, top-level `jsverbs`, or `packages`.
+
+### Code review instructions
+
+- Start with the design doc's "Current-state architecture" and "Gap analysis" sections.
+- Then inspect these files in order:
+  1. `cmd/xgoja/internal/specv2/types.go`
+  2. `cmd/xgoja/internal/plan/plan.go`
+  3. `cmd/xgoja/internal/generate/templates.go`
+  4. `pkg/xgoja/app/runtime_spec.go`
+  5. `pkg/xgoja/app/command_providers.go`
+  6. `pkg/xgoja/providers/http/serve.go`
+- Validate the docs with:
+
+```bash
+docmgr --root go-go-goja/ttmp doctor --ticket GOJA-XGOJA-V2-RUNTIME-001 --stale-after 30
+```
+
+### Technical details
+
+The key lossy conversion is the provider command-set case in `cmd/xgoja/internal/generate/templates.go`. The v2 command has `Sources []string`, but the legacy runtime DTO does not. The design recommends deleting this conversion path entirely and replacing runtime command construction with a loop over v2-native command plans.
+
+Target flow:
+
+```text
+xgoja/v2 YAML
+  -> specv2 validation/defaults
+  -> plan.Compile
+  -> generated xgoja.v2.runtime.json
+  -> app.RuntimePlan
+  -> v2-native host/root/runtime construction
+```
+
+Rejected flow:
+
+```text
+xgoja/v2 YAML
+  -> plan.Compile
+  -> legacy RuntimeSpec { packages, modules, commandProviders, jsverbs }
+  -> app.Host legacy command builders
+```

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/reference/01-investigation-diary.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/reference/01-investigation-diary.md
@@ -22,6 +22,8 @@ RelatedFiles:
       Note: Step 4 generated main decodes RuntimePlan (commit 617b977)
     - Path: cmd/xgoja/root_test.go
       Note: Step 3 generated-binary regression and temporary fixture helper (commit 556ed5c)
+    - Path: examples/xgoja/13-http-serve-jsverbs/Makefile
+      Note: Step 7 runnable HTTP serve smoke target validated (commit 08f1264)
     - Path: examples/xgoja/14-generated-runtime-package/internal/xgojaruntime/xgoja_runtime.gen.go
       Note: Step 4 checked-in runtime package fixture updated for RuntimePlan (commit 617b977)
     - Path: pkg/xgoja/app/assets.go
@@ -50,12 +52,17 @@ RelatedFiles:
       Note: Step 5 CommandSetContext carries SourceRegistry (commit 8bcc367)
     - Path: pkg/xgoja/providerapi/sources.go
       Note: Step 5 provider-facing SourceRegistry API (commit 8bcc367)
+    - Path: pkg/xgoja/providers/http/serve.go
+      Note: Step 7 HTTP serve SourceRegistry and hot reload scoped source cleanup (commit 08f1264)
+    - Path: pkg/xgoja/providers/http/serve_test.go
+      Note: Step 7 HTTP serve SourceRegistry test contexts (commit 08f1264)
 ExternalSources: []
 Summary: ""
 LastUpdated: 0001-01-01T00:00:00Z
 WhatFor: ""
 WhenToUse: ""
 ---
+
 
 
 
@@ -845,4 +852,118 @@ Source consumers now request source descriptors by kind from the host registry:
 sourceRegistry.ListSourcesByKind(providerapi.RuntimeSourceKindJSVerbs)
 sourceRegistry.ListSourcesByKind(providerapi.RuntimeSourceKindHelp)
 sourceRegistry.ListSourcesByKind(providerapi.RuntimeSourceKindAssets)
+```
+
+## Step 7: Port HTTP serve to the command SourceRegistry
+
+I completed the next hard-cutover cleanup slice by removing HTTP serve's direct dependence on the transitional `ctx.JSVerbs` command adapter. The provider command-set now requires `CommandSetContext.Sources`, derives its JS verb source set from that source registry, and uses that same scoped source set for command discovery, hot reload rescans, default watch roots, and TypeScript watch extension detection.
+
+This also validated the surrounding cleanup tasks: the generator no longer has active v2-to-legacy conversion helper paths, provider/runtime initialization continues to run through the final module descriptor path, the `examples/xgoja/13-http-serve-jsverbs` smoke target builds and serves a generated binary with `provider.command-set sources`, and the existing `app.mount`/mountable-handler package tests still pass.
+
+### Prompt Context
+
+**User prompt (verbatim):** "Implement cleanup tasks:
+- Phase 2 Task 18: remove old generator helper remnants, especially v2-to-legacy conversion helpers.
+- Phase 5 Task 35: update providerutil/runtime initializer paths for final `RuntimeModulePlan` model.
+- Phase 6 Tasks 36–39: update HTTP serve to use `ctx.Sources` directly, scope hot reload rescans/watches to command sources, repair smoke tests for `examples/xgoja/13-http-serve-jsverbs`, and validate `app.mount` docs/examples."
+
+**Assistant interpretation:** Finish the remaining generator/providerutil/HTTP serve cleanup slice by eliminating HTTP serve's transitional source adapter usage, validating scoped hot reload and example smoke behavior, and checking mountable HTTP composition still works.
+
+**Inferred user intent:** Continue the hard cutover so active runtime/provider code depends on v2-native `RuntimePlan` and `SourceRegistry` concepts rather than legacy or adapter-era structures.
+
+**Commit (code):** 08f1264 — "Port HTTP serve to SourceRegistry context"
+
+### What I did
+
+- Added `serveCommandJSVerbSources` in `pkg/xgoja/providers/http/serve.go` to require `ctx.Sources` and derive JS verb sources via `ctx.Sources.JSVerbs()`.
+- Updated HTTP serve command discovery to scan the derived command-scoped source set instead of `ctx.JSVerbs`.
+- Updated hot reload to rescan, select default watch roots, and detect TypeScript support from the same scoped source set.
+- Updated `pkg/xgoja/providers/http/serve_test.go` to provide a fake `SourceRegistry` instead of direct `JSVerbs` fields for HTTP serve setup.
+- Checked tasks 18, 35, 36, 37, 38, and 39 in docmgr and updated the ticket changelog.
+
+### Why
+
+- HTTP serve is a provider command-set, so its visible verbs and hot reload watch set must be scoped by `commands[].sources` in the v2 runtime plan.
+- Direct `ctx.JSVerbs` access was the last adapter-era path in this provider and made it easier to accidentally rescan unselected source roots.
+- The hard cutover requires runtime/provider code to express source intent through `SourceRegistry`, not legacy top-level JS verb metadata.
+
+### What worked
+
+- Focused validation passed:
+
+```bash
+go test ./pkg/xgoja/providers/http ./pkg/xgoja/app ./cmd/xgoja/internal/generate -count=1
+go test ./cmd/xgoja ./cmd/xgoja/internal/generate ./pkg/xgoja/app ./pkg/xgoja/providerapi ./pkg/xgoja/providers/http ./pkg/gojahttp ./modules/express -count=1
+```
+
+- The runnable HTTP serve example passed:
+
+```bash
+cd examples/xgoja/13-http-serve-jsverbs && make smoke
+```
+
+- Mountable HTTP handler and Express mount behavior remained green:
+
+```bash
+go test ./pkg/gojahttp ./modules/express -count=1
+```
+
+- The pre-commit hook passed lint, `go generate ./...`, and `go test ./...` before commit `08f1264` landed.
+
+### What didn't work
+
+N/A. This cleanup slice was straightforward after the `SourceRegistry` abstraction existed.
+
+### What I learned
+
+- The HTTP serve provider only needs one source-entry point: `ctx.Sources.JSVerbs()`. Keeping all scans and watch root derivation behind that method makes command scoping explicit.
+- The existing `examples/xgoja/13-http-serve-jsverbs` smoke target already covered the important generated-binary behavior: `serve sites demo --http-listen ...` with `provider.command-set sources`.
+- The app.mount validation did not require new code because the relevant `pkg/gojahttp` and `modules/express` tests still cover the mount ABI and Express composition behavior.
+
+### What was tricky to build
+
+- The provider API still carries `ctx.JSVerbs` as a temporary adapter for other consumers, so the cleanup had to be deliberate: HTTP serve tests now construct `Sources` to prevent accidental regression back to direct adapter use.
+- Hot reload has multiple source-dependent paths: rescan, default watch roots, and TypeScript extension detection. All three needed to use the same scoped source set or command-scoped reload would still be leaky.
+- Task 35 was mostly validation-oriented in this slice because runtime initialization already receives selected module descriptors from the final RuntimePlan-derived command context; the relevant check was that HTTP serve still initializes runtimes correctly after removing direct JS verb adapter access.
+
+### What warrants a second pair of eyes
+
+- Review whether `serveCommandJSVerbSources` should allow an empty source registry for edge cases, or whether failing fast is the right provider command-set contract.
+- Confirm that the fake test SourceRegistry mirrors the production `JSVerbs()` behavior closely enough for future provider tests.
+- Re-check hot reload behavior once the transitional `ctx.JSVerbs` field is removed entirely from `CommandSetContext`.
+
+### What should be done in the future
+
+- Continue Phase 7 generated runtime-package cleanup.
+- Remove remaining transitional compatibility fields/decode paths from `RuntimePlan`.
+- Remove `CommandSetContext.JSVerbs` once all providers and tests use `ctx.Sources`.
+
+### Code review instructions
+
+- Start with `pkg/xgoja/providers/http/serve.go`, especially `serveCommandJSVerbSources`, `newServeCommandSet`, and `serveVerbHotReload`.
+- Then review `pkg/xgoja/providers/http/serve_test.go` for the test registry shape and the updated command contexts.
+- Validate with:
+
+```bash
+go test ./cmd/xgoja ./cmd/xgoja/internal/generate ./pkg/xgoja/app ./pkg/xgoja/providerapi ./pkg/xgoja/providers/http ./pkg/gojahttp ./modules/express -count=1
+cd examples/xgoja/13-http-serve-jsverbs && make smoke
+```
+
+### Technical details
+
+HTTP serve now follows this dependency path:
+
+```go
+func serveCommandJSVerbSources(ctx providerapi.CommandSetContext) (providerapi.JSVerbSourceSet, error) {
+    jsverbSources := ctx.Sources.JSVerbs()
+    return jsverbSources, nil
+}
+```
+
+Hot reload uses that same scoped set for every source-derived operation:
+
+```go
+resolveServeHotReloadVerb(jsverbSources, registry, verb, verbPath)
+defaultServeHotReloadWatchRoots(jsverbSources)
+sourceSetHasTypeScript(jsverbSources)
 ```

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/reference/01-investigation-diary.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/reference/01-investigation-diary.md
@@ -12,6 +12,8 @@ Owners: []
 RelatedFiles:
     - Path: cmd/xgoja/doc
       Note: Step 8 xgoja RuntimePlan/source-registry docs (commit 5f414bd)
+    - Path: cmd/xgoja/internal/generate
+      Note: Step 9 runtime-plan generated naming and xgoja.runtime.json (commit 207bead)
     - Path: cmd/xgoja/internal/generate/generate_test.go
       Note: |-
         Step 4 metadata guard against legacy top-level generated keys (commit 617b977)
@@ -51,6 +53,10 @@ RelatedFiles:
       Note: Step 3 command-scoped JS verb source filtering (commit 556ed5c)
     - Path: pkg/xgoja/app/root.go
       Note: Step 6 JS verb scanning via SourceRegistry (commit f09788a)
+    - Path: pkg/xgoja/app/root_test.go
+      Note: Step 9 active app tests converted to RuntimePlan JSON (commit 207bead)
+    - Path: pkg/xgoja/app/runtime_plan.go
+      Note: Step 9 RuntimePlan-only DTO and removed-key rejection (commit 207bead)
     - Path: pkg/xgoja/app/runtime_spec.go
       Note: |-
         Step 3 interim source IDs on command-provider metadata (commit 556ed5c)
@@ -58,7 +64,9 @@ RelatedFiles:
     - Path: pkg/xgoja/app/source_registry.go
       Note: Step 5 runtime SourceRegistry implementation (commit 8bcc367)
     - Path: pkg/xgoja/providerapi/commands.go
-      Note: Step 5 CommandSetContext carries SourceRegistry (commit 8bcc367)
+      Note: |-
+        Step 5 CommandSetContext carries SourceRegistry (commit 8bcc367)
+        Step 9 SourceRegistry-only provider command context (commit 207bead)
     - Path: pkg/xgoja/providerapi/sources.go
       Note: Step 5 provider-facing SourceRegistry API (commit 8bcc367)
     - Path: pkg/xgoja/providers/http/serve.go
@@ -71,6 +79,7 @@ LastUpdated: 0001-01-01T00:00:00Z
 WhatFor: ""
 WhenToUse: ""
 ---
+
 
 
 
@@ -1101,4 +1110,113 @@ The preferred host entry point remains:
 ```go
 bundle, err := xgojaruntime.NewBundle(xgojaruntime.Options{})
 rt, err := bundle.NewRuntime(ctx)
+```
+
+## Step 9: Remove active runtime legacy compatibility
+
+I removed the remaining active compatibility layer from the xgoja runtime DTO and provider command context. The app runtime now has `runtime_plan.go` instead of `runtime_spec.go`, decodes only v2-native `RuntimePlan` shape, rejects removed top-level keys, and no longer carries hidden compatibility buckets such as legacy modules, command providers, jsverbs, assets, or legacy command objects.
+
+I also removed the `ctx.JSVerbs` transition adapter from `providerapi.CommandSetContext`, renamed generated metadata/API symbols from generic spec naming to runtime-plan naming, renamed the generated metadata file from `xgoja.gen.json` to `xgoja.runtime.json`, and converted active app tests to v2 `RuntimePlan` JSON. The remaining legacy names are now confined to migration code/docs or explicit guard tests.
+
+### Prompt Context
+
+**User prompt (verbatim):** "remove"
+
+**Assistant interpretation:** Remove the remaining active legacy runtime compatibility paths after confirming Phases 7/8 were not enough to make the runtime fully legacy-free.
+
+**Inferred user intent:** Complete the hard cutover so normal xgoja runtime/generator/provider code uses RuntimePlan only and fails if legacy generated metadata appears.
+
+**Commit (code):** 207bead — "Remove xgoja runtime legacy compatibility"
+
+### What I did
+
+- Replaced `pkg/xgoja/app/runtime_spec.go` with `pkg/xgoja/app/runtime_plan.go`.
+- Removed compatibility fields and conversion paths from `RuntimePlan`.
+- Added runtime-plan decode rejection for removed top-level keys: `appName`, `envPrefix`, `configFile`, `packages`, `modules`, `commandProviders`, `jsverbs`, `help`, and `assets`.
+- Removed `CommandSetContext.JSVerbs`; provider command sets must use `ctx.Sources`.
+- Renamed generated output internals from spec naming to runtime-plan naming:
+  - `SpecJSON` -> `RuntimePlanJSON`
+  - `embeddedSpecJSON` -> `embeddedRuntimePlanJSON`
+  - `decodeSpec` -> `decodeRuntimePlan`
+  - `spec.gen.go` -> `runtime_plan.gen.go`
+  - `xgoja.gen.json` -> `xgoja.runtime.json`
+- Converted active app/runtime tests from old generated metadata shape to v2 RuntimePlan JSON.
+- Marked tasks 52, 53, and 54 complete.
+
+### Why
+
+- The hard cutover required no active dual-shape runtime path and no legacy DTO names in normal runtime/generator/provider code.
+- Rejecting removed keys is safer than silently ignoring or translating legacy metadata.
+- Removing `ctx.JSVerbs` prevents new provider code from depending on the transition adapter instead of `SourceRegistry`.
+
+### What worked
+
+- Focused validation passed:
+
+```bash
+go test ./cmd/xgoja/internal/... ./cmd/xgoja ./pkg/xgoja/... -count=1
+go test ./cmd/xgoja/internal/generate ./cmd/xgoja ./pkg/xgoja/app ./pkg/xgoja/providerapi ./pkg/xgoja/providers/http ./pkg/xgoja/providers/host ./pkg/gojahttp ./modules/express -count=1
+cd examples/xgoja/14-generated-runtime-package && make smoke
+```
+
+- The pre-commit hook for commit `207bead` passed lint, `go generate ./...`, and `go test ./...`.
+- The active-code grep sweep no longer reports legacy runtime names outside migration docs/guard tests.
+
+### What didn't work
+
+The broad mechanical rename briefly touched migration-only code (`cmd/xgoja/internal/migratebuildspec` and `cmd/xgoja/internal/specv2/migrate_v1.go`) where legacy build-spec terminology is intentional. I reverted those migration files before committing and verified their tests still pass.
+
+### What I learned
+
+- Most remaining legacy behavior was concentrated in `RuntimePlan.UnmarshalJSON` and tests that still supplied old generated metadata JSON.
+- Migration code must remain explicitly historical; the hard cutover should remove active runtime compatibility without erasing the migration command's ability to read old v1 specs.
+- Naming matters for future maintainers: generated files and APIs now say runtime plan instead of generic spec, which makes the cutover easier to reason about.
+
+### What was tricky to build
+
+- Removing compatibility decode paths surfaced many tests that were still exercising the legacy JSON object shape. Those tests had to be converted to `schema: "xgoja/runtime/v2"`, `runtime.modules`, `sources[]`, and `commands[]` instead of relying on conversion.
+- The generated package API had already moved toward RuntimePlan, but generated binary templates still used spec-oriented local names and file names.
+- Some legacy strings are still valid in migration code and explicit guard tests. The removal sweep therefore needs scoped interpretation rather than a blind repository-wide delete.
+
+### What warrants a second pair of eyes
+
+- Review the new decode rejection in `RuntimePlan.UnmarshalJSON` to confirm the removed-key list is complete but not over-broad.
+- Review generated file renames (`runtime_plan.gen.go`, `xgoja.runtime.json`) for downstream tooling assumptions.
+- Review provider command-set API consumers for the removal of `ctx.JSVerbs`; HTTP serve was already migrated, but external providers may need an update.
+
+### What should be done in the future
+
+- Continue final Phase 10 tasks: example smoke sweep, help/docs validation, final diary/changelog, and final reMarkable upload.
+- Keep legacy migration code quarantined under migration packages and docs only.
+
+### Code review instructions
+
+- Start with `pkg/xgoja/app/runtime_plan.go` and `pkg/xgoja/app/runtime_plan_test.go`.
+- Review `pkg/xgoja/providerapi/commands.go` and `pkg/xgoja/app/command_providers.go` for the `SourceRegistry`-only provider command context.
+- Review `cmd/xgoja/internal/generate/templates/main.go.tmpl`, `templates.go`, and `plan.go` for generated runtime-plan naming.
+- Validate with:
+
+```bash
+go test ./cmd/xgoja/internal/... ./cmd/xgoja ./pkg/xgoja/... -count=1
+go test ./... -count=1
+```
+
+### Technical details
+
+RuntimePlan decoding now rejects old metadata instead of translating it:
+
+```go
+for _, key := range []string{"appName", "envPrefix", "configFile", "packages", "modules", "commandProviders", "jsverbs", "help", "assets"} {
+    if _, ok := payload[key]; ok {
+        return fmt.Errorf("runtime plan uses removed legacy key %q", key)
+    }
+}
+```
+
+Provider command sets now use:
+
+```go
+ctx.Sources.JSVerbs()
+ctx.Sources.ListSourcesByKind(...)
+ctx.Sources.SourceByID(...)
 ```

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/reference/01-investigation-diary.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/reference/01-investigation-diary.md
@@ -3,7 +3,7 @@ Title: Investigation diary
 DocType: reference
 Ticket: GOJA-XGOJA-V2-RUNTIME-001
 Status: active
-Topics: [xgoja, architecture, codegen]
+Topics: [xgoja, architecture, code-generation]
 ---
 
 # Diary

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/reference/01-investigation-diary.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/reference/01-investigation-diary.md
@@ -23,19 +23,30 @@ RelatedFiles:
     - Path: examples/xgoja/14-generated-runtime-package/internal/xgojaruntime/xgoja_runtime.gen.go
       Note: Step 4 checked-in runtime package fixture updated for RuntimePlan (commit 617b977)
     - Path: pkg/xgoja/app/command_providers.go
-      Note: Step 3 passes filtered source set to provider command contexts (commit 556ed5c)
+      Note: |-
+        Step 3 passes filtered source set to provider command contexts (commit 556ed5c)
+        Step 5 provider command contexts receive scoped source registries (commit 8bcc367)
+    - Path: pkg/xgoja/app/command_providers_test.go
+      Note: Step 5 scoped source registry regression coverage (commit 8bcc367)
     - Path: pkg/xgoja/app/jsverb_sources.go
       Note: Step 3 command-scoped JS verb source filtering (commit 556ed5c)
     - Path: pkg/xgoja/app/runtime_spec.go
       Note: |-
         Step 3 interim source IDs on command-provider metadata (commit 556ed5c)
         Step 4 v2 RuntimePlan DTO and transitional decode path (commit 617b977)
+    - Path: pkg/xgoja/app/source_registry.go
+      Note: Step 5 runtime SourceRegistry implementation (commit 8bcc367)
+    - Path: pkg/xgoja/providerapi/commands.go
+      Note: Step 5 CommandSetContext carries SourceRegistry (commit 8bcc367)
+    - Path: pkg/xgoja/providerapi/sources.go
+      Note: Step 5 provider-facing SourceRegistry API (commit 8bcc367)
 ExternalSources: []
 Summary: ""
 LastUpdated: 0001-01-01T00:00:00Z
 WhatFor: ""
 WhenToUse: ""
 ---
+
 
 
 
@@ -588,4 +599,119 @@ commandProviders
 jsverbs
 help
 assets
+```
+
+## Step 5: Add v2 runtime SourceRegistry for provider command sets
+
+I added the provider-facing runtime source registry layer so command providers no longer need to reason only in terms of the legacy JSVerb-specific adapter. Provider command contexts now receive a `SourceRegistry` that can list all command-scoped sources, filter by source kind, look up sources by ID, and expose a JS verb adapter for providers such as HTTP serve that still consume JS verb registries.
+
+This step keeps HTTP serve working while moving the provider API toward the v2 model: commands own source selection, the runtime builds a command-scoped registry, and JS verbs become one adapter on top of the generic source registry rather than the only source API.
+
+### Prompt Context
+
+**User prompt (verbatim):** (same as Step 4)
+
+**Assistant interpretation:** Continue advancing all xgoja v2 cutover phases, with sessionstream deferred until the go-go-goja runtime path is ready.
+
+**Inferred user intent:** Keep removing the legacy runtime bridge and move provider/source APIs toward the v2-native design.
+
+**Commit (code):** 8bcc367 — "Add xgoja runtime SourceRegistry"
+
+### What I did
+
+- Added `pkg/xgoja/providerapi/sources.go` with:
+  - `RuntimeSourceKind`
+  - `RuntimeSourceDescriptor`
+  - `SourceRegistry`
+- Added `pkg/xgoja/app/source_registry.go` with runtime source listing, kind filtering, ID lookup, command scoping, and `JSVerbs()` adapter support.
+- Extended `providerapi.CommandSetContext` with `Sources providerapi.SourceRegistry`.
+- Updated `Host.newCommandSet` to construct a command-scoped `SourceRegistry` from `CommandPlan.Sources`.
+- Kept `ctx.JSVerbs` populated from the scoped registry so existing providers continue working while the API migrates.
+- Added test coverage proving provider command sets receive only selected sources through both `ctx.Sources` and the JS verb adapter.
+- Marked tasks 22, 26, 32, 33, and 34 complete.
+
+### Why
+
+- The v2 runtime plan represents all sources uniformly. Provider commands should receive that uniform view instead of only a global JS verb set.
+- HTTP serve still needs a `JSVerbSourceSet` today, so the registry supplies an adapter while the provider implementation migrates in later phases.
+- Command-scoped source filtering is now centralized in one runtime source registry instead of being hand-built per provider context.
+
+### What worked
+
+- Focused tests passed:
+
+```text
+go test ./cmd/xgoja ./cmd/xgoja/internal/generate ./pkg/xgoja/app ./pkg/xgoja/providerapi ./pkg/xgoja/providers/http -count=1
+```
+
+- The pre-commit hook passed lint, `go generate ./...`, and `go test ./...` before commit `8bcc367` was created.
+
+### What didn't work
+
+The first commit attempt failed lint because the old helper became unused after `SourceRegistry.Scoped` replaced it:
+
+```text
+pkg/xgoja/app/jsverb_sources.go:26:6: func newScopedJSVerbSourceSet is unused (unused)
+```
+
+I removed that helper and reran the commit hook successfully.
+
+A focused test also initially failed because compatibility-only `RuntimePlan.JSVerbs`/`Assets` fields did not have `Kind` set when converted to the unified source view. I adjusted `RuntimePlan.allSources()` to tag those compatibility sources as `jsverbs` or `assets` before filtering.
+
+### What I learned
+
+- The generic source registry can coexist with the JSVerb adapter cleanly: `SourceRegistry.JSVerbs()` returns a provider-compatible `JSVerbSourceSet` built from the same scoped source list.
+- Compatibility fields are still a liability because they require normalization logic. Removing those fields remains important for the final cleanup.
+- Centralizing command source filtering makes provider command tests simpler and avoids duplicating filtering behavior across HTTP serve and future providers.
+
+### What was tricky to build
+
+- The registry had to serve both the new provider-neutral API and the old JSVerb scanning API without widening the old API further.
+- The source kind information is guaranteed in generated v2 output, but not in old test literals. That mismatch surfaced in tests and required transitional normalization.
+- `CommandSetContext` now contains both `Sources` and `JSVerbs`; reviewers should treat `JSVerbs` as an adapter for current providers, not the long-term primary API.
+
+### What warrants a second pair of eyes
+
+- Whether `SourceRegistry.JSVerbs()` should return nil or an empty adapter when no JS verb sources exist. Current behavior returns an adapter over an empty source list.
+- Whether provider-facing `RuntimeSourceDescriptor` should expose more origin metadata before docs are finalized.
+- The temporary compatibility path in `RuntimePlan.allSources()` should be removed once old tests are migrated.
+
+### What should be done in the future
+
+- Update HTTP serve to consume `ctx.Sources` directly and only use `ctx.JSVerbs` as a compatibility adapter during transition.
+- Remove compatibility `RuntimePlan` fields and decode paths.
+- Update provider docs to describe `CommandSetContext.Sources` as the primary source API.
+
+### Code review instructions
+
+- Review `pkg/xgoja/providerapi/sources.go` for the provider-facing API.
+- Review `pkg/xgoja/app/source_registry.go` for scoping and descriptor conversion.
+- Review `pkg/xgoja/app/command_providers.go` to see where each provider command receives a scoped registry.
+- Validate with:
+
+```bash
+go test ./cmd/xgoja ./cmd/xgoja/internal/generate ./pkg/xgoja/app ./pkg/xgoja/providerapi ./pkg/xgoja/providers/http -count=1
+go test ./... -count=1
+```
+
+### Technical details
+
+A provider command scoped like this:
+
+```yaml
+commands:
+  - id: serve
+    type: provider.command-set
+    provider: go-go-goja-http
+    name: serve
+    sources: [site-a]
+```
+
+now receives a `CommandSetContext` where:
+
+```go
+ctx.Sources.SourceByID("site-a") // true
+ctx.Sources.SourceByID("site-b") // false
+ctx.Sources.ListSourcesByKind(providerapi.RuntimeSourceKindJSVerbs) // only site-a
+ctx.JSVerbs.ListJSVerbSources() // only site-a
 ```

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/reference/01-investigation-diary.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/reference/01-investigation-diary.md
@@ -162,3 +162,134 @@ xgoja/v2 YAML
   -> legacy RuntimeSpec { packages, modules, commandProviders, jsverbs }
   -> app.Host legacy command builders
 ```
+
+
+## Step 2: Reproduce provider command-set source loss
+
+I started the implementation work by creating a dedicated branch and then writing a small reproduction script for the first real xgoja v2 runtime bug. The script builds a temporary xgoja/v2 app with two jsverb source sets, attaches only one source set to an HTTP `provider.command-set`, and inspects the generated metadata.
+
+The reproduction proves the architectural gap without introducing a permanently failing test yet: `commands[].sources` is present in the v2 YAML, but the generated legacy `commandProviders` metadata has no source binding, while both jsverb sources remain in a global top-level `jsverbs` list. This is exactly the bridge behavior the cutover must remove.
+
+### Prompt Context
+
+**User prompt (verbatim):** "then work on the tasks one by one, keeping a detailed diary as you work, commit at appropriate intervals."
+
+**Assistant interpretation:** Begin executing the newly-created xgoja v2 hard-cutover ticket task list sequentially, update the diary as work proceeds, and make focused commits.
+
+**Inferred user intent:** Move from design into implementation while preserving reviewable history and continuation context.
+
+**Commit (code):** 64523c433117c1e84f4ef11f59189c0b69af95c1 — "Docs: reproduce xgoja command source loss"
+
+### What I did
+
+- Renamed the local go-go-goja branch from the deleted post-merge `task/goja-sessionstream` branch to `task/xgoja-v2-runtime-cutover`.
+- Marked task 7 complete after recording the dedicated branch baseline.
+- Ran the existing HTTP serve xgoja example smoke test:
+
+```bash
+make -C examples/xgoja/13-http-serve-jsverbs smoke
+```
+
+- Added `scripts/01-reproduce-provider-command-source-loss.sh` under the ticket workspace.
+- The script creates a temporary xgoja/v2 spec with:
+  - two jsverb sources, `site-a` and `site-b`;
+  - one HTTP provider command set with `sources: [site-a]`;
+  - an embedded binary artifact containing both sources.
+- The script builds with a fixed temporary work directory and inspects generated `xgoja.gen.json`.
+- Marked task 8 complete and updated the changelog.
+
+### Why
+
+- Task 8 asks for a concrete reproduction of the provider command-set source bug before changing runtime internals.
+- A script is appropriate at this stage because it captures the current behavior without committing an intentionally failing unit test into the branch before the implementation exists.
+- The reproduction gives future tests exact expected facts to assert after the v2-native runtime plan lands.
+
+### What worked
+
+The existing HTTP serve example still passed:
+
+```bash
+make -C examples/xgoja/13-http-serve-jsverbs smoke
+```
+
+That is important because it shows the current legacy behavior can still work in simple cases by scanning all global jsverb sources.
+
+The reproduction script then succeeded and printed:
+
+```text
+generated command provider metadata: {"id": "serve", "mount": "serve", "name": "serve", "package": "http"}
+generated top-level jsverb sources: [{"embed": true, "id": "site-a", "path": "xgoja_embed/jsverbs/site_a"}, {"embed": true, "id": "site-b", "path": "xgoja_embed/jsverbs/site_b"}]
+OK: reproduced source loss: command sources [site-a] were dropped, while both jsverb sources remain global
+```
+
+### What didn't work
+
+The first version of the reproduction script computed the repository root incorrectly and ascended one directory too far. It failed with:
+
+```text
+go: go.mod file not found in current directory or any parent directory; see 'go help modules'
+```
+
+I fixed the script's `repo_root` calculation from seven parent traversals to six parent traversals from the ticket `scripts/` directory.
+
+### What I learned
+
+- The current HTTP serve example passes because command providers see every runtime jsverb source through the legacy global `RuntimeSpec.JSVerbs` field.
+- The deeper v2 bug is source scoping, not total inability to run HTTP serve.
+- A minimal repro needs at least two source sets. If there is only one source set, global scanning hides the bug.
+
+### What was tricky to build
+
+- The reproduction needed to demonstrate an architectural data-loss bug without relying on fragile CLI help output. Inspecting generated `xgoja.gen.json` is more precise: it shows `commandProviders[0]` lacks `sources` and that both sources are global.
+- The temporary xgoja fixture must use an absolute path for source directories because the generated build runs from a separate work directory.
+
+### What warrants a second pair of eyes
+
+- Whether the reproduction script should remain as a ticket artifact only or be promoted into a permanent regression test once the v2 runtime plan implementation starts.
+- Whether future tests should assert both metadata shape and CLI command visibility. The design likely needs both: metadata guard tests catch legacy reintroduction, while CLI tests prove end-user behavior.
+
+### What should be done in the future
+
+- Task 9 should add active regression tests that initially fail against current runtime behavior and later pass with the v2-native runtime plan.
+- Task 10 should add generated metadata guard assertions that fail if legacy `commandProviders`, `packages`, or top-level `jsverbs` return.
+
+### Code review instructions
+
+- Review `scripts/01-reproduce-provider-command-source-loss.sh`.
+- Run it from `go-go-goja`:
+
+```bash
+ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/scripts/01-reproduce-provider-command-source-loss.sh
+```
+
+- Confirm it prints that command sources were dropped and both jsverb sources remain global.
+
+### Technical details
+
+The temporary v2 command in the reproduction is:
+
+```yaml
+commands:
+  - id: serve
+    type: provider.command-set
+    provider: http
+    name: serve
+    mount: serve
+    sources: [site-a]
+```
+
+The generated metadata currently becomes:
+
+```json
+{
+  "commandProviders": [
+    { "id": "serve", "package": "http", "name": "serve", "mount": "serve" }
+  ],
+  "jsverbs": [
+    { "id": "site-a" },
+    { "id": "site-b" }
+  ]
+}
+```
+
+The missing `sources: ["site-a"]` on the command provider is the data-loss boundary.

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/reference/01-investigation-diary.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/reference/01-investigation-diary.md
@@ -1361,3 +1361,82 @@ In this workspace, the resolved path is missing:
 ```text
 /home/manuel/workspaces/2026-06-12/goja-sessionstream/loupedeck/go.mod
 ```
+
+## Step 11: Upload final reMarkable bundle
+
+I uploaded the final ticket bundle to reMarkable after code, example, help, diary, changelog, and docmgr validation were complete. The bundle includes the design guide, investigation diary, changelog, and task list.
+
+The first upload attempt failed because pandoc interpreted literal `\n` sequences inside a verbatim prompt line as TeX control sequences. I did not change the source diary text; instead, I created a temporary sanitized copy for rendering where literal `\n` sequences were expanded to real line breaks, then uploaded that bundle successfully.
+
+### Prompt Context
+
+**User prompt (verbatim):** (same as Step 10)
+
+**Assistant interpretation:** Complete the remaining final delivery work, including reMarkable upload.
+
+**Inferred user intent:** Put the completed RuntimePlan cutover documentation somewhere reviewable on the reMarkable device.
+
+### What I did
+
+- Attempted to upload the design doc, diary, changelog, and tasks as one bundle.
+- Created a temporary sanitized upload directory at `/tmp/goja-xgoja-v2-upload` after the first pandoc failure.
+- Uploaded the final bundle with:
+
+```bash
+remarquee upload bundle /tmp/goja-xgoja-v2-upload/01-design.md /tmp/goja-xgoja-v2-upload/02-diary.md /tmp/goja-xgoja-v2-upload/03-changelog.md /tmp/goja-xgoja-v2-upload/04-tasks.md --name "GOJA XGOJA V2 Runtime Cutover Final" --remote-dir "/ai/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001" --toc-depth 2 --non-interactive
+```
+
+### Why
+
+- The ticket required a final reMarkable handoff after implementation and validation.
+- The source diary should preserve verbatim prompt context, but the rendered PDF needed a TeX-safe copy.
+
+### What worked
+
+The second upload succeeded:
+
+```text
+OK: uploaded GOJA XGOJA V2 Runtime Cutover Final.pdf -> /ai/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001
+```
+
+### What didn't work
+
+The first upload failed with pandoc/LaTeX:
+
+```text
+Error: pandoc failed: Error producing PDF.
+! Undefined control sequence.
+l.3379 ...batim):} “do these: - Phase 2 cleanup \n
+```
+
+The failure was caused by literal `\n` text inside a long verbatim prompt line.
+
+### What I learned
+
+- Verbatim prompt context can be markdown-valid but still problematic for PDF rendering when backslash sequences reach LaTeX in ordinary text.
+- Keeping a temporary upload-specific sanitized copy is safer than mutating the source diary's exact prompt record.
+
+### What was tricky to build
+
+- The diary skill requires exact verbatim prompt text, but reMarkable PDF generation has different escaping constraints. The compromise was to preserve source-of-truth Markdown and render a sanitized copy only for upload.
+
+### What warrants a second pair of eyes
+
+- Review whether future diary entries should wrap long verbatim prompts containing backslash escapes in fenced code blocks for easier PDF rendering.
+
+### What should be done in the future
+
+N/A
+
+### Code review instructions
+
+- Confirm the upload success line above.
+- Review `/ai/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001/GOJA XGOJA V2 Runtime Cutover Final.pdf` on reMarkable if needed.
+
+### Technical details
+
+The uploaded bundle path is:
+
+```text
+/ai/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001/GOJA XGOJA V2 Runtime Cutover Final.pdf
+```

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/reference/01-investigation-diary.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/reference/01-investigation-diary.md
@@ -1220,3 +1220,144 @@ ctx.Sources.JSVerbs()
 ctx.Sources.ListSourcesByKind(...)
 ctx.Sources.SourceByID(...)
 ```
+
+## Step 10: Final example and help validation
+
+I ran the final validation sweep for affected xgoja examples and documentation/help pages after the RuntimePlan hard cutover. The core generated-runtime examples passed, including runtime-package generation, HTTP serve jsverbs, TypeScript jsverbs, embedded assets, embedded/filesystem/provider jsverbs, command providers, and protobuf builder provider checks.
+
+One example smoke target did not pass: `examples/xgoja/09-provider-shipped-help-docs`. Its failure was environmental rather than caused by the RuntimePlan work: the example points at a sibling `../loupedeck` replacement, but `/home/manuel/workspaces/2026-06-12/goja-sessionstream/loupedeck/go.mod` is absent in this workspace. The example's `doctor` and `list-modules` steps still validated the xgoja/v2 plan shape before `go mod tidy` failed on the missing local module.
+
+### Prompt Context
+
+**User prompt (verbatim):** "go ahead"
+
+**Assistant interpretation:** Continue with the remaining Phase 10 final validation, diary/changelog, and reMarkable handoff work.
+
+**Inferred user intent:** Finish the cutover ticket bookkeeping and delivery after active legacy removal.
+
+### What I did
+
+- Ran the example smoke sweep for:
+  - `01-core-provider`
+  - `02-host-provider`
+  - `03-single-runtime-modules`
+  - `04-module-sections`
+  - `05-command-provider`
+  - `06-runtime-filesystem`
+  - `07-embedded-jsverbs`
+  - `08-provider-shipped-jsverbs`
+  - `09-provider-shipped-help-docs`
+  - `10-embedded-assets-fs`
+  - `13-http-serve-jsverbs`
+  - `14-generated-runtime-package`
+  - `15-protobuf-builder-provider`
+  - `16-typescript-jsverbs`
+- Ran xgoja help rendering for key docs:
+  - `overview`
+  - `user-guide`
+  - `xgoja-v2-reference`
+  - `migrating-to-xgoja-v2`
+  - `provider-runtime-config-and-host-services`
+  - `tutorial-protobuf-builder-provider`
+  - `buildspec-reference`
+- Verified top-level help discovers the main v2 pages.
+- Marked tasks 55 and 56 complete and updated the changelog.
+
+### Why
+
+- Phase 10 requires validating generated outputs and docs after removing the compatibility layer.
+- Example smoke tests catch stale generated JSON shape, generated file naming, source scoping, and runtime package API assumptions.
+- Help rendering catches malformed frontmatter or Markdown that would break user-facing xgoja documentation.
+
+### What worked
+
+These example smoke targets passed:
+
+```text
+01-core-provider PASS
+02-host-provider PASS
+03-single-runtime-modules PASS
+04-module-sections PASS
+05-command-provider PASS
+06-runtime-filesystem PASS
+07-embedded-jsverbs PASS
+08-provider-shipped-jsverbs PASS
+10-embedded-assets-fs PASS
+13-http-serve-jsverbs PASS
+14-generated-runtime-package PASS
+15-protobuf-builder-provider PASS
+16-typescript-jsverbs PASS
+```
+
+Help validation passed:
+
+```bash
+go run ./cmd/xgoja help overview
+go run ./cmd/xgoja help user-guide
+go run ./cmd/xgoja help xgoja-v2-reference
+go run ./cmd/xgoja help migrating-to-xgoja-v2
+go run ./cmd/xgoja help provider-runtime-config-and-host-services
+go run ./cmd/xgoja help tutorial-protobuf-builder-provider
+go run ./cmd/xgoja help buildspec-reference
+go run ./cmd/xgoja help | rg -n "user-guide|xgoja-v2-reference|migrating-to-xgoja-v2"
+```
+
+### What didn't work
+
+`examples/xgoja/09-provider-shipped-help-docs` failed during generated build `go mod tidy`:
+
+```text
+Error: go mod tidy failed: exit status 1
+go: github.com/go-go-golems/loupedeck@v0.0.0 (replaced by /home/manuel/workspaces/2026-06-12/goja-sessionstream/loupedeck): reading /home/manuel/workspaces/2026-06-12/goja-sessionstream/loupedeck/go.mod: open /home/manuel/workspaces/2026-06-12/goja-sessionstream/loupedeck/go.mod: no such file or directory
+```
+
+This is an external checkout/precondition problem: the sibling `loupedeck` directory is not present in this workspace. The failure occurred after `doctor` and `list-modules` succeeded.
+
+### What I learned
+
+- The RuntimePlan cutover did not break the normal generated examples that rely on local go-go-goja providers.
+- The remaining example-suite fragility is from examples that depend on sibling repositories not present in the workspace.
+- Help pages still render after the terminology and API updates.
+
+### What was tricky to build
+
+- The example sweep had to distinguish RuntimePlan failures from missing external-module failures. The 09 example still validates planning but cannot build without the external loupedeck checkout.
+- Some examples intentionally do not perform the same depth of build validation; for example, the protobuf builder provider smoke target currently runs tests, doctor, and list-modules rather than building the generated binary.
+
+### What warrants a second pair of eyes
+
+- Decide whether `09-provider-shipped-help-docs` should be changed to skip gracefully when the sibling loupedeck checkout is absent, or whether the repository should document that precondition more explicitly.
+- Decide whether `15-protobuf-builder-provider` smoke should include the `build` target now that runtime generation has stabilized.
+
+### What should be done in the future
+
+- Upload the final implementation/reference bundle to reMarkable.
+- Optionally revisit the loupedeck-dependent example to make bulk smoke loops more self-contained.
+
+### Code review instructions
+
+- Review `ttmp/.../changelog.md` and this diary entry for validation evidence.
+- Re-run the smoke status loop if needed:
+
+```bash
+for dir in 01-core-provider 02-host-provider 03-single-runtime-modules 04-module-sections 05-command-provider 06-runtime-filesystem 07-embedded-jsverbs 08-provider-shipped-jsverbs 09-provider-shipped-help-docs 10-embedded-assets-fs 13-http-serve-jsverbs 14-generated-runtime-package 15-protobuf-builder-provider 16-typescript-jsverbs; do
+  make -C examples/xgoja/$dir smoke
+ done
+```
+
+### Technical details
+
+The failing 09 example points at:
+
+```yaml
+providers:
+  - id: loupedeck
+    module:
+      replace: ../../../../loupedeck
+```
+
+In this workspace, the resolved path is missing:
+
+```text
+/home/manuel/workspaces/2026-06-12/goja-sessionstream/loupedeck/go.mod
+```

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/reference/01-investigation-diary.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/reference/01-investigation-diary.md
@@ -1,10 +1,32 @@
 ---
 Title: Investigation diary
-DocType: reference
 Ticket: GOJA-XGOJA-V2-RUNTIME-001
 Status: active
-Topics: [xgoja, architecture, code-generation]
+Topics:
+    - xgoja
+    - architecture
+    - code-generation
+DocType: reference
+Intent: ""
+Owners: []
+RelatedFiles:
+    - Path: cmd/xgoja/internal/generate/templates.go
+      Note: Step 3 preserves command sources during current generator bridge (commit 556ed5c)
+    - Path: cmd/xgoja/root_test.go
+      Note: Step 3 generated-binary regression and temporary fixture helper (commit 556ed5c)
+    - Path: pkg/xgoja/app/command_providers.go
+      Note: Step 3 passes filtered source set to provider command contexts (commit 556ed5c)
+    - Path: pkg/xgoja/app/jsverb_sources.go
+      Note: Step 3 command-scoped JS verb source filtering (commit 556ed5c)
+    - Path: pkg/xgoja/app/runtime_spec.go
+      Note: Step 3 interim source IDs on command-provider metadata (commit 556ed5c)
+ExternalSources: []
+Summary: ""
+LastUpdated: 0001-01-01T00:00:00Z
+WhatFor: ""
+WhenToUse: ""
 ---
+
 
 # Diary
 
@@ -293,3 +315,137 @@ The generated metadata currently becomes:
 ```
 
 The missing `sources: ["site-a"]` on the command provider is the data-loss boundary.
+
+## Step 3: Add command-scoped HTTP serve regression coverage and interim source propagation
+
+I turned the ticket reproduction into an active end-to-end regression: a generated xgoja binary now builds with two jsverb sources, mounts the HTTP `serve` provider command with `sources: [site-a]`, and proves the generated CLI exposes only the selected site while still carrying the HTTP serve flags. This gives us a behavior-level guard for the user-visible failure mode before the larger RuntimePlan hard cutover begins.
+
+I also made the smallest runtime-path change needed for that regression to pass: v2 command `sources` are preserved into the current generated command-provider metadata, and provider command contexts receive a filtered JS verb source set. This is deliberately an interim stop on the way to the no-legacy RuntimePlan shape; it fixes the immediate source-loss bug without changing the final hard-cutover requirement.
+
+### Prompt Context
+
+**User prompt (verbatim):** "continue"
+
+**Assistant interpretation:** Continue the xgoja v2 runtime cutover implementation from task 9, adding regression coverage and committing at an appropriate interval.
+
+**Inferred user intent:** Keep advancing the ticket task list one step at a time while preserving a detailed implementation diary and focused commits.
+
+**Commit (code):** 556ed5cb31b55bab893e2e7641a2a7442e3ef2da — "Fix xgoja command-scoped jsverb sources"
+
+### What I did
+
+- Added `TestBuildCommandProviderServeUsesCommandScopedSources` in `cmd/xgoja/root_test.go`.
+- The test builds a generated binary from a temporary xgoja/v2 spec with two jsverb sources and one HTTP `provider.command-set` scoped to `site-a`.
+- The test asserts `scoped-serve serve sitea start --help --long-help` includes `Start A`, `--http-listen`, and `--hot-reload`.
+- The test asserts `scoped-serve serve --help` does not expose `siteb` / `Start B`.
+- Added `Sources []string` to `app.CommandProviderInstanceSpec`.
+- Updated `cmd/xgoja/internal/generate/templates.go` so `applyPlanRuntimeCommand` preserves `command.Sources` for provider command sets.
+- Added `newScopedJSVerbSourceSet` and used it from `Host.newCommandSet` so command providers see only their selected JS verb sources when sources are declared.
+- Marked ticket task 9 complete and updated the ticket changelog.
+
+### Why
+
+- The reproduction script proved metadata data loss, but it did not prove the generated end-user CLI behavior.
+- HTTP `serve` is the real blocked use case for the sessionstream chatbot demo, so the regression needs to verify both jsverb command visibility and HTTP serve flag propagation.
+- The test intentionally uses two sources so global source scanning cannot hide source-scope bugs.
+
+### What worked
+
+- The first version of the test failed before the fix because `site-b` was visible through the HTTP serve command even though the v2 command declared `sources: [site-a]`.
+- After preserving command source IDs and filtering the JS verb source set, the targeted regression passed.
+- The broader focused validation passed:
+
+```text
+go test ./cmd/xgoja ./cmd/xgoja/internal/generate ./pkg/xgoja/app ./pkg/xgoja/providers/http -count=1
+ok  	github.com/go-go-golems/go-go-goja/cmd/xgoja	14.645s
+ok  	github.com/go-go-golems/go-go-goja/cmd/xgoja/internal/generate	0.104s
+ok  	github.com/go-go-golems/go-go-goja/pkg/xgoja/app	0.659s
+ok  	github.com/go-go-golems/go-go-goja/pkg/xgoja/providers/http	0.478s
+```
+
+- The pre-commit hook also ran lint, generation, and `go test ./...` successfully before creating commit `556ed5c`.
+
+### What didn't work
+
+The initial test used provider ID `http`, but the HTTP provider registers itself under package ID `go-go-goja-http`. That produced an error stub instead of real serve subcommands:
+
+```text
+Error: unknown command provider http.serve
+unknown command provider http.serve
+```
+
+After switching the v2 spec provider ID, runtime module provider, and command provider to `go-go-goja-http`, the generated serve commands appeared.
+
+The next version checked short help for `--http-listen`, but Glazed hides detailed flags behind long help. The failure was:
+
+```text
+expected scoped serve help to contain "--http-listen", got:
+# start - Start A
+...
+Use scoped-serve serve sitea start --help --long-help for information about all flags.
+```
+
+I changed the assertion to call `--help --long-help` for the leaf command.
+
+A final test-shape issue was that asking Cobra/Glazed for `serve siteb start --help` returned parent `serve` help rather than a hard error. I changed the negative assertion to inspect `serve --help` and ensure the unselected source is absent from the command tree.
+
+### What I learned
+
+- Provider IDs in xgoja specs must match the provider package ID registered by the provider, not an arbitrary local alias, in the current runtime path.
+- Glazed command help exposes detailed provider-added flags only in long-help output.
+- Behavioral CLI tests are useful but must avoid relying on Cobra's exact unknown-argument error behavior; command-tree visibility is a more stable assertion.
+
+### What was tricky to build
+
+- The runtime bug had two layers: generated metadata dropped `commands[].sources`, and the app runtime gave provider command sets a global JS verb source set. Fixing only one layer was insufficient.
+- The regression needed to prove HTTP serve flag propagation too. That required checking the leaf command's long help, because short help intentionally hides most flags.
+- This fix is intentionally temporary with respect to representation: it extends the legacy bridge enough to preserve source scoping now, but the final ticket still requires replacing `RuntimeSpec`/`CommandProviderInstanceSpec` with the v2-native `RuntimePlan` rather than keeping this shape.
+
+### What warrants a second pair of eyes
+
+- The interim fallback behavior for command providers with no `sources` remains “all JS verb sources”. That preserves current behavior, but the RuntimePlan design should decide whether provider commands should require explicit source selection or keep all-by-kind as a documented default.
+- The test currently verifies command-tree absence via `serve --help`; reviewers should confirm this is the most robust user-visible assertion for Glazed/Cobra command mounting.
+- The generated metadata still uses legacy fields (`commandProviders`, top-level `jsverbs`, `packages`). This is expected for this step only and must be removed in later hard-cutover tasks.
+
+### What should be done in the future
+
+- Task 10 should add a generated metadata guard that fails while legacy top-level runtime fields remain.
+- The upcoming RuntimePlan implementation should replace this interim `Sources` field on `CommandProviderInstanceSpec` with a v2-native command/source representation.
+- Provider command context should eventually carry command identity and a unified source registry, not just the legacy `JSVerbSourceSet` adapter.
+
+### Code review instructions
+
+- Start with `cmd/xgoja/root_test.go`, especially `TestBuildCommandProviderServeUsesCommandScopedSources` and `writeHTTPServeScopedSourcesSpec`.
+- Then review `cmd/xgoja/internal/generate/templates.go` at `applyPlanRuntimeCommand` to confirm v2 command sources are preserved.
+- Then review `pkg/xgoja/app/command_providers.go` and `pkg/xgoja/app/jsverb_sources.go` to confirm provider command contexts receive filtered sources.
+- Validate with:
+
+```bash
+go test ./cmd/xgoja ./cmd/xgoja/internal/generate ./pkg/xgoja/app ./pkg/xgoja/providers/http -count=1
+```
+
+### Technical details
+
+The regression's core v2 command shape is:
+
+```yaml
+commands:
+  - id: serve
+    type: provider.command-set
+    provider: go-go-goja-http
+    name: serve
+    mount: serve
+    sources: [site-a]
+```
+
+The generated binary must expose:
+
+```text
+scoped-serve serve sitea start --help --long-help
+```
+
+and must not expose `siteb` through:
+
+```text
+scoped-serve serve --help
+```

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/reference/01-investigation-diary.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/reference/01-investigation-diary.md
@@ -10,20 +10,29 @@ DocType: reference
 Intent: ""
 Owners: []
 RelatedFiles:
+    - Path: cmd/xgoja/doc
+      Note: Step 8 xgoja RuntimePlan/source-registry docs (commit 5f414bd)
     - Path: cmd/xgoja/internal/generate/generate_test.go
       Note: |-
         Step 4 metadata guard against legacy top-level generated keys (commit 617b977)
         Step 6 workspace.mode:auto replacement regression (commit f09788a)
+        Step 8 generated package legacy-name guard (commit 84a200c)
     - Path: cmd/xgoja/internal/generate/templates.go
       Note: |-
         Step 3 preserves command sources during current generator bridge (commit 556ed5c)
         Step 4 emits v2-native runtime plan JSON (commit 617b977)
     - Path: cmd/xgoja/internal/generate/templates/main.go.tmpl
       Note: Step 4 generated main decodes RuntimePlan (commit 617b977)
+    - Path: cmd/xgoja/internal/generate/templates/runtime_package.go.tmpl
+      Note: Step 8 RuntimePlan runtime-package API (commit 84a200c)
     - Path: cmd/xgoja/root_test.go
       Note: Step 3 generated-binary regression and temporary fixture helper (commit 556ed5c)
+    - Path: examples/xgoja
+      Note: Step 8 affected example README updates (commit 5f414bd)
     - Path: examples/xgoja/13-http-serve-jsverbs/Makefile
       Note: Step 7 runnable HTTP serve smoke target validated (commit 08f1264)
+    - Path: examples/xgoja/14-generated-runtime-package
+      Note: Step 8 regenerated RuntimePlan package example (commit 84a200c)
     - Path: examples/xgoja/14-generated-runtime-package/internal/xgojaruntime/xgoja_runtime.gen.go
       Note: Step 4 checked-in runtime package fixture updated for RuntimePlan (commit 617b977)
     - Path: pkg/xgoja/app/assets.go
@@ -62,6 +71,7 @@ LastUpdated: 0001-01-01T00:00:00Z
 WhatFor: ""
 WhenToUse: ""
 ---
+
 
 
 
@@ -966,4 +976,129 @@ Hot reload uses that same scoped set for every source-derived operation:
 resolveServeHotReloadVerb(jsverbSources, registry, verb, verbPath)
 defaultServeHotReloadWatchRoots(jsverbSources)
 sourceSetHasTypeScript(jsverbSources)
+```
+
+## Step 8: Finish runtime-package and documentation cutover
+
+I completed Phases 7 and 8 of the hard cutover. Generated runtime packages and source fragments now expose the embedded metadata as a v2 runtime plan (`EmbeddedRuntimePlanJSON`, `DecodeRuntimePlan`) instead of using the older generic spec names, while the ergonomic host APIs (`NewBundle`, `Bundle.NewRuntime`, `Bundle.NewRuntimeFromSections`, `AttachDefaultCommands`) remain intact.
+
+I also updated the xgoja help docs and affected example READMEs so the public docs match the current runtime model: generated outputs embed `app.RuntimePlan`, commands are one v2 `commands[]` list, provider commands receive command-scoped `SourceRegistry`, HTTP serve scopes hot reload by command sources, and examples prefer `workspace.mode: auto` over hand-maintained local replacements where the workspace can resolve modules.
+
+### Prompt Context
+
+**User prompt (verbatim):** "ok do 7 and 8. then no legacy at all?"
+
+**Assistant interpretation:** Complete Phase 7 runtime-package cleanup and Phase 8 documentation updates, then clarify whether that eliminates all remaining legacy runtime code.
+
+**Inferred user intent:** Advance the hard cutover through the last planned runtime-package/docs phases before the final no-legacy sweep.
+
+**Commit (code):** 84a200c — "Port generated runtime package API to RuntimePlan"
+
+**Commit (docs):** 5f414bd — "Docs: update xgoja v2 RuntimePlan guide"
+
+### What I did
+
+- Renamed generated runtime-package/source-fragment metadata symbols from `EmbeddedSpecJSON`/`DecodeSpec` to `EmbeddedRuntimePlanJSON`/`DecodeRuntimePlan`.
+- Updated bundle fragments to call `DecodeRuntimePlan`.
+- Added `TestRenderPackagePlanUsesRuntimePlanAPI` to guard generated runtime packages against `EmbeddedSpecJSON`, `DecodeSpec`, and `RuntimeSpec` names.
+- Regenerated `examples/xgoja/14-generated-runtime-package/internal/xgojaruntime/xgoja_runtime.gen.go`; it now embeds `schema: "xgoja/runtime/v2"` with `providers`, `runtime.modules`, `commands`, and `artifacts`.
+- Updated the runtime-package README to document the v2-native API while preserving `NewBundle` and runtime creation APIs as the main host-facing entry points.
+- Updated xgoja overview, user guide, v2 reference, migration guide, provider runtime config docs, protobuf tutorial, and example READMEs for RuntimePlan, command-scoped SourceRegistry, HTTP serve troubleshooting, and workspace-mode guidance.
+- Checked tasks 40-48 and updated the ticket changelog.
+
+### Why
+
+- Phase 7 needed generated package internals to stop looking like generic/legacy runtime specs and instead advertise the RuntimePlan model directly.
+- Phase 8 needed the docs to stop describing older runtime concepts as current behavior and to make command-scoped sources/provider APIs clear for future provider authors.
+- The user asked whether this means no legacy remains; completing docs and runtime-package cleanup makes the remaining legacy much easier to isolate in Phase 10.
+
+### What worked
+
+- Focused tests passed:
+
+```bash
+go test ./cmd/xgoja/internal/generate ./examples/xgoja/14-generated-runtime-package/cmd/host ./pkg/xgoja/app ./pkg/xgoja/providers/http -count=1
+```
+
+- Runtime-package smoke passed:
+
+```bash
+cd examples/xgoja/14-generated-runtime-package && make smoke
+```
+
+- Help pages rendered successfully:
+
+```bash
+go run ./cmd/xgoja help overview
+go run ./cmd/xgoja help user-guide
+go run ./cmd/xgoja help xgoja-v2-reference
+go run ./cmd/xgoja help migrating-to-xgoja-v2
+go run ./cmd/xgoja help provider-runtime-config-and-host-services
+go run ./cmd/xgoja help tutorial-protobuf-builder-provider
+```
+
+- The pre-commit hook for commit `84a200c` passed lint, `go generate ./...`, and `go test ./...`.
+
+### What didn't work
+
+N/A. The runtime-package generation and docs updates applied cleanly.
+
+### What I learned
+
+- The checked-in runtime-package example was still the most visible stale generated output: it decoded a RuntimePlan type, but embedded legacy-shaped JSON and exported legacy-style symbol names.
+- The docs had a mix of current v2 content and older terminology. Updating overview/reference/example snippets together prevents future readers from copying stale `modules`, `jsverbs`, or local-replace patterns.
+- Phases 7 and 8 do not remove every active legacy compatibility path by themselves; they prepare for the Phase 10 removal sweep.
+
+### What was tricky to build
+
+- The generated runtime-package API needed a hard-cutover name change without making host integration awkward. Keeping `NewBundle` and `Bundle.NewRuntime` stable gives host applications a simple path while direct metadata users now see RuntimePlan-specific names.
+- Some docs intentionally mention legacy keys in migration tables. Those references are allowed historical/migration context, but they should not be confused with active runtime API names.
+- Example README snippets had to be updated from old `jsverbs:`/`assets:` examples to v2 `sources[]` plus `artifacts[].sources` without changing the actual examples' behavior.
+
+### What warrants a second pair of eyes
+
+- Review whether removing `DecodeSpec` is acceptable as a generated package API break. It matches the hard-cutover requirement, but downstream generated-package embedders may need a compile-time migration.
+- Review the docs for any remaining stale wording that implies top-level `modules`, `packages`, or `jsverbs` are active v2 fields rather than migration examples.
+- Confirm whether historical docs in older tickets should remain untouched; I intentionally did not rewrite archived `ttmp` documents.
+
+### What should be done in the future
+
+- Phase 9 sessionstream work remains deferred by prior instruction.
+- Phase 10 must remove active compatibility DTO fields/decode paths and add grep/guard coverage for remaining allowed historical references.
+- Final validation and reMarkable upload remain outstanding.
+
+### Code review instructions
+
+- Start with `cmd/xgoja/internal/generate/templates/runtime_package.go.tmpl`, `spec_fragment.go.tmpl`, and `bundle_fragment.go.tmpl` to review generated API changes.
+- Review `examples/xgoja/14-generated-runtime-package/internal/xgojaruntime/xgoja_runtime.gen.go` to confirm the embedded JSON shape is RuntimePlan-native.
+- Review `cmd/xgoja/doc/17-xgoja-v2-reference.md`, `cmd/xgoja/doc/11-provider-runtime-config-and-host-services.md`, and `cmd/xgoja/doc/16-migrating-to-xgoja-v2.md` for user-facing semantics.
+- Validate with:
+
+```bash
+go test ./cmd/xgoja/internal/generate ./examples/xgoja/14-generated-runtime-package/cmd/host ./pkg/xgoja/app ./pkg/xgoja/providers/http -count=1
+cd examples/xgoja/14-generated-runtime-package && make smoke
+go run ./cmd/xgoja help xgoja-v2-reference >/tmp/xgoja-help-v2-reference.txt
+```
+
+### Technical details
+
+Generated runtime package metadata access now looks like:
+
+```go
+const EmbeddedRuntimePlanJSON = `{ ... }`
+
+func DecodeRuntimePlan() (*app.RuntimePlan, error) {
+    runtimePlan := &app.RuntimePlan{}
+    if err := json.Unmarshal([]byte(EmbeddedRuntimePlanJSON), runtimePlan); err != nil {
+        return nil, err
+    }
+    return runtimePlan, nil
+}
+```
+
+The preferred host entry point remains:
+
+```go
+bundle, err := xgojaruntime.NewBundle(xgojaruntime.Options{})
+rt, err := bundle.NewRuntime(ctx)
 ```

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/reference/01-investigation-diary.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/reference/01-investigation-diary.md
@@ -48,13 +48,19 @@ RelatedFiles:
     - Path: pkg/xgoja/app/framework.go
       Note: Step 6 help loading through SourceRegistry kind=help (commit f09788a)
     - Path: pkg/xgoja/app/host.go
-      Note: Step 6 SourceRegistry ownership and CommandPlan dispatch loop (commit f09788a)
+      Note: |-
+        Step 6 SourceRegistry ownership and CommandPlan dispatch loop (commit f09788a)
+        Step 12 builtin jsverb commands use command-scoped source registries (commit bf81e9f)
     - Path: pkg/xgoja/app/jsverb_sources.go
       Note: Step 3 command-scoped JS verb source filtering (commit 556ed5c)
     - Path: pkg/xgoja/app/root.go
-      Note: Step 6 JS verb scanning via SourceRegistry (commit f09788a)
+      Note: |-
+        Step 6 JS verb scanning via SourceRegistry (commit f09788a)
+        Step 12 jsverb command construction receives the selected CommandPlan (commit bf81e9f)
     - Path: pkg/xgoja/app/root_test.go
-      Note: Step 9 active app tests converted to RuntimePlan JSON (commit 207bead)
+      Note: |-
+        Step 9 active app tests converted to RuntimePlan JSON (commit 207bead)
+        Step 12 builtin jsverb source isolation regressions (commit bf81e9f)
     - Path: pkg/xgoja/app/runtime_plan.go
       Note: Step 9 RuntimePlan-only DTO and removed-key rejection (commit 207bead)
     - Path: pkg/xgoja/app/runtime_spec.go
@@ -62,7 +68,11 @@ RelatedFiles:
         Step 3 interim source IDs on command-provider metadata (commit 556ed5c)
         Step 4 v2 RuntimePlan DTO and transitional decode path (commit 617b977)
     - Path: pkg/xgoja/app/source_registry.go
-      Note: Step 5 runtime SourceRegistry implementation (commit 8bcc367)
+      Note: |-
+        Step 5 runtime SourceRegistry implementation (commit 8bcc367)
+        Step 12 empty command source scopes stay empty (commit bf81e9f)
+    - Path: pkg/xgoja/app/source_registry_test.go
+      Note: Step 12 empty and explicit SourceRegistry scoping regressions (commit bf81e9f)
     - Path: pkg/xgoja/providerapi/commands.go
       Note: |-
         Step 5 CommandSetContext carries SourceRegistry (commit 8bcc367)
@@ -79,6 +89,7 @@ LastUpdated: 0001-01-01T00:00:00Z
 WhatFor: ""
 WhenToUse: ""
 ---
+
 
 
 
@@ -1439,4 +1450,97 @@ The uploaded bundle path is:
 
 ```text
 /ai/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001/GOJA XGOJA V2 Runtime Cutover Final.pdf
+```
+
+## Step 12: Address PR review source-scope isolation comments
+
+I addressed the PR #76 review comments about source scope isolation. The changes make an empty command source scope stay empty, and make `builtin.jsverbs` use the current `CommandPlan` when constructing verb commands instead of re-reading the first jsverbs command and using the host-wide source registry.
+
+The implementation closes two command isolation gaps: provider command sets with omitted `sources` no longer see every runtime source, and built-in jsverb commands that declare `sources: [...]` no longer expose unrelated jsverb source roots under either nested or root-mounted command layouts.
+
+### Prompt Context
+
+**User prompt (verbatim):** "Address the code review comments in https://github.com/go-go-golems/go-go-goja/pull/76"
+
+**Assistant interpretation:** Fetch the PR review comments, fix the reported command-source scoping bugs, validate the fix, commit it, and leave explanatory PR review comments.
+
+**Inferred user intent:** Make PR #76 review-ready by addressing the concrete isolation concerns raised by automated code review.
+
+**Commit (code):** bf81e9f — "Fix xgoja command source scoping"
+
+### What I did
+
+- Fetched PR #76 review comments with `gh pr view` and `gh api repos/go-go-golems/go-go-goja/pulls/76/comments`.
+- Removed the `SourceRegistry.Scoped(nil)` fallback that previously returned every runtime source.
+- Routed `builtin.jsverbs` attachment through the current `CommandPlan` so `commands[].sources` is honored for both normal `verbs ...` mounting and `mount: root` mounting.
+- Updated `newVerbsCommand` to receive the already-selected jsverbs `CommandPlan` instead of looking up the first jsverbs command again.
+- Added regression tests for:
+  - empty scoped source registries staying empty;
+  - provider command sets receiving an empty registry when `sources` is omitted;
+  - `builtin.jsverbs` exposing only selected source IDs for both nested and root-mounted commands.
+
+### Why
+
+- PR review correctly identified that an omitted source list should not implicitly grant access to every runtime source.
+- The v2 command contract says source visibility is command-scoped and explicit. Commands that should see multiple sources must list those source IDs.
+
+### What worked
+
+- The scoping fix is small because `SourceRegistry.Scoped` already centralizes command source filtering.
+- Passing the current `CommandPlan` into jsverb command construction lets both root-mounted and nested jsverb commands share the same filtered registry.
+- Validation passed:
+
+```bash
+go test ./pkg/xgoja/app -count=1
+go test ./cmd/xgoja ./cmd/xgoja/internal/generate ./pkg/xgoja/app ./pkg/xgoja/providerapi ./pkg/xgoja/providers/http -count=1
+go test ./cmd/xgoja/internal/... ./cmd/xgoja ./pkg/xgoja/... -count=1
+```
+
+The pre-commit hook also passed lint, `go generate ./...`, and `go test ./...` during commit `bf81e9f`.
+
+### What didn't work
+
+- The first version of the builtin jsverb regression tried to assert hidden commands by executing an invalid command and expecting an error. Cobra printed `unknown command "admin"`, but `ExecuteContext` returned nil in one test layout, so the assertion was not reliable.
+- I changed the test to inspect the Cobra command tree directly with `cobraCommandPathExists`, then still execute the selected public command as a positive runtime check.
+
+### What I learned
+
+- Command isolation needs two separate protections: source registry scoping itself, and ensuring every command builder receives the scoped registry for the current `CommandPlan`.
+- Cobra command tree inspection is a better negative assertion than relying on execution errors for hidden command paths.
+
+### What was tricky to build
+
+- `AttachVerbs` historically re-fetched the first `builtin.jsverbs` command from the runtime plan. That erased the current command instance passed through `AttachCommandPlan`, including its `sources` list. The fix was to keep `AttachVerbs` as the public fallback helper but introduce an internal `attachVerbCommandPlan` path that receives the exact command plan being attached.
+- `SourceRegistry.Scoped` previously treated `len(sourceIDs) == 0` as global access. That was convenient for legacy behavior but contradicted explicit command isolation. Removing that branch changed the default from ambient access to no access.
+
+### What warrants a second pair of eyes
+
+- Confirm that any command intentionally needing all sources now explicitly lists them in generated RuntimePlan output or input `xgoja.yaml`.
+- Review the new negative command-tree test helper to ensure it matches how Glazed/Cobra mounts generated verb commands.
+
+### What should be done in the future
+
+- If a future feature wants an explicit all-sources behavior, add a named syntax for it instead of overloading an omitted `sources` list.
+
+### Code review instructions
+
+- Start with `pkg/xgoja/app/source_registry.go` and `pkg/xgoja/app/host.go`.
+- Review regression coverage in `pkg/xgoja/app/source_registry_test.go`, `pkg/xgoja/app/command_providers_test.go`, and `pkg/xgoja/app/root_test.go`.
+- Re-run:
+
+```bash
+go test ./cmd/xgoja/internal/... ./cmd/xgoja ./pkg/xgoja/... -count=1
+```
+
+### Technical details
+
+The PR comments addressed were:
+
+- `pkg/xgoja/app/source_registry.go`: keep empty command source scopes empty.
+- `pkg/xgoja/app/host.go`: scope builtin jsverb commands to their source list.
+
+Follow-up prompt handled after implementation:
+
+```text
+put review comments when done to explain what you did
 ```

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/reference/01-investigation-diary.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/reference/01-investigation-diary.md
@@ -11,7 +11,9 @@ Intent: ""
 Owners: []
 RelatedFiles:
     - Path: cmd/xgoja/internal/generate/generate_test.go
-      Note: Step 4 metadata guard against legacy top-level generated keys (commit 617b977)
+      Note: |-
+        Step 4 metadata guard against legacy top-level generated keys (commit 617b977)
+        Step 6 workspace.mode:auto replacement regression (commit f09788a)
     - Path: cmd/xgoja/internal/generate/templates.go
       Note: |-
         Step 3 preserves command sources during current generator bridge (commit 556ed5c)
@@ -22,14 +24,22 @@ RelatedFiles:
       Note: Step 3 generated-binary regression and temporary fixture helper (commit 556ed5c)
     - Path: examples/xgoja/14-generated-runtime-package/internal/xgojaruntime/xgoja_runtime.gen.go
       Note: Step 4 checked-in runtime package fixture updated for RuntimePlan (commit 617b977)
+    - Path: pkg/xgoja/app/assets.go
+      Note: Step 6 asset setup through SourceRegistry kind=assets (commit f09788a)
     - Path: pkg/xgoja/app/command_providers.go
       Note: |-
         Step 3 passes filtered source set to provider command contexts (commit 556ed5c)
         Step 5 provider command contexts receive scoped source registries (commit 8bcc367)
     - Path: pkg/xgoja/app/command_providers_test.go
       Note: Step 5 scoped source registry regression coverage (commit 8bcc367)
+    - Path: pkg/xgoja/app/framework.go
+      Note: Step 6 help loading through SourceRegistry kind=help (commit f09788a)
+    - Path: pkg/xgoja/app/host.go
+      Note: Step 6 SourceRegistry ownership and CommandPlan dispatch loop (commit f09788a)
     - Path: pkg/xgoja/app/jsverb_sources.go
       Note: Step 3 command-scoped JS verb source filtering (commit 556ed5c)
+    - Path: pkg/xgoja/app/root.go
+      Note: Step 6 JS verb scanning via SourceRegistry (commit f09788a)
     - Path: pkg/xgoja/app/runtime_spec.go
       Note: |-
         Step 3 interim source IDs on command-provider metadata (commit 556ed5c)
@@ -46,6 +56,7 @@ LastUpdated: 0001-01-01T00:00:00Z
 WhatFor: ""
 WhenToUse: ""
 ---
+
 
 
 
@@ -714,4 +725,124 @@ ctx.Sources.SourceByID("site-a") // true
 ctx.Sources.SourceByID("site-b") // false
 ctx.Sources.ListSourcesByKind(providerapi.RuntimeSourceKindJSVerbs) // only site-a
 ctx.JSVerbs.ListJSVerbSources() // only site-a
+```
+
+## Step 6: Finish requested Phase 2–4 RuntimePlan source consumer cleanup
+
+I completed the requested Phase 2 cleanup, Phase 3 source-registry consumer migration, and Phase 4 runtime app cleanup slice. The runtime host now owns a `SourceRegistry`, JS verb command construction scans through that registry, help and asset setup consume registry-filtered source descriptors, and default command attachment goes through a single `CommandPlan` dispatch loop.
+
+I also added a workspace module replacement regression so `workspace.mode:auto` behavior stays tied to the planner's `GoModules` output instead of requiring provider-local `module.replace` entries in specs. This keeps the generated app path aligned with the intended v2 workspace behavior.
+
+### Prompt Context
+
+**User prompt (verbatim):** "do these:  - Phase 2 cleanup                                                                                                                                                 \n     - Task 20: Verify workspace.mode:auto / plan.GoModules still avoids unnecessary provider replace entries.                                                     \n - Phase 3 source registry completion                                                                                                                              \n     - Task 23: Port JS verb scanning to use SourceRegistry handles directly.                                                                                      \n     - Task 24: Port help loading to SourceRegistry kind=help.                                                                                                     \n     - Task 25: Port asset resolution to SourceRegistry kind=assets.                                                                                                \n - Phase 4 runtime app cleanup                                                                                                                                     \n     - Task 27: Confirm NewRootCommand / NewHost are fully RuntimePlan-based and remove old RuntimeSpec dependency.                                                \n     - Task 28: Confirm runtime factory uses RuntimePlan.Runtime.Modules.                                                                                          \n     - Task 29: Rewrite built-in and provider command attachment as one loop over []CommandPlan.                                                                    \n     - Task 30: Preserve/test root vs nested CLI mount semantics.                                                                                                  \n     - Task 31: Confirm framework/help/logging config uses RuntimePlan.App."
+
+**Assistant interpretation:** Implement and validate the next listed cleanup tasks across generation, source consumers, host command attachment, and RuntimePlan app wiring.
+
+**Inferred user intent:** Keep pushing the hard cutover forward in go-go-goja before returning to sessionstream.
+
+**Commit (code):** f09788a — "Finish RuntimePlan source consumer cleanup"
+
+### What I did
+
+- Updated `TestRenderGoModPlanUsesWorkspaceModulePlan` so a provider import under a workspace-local module uses the planner's `GoModules` replacement and does not need a provider `module.replace` entry.
+- Added `Host.SourceRegistry` and build it in `NewHostWithOptions` from `RuntimePlan` sources.
+- Changed JS verb command construction to scan through `SourceRegistry` instead of directly iterating `RuntimePlan` sources.
+- Changed `verbs sources` listing to use `SourceRegistry.ListSourcesByKind(jsverbs)`.
+- Changed help loading to prefer `SourceRegistry.ListSourcesByKind(help)`.
+- Changed asset store setup to use `SourceRegistry.ListSourcesByKind(assets)`.
+- Reworked `AttachDefaultCommands` to iterate `RuntimePlan.runtimeCommands()` and dispatch through `AttachCommandPlan` for built-in and provider commands.
+- Marked tasks 20, 23, 24, 25, 27, 28, 29, 30, and 31 complete.
+
+### Why
+
+- The previous step introduced `SourceRegistry`, but several consumers still read source slices directly from `RuntimePlan`.
+- A hard cutover needs a single runtime plan path: host setup, source lookup, and command attachment should all flow from RuntimePlan concepts.
+- The command dispatch loop makes `[]CommandPlan` the active command representation rather than treating provider commands as a separate attach phase.
+
+### What worked
+
+- Focused validation passed:
+
+```text
+go test ./cmd/xgoja ./cmd/xgoja/internal/generate ./pkg/xgoja/app ./pkg/xgoja/providerapi ./pkg/xgoja/providers/http -count=1
+```
+
+- The pre-commit hook passed lint, `go generate ./...`, and `go test ./...` before commit `f09788a` landed.
+
+### What didn't work
+
+The first build after changing JS verb scanning failed because a local variable named `jsverbs` shadowed the imported `jsverbs` package in `root.go`:
+
+```text
+pkg/xgoja/app/root.go:296:94: jsverbs.Registry is not a type
+pkg/xgoja/app/root.go:296:118: jsverbs.VerbSpec is not a type
+```
+
+I renamed the local variable to `jsverbSources`.
+
+The first asset-store refactor also passed `[]SourcePlan` to a function that expected provider-facing descriptors:
+
+```text
+cannot use runtimePlan.sourcesByKind(SourceKindAssets) (value of type []SourcePlan) as []providerapi.RuntimeSourceDescriptor value in argument to NewAssetStoreFromSources
+```
+
+I changed `NewAssetStore` to construct a `SourceRegistry` and request asset descriptors from it.
+
+### What I learned
+
+- Once `SourceRegistry` exists at `Host`, the runtime consumers become simpler: each subsystem asks for a source kind instead of knowing the RuntimePlan layout.
+- `go test ./...` through the pre-commit hook remains useful because generated fixtures and example packages catch stale template/runtime assumptions.
+- The command loop can coexist with the older explicit `AttachEval`/`AttachRun` methods, but `AttachDefaultCommands` no longer needs separate built-in/provider phases.
+
+### What was tricky to build
+
+- The migration still has transitional compatibility fields in `RuntimePlan`, so source consumers must avoid accidentally depending on them directly. Routing through `SourceRegistry` helps isolate that compatibility normalization.
+- Help and asset sources have different embedded filesystems from JS verbs, so the registry exposes descriptors while the actual embedded FS remains owned by the subsystem (`EmbeddedHelp`, `EmbeddedAssets`).
+- The command dispatch loop had to preserve existing root-mounted JS verb semantics and provider mount semantics while changing attachment order.
+
+### What warrants a second pair of eyes
+
+- The `AttachDefaultCommands` ordering now follows `runtimeCommands()` order for configured commands, then adds utility commands (`modules`, `selected-modules`, `types`). Reviewers should confirm this is acceptable for generated CLIs.
+- Help and asset loading use registry descriptors but still rely on their subsystem-specific embedded FS values. That is intentional, but worth checking for provider-source edge cases.
+- Task 30 is satisfied by existing root/nested JS verb mount tests plus the preserved dispatch behavior; a future cleanup could add a new pure-v2 JSON mount test after compatibility fields are removed.
+
+### What should be done in the future
+
+- Remove the remaining transitional compatibility fields/decode paths from `RuntimePlan`.
+- Update HTTP serve to consume `ctx.Sources` directly instead of the JSVerb adapter.
+- Continue with providerutil/runtime initializer cleanup and docs.
+
+### Code review instructions
+
+- Start with `pkg/xgoja/app/host.go` to review SourceRegistry ownership and the `AttachCommandPlan` loop.
+- Review `pkg/xgoja/app/root.go` for JS verb scanning through SourceRegistry.
+- Review `pkg/xgoja/app/framework.go` and `pkg/xgoja/app/assets.go` for help/assets source kind migration.
+- Review `cmd/xgoja/internal/generate/generate_test.go` for workspace-mode replacement coverage.
+- Validate with:
+
+```bash
+go test ./cmd/xgoja ./cmd/xgoja/internal/generate ./pkg/xgoja/app ./pkg/xgoja/providerapi ./pkg/xgoja/providers/http -count=1
+go test ./... -count=1
+```
+
+### Technical details
+
+`AttachDefaultCommands` now follows this pattern:
+
+```go
+for _, command := range h.RuntimePlan.runtimeCommands() {
+    h.AttachCommandPlan(root, command)
+}
+h.AttachModules(root)
+h.AttachSelectedModules(root)
+h.AttachTypes(root)
+```
+
+Source consumers now request source descriptors by kind from the host registry:
+
+```go
+sourceRegistry.ListSourcesByKind(providerapi.RuntimeSourceKindJSVerbs)
+sourceRegistry.ListSourcesByKind(providerapi.RuntimeSourceKindHelp)
+sourceRegistry.ListSourcesByKind(providerapi.RuntimeSourceKindAssets)
 ```

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/scripts/01-reproduce-provider-command-source-loss.sh
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/scripts/01-reproduce-provider-command-source-loss.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../../.." && pwd)"
+cd "$repo_root"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/site-a" "$tmp/site-b" "$tmp/build"
+
+cat > "$tmp/site-a/a.js" <<'JS'
+__package__({ name: "sitea" })
+__verb__("serve", { name: "serve", output: "text", short: "Serve A" })
+function serve() { return "a" }
+JS
+
+cat > "$tmp/site-b/b.js" <<'JS'
+__package__({ name: "siteb" })
+__verb__("serve", { name: "serve", output: "text", short: "Serve B" })
+function serve() { return "b" }
+JS
+
+cat > "$tmp/xgoja.yaml" <<YAML
+schema: xgoja/v2
+name: source-loss-repro
+go:
+  module: xgoja.generated/source-loss-repro
+  version: "1.26"
+workspace:
+  mode: auto
+providers:
+  - id: http
+    import: github.com/go-go-golems/go-go-goja/pkg/xgoja/providers/http
+runtime:
+  modules:
+    - provider: http
+      name: express
+sources:
+  - id: site-a
+    kind: jsverbs
+    from:
+      dir: $tmp/site-a
+    language: javascript
+  - id: site-b
+    kind: jsverbs
+    from:
+      dir: $tmp/site-b
+    language: javascript
+commands:
+  - id: serve
+    type: provider.command-set
+    provider: http
+    name: serve
+    mount: serve
+    sources: [site-a]
+artifacts:
+  - id: binary
+    type: binary
+    output: $tmp/source-loss-repro
+    sources: [site-a, site-b]
+YAML
+
+GOWORK=off go run ./cmd/xgoja build -f "$tmp/xgoja.yaml" --work-dir "$tmp/build" --xgoja-replace "$repo_root" --keep-work >/tmp/xgoja-source-loss-build.log
+
+python3 - "$tmp/build/xgoja.gen.json" <<'PY'
+import json, sys
+p = sys.argv[1]
+with open(p) as f:
+    data = json.load(f)
+providers = data.get("commandProviders", [])
+jsverbs = data.get("jsverbs", [])
+if not providers:
+    raise SystemExit("repro failed: generated metadata has no commandProviders")
+provider = providers[0]
+print("generated command provider metadata:", json.dumps(provider, sort_keys=True))
+print("generated top-level jsverb sources:", json.dumps(jsverbs, sort_keys=True))
+if "sources" in provider:
+    raise SystemExit("unexpected: command provider already preserves sources")
+ids = sorted(s.get("id") for s in jsverbs)
+if ids != ["site-a", "site-b"]:
+    raise SystemExit(f"unexpected jsverb source ids: {ids}")
+print("OK: reproduced source loss: command sources [site-a] were dropped, while both jsverb sources remain global")
+PY

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/tasks.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/tasks.md
@@ -45,12 +45,12 @@
 - [x] Phase 7: Port generated runtime-package artifacts to RuntimePlan and remove legacy RuntimeSpec from generated package internals
 - [x] Phase 7: Update examples/xgoja/14-generated-runtime-package and its host code/tests for the v2-native runtime plan
 - [x] Phase 7: Ensure runtime-package public APIs such as NewBundle/NewRuntime remain ergonomic while internals no longer load legacy metadata
-- [ ] Phase 8: Update xgoja user guide to describe the v2-native runtime plan and command-scoped sources
-- [ ] Phase 8: Update xgoja v2 reference to make providers/runtime.modules/sources/commands/artifacts the authoritative runtime concepts
-- [ ] Phase 8: Update migrating-to-xgoja-v2 guide to document the hard runtime cutover and remove legacy bridge language
-- [ ] Phase 8: Update provider runtime config and host services docs for the new CommandSetContext/source registry API
-- [ ] Phase 8: Update protobuf builder provider tutorial and all affected xgoja example READMEs/YAML files to remove unnecessary replace entries where workspace.mode:auto works
-- [ ] Phase 8: Add a troubleshooting section for provider.command-set sources, CLI mount vs HTTP mount, and workspace module resolution
+- [x] Phase 8: Update xgoja user guide to describe the v2-native runtime plan and command-scoped sources
+- [x] Phase 8: Update xgoja v2 reference to make providers/runtime.modules/sources/commands/artifacts the authoritative runtime concepts
+- [x] Phase 8: Update migrating-to-xgoja-v2 guide to document the hard runtime cutover and remove legacy bridge language
+- [x] Phase 8: Update provider runtime config and host services docs for the new CommandSetContext/source registry API
+- [x] Phase 8: Update protobuf builder provider tutorial and all affected xgoja example READMEs/YAML files to remove unnecessary replace entries where workspace.mode:auto works
+- [x] Phase 8: Add a troubleshooting section for provider.command-set sources, CLI mount vs HTTP mount, and workspace module resolution
 - [ ] Phase 9: Finish the real sessionstream goja-chatdemo-server xgoja app after provider command sources work end-to-end
 - [ ] Phase 9: Add a smoke test that builds the xgoja chatbot binary, starts HTTP serve, connects a WebSocket client, posts /api/chat, and receives assistant UI events
 - [ ] Phase 9: Decide whether the chatbot server example belongs in sessionstream examples, go-go-goja examples, or both with cross-references

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/tasks.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/tasks.md
@@ -20,7 +20,7 @@
 - [ ] Phase 1: Represent all runtime sources as []SourcePlan with kind/origin metadata instead of separate jsverbs/help/assets buckets
 - [x] Phase 1: Add JSON encode/decode tests for RuntimePlan including command sources, modules, config, lazy, and embedded source origins
 - [x] Phase 2: Rewrite cmd/xgoja/internal/generate runtime metadata rendering to emit xgoja.v2.runtime.json in v2-native shape
-- [ ] Phase 2: Remove applyPlanRuntimeCommand and the v2-to-legacy runtime source conversion helpers from generator code
+- [x] Phase 2: Remove applyPlanRuntimeCommand and the v2-to-legacy runtime source conversion helpers from generator code
 - [x] Phase 2: Update generated main.go templates to load RuntimePlan instead of RuntimeSpec and to embed v2 runtime plan JSON
 - [x] Phase 2: Ensure generated Go module replacement behavior still uses workspace.mode:auto and plan.GoModules without requiring provider.module.replace in examples
 - [x] Phase 2: Add golden tests for generated main.go and runtime plan JSON for binary artifacts
@@ -37,11 +37,11 @@
 - [x] Phase 5: Change providerapi.CommandSetContext to carry v2 command ID, provider, name, mount, config, selected modules, and command-scoped source registry
 - [x] Phase 5: Provide a JSVerbSourceSet adapter derived from the command-scoped SourceRegistry for providers that consume jsverb sources
 - [x] Phase 5: Update provider command-set tests so command providers receive only the sources declared on their command
-- [ ] Phase 5: Update providerutil/runtime initializer paths to work with RuntimeModulePlan descriptors after the cutover
-- [ ] Phase 6: Update pkg/xgoja/providers/http serve command to consume command-scoped jsverb sources and fail clearly when no sources are configured
-- [ ] Phase 6: Update HTTP serve hot-reload to re-scan and watch only command-scoped jsverb sources
-- [ ] Phase 6: Add/repair smoke tests for examples/xgoja/13-http-serve-jsverbs using provider.command-set sources and --http-listen
-- [ ] Phase 6: Validate app.mount documentation examples still work with the updated HTTP provider runtime setup
+- [x] Phase 5: Update providerutil/runtime initializer paths to work with RuntimeModulePlan descriptors after the cutover
+- [x] Phase 6: Update pkg/xgoja/providers/http serve command to consume command-scoped jsverb sources and fail clearly when no sources are configured
+- [x] Phase 6: Update HTTP serve hot-reload to re-scan and watch only command-scoped jsverb sources
+- [x] Phase 6: Add/repair smoke tests for examples/xgoja/13-http-serve-jsverbs using provider.command-set sources and --http-listen
+- [x] Phase 6: Validate app.mount documentation examples still work with the updated HTTP provider runtime setup
 - [ ] Phase 7: Port generated runtime-package artifacts to RuntimePlan and remove legacy RuntimeSpec from generated package internals
 - [ ] Phase 7: Update examples/xgoja/14-generated-runtime-package and its host code/tests for the v2-native runtime plan
 - [ ] Phase 7: Ensure runtime-package public APIs such as NewBundle/NewRuntime remain ergonomic while internals no longer load legacy metadata

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/tasks.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/tasks.md
@@ -11,7 +11,7 @@
 - [x] Validate docs and upload bundle to reMarkable
 - [x] Phase 0: Create a dedicated implementation branch for the xgoja v2 runtime hard cutover and record the baseline commit/test state
 - [x] Phase 0: Reproduce the provider.command-set sources bug with a minimal xgoja/v2 fixture that uses sources: [sites]
-- [ ] Phase 0: Add a failing test proving generated serve commands expose jsverb subcommands and HTTP serve flags when command sources are declared
+- [x] Phase 0: Add a failing test proving generated serve commands expose jsverb subcommands and HTTP serve flags when command sources are declared
 - [ ] Phase 0: Add a generated-runtime metadata assertion that v2 output must not contain legacy commandProviders/packages/jsverbs top-level fields
 - [ ] Phase 0: Inventory all active references to RuntimeSpec, PackageSpec, CommandsSpec, CommandProviderInstanceSpec, JSVerbSourceSpec, HelpSourceSpec, AssetSourceSpec, and xgoja.gen.json
 - [ ] Phase 1: Design and implement app.RuntimePlan with v2-native AppPlan, RuntimeSection, RuntimeModulePlan, SourcePlan, CommandPlan, and ConfigFilePlan types

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/tasks.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/tasks.md
@@ -57,7 +57,7 @@
 - [x] Phase 10: Remove or rename all active legacy runtime DTO names and fail CI if generated v2 output reintroduces commandProviders/packages/jsverbs legacy fields
 - [x] Phase 10: Run rg-based removal sweep and document any remaining allowed historical references in tests or migration docs
 - [x] Phase 10: Run full validation: go test ./cmd/xgoja/... ./pkg/xgoja/... ./pkg/gojahttp ./modules/express -count=1 and go test ./... -count=1
-- [ ] Phase 10: Run all xgoja example smoke tests affected by runtime generation and update any stale fixtures/goldens
-- [ ] Phase 10: Run doc/help validation for xgoja docs and verify migration guide/help pages are discoverable through xgoja help
-- [ ] Phase 10: Update ticket diary/changelog with implementation commits, validation commands, failures, and follow-up risks
+- [x] Phase 10: Run all xgoja example smoke tests affected by runtime generation and update any stale fixtures/goldens
+- [x] Phase 10: Run doc/help validation for xgoja docs and verify migration guide/help pages are discoverable through xgoja help
+- [x] Phase 10: Update ticket diary/changelog with implementation commits, validation commands, failures, and follow-up risks
 - [ ] Phase 10: Upload final implementation/reference bundle to reMarkable after docs and tests pass

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/tasks.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/tasks.md
@@ -42,9 +42,9 @@
 - [x] Phase 6: Update HTTP serve hot-reload to re-scan and watch only command-scoped jsverb sources
 - [x] Phase 6: Add/repair smoke tests for examples/xgoja/13-http-serve-jsverbs using provider.command-set sources and --http-listen
 - [x] Phase 6: Validate app.mount documentation examples still work with the updated HTTP provider runtime setup
-- [ ] Phase 7: Port generated runtime-package artifacts to RuntimePlan and remove legacy RuntimeSpec from generated package internals
-- [ ] Phase 7: Update examples/xgoja/14-generated-runtime-package and its host code/tests for the v2-native runtime plan
-- [ ] Phase 7: Ensure runtime-package public APIs such as NewBundle/NewRuntime remain ergonomic while internals no longer load legacy metadata
+- [x] Phase 7: Port generated runtime-package artifacts to RuntimePlan and remove legacy RuntimeSpec from generated package internals
+- [x] Phase 7: Update examples/xgoja/14-generated-runtime-package and its host code/tests for the v2-native runtime plan
+- [x] Phase 7: Ensure runtime-package public APIs such as NewBundle/NewRuntime remain ergonomic while internals no longer load legacy metadata
 - [ ] Phase 8: Update xgoja user guide to describe the v2-native runtime plan and command-scoped sources
 - [ ] Phase 8: Update xgoja v2 reference to make providers/runtime.modules/sources/commands/artifacts the authoritative runtime concepts
 - [ ] Phase 8: Update migrating-to-xgoja-v2 guide to document the hard runtime cutover and remove legacy bridge language

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/tasks.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/tasks.md
@@ -24,19 +24,19 @@
 - [x] Phase 2: Update generated main.go templates to load RuntimePlan instead of RuntimeSpec and to embed v2 runtime plan JSON
 - [ ] Phase 2: Ensure generated Go module replacement behavior still uses workspace.mode:auto and plan.GoModules without requiring provider.module.replace in examples
 - [x] Phase 2: Add golden tests for generated main.go and runtime plan JSON for binary artifacts
-- [ ] Phase 3: Implement a unified runtime SourceRegistry that resolves sources by ID and filters by source kind
+- [x] Phase 3: Implement a unified runtime SourceRegistry that resolves sources by ID and filters by source kind
 - [ ] Phase 3: Port JS verb scanning to use SourceRegistry handles while preserving TypeScript compile/bundle options and runtime module externals
 - [ ] Phase 3: Port help loading to use SourceRegistry kind=help instead of legacy HelpSpec sources
 - [ ] Phase 3: Port asset resolution and AssetStore setup to use SourceRegistry kind=assets instead of legacy AssetSourceSpec
-- [ ] Phase 3: Add tests for command-scoped source selection, all-sources-by-kind lookup, embedded source roots, provider sources, and workspace sources
+- [x] Phase 3: Add tests for command-scoped source selection, all-sources-by-kind lookup, embedded source roots, provider sources, and workspace sources
 - [ ] Phase 4: Rewrite app.NewRootCommand/NewHost/NewHostWithOptions to accept RuntimePlan and remove active RuntimeSpec dependency
 - [ ] Phase 4: Rewrite runtime factory module setup to read plan.Runtime.Modules and pass RuntimeModulePlan config to provider module factories
 - [ ] Phase 4: Rewrite built-in command attachment as one loop over []CommandPlan for eval, run, repl, jsverbs, and provider.command-set
 - [ ] Phase 4: Preserve CLI mount semantics for command Mount fields and add tests for root vs nested command mounting
 - [ ] Phase 4: Update generated framework/help/logging installation to use RuntimePlan app/config fields
-- [ ] Phase 5: Change providerapi.CommandSetContext to carry v2 command ID, provider, name, mount, config, selected modules, and command-scoped source registry
-- [ ] Phase 5: Provide a JSVerbSourceSet adapter derived from the command-scoped SourceRegistry for providers that consume jsverb sources
-- [ ] Phase 5: Update provider command-set tests so command providers receive only the sources declared on their command
+- [x] Phase 5: Change providerapi.CommandSetContext to carry v2 command ID, provider, name, mount, config, selected modules, and command-scoped source registry
+- [x] Phase 5: Provide a JSVerbSourceSet adapter derived from the command-scoped SourceRegistry for providers that consume jsverb sources
+- [x] Phase 5: Update provider command-set tests so command providers receive only the sources declared on their command
 - [ ] Phase 5: Update providerutil/runtime initializer paths to work with RuntimeModulePlan descriptors after the cutover
 - [ ] Phase 6: Update pkg/xgoja/providers/http serve command to consume command-scoped jsverb sources and fail clearly when no sources are configured
 - [ ] Phase 6: Update HTTP serve hot-reload to re-scan and watch only command-scoped jsverb sources

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/tasks.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/tasks.md
@@ -1,0 +1,11 @@
+# Tasks
+
+## TODO
+
+- [x] Add tasks here
+
+- [x] Create ticket and initial xgoja v2 runtime cutover docs
+- [x] Gather evidence from specv2, planner, generator, app runtime, provider API, and HTTP serve provider
+- [x] Write intern-facing hard-cutover design and implementation guide
+- [x] Relate key files and update changelog
+- [ ] Validate docs and upload bundle to reMarkable

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/tasks.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/tasks.md
@@ -60,4 +60,4 @@
 - [x] Phase 10: Run all xgoja example smoke tests affected by runtime generation and update any stale fixtures/goldens
 - [x] Phase 10: Run doc/help validation for xgoja docs and verify migration guide/help pages are discoverable through xgoja help
 - [x] Phase 10: Update ticket diary/changelog with implementation commits, validation commands, failures, and follow-up risks
-- [ ] Phase 10: Upload final implementation/reference bundle to reMarkable after docs and tests pass
+- [x] Phase 10: Upload final implementation/reference bundle to reMarkable after docs and tests pass

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/tasks.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/tasks.md
@@ -12,18 +12,18 @@
 - [x] Phase 0: Create a dedicated implementation branch for the xgoja v2 runtime hard cutover and record the baseline commit/test state
 - [x] Phase 0: Reproduce the provider.command-set sources bug with a minimal xgoja/v2 fixture that uses sources: [sites]
 - [x] Phase 0: Add a failing test proving generated serve commands expose jsverb subcommands and HTTP serve flags when command sources are declared
-- [ ] Phase 0: Add a generated-runtime metadata assertion that v2 output must not contain legacy commandProviders/packages/jsverbs top-level fields
+- [x] Phase 0: Add a generated-runtime metadata assertion that v2 output must not contain legacy commandProviders/packages/jsverbs top-level fields
 - [ ] Phase 0: Inventory all active references to RuntimeSpec, PackageSpec, CommandsSpec, CommandProviderInstanceSpec, JSVerbSourceSpec, HelpSourceSpec, AssetSourceSpec, and xgoja.gen.json
-- [ ] Phase 1: Design and implement app.RuntimePlan with v2-native AppPlan, RuntimeSection, RuntimeModulePlan, SourcePlan, CommandPlan, and ConfigFilePlan types
+- [x] Phase 1: Design and implement app.RuntimePlan with v2-native AppPlan, RuntimeSection, RuntimeModulePlan, SourcePlan, CommandPlan, and ConfigFilePlan types
 - [ ] Phase 1: Replace legacy package terminology in runtime types with provider terminology while preserving provider registry lookup semantics
 - [ ] Phase 1: Represent all runtime commands as []CommandPlan instead of CommandsSpec plus CommandProviderInstanceSpec
 - [ ] Phase 1: Represent all runtime sources as []SourcePlan with kind/origin metadata instead of separate jsverbs/help/assets buckets
-- [ ] Phase 1: Add JSON encode/decode tests for RuntimePlan including command sources, modules, config, lazy, and embedded source origins
-- [ ] Phase 2: Rewrite cmd/xgoja/internal/generate runtime metadata rendering to emit xgoja.v2.runtime.json in v2-native shape
+- [x] Phase 1: Add JSON encode/decode tests for RuntimePlan including command sources, modules, config, lazy, and embedded source origins
+- [x] Phase 2: Rewrite cmd/xgoja/internal/generate runtime metadata rendering to emit xgoja.v2.runtime.json in v2-native shape
 - [ ] Phase 2: Remove applyPlanRuntimeCommand and the v2-to-legacy runtime source conversion helpers from generator code
-- [ ] Phase 2: Update generated main.go templates to load RuntimePlan instead of RuntimeSpec and to embed v2 runtime plan JSON
+- [x] Phase 2: Update generated main.go templates to load RuntimePlan instead of RuntimeSpec and to embed v2 runtime plan JSON
 - [ ] Phase 2: Ensure generated Go module replacement behavior still uses workspace.mode:auto and plan.GoModules without requiring provider.module.replace in examples
-- [ ] Phase 2: Add golden tests for generated main.go and runtime plan JSON for binary artifacts
+- [x] Phase 2: Add golden tests for generated main.go and runtime plan JSON for binary artifacts
 - [ ] Phase 3: Implement a unified runtime SourceRegistry that resolves sources by ID and filters by source kind
 - [ ] Phase 3: Port JS verb scanning to use SourceRegistry handles while preserving TypeScript compile/bundle options and runtime module externals
 - [ ] Phase 3: Port help loading to use SourceRegistry kind=help instead of legacy HelpSpec sources

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/tasks.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/tasks.md
@@ -54,8 +54,8 @@
 - [ ] Phase 9: Finish the real sessionstream goja-chatdemo-server xgoja app after provider command sources work end-to-end
 - [ ] Phase 9: Add a smoke test that builds the xgoja chatbot binary, starts HTTP serve, connects a WebSocket client, posts /api/chat, and receives assistant UI events
 - [ ] Phase 9: Decide whether the chatbot server example belongs in sessionstream examples, go-go-goja examples, or both with cross-references
-- [ ] Phase 10: Remove or rename all active legacy runtime DTO names and fail CI if generated v2 output reintroduces commandProviders/packages/jsverbs legacy fields
-- [ ] Phase 10: Run rg-based removal sweep and document any remaining allowed historical references in tests or migration docs
+- [x] Phase 10: Remove or rename all active legacy runtime DTO names and fail CI if generated v2 output reintroduces commandProviders/packages/jsverbs legacy fields
+- [x] Phase 10: Run rg-based removal sweep and document any remaining allowed historical references in tests or migration docs
 - [ ] Phase 10: Run full validation: go test ./cmd/xgoja/... ./pkg/xgoja/... ./pkg/gojahttp ./modules/express -count=1 and go test ./... -count=1
 - [ ] Phase 10: Run all xgoja example smoke tests affected by runtime generation and update any stale fixtures/goldens
 - [ ] Phase 10: Run doc/help validation for xgoja docs and verify migration guide/help pages are discoverable through xgoja help

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/tasks.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/tasks.md
@@ -9,8 +9,8 @@
 - [x] Write intern-facing hard-cutover design and implementation guide
 - [x] Relate key files and update changelog
 - [x] Validate docs and upload bundle to reMarkable
-- [ ] Phase 0: Create a dedicated implementation branch for the xgoja v2 runtime hard cutover and record the baseline commit/test state
-- [ ] Phase 0: Reproduce the provider.command-set sources bug with a minimal xgoja/v2 fixture that uses sources: [sites]
+- [x] Phase 0: Create a dedicated implementation branch for the xgoja v2 runtime hard cutover and record the baseline commit/test state
+- [x] Phase 0: Reproduce the provider.command-set sources bug with a minimal xgoja/v2 fixture that uses sources: [sites]
 - [ ] Phase 0: Add a failing test proving generated serve commands expose jsverb subcommands and HTTP serve flags when command sources are declared
 - [ ] Phase 0: Add a generated-runtime metadata assertion that v2 output must not contain legacy commandProviders/packages/jsverbs top-level fields
 - [ ] Phase 0: Inventory all active references to RuntimeSpec, PackageSpec, CommandsSpec, CommandProviderInstanceSpec, JSVerbSourceSpec, HelpSourceSpec, AssetSourceSpec, and xgoja.gen.json

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/tasks.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/tasks.md
@@ -8,4 +8,56 @@
 - [x] Gather evidence from specv2, planner, generator, app runtime, provider API, and HTTP serve provider
 - [x] Write intern-facing hard-cutover design and implementation guide
 - [x] Relate key files and update changelog
-- [ ] Validate docs and upload bundle to reMarkable
+- [x] Validate docs and upload bundle to reMarkable
+- [ ] Phase 0: Create a dedicated implementation branch for the xgoja v2 runtime hard cutover and record the baseline commit/test state
+- [ ] Phase 0: Reproduce the provider.command-set sources bug with a minimal xgoja/v2 fixture that uses sources: [sites]
+- [ ] Phase 0: Add a failing test proving generated serve commands expose jsverb subcommands and HTTP serve flags when command sources are declared
+- [ ] Phase 0: Add a generated-runtime metadata assertion that v2 output must not contain legacy commandProviders/packages/jsverbs top-level fields
+- [ ] Phase 0: Inventory all active references to RuntimeSpec, PackageSpec, CommandsSpec, CommandProviderInstanceSpec, JSVerbSourceSpec, HelpSourceSpec, AssetSourceSpec, and xgoja.gen.json
+- [ ] Phase 1: Design and implement app.RuntimePlan with v2-native AppPlan, RuntimeSection, RuntimeModulePlan, SourcePlan, CommandPlan, and ConfigFilePlan types
+- [ ] Phase 1: Replace legacy package terminology in runtime types with provider terminology while preserving provider registry lookup semantics
+- [ ] Phase 1: Represent all runtime commands as []CommandPlan instead of CommandsSpec plus CommandProviderInstanceSpec
+- [ ] Phase 1: Represent all runtime sources as []SourcePlan with kind/origin metadata instead of separate jsverbs/help/assets buckets
+- [ ] Phase 1: Add JSON encode/decode tests for RuntimePlan including command sources, modules, config, lazy, and embedded source origins
+- [ ] Phase 2: Rewrite cmd/xgoja/internal/generate runtime metadata rendering to emit xgoja.v2.runtime.json in v2-native shape
+- [ ] Phase 2: Remove applyPlanRuntimeCommand and the v2-to-legacy runtime source conversion helpers from generator code
+- [ ] Phase 2: Update generated main.go templates to load RuntimePlan instead of RuntimeSpec and to embed v2 runtime plan JSON
+- [ ] Phase 2: Ensure generated Go module replacement behavior still uses workspace.mode:auto and plan.GoModules without requiring provider.module.replace in examples
+- [ ] Phase 2: Add golden tests for generated main.go and runtime plan JSON for binary artifacts
+- [ ] Phase 3: Implement a unified runtime SourceRegistry that resolves sources by ID and filters by source kind
+- [ ] Phase 3: Port JS verb scanning to use SourceRegistry handles while preserving TypeScript compile/bundle options and runtime module externals
+- [ ] Phase 3: Port help loading to use SourceRegistry kind=help instead of legacy HelpSpec sources
+- [ ] Phase 3: Port asset resolution and AssetStore setup to use SourceRegistry kind=assets instead of legacy AssetSourceSpec
+- [ ] Phase 3: Add tests for command-scoped source selection, all-sources-by-kind lookup, embedded source roots, provider sources, and workspace sources
+- [ ] Phase 4: Rewrite app.NewRootCommand/NewHost/NewHostWithOptions to accept RuntimePlan and remove active RuntimeSpec dependency
+- [ ] Phase 4: Rewrite runtime factory module setup to read plan.Runtime.Modules and pass RuntimeModulePlan config to provider module factories
+- [ ] Phase 4: Rewrite built-in command attachment as one loop over []CommandPlan for eval, run, repl, jsverbs, and provider.command-set
+- [ ] Phase 4: Preserve CLI mount semantics for command Mount fields and add tests for root vs nested command mounting
+- [ ] Phase 4: Update generated framework/help/logging installation to use RuntimePlan app/config fields
+- [ ] Phase 5: Change providerapi.CommandSetContext to carry v2 command ID, provider, name, mount, config, selected modules, and command-scoped source registry
+- [ ] Phase 5: Provide a JSVerbSourceSet adapter derived from the command-scoped SourceRegistry for providers that consume jsverb sources
+- [ ] Phase 5: Update provider command-set tests so command providers receive only the sources declared on their command
+- [ ] Phase 5: Update providerutil/runtime initializer paths to work with RuntimeModulePlan descriptors after the cutover
+- [ ] Phase 6: Update pkg/xgoja/providers/http serve command to consume command-scoped jsverb sources and fail clearly when no sources are configured
+- [ ] Phase 6: Update HTTP serve hot-reload to re-scan and watch only command-scoped jsverb sources
+- [ ] Phase 6: Add/repair smoke tests for examples/xgoja/13-http-serve-jsverbs using provider.command-set sources and --http-listen
+- [ ] Phase 6: Validate app.mount documentation examples still work with the updated HTTP provider runtime setup
+- [ ] Phase 7: Port generated runtime-package artifacts to RuntimePlan and remove legacy RuntimeSpec from generated package internals
+- [ ] Phase 7: Update examples/xgoja/14-generated-runtime-package and its host code/tests for the v2-native runtime plan
+- [ ] Phase 7: Ensure runtime-package public APIs such as NewBundle/NewRuntime remain ergonomic while internals no longer load legacy metadata
+- [ ] Phase 8: Update xgoja user guide to describe the v2-native runtime plan and command-scoped sources
+- [ ] Phase 8: Update xgoja v2 reference to make providers/runtime.modules/sources/commands/artifacts the authoritative runtime concepts
+- [ ] Phase 8: Update migrating-to-xgoja-v2 guide to document the hard runtime cutover and remove legacy bridge language
+- [ ] Phase 8: Update provider runtime config and host services docs for the new CommandSetContext/source registry API
+- [ ] Phase 8: Update protobuf builder provider tutorial and all affected xgoja example READMEs/YAML files to remove unnecessary replace entries where workspace.mode:auto works
+- [ ] Phase 8: Add a troubleshooting section for provider.command-set sources, CLI mount vs HTTP mount, and workspace module resolution
+- [ ] Phase 9: Finish the real sessionstream goja-chatdemo-server xgoja app after provider command sources work end-to-end
+- [ ] Phase 9: Add a smoke test that builds the xgoja chatbot binary, starts HTTP serve, connects a WebSocket client, posts /api/chat, and receives assistant UI events
+- [ ] Phase 9: Decide whether the chatbot server example belongs in sessionstream examples, go-go-goja examples, or both with cross-references
+- [ ] Phase 10: Remove or rename all active legacy runtime DTO names and fail CI if generated v2 output reintroduces commandProviders/packages/jsverbs legacy fields
+- [ ] Phase 10: Run rg-based removal sweep and document any remaining allowed historical references in tests or migration docs
+- [ ] Phase 10: Run full validation: go test ./cmd/xgoja/... ./pkg/xgoja/... ./pkg/gojahttp ./modules/express -count=1 and go test ./... -count=1
+- [ ] Phase 10: Run all xgoja example smoke tests affected by runtime generation and update any stale fixtures/goldens
+- [ ] Phase 10: Run doc/help validation for xgoja docs and verify migration guide/help pages are discoverable through xgoja help
+- [ ] Phase 10: Update ticket diary/changelog with implementation commits, validation commands, failures, and follow-up risks
+- [ ] Phase 10: Upload final implementation/reference bundle to reMarkable after docs and tests pass

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/tasks.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/tasks.md
@@ -56,7 +56,7 @@
 - [ ] Phase 9: Decide whether the chatbot server example belongs in sessionstream examples, go-go-goja examples, or both with cross-references
 - [x] Phase 10: Remove or rename all active legacy runtime DTO names and fail CI if generated v2 output reintroduces commandProviders/packages/jsverbs legacy fields
 - [x] Phase 10: Run rg-based removal sweep and document any remaining allowed historical references in tests or migration docs
-- [ ] Phase 10: Run full validation: go test ./cmd/xgoja/... ./pkg/xgoja/... ./pkg/gojahttp ./modules/express -count=1 and go test ./... -count=1
+- [x] Phase 10: Run full validation: go test ./cmd/xgoja/... ./pkg/xgoja/... ./pkg/gojahttp ./modules/express -count=1 and go test ./... -count=1
 - [ ] Phase 10: Run all xgoja example smoke tests affected by runtime generation and update any stale fixtures/goldens
 - [ ] Phase 10: Run doc/help validation for xgoja docs and verify migration guide/help pages are discoverable through xgoja help
 - [ ] Phase 10: Update ticket diary/changelog with implementation commits, validation commands, failures, and follow-up risks

--- a/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/tasks.md
+++ b/ttmp/2026/06/13/GOJA-XGOJA-V2-RUNTIME-001--replace-legacy-xgoja-runtime-metadata-bridge-with-v2-native-runtime-plan/tasks.md
@@ -22,18 +22,18 @@
 - [x] Phase 2: Rewrite cmd/xgoja/internal/generate runtime metadata rendering to emit xgoja.v2.runtime.json in v2-native shape
 - [ ] Phase 2: Remove applyPlanRuntimeCommand and the v2-to-legacy runtime source conversion helpers from generator code
 - [x] Phase 2: Update generated main.go templates to load RuntimePlan instead of RuntimeSpec and to embed v2 runtime plan JSON
-- [ ] Phase 2: Ensure generated Go module replacement behavior still uses workspace.mode:auto and plan.GoModules without requiring provider.module.replace in examples
+- [x] Phase 2: Ensure generated Go module replacement behavior still uses workspace.mode:auto and plan.GoModules without requiring provider.module.replace in examples
 - [x] Phase 2: Add golden tests for generated main.go and runtime plan JSON for binary artifacts
 - [x] Phase 3: Implement a unified runtime SourceRegistry that resolves sources by ID and filters by source kind
-- [ ] Phase 3: Port JS verb scanning to use SourceRegistry handles while preserving TypeScript compile/bundle options and runtime module externals
-- [ ] Phase 3: Port help loading to use SourceRegistry kind=help instead of legacy HelpSpec sources
-- [ ] Phase 3: Port asset resolution and AssetStore setup to use SourceRegistry kind=assets instead of legacy AssetSourceSpec
+- [x] Phase 3: Port JS verb scanning to use SourceRegistry handles while preserving TypeScript compile/bundle options and runtime module externals
+- [x] Phase 3: Port help loading to use SourceRegistry kind=help instead of legacy HelpSpec sources
+- [x] Phase 3: Port asset resolution and AssetStore setup to use SourceRegistry kind=assets instead of legacy AssetSourceSpec
 - [x] Phase 3: Add tests for command-scoped source selection, all-sources-by-kind lookup, embedded source roots, provider sources, and workspace sources
-- [ ] Phase 4: Rewrite app.NewRootCommand/NewHost/NewHostWithOptions to accept RuntimePlan and remove active RuntimeSpec dependency
-- [ ] Phase 4: Rewrite runtime factory module setup to read plan.Runtime.Modules and pass RuntimeModulePlan config to provider module factories
-- [ ] Phase 4: Rewrite built-in command attachment as one loop over []CommandPlan for eval, run, repl, jsverbs, and provider.command-set
-- [ ] Phase 4: Preserve CLI mount semantics for command Mount fields and add tests for root vs nested command mounting
-- [ ] Phase 4: Update generated framework/help/logging installation to use RuntimePlan app/config fields
+- [x] Phase 4: Rewrite app.NewRootCommand/NewHost/NewHostWithOptions to accept RuntimePlan and remove active RuntimeSpec dependency
+- [x] Phase 4: Rewrite runtime factory module setup to read plan.Runtime.Modules and pass RuntimeModulePlan config to provider module factories
+- [x] Phase 4: Rewrite built-in command attachment as one loop over []CommandPlan for eval, run, repl, jsverbs, and provider.command-set
+- [x] Phase 4: Preserve CLI mount semantics for command Mount fields and add tests for root vs nested command mounting
+- [x] Phase 4: Update generated framework/help/logging installation to use RuntimePlan app/config fields
 - [x] Phase 5: Change providerapi.CommandSetContext to carry v2 command ID, provider, name, mount, config, selected modules, and command-scoped source registry
 - [x] Phase 5: Provide a JSVerbSourceSet adapter derived from the command-scoped SourceRegistry for providers that consume jsverb sources
 - [x] Phase 5: Update provider command-set tests so command providers receive only the sources declared on their command


### PR DESCRIPTION
This change completes the v2 cutover by replacing the legacy `app.RuntimeSpec`
with a new, v2-native `app.RuntimePlan`. This aligns the embedded runtime
metadata with the `schema: xgoja/v2` configuration, providing a more
structured and consistent model for generated applications.

Key Changes:

*   **New `app.RuntimePlan`**: A unified, schema-driven (`xgoja/runtime/v2`)
    struct now represents the runtime configuration. It replaces the legacy
    `app.RuntimeSpec` and its disparate fields.
    -   Sources (`jsverbs`, `help`, `assets`) are unified into a single
        `sources` list with a `kind` field.
    -   Built-in and provider commands are now managed in a single, ordered
        `commands` list.

*   **Command-Scoped Sources**: A new `SourceRegistry` API is introduced, which
    provides sources to provider commands. This registry is scoped to the
    `sources` array defined on a command in `xgoja.yaml`, improving isolation.
    For example, an HTTP `serve` command will now only scan and hot-reload the
    jsverb sources explicitly assigned to it.

*   **Provider API Update (Breaking Change)**:
    -   `providerapi.CommandSetContext` now includes a `Sources SourceRegistry`
        field, replacing the old `JSVerbs` field.
    -   Provider authors must update their command set implementations to use the
        new `SourceRegistry` API.

*   **Generator and Runtime Updates**:
    -   The code generator now embeds `app.RuntimePlan` JSON into binaries and
        runtime packages.
    -   Generated packages expose a v2-native API, including
        `EmbeddedRuntimePlanJSON` and `DecodeRuntimePlan`.
    -   The internal runtime host and factory are updated to consume the new
        `RuntimePlan`.

*   **Documentation and Examples**: All documentation, migration guides, and
    examples have been updated to reflect the new v2 model and configuration
    schema.