### PR TITLE
Add parser-backed xgoja sourcegraph imports

### DIFF
--- a/cmd/xgoja/doc/17-xgoja-v2-reference.md
+++ b/cmd/xgoja/doc/17-xgoja-v2-reference.md
@@ -262,6 +262,27 @@ from:
 
 Workspace origins require the module to resolve to a local directory.
 
+### Static import graph validation
+
+Executable source sets (`jsverbs` and `script`) are parsed during planning so xgoja can validate local helper imports and runtime module aliases before generating a binary. The source graph accepts standard JavaScript, ESM, TypeScript, and TSX static imports, including:
+
+```js
+const assets = require("fs:assets")
+import express from "express"
+import "./setup"
+export { helper } from "./helper"
+await import("./dynamic")
+```
+
+Bare specifiers must match a selected `runtime.modules[].name` or `runtime.modules[].as` alias. Aliases may contain punctuation such as `fs:assets`; use the literal alias in source code rather than hiding it behind string concatenation.
+
+Non-literal dynamic imports are rejected because generated xgoja apps require a closed static source graph:
+
+```js
+// Avoid: sourcegraph cannot validate this dependency statically.
+require(["fs", "assets"].join(":"))
+```
+
 ### TypeScript compile intent
 
 ```yaml

--- a/cmd/xgoja/internal/plan/plan_test.go
+++ b/cmd/xgoja/internal/plan/plan_test.go
@@ -62,6 +62,45 @@ func TestCompileBuildsProviderSourceAndWorkspacePlans(t *testing.T) {
 	}
 }
 
+func TestCompileAllowsColonRuntimeAliasImports(t *testing.T) {
+	dir := t.TempDir()
+	verbsDir := filepath.Join(dir, "verbs")
+	if err := os.MkdirAll(verbsDir, 0o755); err != nil {
+		t.Fatalf("mkdir verbs: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(verbsDir, "site.js"), []byte(`const assets = require("fs:assets")`), 0o644); err != nil {
+		t.Fatalf("write site: %v", err)
+	}
+	p, err := Compile(Options{Config: specv2.Config{
+		Schema:    specv2.Schema,
+		Name:      "fixture",
+		BaseDir:   dir,
+		Go:        specv2.GoSpec{Module: "example.com/fixture", Version: "1.26"},
+		Workspace: specv2.WorkspaceSpec{Mode: string(workspace.ModeOff)},
+		Providers: []specv2.ProviderSpec{{
+			ID:       "fixture",
+			Import:   "example.com/fixture/provider",
+			Register: "Register",
+			Module:   specv2.ProviderModuleSpec{Version: "v1.2.3"},
+		}},
+		Runtime: specv2.RuntimeSpec{Modules: []specv2.RuntimeModuleSpec{{Provider: "fixture", Name: "hello", As: "fs:assets"}}},
+		Sources: []specv2.SourceSpec{{
+			ID:         "verbs",
+			Kind:       specv2.SourceKindJSVerbs,
+			From:       specv2.SourceFromSpec{Dir: "verbs"},
+			Extensions: []string{".js"},
+		}},
+		Commands:  []specv2.CommandSurfaceSpec{{ID: "verbs", Type: "builtin.jsverbs", Sources: []string{"verbs"}}},
+		Artifacts: []specv2.ArtifactSpec{{ID: "bin", Type: "binary", Output: "dist/fixture", Sources: []string{"verbs"}}},
+	}, Providers: providerRegistry(t), StartDir: dir})
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	if got := p.RuntimeAliases; len(got) != 1 || got[0] != "fs:assets" {
+		t.Fatalf("runtime aliases = %#v, want fs:assets", got)
+	}
+}
+
 func TestCompileRejectsUnknownBareImport(t *testing.T) {
 	dir := t.TempDir()
 	verbsDir := filepath.Join(dir, "verbs")

--- a/examples/xgoja/17-sourcegraph-runtime-aliases/Makefile
+++ b/examples/xgoja/17-sourcegraph-runtime-aliases/Makefile
@@ -1,0 +1,50 @@
+.DEFAULT_GOAL := smoke
+
+REPO_ROOT := $(abspath ../../..)
+BIN := $(CURDIR)/dist/sourcegraph-runtime-aliases
+XGOJA := cd $(REPO_ROOT) && GOWORK=off go run ./cmd/xgoja
+HTTP_ADDR := 127.0.0.1:18790
+
+.PHONY: smoke doctor build builtin-smoke serve-smoke prove-self-contained clean
+
+smoke: doctor build builtin-smoke serve-smoke prove-self-contained
+
+doctor:
+	$(XGOJA) doctor -f $(CURDIR)/xgoja.yaml
+
+build:
+	$(XGOJA) build -f $(CURDIR)/xgoja.yaml --output $(BIN) --xgoja-replace $(REPO_ROOT) --keep-work
+
+builtin-smoke: build
+	$(BIN) verbs typed echo | tee /tmp/xgoja-sourcegraph-aliases-typed.txt
+	grep -q 'typed:sourcegraph-aliases:function' /tmp/xgoja-sourcegraph-aliases-typed.txt
+	$(BIN) verbs sources | grep -q 'ts-tools'
+
+serve-smoke: build
+	@set -eu; \
+	log=$$(mktemp); \
+	$(BIN) serve imports serve --http-listen $(HTTP_ADDR) >$$log 2>&1 & \
+	pid=$$!; \
+	trap 'kill $$pid >/dev/null 2>&1 || true; wait $$pid >/dev/null 2>&1 || true; rm -f $$log' EXIT; \
+	for i in $$(seq 1 80); do \
+		if curl -fsS http://$(HTTP_ADDR)/healthz >/tmp/xgoja-sourcegraph-health.json 2>/dev/null; then break; fi; \
+		if ! kill -0 $$pid >/dev/null 2>&1; then cat $$log; exit 1; fi; \
+		sleep 0.1; \
+	done; \
+	grep -q '"ok":true' /tmp/xgoja-sourcegraph-health.json; \
+	grep -q 'helper:health' /tmp/xgoja-sourcegraph-health.json; \
+	curl -fsS http://$(HTTP_ADDR)/ | grep -q 'sourcegraph runtime aliases'; \
+	curl -fsS http://$(HTTP_ADDR)/static/app.js | grep -q 'embedded asset bundle'; \
+	curl -fsS http://$(HTTP_ADDR)/api/config | grep -q 'helper:config'; \
+	kill $$pid >/dev/null 2>&1 || true; \
+	wait $$pid >/dev/null 2>&1 || true
+
+prove-self-contained: build
+	@set -eu; \
+	tmp=$$(mktemp -d); \
+	cp $(BIN) $$tmp/sourcegraph-runtime-aliases; \
+	cd $$tmp; \
+	./sourcegraph-runtime-aliases verbs typed echo | grep -q 'typed:sourcegraph-aliases:function'
+
+clean:
+	rm -rf $(CURDIR)/dist

--- a/examples/xgoja/17-sourcegraph-runtime-aliases/README.md
+++ b/examples/xgoja/17-sourcegraph-runtime-aliases/README.md
@@ -1,0 +1,73 @@
+# xgoja sourcegraph runtime aliases coverage
+
+This example is a regression guard for xgoja source graph import resolution. It intentionally combines several source and runtime features in one generated binary:
+
+- JavaScript jsverbs with a local `require("./helper.js")` import.
+- TypeScript jsverbs with a local `import { format } from "./format"` import.
+- Literal runtime aliases with colons, especially `require("fs:assets")`.
+- Embedded assets served through the host `fs` provider alias `fs:assets`.
+- Express HTTP serving through the `go-go-goja-http` provider command set.
+- Builtin `verbs` command execution and provider-backed `serve` command execution.
+- A generated DTS artifact.
+
+The important regression is that static source scanning must accept selected runtime aliases exactly as declared, including aliases such as `fs:assets`. The runtime already supports this alias; the source graph must not reject it as an unknown bare specifier.
+
+## Run
+
+```bash
+make -C examples/xgoja/17-sourcegraph-runtime-aliases smoke
+```
+
+The smoke target validates the xgoja spec, builds the generated binary, runs a TypeScript jsverb that reads embedded config through `require("fs:assets")`, serves an Express site from a JavaScript jsverb, checks embedded static assets, and proves the built binary can run away from the original source tree.
+
+## Manual HTTP run
+
+```bash
+make -C examples/xgoja/17-sourcegraph-runtime-aliases build
+examples/xgoja/17-sourcegraph-runtime-aliases/dist/sourcegraph-runtime-aliases \
+  serve imports serve \
+  --http-listen 127.0.0.1:18790
+```
+
+Then open:
+
+- <http://127.0.0.1:18790/>
+- <http://127.0.0.1:18790/api/config>
+- <http://127.0.0.1:18790/static/app.js>
+
+## Key xgoja fragment
+
+```yaml
+runtime:
+  modules:
+    - provider: go-go-goja-host
+      name: fs
+      as: fs:assets
+      config:
+        embedded:
+          allow: true
+          mounts:
+            - asset: web-assets
+              mount: /app
+    - provider: go-go-goja-http
+      name: express
+sources:
+  - id: js-site
+    kind: jsverbs
+    from:
+      dir: ./verbs-js
+  - id: ts-tools
+    kind: jsverbs
+    from:
+      dir: ./verbs-ts
+    language: typescript
+    compile:
+      mode: runtime
+      bundle: true
+  - id: web-assets
+    kind: assets
+    from:
+      dir: ./assets
+```
+
+Both `verbs-js/site.js` and `verbs-ts/tools.ts` use literal `require("fs:assets")`.

--- a/examples/xgoja/17-sourcegraph-runtime-aliases/assets/config/default.json
+++ b/examples/xgoja/17-sourcegraph-runtime-aliases/assets/config/default.json
@@ -1,0 +1,1 @@
+{"name":"sourcegraph-aliases","ok":true}

--- a/examples/xgoja/17-sourcegraph-runtime-aliases/assets/public/app.js
+++ b/examples/xgoja/17-sourcegraph-runtime-aliases/assets/public/app.js
@@ -1,0 +1,8 @@
+fetch('/api/config')
+  .then((response) => response.json())
+  .then((data) => {
+    document.getElementById('status').textContent = 'embedded asset bundle: ' + data.config.name
+  })
+  .catch((err) => {
+    document.getElementById('status').textContent = String(err)
+  })

--- a/examples/xgoja/17-sourcegraph-runtime-aliases/assets/public/index.html
+++ b/examples/xgoja/17-sourcegraph-runtime-aliases/assets/public/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>xgoja sourcegraph runtime aliases</title>
+  <script src="/static/app.js" defer></script>
+</head>
+<body>
+  <h1>xgoja sourcegraph runtime aliases</h1>
+  <p id="status">loading</p>
+</body>
+</html>

--- a/examples/xgoja/17-sourcegraph-runtime-aliases/verbs-js/helper.js
+++ b/examples/xgoja/17-sourcegraph-runtime-aliases/verbs-js/helper.js
@@ -1,0 +1,5 @@
+function decorate(value) {
+  return `helper:${value}`
+}
+
+module.exports = { decorate }

--- a/examples/xgoja/17-sourcegraph-runtime-aliases/verbs-js/site.js
+++ b/examples/xgoja/17-sourcegraph-runtime-aliases/verbs-js/site.js
@@ -1,0 +1,26 @@
+const express = require("express")
+const assets = require("fs:assets")
+const { decorate } = require("./helper.js")
+
+__package__({ name: "imports", short: "Runtime alias import coverage" })
+
+__verb__("serve", {
+  name: "serve",
+  output: "text",
+  short: "Serve a site that uses local imports, runtime aliases, and embedded assets"
+})
+function serve() {
+  const app = express.app()
+
+  app.get("/", (_req, res) => {
+    res.type("text/html").send(assets.readFileSync("/app/public/index.html", "utf8"))
+  })
+  app.staticFromAssetsModule("/static", assets, "/app/public")
+  app.get("/api/config", (_req, res) => {
+    const config = JSON.parse(assets.readFileSync("/app/config/default.json", "utf8"))
+    res.json({ ok: true, config, decorated: decorate("config") })
+  })
+  app.get("/healthz", (_req, res) => {
+    res.json({ ok: true, site: "sourcegraph-runtime-aliases", decorated: decorate("health") })
+  })
+}

--- a/examples/xgoja/17-sourcegraph-runtime-aliases/verbs-ts/format.ts
+++ b/examples/xgoja/17-sourcegraph-runtime-aliases/verbs-ts/format.ts
@@ -1,0 +1,3 @@
+export function format(name: string): string {
+  return `typed:${name}`
+}

--- a/examples/xgoja/17-sourcegraph-runtime-aliases/verbs-ts/tools.ts
+++ b/examples/xgoja/17-sourcegraph-runtime-aliases/verbs-ts/tools.ts
@@ -1,0 +1,12 @@
+import { format } from "./format"
+
+const assets = require("fs:assets")
+const express = require("express")
+
+__package__({ name: "typed", short: "TypeScript sourcegraph coverage" })
+__verb__("echo", { name: "echo", output: "text", short: "Read embedded config through a colon runtime alias" })
+
+function echo(): string {
+  const config = JSON.parse(assets.readFileSync("/app/config/default.json", "utf8"))
+  return format(config.name + ":" + typeof express.app)
+}

--- a/examples/xgoja/17-sourcegraph-runtime-aliases/xgoja.yaml
+++ b/examples/xgoja/17-sourcegraph-runtime-aliases/xgoja.yaml
@@ -1,0 +1,87 @@
+schema: xgoja/v2
+name: sourcegraph-runtime-aliases
+app:
+  name: sourcegraph-runtime-aliases
+go:
+  module: xgoja.generated/sourcegraph-runtime-aliases
+  version: "1.26"
+workspace:
+  mode: auto
+providers:
+  - id: go-go-goja-host
+    import: github.com/go-go-golems/go-go-goja/pkg/xgoja/providers/host
+    register: Register
+  - id: go-go-goja-http
+    import: github.com/go-go-golems/go-go-goja/pkg/xgoja/providers/http
+    register: Register
+runtime:
+  modules:
+    - provider: go-go-goja-host
+      name: fs
+      as: fs:assets
+      config:
+        embedded:
+          allow: true
+          mounts:
+            - asset: web-assets
+              mount: /app
+    - provider: go-go-goja-host
+      name: fs
+      as: fs:host
+      config:
+        allow: true
+    - provider: go-go-goja-http
+      name: express
+sources:
+  - id: js-site
+    kind: jsverbs
+    from:
+      dir: ./verbs-js
+    language: javascript
+  - id: ts-tools
+    kind: jsverbs
+    from:
+      dir: ./verbs-ts
+    include:
+      - "**/*.ts"
+    exclude:
+      - "**/*.test.ts"
+    extensions:
+      - .ts
+    language: typescript
+    compile:
+      mode: runtime
+      bundle: true
+  - id: web-assets
+    kind: assets
+    from:
+      dir: ./assets
+commands:
+  - id: verbs
+    type: builtin.jsverbs
+    name: verbs
+    sources:
+      - js-site
+      - ts-tools
+  - id: http-serve
+    type: provider.command-set
+    name: serve
+    mount: serve
+    provider: go-go-goja-http
+    sources:
+      - js-site
+artifacts:
+  - id: binary
+    type: binary
+    output: dist/sourcegraph-runtime-aliases
+    sources:
+      - js-site
+      - ts-tools
+  - id: embedded-assets
+    type: embedded-assets
+    sources:
+      - web-assets
+  - id: declarations
+    type: dts
+    output: js/types/xgoja-modules.d.ts
+    strict: true

--- a/go.mod
+++ b/go.mod
@@ -131,6 +131,7 @@ require (
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/tiendc/go-deepcopy v1.7.1 // indirect
 	github.com/tj/go-naturaldate v1.3.0 // indirect
+	github.com/tree-sitter/tree-sitter-typescript v0.23.2 // indirect
 	github.com/ugorji/go/codec v1.3.0 // indirect
 	github.com/vektah/gqlparser/v2 v2.5.30 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -328,6 +328,8 @@ github.com/tree-sitter/tree-sitter-ruby v0.23.1 h1:T/NKHUA+iVbHM440hFx+lzVOzS4dV
 github.com/tree-sitter/tree-sitter-ruby v0.23.1/go.mod h1:kUS4kCCQloFcdX6sdpr8p6r2rogbM6ZjTox5ZOQy8cA=
 github.com/tree-sitter/tree-sitter-rust v0.23.2 h1:6AtoooCW5GqNrRpfnvl0iUhxTAZEovEmLKDbyHlfw90=
 github.com/tree-sitter/tree-sitter-rust v0.23.2/go.mod h1:hfeGWic9BAfgTrc7Xf6FaOAguCFJRo3RBbs7QJ6D7MI=
+github.com/tree-sitter/tree-sitter-typescript v0.23.2 h1:/Odvphn18PniVixb9e97X0DbNVsU6Qocv9mfkyzdXwU=
+github.com/tree-sitter/tree-sitter-typescript v0.23.2/go.mod h1:zjzMXT/Ulffel2xfOcAkQQkiAkmgnbtPGlFQw/5X4xA=
 github.com/ugorji/go/codec v1.3.0 h1:Qd2W2sQawAfG8XSvzwhBeoGq71zXOC/Q1E9y/wUcsUA=
 github.com/ugorji/go/codec v1.3.0/go.mod h1:pRBVtBSKl77K30Bv8R2P+cLSGaTtex6fsA2Wjqmfxj4=
 github.com/vektah/gqlparser/v2 v2.5.30 h1:EqLwGAFLIzt1wpx1IPpY67DwUujF1OfzgEyDsLrN6kE=

--- a/pkg/xgoja/app/command_providers.go
+++ b/pkg/xgoja/app/command_providers.go
@@ -74,7 +74,7 @@ func (h *Host) newCommandSet(instance CommandPlan, provider providerapi.CommandS
 	if err != nil {
 		return nil, err
 	}
-	sourceRegistry := h.SourceRegistry.Scoped(instance.Sources)
+	sourceRegistry := h.SourceRegistry.ScopedWithRuntimeAliases(instance.Sources, moduleAliases(selected))
 	set, err := provider.NewCommandSet(providerapi.CommandSetContext{
 		Context:         context.Background(),
 		PackageID:       instance.ProviderID(),

--- a/pkg/xgoja/app/host.go
+++ b/pkg/xgoja/app/host.go
@@ -36,7 +36,7 @@ func NewHost(providers *providerapi.ProviderRegistry, runtimePlan *RuntimePlan) 
 }
 
 func NewHostWithOptions(providers *providerapi.ProviderRegistry, runtimePlan *RuntimePlan, opts HostOptions) *Host {
-	sourceRegistry := NewSourceRegistry(providers, opts.EmbeddedJSVerbs, runtimePlan.allSources())
+	sourceRegistry := NewSourceRegistryWithRuntimeAliases(providers, opts.EmbeddedJSVerbs, runtimePlan.allSources(), runtimePlanModuleAliases(runtimePlan.runtimeModules()))
 	services := HostServices{Assets: NewAssetStoreFromSources(opts.EmbeddedAssets, sourceRegistry.ListSourcesByKind(providerapi.RuntimeSourceKindAssets))}
 	if opts.ConfigureServices != nil {
 		opts.ConfigureServices(&services)

--- a/pkg/xgoja/app/jsverb_sources.go
+++ b/pkg/xgoja/app/jsverb_sources.go
@@ -13,13 +13,15 @@ type jsVerbSourceSet struct {
 	providers       *providerapi.ProviderRegistry
 	embeddedJSVerbs fs.FS
 	sources         []SourcePlan
+	runtimeAliases  []string
 }
 
-func newJSVerbSourceSet(providers *providerapi.ProviderRegistry, embeddedJSVerbs fs.FS, sources []SourcePlan) *jsVerbSourceSet {
+func newJSVerbSourceSet(providers *providerapi.ProviderRegistry, embeddedJSVerbs fs.FS, sources []SourcePlan, runtimeAliases []string) *jsVerbSourceSet {
 	return &jsVerbSourceSet{
 		providers:       providers,
 		embeddedJSVerbs: embeddedJSVerbs,
 		sources:         append([]SourcePlan(nil), sources...),
+		runtimeAliases:  appendUniqueStrings(nil, runtimeAliases...),
 	}
 }
 
@@ -85,7 +87,7 @@ func (s *jsVerbSourceSet) ScanJSVerbSource(id string) (*jsverbs.Registry, error)
 		if source.ID != id {
 			continue
 		}
-		return scanVerbSource(s.providers, s.embeddedJSVerbs, source, allProviderRuntimeAliases(s.providers))
+		return scanVerbSource(s.providers, s.embeddedJSVerbs, source, sourceGraphRuntimeAliases(s.runtimeAliases))
 	}
 	return nil, fmt.Errorf("unknown jsverb source %q", id)
 }
@@ -96,7 +98,7 @@ func (s *jsVerbSourceSet) ScanAllJSVerbSources() ([]*jsverbs.Registry, error) {
 	}
 	registries := make([]*jsverbs.Registry, 0, len(s.sources))
 	for _, source := range s.sources {
-		registry, err := scanVerbSource(s.providers, s.embeddedJSVerbs, source, allProviderRuntimeAliases(s.providers))
+		registry, err := scanVerbSource(s.providers, s.embeddedJSVerbs, source, sourceGraphRuntimeAliases(s.runtimeAliases))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/xgoja/app/jsverb_sources_test.go
+++ b/pkg/xgoja/app/jsverb_sources_test.go
@@ -17,7 +17,7 @@ func TestJSVerbSourceSetListIncludesTypeScriptDescriptor(t *testing.T) {
 			Define:       map[string]string{"process.env.NODE_ENV": "\"test\""},
 			CheckCommand: []string{"tsc", "--noEmit"},
 		},
-	}})
+	}}, nil)
 
 	sources := set.ListJSVerbSources()
 	if len(sources) != 1 {

--- a/pkg/xgoja/app/root.go
+++ b/pkg/xgoja/app/root.go
@@ -386,6 +386,19 @@ func sourceGraphRuntimeAliases(selectedAliases []string) []string {
 	return appendUniqueStrings(nil, selectedAliases...)
 }
 
+func runtimePlanModuleAliases(modules []RuntimeModulePlan) []string {
+	aliases := []string{}
+	for _, module := range modules {
+		if module.Name != "" {
+			aliases = append(aliases, module.Name)
+		}
+		if module.As != "" {
+			aliases = append(aliases, module.As)
+		}
+	}
+	return appendUniqueStrings(nil, aliases...)
+}
+
 func allProviderRuntimeAliases(providers *providerapi.ProviderRegistry) []string {
 	if providers == nil {
 		return nil

--- a/pkg/xgoja/app/source_registry.go
+++ b/pkg/xgoja/app/source_registry.go
@@ -12,12 +12,17 @@ type SourceRegistry struct {
 	providers       *providerapi.ProviderRegistry
 	embeddedJSVerbs fs.FS
 	sources         []SourcePlan
+	runtimeAliases  []string
 }
 
 var _ providerapi.SourceRegistry = (*SourceRegistry)(nil)
 
 func NewSourceRegistry(providers *providerapi.ProviderRegistry, embeddedJSVerbs fs.FS, sources []SourcePlan) *SourceRegistry {
-	return &SourceRegistry{providers: providers, embeddedJSVerbs: embeddedJSVerbs, sources: append([]SourcePlan(nil), sources...)}
+	return NewSourceRegistryWithRuntimeAliases(providers, embeddedJSVerbs, sources, nil)
+}
+
+func NewSourceRegistryWithRuntimeAliases(providers *providerapi.ProviderRegistry, embeddedJSVerbs fs.FS, sources []SourcePlan, runtimeAliases []string) *SourceRegistry {
+	return &SourceRegistry{providers: providers, embeddedJSVerbs: embeddedJSVerbs, sources: append([]SourcePlan(nil), sources...), runtimeAliases: appendUniqueStrings(nil, runtimeAliases...)}
 }
 
 func (r *SourceRegistry) ListSources() []providerapi.RuntimeSourceDescriptor {
@@ -61,7 +66,7 @@ func (r *SourceRegistry) JSVerbs() providerapi.JSVerbSourceSet {
 	if r == nil {
 		return nil
 	}
-	return newJSVerbSourceSet(r.providers, r.embeddedJSVerbs, filterSourcesByKind(r.sources, SourceKindJSVerbs))
+	return newJSVerbSourceSet(r.providers, r.embeddedJSVerbs, filterSourcesByKind(r.sources, SourceKindJSVerbs), r.runtimeAliases)
 }
 
 func (r *SourceRegistry) scanJSVerbSource(id string, runtimeAliases []string) (*jsverbs.Registry, error) {
@@ -93,7 +98,16 @@ func (r *SourceRegistry) Scoped(sourceIDs []string) *SourceRegistry {
 			filtered = append(filtered, source)
 		}
 	}
-	return NewSourceRegistry(r.providers, r.embeddedJSVerbs, filtered)
+	return NewSourceRegistryWithRuntimeAliases(r.providers, r.embeddedJSVerbs, filtered, r.runtimeAliases)
+}
+
+func (r *SourceRegistry) ScopedWithRuntimeAliases(sourceIDs []string, runtimeAliases []string) *SourceRegistry {
+	scoped := r.Scoped(sourceIDs)
+	if scoped == nil {
+		return nil
+	}
+	scoped.runtimeAliases = appendUniqueStrings(nil, runtimeAliases...)
+	return scoped
 }
 
 func filterSourcesByKind(sources []SourcePlan, kind SourceKind) []SourcePlan {

--- a/pkg/xgoja/sourcegraph/graph.go
+++ b/pkg/xgoja/sourcegraph/graph.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strings"
 
@@ -165,9 +164,16 @@ func (g *Graph) ImportResolutions(file File) []ImportResolution {
 }
 
 func (g *Graph) resolveFileImports(file File, contents string) ([]ImportResolution, error) {
-	imports := parseImports(contents)
+	imports, err := parseImports(file.Path, []byte(contents))
+	if err != nil {
+		return nil, err
+	}
 	out := make([]ImportResolution, 0, len(imports))
-	for _, specifier := range imports {
+	for _, imp := range imports {
+		if imp.Dynamic {
+			return nil, fmt.Errorf("%s contains dynamic non-literal %s import", file.Path, imp.Kind)
+		}
+		specifier := imp.Specifier
 		if strings.HasPrefix(specifier, ".") {
 			target, err := g.resolveLocal(file, specifier)
 			if err != nil {
@@ -311,22 +317,6 @@ func includePath(rel string, source SourceSet) bool {
 		}
 	}
 	return true
-}
-
-var importRE = regexp.MustCompile(`(?m)(?:import\s+(?:[^"']+\s+from\s+)?|require\()\s*["']([^"']+)["']`)
-
-func parseImports(contents string) []string {
-	matches := importRE.FindAllStringSubmatch(contents, -1)
-	out := make([]string, 0, len(matches))
-	seen := map[string]bool{}
-	for _, match := range matches {
-		if len(match) < 2 || seen[match[1]] {
-			continue
-		}
-		seen[match[1]] = true
-		out = append(out, match[1])
-	}
-	return out
 }
 
 func fileKey(file File) string { return file.SourceSetID + "\x00" + file.Path }

--- a/pkg/xgoja/sourcegraph/graph_test.go
+++ b/pkg/xgoja/sourcegraph/graph_test.go
@@ -87,6 +87,98 @@ const express = require("express")
 	}
 }
 
+func TestResolveImportsAllowsColonRuntimeAliases(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "site.js"), `const assets = require("fs:assets")
+import db from "db:readonly"
+`)
+	graph, err := Build([]SourceSet{{ID: "sites", Kind: SourceKindJSVerbs, Origin: Origin{Kind: OriginDisk, Dir: root}, Extensions: []string{".js"}}}, Options{RuntimeModuleAliases: []string{"fs:assets", "db:readonly"}})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if err := graph.ResolveImports(readSourceFile); err != nil {
+		t.Fatalf("ResolveImports: %v", err)
+	}
+	var site File
+	for _, file := range graph.Files() {
+		if file.Path == "site.js" {
+			site = file
+		}
+	}
+	resolutions := graph.ImportResolutions(site)
+	if len(resolutions) != 2 {
+		t.Fatalf("resolutions = %#v", resolutions)
+	}
+	if resolutions[0].Kind != ImportRuntime || resolutions[0].Alias != "fs:assets" {
+		t.Fatalf("first runtime resolution = %#v", resolutions[0])
+	}
+	if resolutions[1].Kind != ImportRuntime || resolutions[1].Alias != "db:readonly" {
+		t.Fatalf("second runtime resolution = %#v", resolutions[1])
+	}
+}
+
+func TestResolveImportsParsesESMExportDynamicAndIgnoresStrings(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "site.tsx"), `import type { Thing } from "./types"
+import { helper } from "./helper"
+import assets from "fs:assets"
+import "./setup"
+export { more } from "./more"
+const dynamic = await import("./dynamic")
+const commented = "require('not-real')" // import "also-not-real"
+export const View = () => <section>{helper}</section>
+`)
+	writeFile(t, filepath.Join(root, "types.ts"), `export interface Thing { name: string }`)
+	writeFile(t, filepath.Join(root, "helper.ts"), `export const helper = 1`)
+	writeFile(t, filepath.Join(root, "setup.ts"), `export const setup = true`)
+	writeFile(t, filepath.Join(root, "more.ts"), `export const more = true`)
+	writeFile(t, filepath.Join(root, "dynamic.ts"), `export const dynamic = true`)
+	graph, err := Build([]SourceSet{{ID: "sites", Kind: SourceKindJSVerbs, Origin: Origin{Kind: OriginDisk, Dir: root}, Extensions: []string{".ts", ".tsx"}}}, Options{RuntimeModuleAliases: []string{"fs:assets"}})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if err := graph.ResolveImports(readSourceFile); err != nil {
+		t.Fatalf("ResolveImports: %v", err)
+	}
+	var site File
+	for _, file := range graph.Files() {
+		if file.Path == "site.tsx" {
+			site = file
+		}
+	}
+	resolutions := graph.ImportResolutions(site)
+	if len(resolutions) != 6 {
+		t.Fatalf("resolutions = %#v", resolutions)
+	}
+	want := []ImportResolution{
+		{Kind: ImportLocal, TargetPath: "types.ts"},
+		{Kind: ImportLocal, TargetPath: "helper.ts"},
+		{Kind: ImportRuntime, Alias: "fs:assets"},
+		{Kind: ImportLocal, TargetPath: "setup.ts"},
+		{Kind: ImportLocal, TargetPath: "more.ts"},
+		{Kind: ImportLocal, TargetPath: "dynamic.ts"},
+	}
+	for i, wantResolution := range want {
+		got := resolutions[i]
+		if got.Kind != wantResolution.Kind || got.TargetPath != wantResolution.TargetPath || got.Alias != wantResolution.Alias {
+			t.Fatalf("resolution[%d] = %#v, want kind=%s target=%q alias=%q", i, got, wantResolution.Kind, wantResolution.TargetPath, wantResolution.Alias)
+		}
+	}
+}
+
+func TestResolveImportsRejectsDynamicNonLiteralImport(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "site.js"), `const assets = require(["fs", "assets"].join(":"))`)
+	graph, err := Build([]SourceSet{{ID: "sites", Kind: SourceKindJSVerbs, Origin: Origin{Kind: OriginDisk, Dir: root}, Extensions: []string{".js"}}}, Options{RuntimeModuleAliases: []string{"fs:assets"}})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	err = graph.ResolveImports(readSourceFile)
+	if err == nil || !strings.Contains(err.Error(), "dynamic non-literal require import") {
+		t.Fatalf("expected dynamic import error, got %v", err)
+	}
+}
+
 func TestResolveImportsRejectsUnknownBareImport(t *testing.T) {
 	root := t.TempDir()
 	writeFile(t, filepath.Join(root, "site.ts"), `import x from "left-pad"`)

--- a/pkg/xgoja/sourcegraph/imports.go
+++ b/pkg/xgoja/sourcegraph/imports.go
@@ -1,0 +1,142 @@
+package sourcegraph
+
+import (
+	"fmt"
+	"path"
+	"strings"
+
+	tree_sitter "github.com/tree-sitter/go-tree-sitter"
+	tree_sitter_javascript "github.com/tree-sitter/tree-sitter-javascript/bindings/go"
+	tree_sitter_typescript "github.com/tree-sitter/tree-sitter-typescript/bindings/go"
+)
+
+type importSpec struct {
+	Specifier string
+	Kind      string
+	Dynamic   bool
+}
+
+func parseImports(filename string, source []byte) ([]importSpec, error) {
+	parser := tree_sitter.NewParser()
+	defer parser.Close()
+
+	language := languageForPath(filename)
+	if err := parser.SetLanguage(language); err != nil {
+		return nil, fmt.Errorf("configure parser for %s: %w", filename, err)
+	}
+	tree := parser.Parse(source, nil)
+	if tree == nil {
+		return nil, fmt.Errorf("parse %s: parser returned nil tree", filename)
+	}
+	defer tree.Close()
+	root := tree.RootNode()
+	if root == nil {
+		return nil, fmt.Errorf("parse %s: parser returned nil root", filename)
+	}
+	if root.HasError() {
+		return nil, fmt.Errorf("parse %s: syntax errors while collecting imports", filename)
+	}
+
+	seen := map[string]bool{}
+	out := []importSpec{}
+	add := func(spec importSpec) {
+		key := fmt.Sprintf("%s\x00%s\x00%t", spec.Kind, spec.Specifier, spec.Dynamic)
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		out = append(out, spec)
+	}
+
+	walkTree(root, source, func(n *tree_sitter.Node) {
+		switch n.Kind() {
+		case "import_statement":
+			if specifier, ok := staticSourceField(n, source); ok {
+				add(importSpec{Kind: "import", Specifier: specifier})
+			}
+		case "export_statement":
+			if specifier, ok := staticSourceField(n, source); ok {
+				add(importSpec{Kind: "export", Specifier: specifier})
+			}
+		case "call_expression":
+			fn := n.ChildByFieldName("function")
+			if fn == nil {
+				return
+			}
+			fnText := strings.TrimSpace(fn.Utf8Text(source))
+			if fnText != "require" && fnText != "import" {
+				return
+			}
+			args := n.ChildByFieldName("arguments")
+			if specifier, ok := firstArgumentStringLiteral(args, source); ok {
+				add(importSpec{Kind: fnText, Specifier: specifier})
+				return
+			}
+			add(importSpec{Kind: fnText, Dynamic: true})
+		}
+	})
+	return out, nil
+}
+
+func languageForPath(filename string) *tree_sitter.Language {
+	switch strings.ToLower(path.Ext(filename)) {
+	case ".ts", ".mts", ".cts":
+		return tree_sitter.NewLanguage(tree_sitter_typescript.LanguageTypescript())
+	case ".tsx":
+		return tree_sitter.NewLanguage(tree_sitter_typescript.LanguageTSX())
+	default:
+		return tree_sitter.NewLanguage(tree_sitter_javascript.Language())
+	}
+}
+
+func staticSourceField(n *tree_sitter.Node, source []byte) (string, bool) {
+	if n == nil {
+		return "", false
+	}
+	sourceNode := n.ChildByFieldName("source")
+	if sourceNode == nil || sourceNode.Kind() != "string" {
+		return "", false
+	}
+	return unquoteTreeSitterString(sourceNode.Utf8Text(source)), true
+}
+
+func firstArgumentStringLiteral(args *tree_sitter.Node, source []byte) (string, bool) {
+	if args == nil {
+		return "", false
+	}
+	cursor := args.Walk()
+	defer cursor.Close()
+	children := args.NamedChildren(cursor)
+	if len(children) == 0 {
+		return "", false
+	}
+	first := children[0]
+	if first.Kind() != "string" {
+		return "", false
+	}
+	return unquoteTreeSitterString(first.Utf8Text(source)), true
+}
+
+func walkTree(n *tree_sitter.Node, source []byte, visit func(*tree_sitter.Node)) {
+	if n == nil {
+		return
+	}
+	visit(n)
+	cursor := n.Walk()
+	defer cursor.Close()
+	for _, child := range n.NamedChildren(cursor) {
+		childCopy := child
+		walkTree(&childCopy, source, visit)
+	}
+}
+
+func unquoteTreeSitterString(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) >= 2 {
+		quote := s[0]
+		if (quote == '\'' || quote == '"' || quote == '`') && s[len(s)-1] == quote {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
+}

--- a/ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-ALIASES-001--fix-xgoja-jsverb-sourcegraph-runtime-aliases-and-add-import-coverage-example/README.md
+++ b/ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-ALIASES-001--fix-xgoja-jsverb-sourcegraph-runtime-aliases-and-add-import-coverage-example/README.md
@@ -1,0 +1,21 @@
+# Fix xgoja jsverb sourcegraph runtime aliases and add import coverage example
+
+This is the document workspace for ticket GOJA-XGOJA-SOURCEGRAPH-ALIASES-001.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr doc add --ticket GOJA-XGOJA-SOURCEGRAPH-ALIASES-001 --doc-type design-doc --title "My Design"`
+- Import sources: `docmgr import file --ticket GOJA-XGOJA-SOURCEGRAPH-ALIASES-001 --file /path/to/doc.md`
+- Update metadata: `docmgr meta update --ticket GOJA-XGOJA-SOURCEGRAPH-ALIASES-001 --field Status --value review`

--- a/ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-ALIASES-001--fix-xgoja-jsverb-sourcegraph-runtime-aliases-and-add-import-coverage-example/changelog.md
+++ b/ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-ALIASES-001--fix-xgoja-jsverb-sourcegraph-runtime-aliases-and-add-import-coverage-example/changelog.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 2026-06-14
+
+- Initial workspace created
+

--- a/ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-ALIASES-001--fix-xgoja-jsverb-sourcegraph-runtime-aliases-and-add-import-coverage-example/design-doc/01-sourcegraph-runtime-aliases-regression-and-coverage-plan.md
+++ b/ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-ALIASES-001--fix-xgoja-jsverb-sourcegraph-runtime-aliases-and-add-import-coverage-example/design-doc/01-sourcegraph-runtime-aliases-regression-and-coverage-plan.md
@@ -1,0 +1,53 @@
+---
+Title: Sourcegraph runtime aliases regression and coverage plan
+Ticket: GOJA-XGOJA-SOURCEGRAPH-ALIASES-001
+Status: active
+Topics:
+    - xgoja
+    - code-generation
+    - runtime
+    - testing
+DocType: design-doc
+Intent: long-term
+Owners: []
+RelatedFiles: []
+ExternalSources: []
+Summary: ""
+LastUpdated: 2026-06-14T09:24:48.461461129-04:00
+WhatFor: ""
+WhenToUse: ""
+---
+
+# Sourcegraph runtime aliases regression and coverage plan
+
+## Executive Summary
+
+<!-- Provide a high-level overview of the design proposal -->
+
+## Problem Statement
+
+<!-- Describe the problem this design addresses -->
+
+## Proposed Solution
+
+<!-- Describe the proposed solution in detail -->
+
+## Design Decisions
+
+<!-- Document key design decisions and rationale -->
+
+## Alternatives Considered
+
+<!-- List alternative approaches that were considered and why they were rejected -->
+
+## Implementation Plan
+
+<!-- Outline the steps to implement this design -->
+
+## Open Questions
+
+<!-- List any unresolved questions or concerns -->
+
+## References
+
+<!-- Link to related documents, RFCs, or external resources -->

--- a/ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-ALIASES-001--fix-xgoja-jsverb-sourcegraph-runtime-aliases-and-add-import-coverage-example/index.md
+++ b/ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-ALIASES-001--fix-xgoja-jsverb-sourcegraph-runtime-aliases-and-add-import-coverage-example/index.md
@@ -1,0 +1,58 @@
+---
+Title: Fix xgoja jsverb sourcegraph runtime aliases and add import coverage example
+Ticket: GOJA-XGOJA-SOURCEGRAPH-ALIASES-001
+Status: active
+Topics:
+    - xgoja
+    - code-generation
+    - runtime
+    - testing
+DocType: index
+Intent: long-term
+Owners: []
+RelatedFiles: []
+ExternalSources: []
+Summary: ""
+LastUpdated: 2026-06-14T09:24:48.126833832-04:00
+WhatFor: ""
+WhenToUse: ""
+---
+
+# Fix xgoja jsverb sourcegraph runtime aliases and add import coverage example
+
+## Overview
+
+<!-- Provide a brief overview of the ticket, its goals, and current status -->
+
+## Key Links
+
+- **Related Files**: See frontmatter RelatedFiles field
+- **External Sources**: See frontmatter ExternalSources field
+
+## Status
+
+Current status: **active**
+
+## Topics
+
+- xgoja
+- code-generation
+- runtime
+- testing
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-ALIASES-001--fix-xgoja-jsverb-sourcegraph-runtime-aliases-and-add-import-coverage-example/reference/01-investigation-diary.md
+++ b/ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-ALIASES-001--fix-xgoja-jsverb-sourcegraph-runtime-aliases-and-add-import-coverage-example/reference/01-investigation-diary.md
@@ -1,0 +1,41 @@
+---
+Title: Investigation diary
+Ticket: GOJA-XGOJA-SOURCEGRAPH-ALIASES-001
+Status: active
+Topics:
+    - xgoja
+    - code-generation
+    - runtime
+    - testing
+DocType: reference
+Intent: long-term
+Owners: []
+RelatedFiles: []
+ExternalSources: []
+Summary: ""
+LastUpdated: 2026-06-14T09:24:48.773886591-04:00
+WhatFor: ""
+WhenToUse: ""
+---
+
+# Investigation diary
+
+## Goal
+
+<!-- What is the purpose of this reference document? -->
+
+## Context
+
+<!-- Provide background context needed to use this reference -->
+
+## Quick Reference
+
+<!-- Provide copy/paste-ready content, API contracts, or quick-look tables -->
+
+## Usage Examples
+
+<!-- Show how to use this reference in practice -->
+
+## Related
+
+<!-- Link to related documents or resources -->

--- a/ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-ALIASES-001--fix-xgoja-jsverb-sourcegraph-runtime-aliases-and-add-import-coverage-example/tasks.md
+++ b/ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-ALIASES-001--fix-xgoja-jsverb-sourcegraph-runtime-aliases-and-add-import-coverage-example/tasks.md
@@ -1,0 +1,9 @@
+# Tasks
+
+## TODO
+
+- [ ] Add tasks here
+
+- [ ] Reproduce literal require of colon-containing runtime aliases from jsverb sources
+- [ ] Fix jsverb sourcegraph alias resolution for selected runtime aliases such as fs:assets
+- [ ] Add broad xgoja example covering local imports, runtime aliases, embedded assets, provider commands, builtin jsverbs, and smoke validation

--- a/ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-PARSER-001--replace-xgoja-sourcegraph-regex-import-scanning-with-parser-backed-runtime-alias-resolution/README.md
+++ b/ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-PARSER-001--replace-xgoja-sourcegraph-regex-import-scanning-with-parser-backed-runtime-alias-resolution/README.md
@@ -1,0 +1,21 @@
+# Replace xgoja sourcegraph regex import scanning with parser-backed runtime alias resolution
+
+This is the document workspace for ticket GOJA-XGOJA-SOURCEGRAPH-PARSER-001.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr doc add --ticket GOJA-XGOJA-SOURCEGRAPH-PARSER-001 --doc-type design-doc --title "My Design"`
+- Import sources: `docmgr import file --ticket GOJA-XGOJA-SOURCEGRAPH-PARSER-001 --file /path/to/doc.md`
+- Update metadata: `docmgr meta update --ticket GOJA-XGOJA-SOURCEGRAPH-PARSER-001 --field Status --value review`

--- a/ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-PARSER-001--replace-xgoja-sourcegraph-regex-import-scanning-with-parser-backed-runtime-alias-resolution/changelog.md
+++ b/ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-PARSER-001--replace-xgoja-sourcegraph-regex-import-scanning-with-parser-backed-runtime-alias-resolution/changelog.md
@@ -24,3 +24,13 @@ Implemented tree-sitter-backed sourcegraph import parsing and RuntimePlan alias 
 - /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/pkg/xgoja/app/source_registry.go — Carries runtime aliases into jsverb source scans
 - /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/pkg/xgoja/sourcegraph/imports.go — New parser-backed collector
 
+
+## 2026-06-14
+
+Committed parser-backed sourcegraph import parsing, RuntimePlan alias propagation, and broad sourcegraph runtime-alias example (commit bf00208).
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/examples/xgoja/17-sourcegraph-runtime-aliases — Smoke example committed in bf00208
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/pkg/xgoja/sourcegraph/imports.go — Parser-backed collector committed in bf00208
+

--- a/ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-PARSER-001--replace-xgoja-sourcegraph-regex-import-scanning-with-parser-backed-runtime-alias-resolution/changelog.md
+++ b/ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-PARSER-001--replace-xgoja-sourcegraph-regex-import-scanning-with-parser-backed-runtime-alias-resolution/changelog.md
@@ -1,0 +1,26 @@
+# Changelog
+
+## 2026-06-14
+
+- Initial workspace created
+
+
+## 2026-06-14
+
+Created sourcegraph parser ticket, preserved Goja/esbuild/tree-sitter experiments, and confirmed tree-sitter TypeScript/TSX support is a strong implementation path.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-PARSER-001--replace-xgoja-sourcegraph-regex-import-scanning-with-parser-backed-runtime-alias-resolution/design-doc/01-parser-backed-xgoja-sourcegraph-import-resolution-design.md — Initial design and parser comparison
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-PARSER-001--replace-xgoja-sourcegraph-regex-import-scanning-with-parser-backed-runtime-alias-resolution/scripts/04-treesitter-typescript-experiment.sh — TypeScript/TSX tree-sitter evidence
+
+
+## 2026-06-14
+
+Implemented tree-sitter-backed sourcegraph import parsing and RuntimePlan alias propagation; focused tests and sourcegraph-runtime-aliases smoke pass.
+
+### Related Files
+
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/pkg/xgoja/app/source_registry.go — Carries runtime aliases into jsverb source scans
+- /home/manuel/workspaces/2026-06-12/goja-sessionstream/go-go-goja/pkg/xgoja/sourcegraph/imports.go — New parser-backed collector
+

--- a/ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-PARSER-001--replace-xgoja-sourcegraph-regex-import-scanning-with-parser-backed-runtime-alias-resolution/design-doc/01-parser-backed-xgoja-sourcegraph-import-resolution-design.md
+++ b/ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-PARSER-001--replace-xgoja-sourcegraph-regex-import-scanning-with-parser-backed-runtime-alias-resolution/design-doc/01-parser-backed-xgoja-sourcegraph-import-resolution-design.md
@@ -1,0 +1,341 @@
+---
+Title: Parser-backed xgoja sourcegraph import resolution design
+Ticket: GOJA-XGOJA-SOURCEGRAPH-PARSER-001
+Status: active
+Topics:
+    - xgoja
+    - sourcegraph
+    - typescript
+    - code-generation
+DocType: design-doc
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: go-go-goja/examples/xgoja/17-sourcegraph-runtime-aliases
+      Note: Broad xgoja sourcegraph/runtime alias example
+    - Path: go-go-goja/pkg/jsparse/treesitter.go
+      Note: Existing tree-sitter integration pattern used by experiments
+    - Path: go-go-goja/pkg/xgoja/app/command_providers.go
+      Note: Command-selected aliases for provider command source registries
+    - Path: go-go-goja/pkg/xgoja/app/root.go
+      Note: Runtime jsverb source scanning and runtime alias input path
+    - Path: go-go-goja/pkg/xgoja/app/source_registry.go
+      Note: Runtime alias propagation for source scans
+    - Path: go-go-goja/pkg/xgoja/sourcegraph/graph.go
+      Note: |-
+        Current regex import parsing and sourcegraph resolution target
+        Sourcegraph resolution now uses parser-backed import specs and dynamic import diagnostics
+    - Path: go-go-goja/pkg/xgoja/sourcegraph/graph_test.go
+      Note: Parser-backed sourcegraph regression coverage
+    - Path: go-go-goja/pkg/xgoja/sourcegraph/imports.go
+      Note: Tree-sitter-backed import collector implementation
+    - Path: go-go-goja/ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-PARSER-001--replace-xgoja-sourcegraph-regex-import-scanning-with-parser-backed-runtime-alias-resolution/scripts/04-treesitter-typescript-experiment.sh
+      Note: Self-contained TypeScript/TSX tree-sitter experiment
+ExternalSources: []
+Summary: Design and experiment notes for replacing regex-based xgoja sourcegraph import scanning with parser-backed resolution and correct RuntimePlan alias propagation.
+LastUpdated: 2026-06-14T09:42:16.138610864-04:00
+WhatFor: Planning the xgoja sourcegraph import parser/runtime-alias fix.
+WhenToUse: Use when implementing parser-backed import graph resolution for xgoja RuntimePlan sources.
+---
+
+
+
+# Parser-backed xgoja sourcegraph import resolution design
+
+## Executive Summary
+
+xgoja v2 made `RuntimePlan` the authoritative model for runtime modules, source sets, and command source scopes. The current source graph still extracts imports with a regular expression in `pkg/xgoja/sourcegraph/graph.go`, and some scan paths use provider capability aliases rather than the configured `runtime.modules[].as` aliases. That combination is fragile: literal runtime aliases such as `require("fs:assets")` should be accepted when the RuntimePlan selects `as: fs:assets`, while unknown bare imports should still fail early.
+
+The recommended solution is a staged replacement of regex import scanning with a parser-backed collector, plus a first fix that propagates configured command/runtime aliases into every sourcegraph scan. The experiments in this ticket show that Goja's parser is useful for CommonJS `require(...)` only, esbuild's public Build/metafile API robustly handles JS/TS/ESM imports with runtime aliases marked external, and the already-present tree-sitter JavaScript grammar can extract imports without false positives but needs either a TypeScript grammar dependency or error-tolerant handling for TS-specific syntax.
+
+## Problem Statement
+
+Current sourcegraph import extraction is based on:
+
+```go
+var importRE = regexp.MustCompile(`(?m)(?:import\s+(?:[^"']+\s+from\s+)?|require\()\s*["']([^"']+)["']`)
+```
+
+That regex is not a real JavaScript or TypeScript parser. It can miss valid import forms, can be confused by comments/strings, and cannot classify dynamic imports precisely. The immediate user-visible issue is runtime aliases containing `:` (for example `fs:assets`) in jsverb sources. Those aliases should be validated against selected RuntimePlan modules, not rejected as unknown bare imports and not hidden behind dynamic workarounds such as `require(["fs", "assets"].join(":"))`.
+
+The fix must preserve the xgoja v2 guarantees documented in `GOJA-XGOJA-V2-RUNTIME-001`:
+
+- `RuntimePlan` is authoritative.
+- `sources[]` are first-class and command-scoped.
+- Provider command sets receive only their command-selected sources.
+- Empty/omitted command source scopes stay empty.
+- Runtime module aliases come from configured runtime modules, including aliases with punctuation such as `fs:assets`.
+
+## Evidence and Experiments
+
+The ticket scripts live in `scripts/`:
+
+- `01-goja-parser-experiment.go`
+- `02-esbuild-import-experiment.go`
+- `03-treesitter-import-experiment.go`
+
+### Goja parser experiment
+
+Goja's AST parser accepts CommonJS-style source:
+
+```text
+const x = require("fs:assets"); -> <nil>
+```
+
+But it rejects ESM and dynamic import syntax:
+
+```text
+import assets from "fs:assets";   -> Unexpected reserved word
+import "./setup.js";              -> Unexpected reserved word
+export { x } from "./x.js";       -> Unexpected reserved word
+const x = await import("./x.js"); -> Unexpected reserved word
+```
+
+Conclusion: Goja can be a CommonJS collector for literal `require("...")`, but it is not sufficient as the sole sourcegraph parser.
+
+### Esbuild experiment
+
+Esbuild does not expose a public AST parser API; its public Go API exposes `Build`, `Transform`, and `Context`. However, `api.Build` with `Bundle: true`, `Write: false`, and `Metafile: true` can serve as an import collector.
+
+Without configured externals, esbuild rejects runtime aliases and unknown bare imports:
+
+```text
+ERR: Could not resolve "fs:assets"
+ERR: Could not resolve "express"
+```
+
+With aliases marked external:
+
+```go
+External: []string{"fs:assets", "fs:host", "express"}
+```
+
+it records imports in the metafile:
+
+```text
+path="fs:assets" kind=require-call external=true
+path="express" kind=require-call external=true
+path="./dynamic.js" kind=dynamic-import external=false
+```
+
+It also handles TypeScript/ESM import syntax:
+
+```text
+path="fs:assets" kind=import-statement external=true
+path="./more.js" kind=import-statement external=false
+```
+
+Conclusion: esbuild is the strongest single existing dependency for robust JS/TS import collection, even though it is not an AST parser API.
+
+### Tree-sitter JavaScript experiment
+
+The repo already depends on:
+
+```text
+github.com/tree-sitter/go-tree-sitter
+github.com/tree-sitter/tree-sitter-javascript
+```
+
+The experiment used that existing JavaScript grammar directly. It successfully parsed and extracted:
+
+```text
+require("fs:assets")           -> fs:assets
+import assets from "fs:assets" -> fs:assets
+import "./setup.js"            -> ./setup.js
+export { x } from "./x.js"     -> ./x.js
+await import("./x.js")         -> ./x.js
+```
+
+It also avoided regex false positives in strings/comments:
+
+```js
+const s = "require('not-real')"; // import "also-not-real"
+```
+
+No import edges were emitted for that case.
+
+For TypeScript-ish source, the JavaScript grammar reported `hasError=true` but still recovered enough to extract import/export sources:
+
+```text
+./types
+./helper
+fs:assets
+./more
+```
+
+### Tree-sitter TypeScript experiment
+
+A fourth experiment used `github.com/tree-sitter/tree-sitter-typescript@v0.23.2` in a temporary module so the repo `go.mod` stayed untouched. The package exposes both `LanguageTypescript()` and `LanguageTSX()`.
+
+The TypeScript grammar parsed TypeScript-specific syntax cleanly:
+
+```text
+hasError=false
+import type { Thing } from "./types" -> ./types
+import { helper } from "./helper"    -> ./helper
+import assets from "fs:assets"       -> fs:assets
+export { more } from "./more"        -> ./more
+await import("./dynamic")            -> ./dynamic
+require("fs:host")                   -> fs:host
+require(["fs", "assets"].join(":")) -> dynamic=true
+```
+
+The TSX grammar also parsed JSX/TSX without errors and extracted:
+
+```text
+react
+fs:assets
+./Widget
+```
+
+It also avoided false positives inside TypeScript string literals and comments.
+
+Conclusion: tree-sitter with the TypeScript grammar is now the most attractive parser-backed implementation path. It avoids esbuild's no-write build/metafile indirection, supports JS/ESM/TypeScript/TSX as concrete syntax trees, and already matches the sourcegraph need: extract literal import specifiers and flag dynamic imports. The cost is adding one direct dependency on `tree-sitter-typescript`.
+
+## Proposed Solution
+
+### Phase 1: Fix configured runtime alias propagation
+
+Before changing parsers, make sourcegraph scans use the aliases selected by the active RuntimePlan command/module set.
+
+Do not rely on provider-wide aliases alone:
+
+```go
+allProviderRuntimeAliases(providers)
+```
+
+Instead, derive aliases from the configured runtime module descriptors selected for the command:
+
+```go
+moduleAliases(selectedModules)
+```
+
+and ensure aliases such as `fs:assets` flow into:
+
+- planner sourcegraph validation;
+- builtin jsverb scans;
+- provider command-set scans via `SourceRegistry`;
+- hot-reload rescans.
+
+### Phase 2: Introduce an import collector interface
+
+Add a small interface inside `pkg/xgoja/sourcegraph`:
+
+```go
+type ImportCollector interface {
+    CollectImports(filename string, source []byte) ([]ImportSpec, error)
+}
+
+type ImportSpec struct {
+    Specifier string
+    Kind      ImportSyntaxKind // import-statement, export-from, require-call, dynamic-import
+    Dynamic   bool
+}
+```
+
+`Graph.ResolveImports` should depend on the interface instead of directly calling `parseImports`.
+
+### Phase 3: Implement tree-sitter collector for JS/ESM/CommonJS
+
+Use tree-sitter for `.js`, `.jsx`, `.mjs`, and `.cjs` first. It covers the forms that Goja's parser rejects and avoids regex false positives.
+
+Production behavior should include:
+
+- `import ... from "x"`
+- `import "x"`
+- `export ... from "x"`
+- `require("x")`
+- `import("x")`
+- diagnostic for `require(expr)` and `import(expr)` when `expr` is not a string literal.
+
+### Phase 4: Add tree-sitter TypeScript/TSX support
+
+Add `github.com/tree-sitter/tree-sitter-typescript` and choose the grammar by file extension:
+
+- `.js`, `.jsx`, `.mjs`, `.cjs` -> `tree-sitter-javascript` or the TSX grammar if it proves sufficient for JSX.
+- `.ts`, `.mts`, `.cts` -> `tree-sitter-typescript` `LanguageTypescript()`.
+- `.tsx` -> `tree-sitter-typescript` `LanguageTSX()`.
+
+Recommendation: use tree-sitter for TypeScript/TSX sourcegraph parsing. Esbuild remains useful for compilation and as an alternative import-collector design, but the TypeScript tree-sitter experiment showed clean parsing and simpler static import extraction for sourcegraph's needs.
+
+### Phase 5: Remove regex collector after parity tests
+
+Keep the regex parser only as a temporary fallback during implementation. Remove it after tests cover:
+
+- CommonJS require;
+- ESM imports;
+- side-effect imports;
+- export-from imports;
+- dynamic imports;
+- non-literal dynamic import diagnostics;
+- colon runtime aliases;
+- unknown bare imports;
+- local extension resolution;
+- path escape rejection;
+- TypeScript imports.
+
+## Design Decisions
+
+### Decision: Sourcegraph remains the authority
+
+Keep import resolution in `pkg/xgoja/sourcegraph`. Parser-backed extraction is an implementation detail. The package should continue to own classification into local imports, runtime aliases, and unknown imports.
+
+### Decision: RuntimePlan aliases are explicit inputs
+
+Parser choice does not fix alias semantics by itself. `fs:assets` only works if the sourcegraph receives `fs:assets` as a valid runtime alias for the command/source scan.
+
+### Decision: Dynamic non-literal imports need diagnostics
+
+A workaround such as:
+
+```js
+require(["fs", "assets"].join(":"))
+```
+
+hides dependencies from a static source graph. The implementation should warn or fail for non-literal dynamic imports in strict generated-app validation.
+
+## Alternatives Considered
+
+### Keep regex and patch edge cases
+
+Rejected. It may fix `fs:assets`, but it will keep failing on syntax coverage and false positives.
+
+### Use Goja AST parser only
+
+Rejected as a sole solution. It is useful for CommonJS but rejects ESM import/export forms and TypeScript syntax.
+
+### Use esbuild only
+
+Viable. It handles TypeScript and dependency resolution well. The drawback is that it is a build/resolution API rather than a direct parser API, so sourcegraph would need a no-write build/metafile integration and careful custom external/local semantics.
+
+### Use tree-sitter only
+
+Preferred after the TypeScript experiment. With `tree-sitter-typescript`, tree-sitter covers JS, ESM, CommonJS, TypeScript, and TSX import syntax directly. Sourcegraph can extract literal specifiers from CST nodes and classify dynamic imports without invoking a bundler-style resolver.
+
+## Implementation Plan
+
+1. Add failing regression tests for literal `require("fs:assets")` and `import assets from "fs:assets"` using configured RuntimePlan aliases.
+2. Fix alias propagation so command/runtime scans use selected configured module aliases.
+3. Add `ImportCollector` to `pkg/xgoja/sourcegraph`.
+4. Add `tree-sitter-typescript` and implement tree-sitter collectors for JS/ESM/CommonJS/TS/TSX.
+5. Add table-driven sourcegraph tests for all import forms and diagnostics.
+6. Keep esbuild as a reference experiment and fallback option, not the first implementation path.
+7. Update `examples/xgoja/17-sourcegraph-runtime-aliases` to use literal `require("fs:assets")` and ESM/TS import coverage.
+8. Remove regex collector after parity tests pass.
+9. Update xgoja v2 docs to explain static import requirements and dynamic import diagnostics.
+
+## Open Questions
+
+- Should generated xgoja builds fail on non-literal dynamic imports, or should they warn and ignore them?
+- Should TypeScript parsing use esbuild only, or should the repo add `tree-sitter-typescript` for CST parity?
+- Should sourcegraph allow node_modules/package imports in a future mode, or continue to reject all unknown bare imports?
+
+## References
+
+- `pkg/xgoja/sourcegraph/graph.go`
+- `cmd/xgoja/internal/plan/plan.go`
+- `pkg/xgoja/app/root.go`
+- `pkg/xgoja/app/jsverb_sources.go`
+- `pkg/jsparse/treesitter.go`
+- `pkg/jsparse/analyze.go`
+- Ticket: `GOJA-XGOJA-V2-RUNTIME-001`

--- a/ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-PARSER-001--replace-xgoja-sourcegraph-regex-import-scanning-with-parser-backed-runtime-alias-resolution/index.md
+++ b/ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-PARSER-001--replace-xgoja-sourcegraph-regex-import-scanning-with-parser-backed-runtime-alias-resolution/index.md
@@ -1,0 +1,58 @@
+---
+Title: Replace xgoja sourcegraph regex import scanning with parser-backed runtime alias resolution
+Ticket: GOJA-XGOJA-SOURCEGRAPH-PARSER-001
+Status: active
+Topics:
+    - xgoja
+    - sourcegraph
+    - typescript
+    - code-generation
+DocType: index
+Intent: long-term
+Owners: []
+RelatedFiles: []
+ExternalSources: []
+Summary: ""
+LastUpdated: 2026-06-14T09:42:15.792235578-04:00
+WhatFor: ""
+WhenToUse: ""
+---
+
+# Replace xgoja sourcegraph regex import scanning with parser-backed runtime alias resolution
+
+## Overview
+
+<!-- Provide a brief overview of the ticket, its goals, and current status -->
+
+## Key Links
+
+- **Related Files**: See frontmatter RelatedFiles field
+- **External Sources**: See frontmatter ExternalSources field
+
+## Status
+
+Current status: **active**
+
+## Topics
+
+- xgoja
+- sourcegraph
+- typescript
+- code-generation
+
+## Tasks
+
+See [tasks.md](./tasks.md) for the current task list.
+
+## Changelog
+
+See [changelog.md](./changelog.md) for recent changes and decisions.
+
+## Structure
+
+- design/ - Architecture and design documents
+- reference/ - Prompt packs, API contracts, context summaries
+- playbooks/ - Command sequences and test procedures
+- scripts/ - Temporary code and tooling
+- various/ - Working notes and research
+- archive/ - Deprecated or reference-only artifacts

--- a/ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-PARSER-001--replace-xgoja-sourcegraph-regex-import-scanning-with-parser-backed-runtime-alias-resolution/reference/01-investigation-diary.md
+++ b/ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-PARSER-001--replace-xgoja-sourcegraph-regex-import-scanning-with-parser-backed-runtime-alias-resolution/reference/01-investigation-diary.md
@@ -409,3 +409,78 @@ ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-PARSER-001--replace-xgoja-sourcegraph-reg
 ```
 
 I fixed this by adding `//go:build ignore` to each standalone Go experiment script. They remain runnable with `go run path/to/script.go`, but they are excluded from package builds and broad `go test ./...`.
+
+## Step 4: Document static sourcegraph import rules
+
+I added a user-facing note to the xgoja v2 reference explaining the now-visible static import graph behavior. The docs now say that executable source sets are parsed during planning, runtime module aliases may be imported literally even when they contain punctuation such as `fs:assets`, and non-literal dynamic imports are rejected because generated xgoja apps require a closed static graph.
+
+This closes the documentation follow-up from the implementation tasks: the dynamic import diagnostic is user-visible, so the reference should explain how to write source that the planner can validate.
+
+### Prompt Context
+
+**User prompt (verbatim):** (same as Step 3)
+
+**Assistant interpretation:** Continue executing the task plan and complete user-facing docs for sourcegraph behavior that became visible after parser-backed import validation.
+
+**Inferred user intent:** Finish the ticket work rather than leaving behavioral changes undocumented.
+
+### What I did
+
+- Updated `cmd/xgoja/doc/17-xgoja-v2-reference.md` with a `Static import graph validation` section.
+- Documented accepted static forms:
+  - `require("fs:assets")`
+  - ESM imports
+  - side-effect imports
+  - export-from imports
+  - literal dynamic imports
+- Documented that bare specifiers must match selected `runtime.modules[].name` or `runtime.modules[].as` aliases.
+- Documented that non-literal dynamic imports such as `require(["fs", "assets"].join(":"))` should be avoided.
+- Rendered the help page successfully:
+
+```bash
+go run ./cmd/xgoja help xgoja-v2-reference >/tmp/xgoja-v2-reference-help.txt
+```
+
+- Re-ran docmgr doctor for the parser ticket successfully.
+
+### Why
+
+- The parser-backed sourcegraph change makes dynamic import handling visible to users.
+- Users should know that literal colon aliases are supported and preferred, so they do not keep using dynamic require workarounds.
+
+### What worked
+
+The help page rendered without errors, and the ticket doctor stayed clean.
+
+### What didn't work
+
+N/A
+
+### What I learned
+
+- The v2 reference already had a natural `Sources` section for this explanation, so the documentation update stayed small.
+
+### What was tricky to build
+
+- The wording needed to distinguish literal dynamic imports (`await import("./dynamic")`, which sourcegraph can validate) from non-literal dynamic imports (`require(expr)`, which sourcegraph cannot validate statically).
+
+### What warrants a second pair of eyes
+
+- Confirm whether the dynamic import policy should be documented as a hard generated-app requirement or softened if a future runtime script mode permits dynamic imports.
+
+### What should be done in the future
+
+N/A
+
+### Code review instructions
+
+- Review `cmd/xgoja/doc/17-xgoja-v2-reference.md`, section `Static import graph validation`.
+- Validate with:
+
+```bash
+go run ./cmd/xgoja help xgoja-v2-reference >/tmp/xgoja-v2-reference-help.txt
+```
+
+### Technical details
+
+The documented invariant is: sourcegraph must see every local or runtime dependency as a literal import specifier so it can classify it as local, runtime alias, or unknown before generation.

--- a/ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-PARSER-001--replace-xgoja-sourcegraph-regex-import-scanning-with-parser-backed-runtime-alias-resolution/reference/01-investigation-diary.md
+++ b/ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-PARSER-001--replace-xgoja-sourcegraph-regex-import-scanning-with-parser-backed-runtime-alias-resolution/reference/01-investigation-diary.md
@@ -1,0 +1,409 @@
+---
+Title: Investigation diary
+Ticket: GOJA-XGOJA-SOURCEGRAPH-PARSER-001
+Status: active
+Topics:
+    - xgoja
+    - sourcegraph
+    - typescript
+    - code-generation
+DocType: reference
+Intent: long-term
+Owners: []
+RelatedFiles: []
+ExternalSources: []
+Summary: "Diary for parser-backed xgoja sourcegraph import resolution investigation."
+LastUpdated: 2026-06-14T09:42:16.138610864-04:00
+WhatFor: "Chronological notes for sourcegraph parser/runtime alias investigation."
+WhenToUse: "Read before implementing GOJA-XGOJA-SOURCEGRAPH-PARSER-001."
+---
+
+# Diary
+
+## Goal
+
+This diary captures the investigation and design work for replacing xgoja sourcegraph's regex-based import scanning with parser-backed import collection and correct RuntimePlan alias propagation.
+
+## Step 1: Create parser-backed sourcegraph ticket and compare parser options
+
+I created a dedicated docmgr ticket under `go-go-goja/ttmp` for the sourcegraph import parser/runtime alias work. The ticket now contains a design document, this diary, task list, and three runnable experiment scripts that compare Goja parser, esbuild Build/metafile collection, and tree-sitter JavaScript parsing.
+
+The third experiment confirms that tree-sitter would help substantially for JavaScript/ESM/CommonJS import extraction because it already parses import/export forms that Goja rejects and avoids regex false positives in comments and strings. The caveat is TypeScript: the repo currently has `tree-sitter-javascript`, not `tree-sitter-typescript`, so TS-specific syntax recovers with parse errors unless we add the TypeScript grammar or use esbuild for TS/TSX.
+
+### Prompt Context
+
+**User prompt (verbatim):** "Ok, create a new ticket in `docmgr --root go-go-goja/ttmp ...` to handle these issues, copy all thes cripts you've been using for testing in there too. Would using treesitter work and make your job easier? run a third experiment"
+
+**User prompt (verbatim):** "(we already use treesitter in parts of go-go-goja)"
+
+**Assistant interpretation:** Create a new docmgr ticket in the go-go-goja ticket workspace for sourcegraph parser/runtime alias issues, preserve the parser experiments as ticket scripts, run an additional tree-sitter experiment, and evaluate whether tree-sitter is a good implementation path.
+
+**Inferred user intent:** Turn the ad-hoc parser investigation into a structured implementation ticket with reproducible evidence and a concrete recommendation for the next sourcegraph fix.
+
+### What I did
+
+- Created ticket `GOJA-XGOJA-SOURCEGRAPH-PARSER-001` with `docmgr --root go-go-goja/ttmp`.
+- Added design document `design-doc/01-parser-backed-xgoja-sourcegraph-import-resolution-design.md`.
+- Added this investigation diary.
+- Copied/wrote experiment scripts:
+  - `scripts/01-goja-parser-experiment.go`
+  - `scripts/02-esbuild-import-experiment.go`
+  - `scripts/03-treesitter-import-experiment.go`
+- Ran all three experiments from the go-go-goja repo root.
+- Updated `tasks.md` with completed setup/experiment tasks and implementation follow-ups.
+
+### Why
+
+- The current sourcegraph regex parser is too fragile for xgoja v2's RuntimePlan/source graph contract.
+- Literal aliases such as `fs:assets` should be statically visible, validated, and allowed when selected by `runtime.modules[].as`.
+- Parser experiments make the implementation choice evidence-based instead of speculative.
+
+### What worked
+
+The Goja parser experiment confirmed Goja can parse CommonJS `require("fs:assets")` but not ESM import/export forms.
+
+The esbuild experiment confirmed that esbuild can collect JS/TS/ESM imports via Build/metafile when runtime aliases are marked external.
+
+The tree-sitter experiment confirmed the existing tree-sitter JavaScript grammar can extract:
+
+```text
+require("fs:assets")
+import assets from "fs:assets"
+import "./setup.js"
+export { x } from "./x.js"
+await import("./x.js")
+```
+
+It also emitted no false import edges for:
+
+```js
+const s = "require('not-real')"; // import "also-not-real"
+```
+
+### What didn't work
+
+The existing tree-sitter JavaScript grammar reports parse errors for TypeScript-only syntax:
+
+```text
+hasError=true
+```
+
+for a source containing `import type` and `export interface`. It still recovered enough to extract import strings, but that is not a clean production TS parser story.
+
+Non-literal dynamic require remains intentionally not statically resolvable:
+
+```js
+require(["fs", "host"].join(":"))
+```
+
+The tree-sitter experiment recorded this as a dynamic edge rather than a concrete `fs:host` import.
+
+### What I learned
+
+- Tree-sitter would make the JS/ESM/CommonJS side easier than using Goja AST directly because Goja rejects ESM import/export syntax.
+- Esbuild is still the best already-present tool for TypeScript/TSX import collection because xgoja already uses it for TypeScript compilation and it handles alias externals cleanly.
+- Parser choice does not replace the alias propagation fix: sourcegraph still needs configured RuntimePlan aliases such as `fs:assets` as inputs.
+
+### What was tricky to build
+
+- The tree-sitter experiment had to inspect concrete syntax tree node kinds rather than rely on a high-level import API. The useful nodes were `import_statement`, `export_statement`, and `call_expression` with function `require` or `import`.
+- The current repo dependency is `tree-sitter-javascript`, so TypeScript support is only error-tolerant recovery unless another grammar is added.
+- Distinguishing literal imports from non-literal dynamic imports is important. A parser can tell us that `require(["fs", "host"].join(":"))` is a dynamic call, but it should not pretend that this is statically known.
+
+### What warrants a second pair of eyes
+
+- Decide whether TS/TSX sourcegraph parsing should use esbuild only or add `tree-sitter-typescript`.
+- Decide whether strict generated builds should fail or warn on non-literal dynamic imports.
+- Review the planned alias propagation path so provider-wide aliases do not accidentally replace command-selected RuntimePlan aliases.
+
+### What should be done in the future
+
+- Implement failing regressions for literal `require("fs:assets")` and ESM/TS alias imports.
+- Fix configured RuntimePlan alias propagation before swapping parsers.
+- Introduce an `ImportCollector` abstraction and implement parser-backed collection.
+
+### Code review instructions
+
+- Start with the design document for the parser comparison and staged implementation plan.
+- Run the experiments from the repo root:
+
+```bash
+go run ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-PARSER-001--replace-xgoja-sourcegraph-regex-import-scanning-with-parser-backed-runtime-alias-resolution/scripts/01-goja-parser-experiment.go
+go run ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-PARSER-001--replace-xgoja-sourcegraph-regex-import-scanning-with-parser-backed-runtime-alias-resolution/scripts/02-esbuild-import-experiment.go
+go run ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-PARSER-001--replace-xgoja-sourcegraph-regex-import-scanning-with-parser-backed-runtime-alias-resolution/scripts/03-treesitter-import-experiment.go
+```
+
+### Technical details
+
+The preferred staged direction is:
+
+```text
+RuntimePlan selected modules
+  -> configured runtime aliases including runtime.modules[].as
+  -> SourceRegistry command source scope
+  -> parser-backed sourcegraph ImportCollector
+  -> local/runtime/unknown import resolution
+```
+
+Tree-sitter is attractive for JS because it is already present and catches ESM syntax without regex false positives. Esbuild remains attractive for TS because it already understands TypeScript and can mark xgoja runtime aliases external.
+
+## Step 2: Try tree-sitter TypeScript and TSX support
+
+I ran a fourth experiment using `github.com/tree-sitter/tree-sitter-typescript` in a temporary Go module so the repository `go.mod` stayed unchanged. This tested whether a tree-sitter-only sourcegraph parser can cover TypeScript and TSX cleanly instead of delegating TS/TSX import collection to esbuild.
+
+The experiment was positive: the TypeScript grammar parsed `import type`, `export interface`, dynamic `import("...")`, literal `require("...")`, and non-literal dynamic `require(expr)` without errors. The TSX grammar also parsed JSX/TSX syntax and extracted `react`, `fs:assets`, and local component imports. This makes tree-sitter with the TypeScript grammar the preferred implementation path for sourcegraph import collection.
+
+### Prompt Context
+
+**User prompt (verbatim):** "can we try with typescript treesitter support?"
+
+**Assistant interpretation:** Run an additional experiment with the actual tree-sitter TypeScript grammar, not just the existing JavaScript grammar's error recovery, and update the ticket evidence/recommendation.
+
+**Inferred user intent:** Determine whether adding tree-sitter TypeScript support would be simpler and more robust than using esbuild as the TS/TSX import collector.
+
+### What I did
+
+- Added `scripts/04-treesitter-typescript-experiment.sh`.
+- The script creates a temporary Go module and installs:
+  - `github.com/tree-sitter/go-tree-sitter@v0.25.0`
+  - `github.com/tree-sitter/tree-sitter-typescript@v0.23.2`
+- Tested `LanguageTypescript()` on TypeScript source containing:
+  - `import type`
+  - normal ESM imports
+  - `fs:assets` alias import
+  - `export ... from`
+  - `export interface`
+  - dynamic `import("./dynamic")`
+  - literal `require("fs:host")`
+  - non-literal `require(["fs", "assets"].join(":"))`
+- Tested `LanguageTSX()` on TSX source containing React-style JSX and imports.
+- Updated the design doc and task list to recommend tree-sitter TypeScript support as the first implementation path.
+
+### Why
+
+- The existing JavaScript tree-sitter grammar recovered from TypeScript syntax but reported parse errors.
+- A production sourcegraph parser should not depend on error recovery for standard `.ts` and `.tsx` files.
+- The implementation should use the simplest parser model that covers xgoja's JS/TS source surface.
+
+### What worked
+
+The TypeScript grammar parsed without errors:
+
+```text
+== typescript-imports ==
+hasError=false
+edge kind=import specifier="./types" dynamic=false
+edge kind=import specifier="./helper" dynamic=false
+edge kind=import specifier="fs:assets" dynamic=false
+edge kind=export specifier="./more" dynamic=false
+edge kind=import specifier="./dynamic" dynamic=false
+edge kind=require specifier="fs:host" dynamic=false
+edge kind=require specifier="" dynamic=true
+```
+
+The TSX grammar also parsed without errors:
+
+```text
+== tsx-imports ==
+hasError=false
+edge kind=import specifier="react" dynamic=false
+edge kind=import specifier="fs:assets" dynamic=false
+edge kind=import specifier="./Widget" dynamic=false
+```
+
+The false-positive case still emitted no import edges:
+
+```text
+== comment-string-false-positive ==
+hasError=false
+```
+
+### What didn't work
+
+N/A. The experiment succeeded. The only caveat is that adopting this approach requires adding `github.com/tree-sitter/tree-sitter-typescript` as a repository dependency.
+
+### What I learned
+
+- `tree-sitter-typescript` exposes both `LanguageTypescript()` and `LanguageTSX()` from `github.com/tree-sitter/tree-sitter-typescript/bindings/go`.
+- Tree-sitter gives sourcegraph the exact data it needs: literal import specifiers plus the ability to distinguish dynamic/non-literal imports from static imports.
+- Esbuild remains a useful comparison point, but tree-sitter is a cleaner fit for sourcegraph import extraction because it does not require running a no-write bundle build.
+
+### What was tricky to build
+
+- The experiment is intentionally a shell script rather than a plain Go file because the repo does not yet depend on `tree-sitter-typescript`. The script creates a temporary module so the evidence is reproducible without modifying `go.mod` during investigation.
+- Dynamic `require(["fs", "assets"].join(":"))` contains string literals inside the argument expression. The collector must not treat those nested strings as import specifiers; it should mark the call dynamic instead.
+
+### What warrants a second pair of eyes
+
+- Confirm that adding `tree-sitter-typescript` is acceptable dependency-wise.
+- Review whether the production collector should use tree-sitter queries or explicit CST walking by node kind/field name.
+- Decide whether dynamic non-literal imports should be hard errors in generated builds.
+
+### What should be done in the future
+
+- Add `tree-sitter-typescript` to `go.mod` when implementing the parser-backed collector.
+- Implement a collector that selects JavaScript, TypeScript, or TSX grammar by extension.
+- Add table-driven tests for the exact cases from this experiment.
+
+### Code review instructions
+
+- Run:
+
+```bash
+ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-PARSER-001--replace-xgoja-sourcegraph-regex-import-scanning-with-parser-backed-runtime-alias-resolution/scripts/04-treesitter-typescript-experiment.sh
+```
+
+- Review the design doc's updated Tree-sitter TypeScript experiment and Phase 4 recommendation.
+
+### Technical details
+
+The production parser should map extensions approximately as follows:
+
+```text
+.js/.jsx/.mjs/.cjs -> JavaScript or TSX grammar
+.ts/.mts/.cts      -> LanguageTypescript()
+.tsx               -> LanguageTSX()
+```
+
+For import extraction, the relevant nodes are still `import_statement`, `export_statement`, and `call_expression` where the function node is `require` or `import`.
+
+## Step 3: Implement tree-sitter sourcegraph parsing and runtime alias propagation
+
+I turned the parser experiments into active sourcegraph behavior. The regex import extractor is gone from `pkg/xgoja/sourcegraph`; sourcegraph now parses JavaScript, ESM, TypeScript, and TSX with tree-sitter, extracts static import/export/require/dynamic-import specifiers, and rejects non-literal dynamic imports instead of silently missing them.
+
+I also fixed the runtime scanning side of the original `fs:assets` issue. Provider command-set source scans now receive aliases from the command-selected RuntimePlan modules, so a command using `runtime.modules[].as: fs:assets` can literally import `require("fs:assets")` without the dynamic workaround.
+
+### Prompt Context
+
+**User prompt (verbatim):** "Create a detailed list of tasks and add to the ticket, then work on them one by one, committing at appropriate intervals, and keeping a detailed diary."
+
+**Assistant interpretation:** Expand the ticket task plan, begin implementing the sourcegraph parser/runtime-alias fixes, update the diary as work proceeds, and commit at sensible milestones.
+
+**Inferred user intent:** Move the parser investigation from design into working code while preserving task bookkeeping and review context.
+
+### What I did
+
+- Rewrote the ticket task list into a detailed implementation plan with completed investigation tasks and implementation phases.
+- Added `github.com/tree-sitter/tree-sitter-typescript v0.23.2` to `go.mod` / `go.sum`.
+- Added `pkg/xgoja/sourcegraph/imports.go` with tree-sitter-backed import extraction.
+- Removed the regex-based `parseImports` implementation from `pkg/xgoja/sourcegraph/graph.go`.
+- Updated sourcegraph import resolution to reject dynamic non-literal import calls.
+- Added sourcegraph tests for:
+  - colon runtime aliases;
+  - TypeScript/TSX import extraction;
+  - side-effect imports;
+  - export-from imports;
+  - dynamic `import("...")`;
+  - false-positive strings/comments;
+  - non-literal dynamic `require(...)` diagnostics.
+- Kept planner coverage for configured `runtime.modules[].as` aliases in `cmd/xgoja/internal/plan/plan_test.go`.
+- Threaded RuntimePlan module aliases through runtime source scanning:
+  - `SourceRegistry` now stores runtime aliases;
+  - `SourceRegistry.JSVerbs()` passes those aliases into scans;
+  - provider command sets override scoped source registries with aliases from their selected modules;
+  - host-level source registry receives aliases from `RuntimePlan.Runtime.Modules`.
+- Ran the sourcegraph/runtime alias example smoke target successfully.
+
+### Why
+
+- Regex import scanning was the wrong abstraction for v2 sourcegraph validation.
+- `fs:assets` is a configured runtime alias, so sourcegraph must validate it against RuntimePlan module selections rather than provider-wide default module names.
+- Dynamic `require(["fs", "assets"].join(":"))` hides dependencies from the static graph; sourcegraph should encourage literal imports and flag non-literal dynamic imports.
+
+### What worked
+
+Focused tests passed:
+
+```bash
+go test ./cmd/xgoja/internal/plan ./pkg/xgoja/sourcegraph ./pkg/xgoja/app ./pkg/xgoja/providers/http -count=1
+```
+
+The broad sourcegraph/runtime alias example passed after the alias propagation fix:
+
+```bash
+make -C examples/xgoja/17-sourcegraph-runtime-aliases clean smoke
+make -C examples/xgoja/17-sourcegraph-runtime-aliases serve-smoke prove-self-contained
+```
+
+The example builds a generated binary and validates literal `require("fs:assets")` in the HTTP serve provider command path.
+
+### What didn't work
+
+The earlier example smoke had failed before this fix with:
+
+```text
+create command set go-go-goja-http.serve: resolve imports for jsverb source js-site: site.js imports unknown bare specifier "fs:assets"
+```
+
+The root cause was not the regex parser's ability to match `fs:assets`; it was runtime scan alias propagation. Provider command scans used provider-wide aliases instead of the configured RuntimePlan alias set selected for the command.
+
+### What I learned
+
+- The parser and alias issues were separate. Tree-sitter fixes syntax coverage and false positives; alias propagation fixes the literal runtime alias rejection.
+- Tree-sitter TypeScript support makes sourcegraph parsing straightforward for TSX without invoking esbuild's build pipeline.
+- Command-selected module aliases are the right input for provider command-set scans because command providers can select a subset of runtime modules.
+
+### What was tricky to build
+
+- Dynamic calls need careful CST handling. The collector must not treat nested string literals inside `require(["fs", "assets"].join(":"))` as static import specifiers.
+- The existing `SourceRegistry` API is provider-facing and does not expose aliases, so aliases were added as internal runtime state while keeping the provider-facing interface unchanged.
+- Host-level scans and provider command scans have different alias scopes: host setup can use all RuntimePlan aliases, while command providers should use their selected module descriptors.
+
+### What warrants a second pair of eyes
+
+- Review whether dynamic non-literal imports should be hard errors in all sourcegraph scans, or whether some runtime script modes need a warning-only policy.
+- Review whether `.jsx` should use the JavaScript grammar or the TSX grammar in production; the current implementation uses JavaScript for JS/JSX and TypeScript TSX only for `.tsx`.
+- Review alias scoping in `SourceRegistry.ScopedWithRuntimeAliases` and `Host.newCommandSet` to confirm commands with explicit `modules:` are isolated as intended.
+
+### What should be done in the future
+
+- Finalize and commit the example directory.
+- Update user-facing docs if dynamic import errors need documentation.
+- Run broader xgoja validation before final handoff.
+
+### Code review instructions
+
+- Start with `pkg/xgoja/sourcegraph/imports.go` and `pkg/xgoja/sourcegraph/graph.go`.
+- Then review alias propagation in:
+  - `pkg/xgoja/app/source_registry.go`
+  - `pkg/xgoja/app/jsverb_sources.go`
+  - `pkg/xgoja/app/command_providers.go`
+  - `pkg/xgoja/app/host.go`
+- Review tests in:
+  - `pkg/xgoja/sourcegraph/graph_test.go`
+  - `cmd/xgoja/internal/plan/plan_test.go`
+- Validate with:
+
+```bash
+go test ./cmd/xgoja/internal/plan ./pkg/xgoja/sourcegraph ./pkg/xgoja/app ./pkg/xgoja/providers/http -count=1
+make -C examples/xgoja/17-sourcegraph-runtime-aliases smoke
+```
+
+### Technical details
+
+The new static import collector recognizes these CST nodes:
+
+```text
+import_statement source: string
+export_statement source: string
+call_expression function: require/import, first argument: string
+```
+
+Non-literal dynamic calls produce a dynamic import spec and sourcegraph currently rejects them with:
+
+```text
+<file> contains dynamic non-literal <kind> import
+```
+
+### Pre-commit failure note
+
+The first commit attempt failed because the three copied Go experiment scripts lived in the same `scripts` directory as `package main` files, so `go test ./...` treated them as one package and saw multiple `main` declarations:
+
+```text
+ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-PARSER-001--replace-xgoja-sourcegraph-regex-import-scanning-with-parser-backed-runtime-alias-resolution/scripts/02-esbuild-import-experiment.go:75:6: main redeclared in this block
+	ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-PARSER-001--replace-xgoja-sourcegraph-regex-import-scanning-with-parser-backed-runtime-alias-resolution/scripts/01-goja-parser-experiment.go:9:6: other declaration of main
+ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-PARSER-001--replace-xgoja-sourcegraph-regex-import-scanning-with-parser-backed-runtime-alias-resolution/scripts/03-treesitter-import-experiment.go:17:6: main redeclared in this block
+	ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-PARSER-001--replace-xgoja-sourcegraph-regex-import-scanning-with-parser-backed-runtime-alias-resolution/scripts/01-goja-parser-experiment.go:9:6: other declaration of main
+```
+
+I fixed this by adding `//go:build ignore` to each standalone Go experiment script. They remain runnable with `go run path/to/script.go`, but they are excluded from package builds and broad `go test ./...`.

--- a/ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-PARSER-001--replace-xgoja-sourcegraph-regex-import-scanning-with-parser-backed-runtime-alias-resolution/reference/01-investigation-diary.md
+++ b/ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-PARSER-001--replace-xgoja-sourcegraph-regex-import-scanning-with-parser-backed-runtime-alias-resolution/reference/01-investigation-diary.md
@@ -281,6 +281,8 @@ I also fixed the runtime scanning side of the original `fs:assets` issue. Provid
 
 **Inferred user intent:** Move the parser investigation from design into working code while preserving task bookkeeping and review context.
 
+**Commit (code):** bf00208 — "Add parser-backed xgoja sourcegraph imports"
+
 ### What I did
 
 - Rewrote the ticket task list into a detailed implementation plan with completed investigation tasks and implementation phases.

--- a/ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-PARSER-001--replace-xgoja-sourcegraph-regex-import-scanning-with-parser-backed-runtime-alias-resolution/scripts/01-goja-parser-experiment.go
+++ b/ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-PARSER-001--replace-xgoja-sourcegraph-regex-import-scanning-with-parser-backed-runtime-alias-resolution/scripts/01-goja-parser-experiment.go
@@ -1,0 +1,23 @@
+//go:build ignore
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/dop251/goja/parser"
+)
+
+func main() {
+	cases := []string{
+		`const x = require("fs:assets");`,
+		`import assets from "fs:assets";`,
+		`import "./setup.js";`,
+		`export { x } from "./x.js";`,
+		`const x = await import("./x.js");`,
+	}
+	for _, src := range cases {
+		_, err := parser.ParseFile(nil, "test.js", src, 0)
+		fmt.Printf("%q -> %v\n", src, err)
+	}
+}

--- a/ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-PARSER-001--replace-xgoja-sourcegraph-regex-import-scanning-with-parser-backed-runtime-alias-resolution/scripts/02-esbuild-import-experiment.go
+++ b/ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-PARSER-001--replace-xgoja-sourcegraph-regex-import-scanning-with-parser-backed-runtime-alias-resolution/scripts/02-esbuild-import-experiment.go
@@ -1,0 +1,107 @@
+//go:build ignore
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/evanw/esbuild/pkg/api"
+)
+
+type metafile struct {
+	Inputs map[string]struct {
+		Imports []struct {
+			Path     string `json:"path"`
+			Kind     string `json:"kind"`
+			External bool   `json:"external"`
+		} `json:"imports"`
+	} `json:"inputs"`
+}
+
+func write(path, s string) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		panic(err)
+	}
+	if err := os.WriteFile(path, []byte(s), 0o644); err != nil {
+		panic(err)
+	}
+}
+
+func run(label, entry string, external []string) {
+	var resolved []string
+	result := api.Build(api.BuildOptions{
+		EntryPoints: []string{entry},
+		Bundle:      true,
+		Write:       false,
+		Metafile:    true,
+		LogLevel:    api.LogLevelSilent,
+		Platform:    api.PlatformNeutral,
+		Format:      api.FormatCommonJS,
+		External:    external,
+		Plugins: []api.Plugin{{
+			Name: "trace-resolve",
+			Setup: func(build api.PluginBuild) {
+				build.OnResolve(api.OnResolveOptions{Filter: ".*"}, func(args api.OnResolveArgs) (api.OnResolveResult, error) {
+					resolved = append(resolved, fmt.Sprintf("path=%q importer=%q kind=%v namespace=%q", args.Path, args.Importer, args.Kind, args.Namespace))
+					return api.OnResolveResult{}, nil
+				})
+			},
+		}},
+	})
+	fmt.Println("\n==", label, "==")
+	fmt.Println("errors:", len(result.Errors), "warnings:", len(result.Warnings))
+	for _, e := range result.Errors {
+		fmt.Println("ERR:", e.Text)
+	}
+	fmt.Println("OnResolve callbacks:")
+	for _, s := range resolved {
+		fmt.Println(" ", s)
+	}
+	if result.Metafile != "" {
+		var mf metafile
+		if err := json.Unmarshal([]byte(result.Metafile), &mf); err != nil {
+			panic(err)
+		}
+		fmt.Println("Metafile imports:")
+		for input, data := range mf.Inputs {
+			for _, imp := range data.Imports {
+				fmt.Printf("  from=%s path=%q kind=%s external=%v\n", input, imp.Path, imp.Kind, imp.External)
+			}
+		}
+	}
+}
+
+func main() {
+	dir, err := os.MkdirTemp("", "xgoja-esbuild-imports-*")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(dir)
+	write(filepath.Join(dir, "helper.js"), `export const helper = "helper";`)
+	write(filepath.Join(dir, "more.js"), `export const more = "more";`)
+	write(filepath.Join(dir, "dynamic.js"), `export const dyn = "dyn";`)
+	write(filepath.Join(dir, "entry.js"), `
+import "./helper.js";
+export { more } from "./more.js";
+const assets = require("fs:assets");
+const express = require("express");
+import("./dynamic.js");
+const dynamicRequire = require(["fs", "host"].join(":"));
+`)
+	write(filepath.Join(dir, "entry.ts"), `
+import type { Thing } from "./types";
+import { helper } from "./helper";
+import assets from "fs:assets";
+export { more } from "./more";
+export interface Thing { name: string }
+console.log(helper, assets);
+`)
+	write(filepath.Join(dir, "types.ts"), `export interface Thing { name: string }`)
+
+	run("JS without externals", filepath.Join(dir, "entry.js"), nil)
+	run("JS with colon/bare externals", filepath.Join(dir, "entry.js"), []string{"fs:assets", "fs:host", "express"})
+	run("TS with colon external", filepath.Join(dir, "entry.ts"), []string{"fs:assets"})
+}

--- a/ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-PARSER-001--replace-xgoja-sourcegraph-regex-import-scanning-with-parser-backed-runtime-alias-resolution/scripts/03-treesitter-import-experiment.go
+++ b/ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-PARSER-001--replace-xgoja-sourcegraph-regex-import-scanning-with-parser-backed-runtime-alias-resolution/scripts/03-treesitter-import-experiment.go
@@ -1,0 +1,125 @@
+//go:build ignore
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	tree_sitter "github.com/tree-sitter/go-tree-sitter"
+	tree_sitter_javascript "github.com/tree-sitter/tree-sitter-javascript/bindings/go"
+)
+
+type edge struct {
+	Kind      string
+	Specifier string
+	Dynamic   bool
+}
+
+func main() {
+	cases := map[string]string{
+		"cjs-require":                   `const x = require("fs:assets");`,
+		"esm-import":                    `import assets from "fs:assets";`,
+		"side-effect-import":            `import "./setup.js";`,
+		"export-from":                   `export { x } from "./x.js";`,
+		"dynamic-import":                `const x = await import("./x.js");`,
+		"dynamic-require-expression":    `const x = require(["fs", "host"].join(":"));`,
+		"string-comment-false-positive": `const s = "require('not-real')"; // import "also-not-real"`,
+		"typescript-ish": `
+import type { Thing } from "./types";
+import { helper } from "./helper";
+import assets from "fs:assets";
+export { more } from "./more";
+export interface Thing { name: string }
+`,
+	}
+
+	parser := tree_sitter.NewParser()
+	lang := tree_sitter.NewLanguage(tree_sitter_javascript.Language())
+	if err := parser.SetLanguage(lang); err != nil {
+		panic(err)
+	}
+	defer parser.Close()
+
+	for name, src := range cases {
+		tree := parser.Parse([]byte(src), nil)
+		root := tree.RootNode()
+		fmt.Printf("\n== %s ==\n", name)
+		fmt.Printf("hasError=%v\n", root.HasError())
+		fmt.Printf("sexp=%s\n", root.ToSexp())
+		for _, e := range collect(root, []byte(src)) {
+			fmt.Printf("edge kind=%s specifier=%q dynamic=%v\n", e.Kind, e.Specifier, e.Dynamic)
+		}
+		tree.Close()
+	}
+}
+
+func collect(root *tree_sitter.Node, src []byte) []edge {
+	var out []edge
+	walk(root, src, func(n *tree_sitter.Node) {
+		switch n.Kind() {
+		case "import_statement":
+			for _, s := range stringDescendants(n, src) {
+				out = append(out, edge{Kind: "import", Specifier: unquote(s)})
+			}
+		case "export_statement":
+			for _, s := range stringDescendants(n, src) {
+				out = append(out, edge{Kind: "export", Specifier: unquote(s)})
+			}
+		case "call_expression":
+			fn := n.ChildByFieldName("function")
+			if fn == nil {
+				return
+			}
+			fnText := strings.TrimSpace(fn.Utf8Text(src))
+			if fnText != "require" && fnText != "import" {
+				return
+			}
+			args := n.ChildByFieldName("arguments")
+			strings := stringDescendants(args, src)
+			if len(strings) == 1 {
+				out = append(out, edge{Kind: fnText, Specifier: unquote(strings[0])})
+			} else {
+				out = append(out, edge{Kind: fnText, Dynamic: true})
+			}
+		}
+	})
+	return out
+}
+
+func walk(n *tree_sitter.Node, src []byte, visit func(*tree_sitter.Node)) {
+	if n == nil {
+		return
+	}
+	visit(n)
+	cursor := n.Walk()
+	defer cursor.Close()
+	for _, child := range n.NamedChildren(cursor) {
+		childCopy := child
+		walk(&childCopy, src, visit)
+	}
+}
+
+func stringDescendants(n *tree_sitter.Node, src []byte) []string {
+	if n == nil {
+		return nil
+	}
+	var out []string
+	walk(n, src, func(child *tree_sitter.Node) {
+		if child.Kind() == "string" {
+			out = append(out, child.Utf8Text(src))
+		}
+	})
+	return out
+}
+
+func unquote(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) >= 2 {
+		q := s[0]
+		if (q == '\'' || q == '"' || q == '`') && s[len(s)-1] == q {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
+}

--- a/ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-PARSER-001--replace-xgoja-sourcegraph-regex-import-scanning-with-parser-backed-runtime-alias-resolution/scripts/04-treesitter-typescript-experiment.sh
+++ b/ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-PARSER-001--replace-xgoja-sourcegraph-regex-import-scanning-with-parser-backed-runtime-alias-resolution/scripts/04-treesitter-typescript-experiment.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Self-contained experiment so the ticket can evaluate tree-sitter-typescript
+# without modifying the repository go.mod. If adopted, add
+# github.com/tree-sitter/tree-sitter-typescript to go-go-goja/go.mod.
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+cd "$tmpdir"
+
+go mod init xgoja-ts-tree-exp >/dev/null
+go get github.com/tree-sitter/go-tree-sitter@v0.25.0 >/dev/null
+go get github.com/tree-sitter/tree-sitter-typescript@v0.23.2 >/dev/null
+
+cat > main.go <<'GO'
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	tree_sitter "github.com/tree-sitter/go-tree-sitter"
+	tree_sitter_typescript "github.com/tree-sitter/tree-sitter-typescript/bindings/go"
+)
+
+type edge struct {
+	Kind      string
+	Specifier string
+	Dynamic   bool
+}
+
+func main() {
+	cases := map[string]struct {
+		Source string
+		TSX    bool
+	}{
+		"typescript-imports": {Source: `
+import type { Thing } from "./types";
+import { helper } from "./helper";
+import assets from "fs:assets";
+export { more } from "./more";
+export interface Thing { name: string }
+const loaded = await import("./dynamic");
+const host = require("fs:host");
+const hidden = require(["fs", "assets"].join(":"));
+`},
+		"tsx-imports": {TSX: true, Source: `
+import React from "react";
+import assets from "fs:assets";
+import Widget from "./Widget";
+type Props = { name: string };
+export const View = (props: Props) => <section>{props.name}</section>;
+`},
+		"comment-string-false-positive": {Source: `
+const s: string = "import nope from 'not-real'";
+// require("also-not-real")
+`},
+	}
+
+	for name, tc := range cases {
+		parser := tree_sitter.NewParser()
+		var lang *tree_sitter.Language
+		if tc.TSX {
+			lang = tree_sitter.NewLanguage(tree_sitter_typescript.LanguageTSX())
+		} else {
+			lang = tree_sitter.NewLanguage(tree_sitter_typescript.LanguageTypescript())
+		}
+		if err := parser.SetLanguage(lang); err != nil {
+			panic(err)
+		}
+		tree := parser.Parse([]byte(tc.Source), nil)
+		root := tree.RootNode()
+		fmt.Printf("\n== %s ==\n", name)
+		fmt.Printf("hasError=%v\n", root.HasError())
+		fmt.Printf("sexp=%s\n", root.ToSexp())
+		for _, e := range collect(root, []byte(tc.Source)) {
+			fmt.Printf("edge kind=%s specifier=%q dynamic=%v\n", e.Kind, e.Specifier, e.Dynamic)
+		}
+		tree.Close()
+		parser.Close()
+	}
+}
+
+func collect(root *tree_sitter.Node, src []byte) []edge {
+	var out []edge
+	walk(root, src, func(n *tree_sitter.Node) {
+		switch n.Kind() {
+		case "import_statement":
+			for _, s := range stringDescendants(n, src) {
+				out = append(out, edge{Kind: "import", Specifier: unquote(s)})
+			}
+		case "export_statement":
+			for _, s := range stringDescendants(n, src) {
+				out = append(out, edge{Kind: "export", Specifier: unquote(s)})
+			}
+		case "call_expression":
+			fn := n.ChildByFieldName("function")
+			if fn == nil {
+				return
+			}
+			fnText := strings.TrimSpace(fn.Utf8Text(src))
+			if fnText != "require" && fnText != "import" {
+				return
+			}
+			args := n.ChildByFieldName("arguments")
+			strings := stringDescendants(args, src)
+			if len(strings) == 1 {
+				out = append(out, edge{Kind: fnText, Specifier: unquote(strings[0])})
+			} else {
+				out = append(out, edge{Kind: fnText, Dynamic: true})
+			}
+		}
+	})
+	return out
+}
+
+func walk(n *tree_sitter.Node, src []byte, visit func(*tree_sitter.Node)) {
+	if n == nil {
+		return
+	}
+	visit(n)
+	cursor := n.Walk()
+	defer cursor.Close()
+	for _, child := range n.NamedChildren(cursor) {
+		childCopy := child
+		walk(&childCopy, src, visit)
+	}
+}
+
+func stringDescendants(n *tree_sitter.Node, src []byte) []string {
+	if n == nil {
+		return nil
+	}
+	var out []string
+	walk(n, src, func(child *tree_sitter.Node) {
+		if child.Kind() == "string" {
+			out = append(out, child.Utf8Text(src))
+		}
+	})
+	return out
+}
+
+func unquote(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) >= 2 {
+		q := s[0]
+		if (q == '\'' || q == '"' || q == '`') && s[len(s)-1] == q {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
+}
+GO
+
+go run main.go

--- a/ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-PARSER-001--replace-xgoja-sourcegraph-regex-import-scanning-with-parser-backed-runtime-alias-resolution/tasks.md
+++ b/ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-PARSER-001--replace-xgoja-sourcegraph-regex-import-scanning-with-parser-backed-runtime-alias-resolution/tasks.md
@@ -1,0 +1,53 @@
+# Tasks
+
+## Completed Investigation
+
+- [x] Create ticket workspace and add design/diary documents.
+- [x] Copy Goja parser and esbuild import-collector experiments into ticket scripts.
+- [x] Run a tree-sitter JavaScript import extraction experiment using the repo's existing dependency.
+- [x] Run a tree-sitter TypeScript/TSX experiment in a temporary module without modifying repo go.mod.
+- [x] Record initial parser comparison and implementation recommendation.
+
+## Implementation Plan
+
+### 1. Guard the runtime-alias regression
+
+- [x] Add/keep focused sourcegraph unit coverage for colon-containing runtime aliases such as `fs:assets` and `db:readonly`.
+- [x] Add/keep planner coverage proving configured `runtime.modules[].as` aliases flow into `Plan.RuntimeAliases`.
+- [x] Add coverage for ESM, side-effect import, export-from, dynamic import, and false-positive string/comment cases.
+- [x] Add coverage for non-literal dynamic `require(...)` / `import(...)` diagnostics.
+
+### 2. Fix configured alias propagation in runtime scans
+
+- [x] Audit all sourcegraph scan entry points (`cmd/xgoja/internal/plan`, builtin jsverbs, provider command contexts, hot reload).
+- [x] Replace provider-wide alias fallbacks with selected RuntimePlan module aliases where a command/runtime context is available.
+- [x] Ensure `SourceRegistry.JSVerbs()` scans receive aliases selected for the command that owns the source scope.
+- [x] Validate literal `require("fs:assets")` works in the generated example without the dynamic `require(["fs", "assets"].join(":"))` workaround.
+
+### 3. Add parser-backed import collection
+
+- [x] Add `github.com/tree-sitter/tree-sitter-typescript` to `go.mod` / `go.sum`.
+- [x] Introduce parser-backed import collection in `pkg/xgoja/sourcegraph`.
+- [x] Implement tree-sitter import collection for JS/ESM/CommonJS/TS/TSX.
+- [x] Select JavaScript, TypeScript, or TSX grammar by source file extension.
+- [x] Remove the regex parser once table-driven tests pass.
+- [x] Preserve sourcegraph's current local/runtime/unknown import classification and path-escape checks.
+
+### 4. Strengthen example coverage
+
+- [x] Finalize `examples/xgoja/17-sourcegraph-runtime-aliases` as a broad sourcegraph/runtime example.
+- [x] Ensure the example uses literal runtime aliases (`require("fs:assets")`, `import ... from "fs:assets"`) rather than dynamic workarounds.
+- [x] Cover JavaScript and TypeScript jsverb source sets, local imports, embedded assets, host FS, HTTP provider command sets, builtin jsverbs, and DTS generation.
+- [x] Add a smoke target that builds the generated binary, runs it, and validates HTTP/API output.
+- [x] Remove generated `dist/` binaries from the working tree and keep them ignored or generated-only.
+
+### 5. Documentation, validation, and handoff
+
+- [ ] Update xgoja docs if parser behavior or dynamic import diagnostics become user-visible.
+- [x] Update the ticket design doc with final implementation decisions.
+- [x] Keep the investigation diary updated after each implementation step.
+- [x] Relate modified code/example files to the ticket design doc.
+- [x] Run focused tests: `go test ./pkg/xgoja/sourcegraph ./cmd/xgoja/internal/plan ./pkg/xgoja/app -count=1`.
+- [x] Run example smoke: `make -C examples/xgoja/17-sourcegraph-runtime-aliases smoke`.
+- [x] Run broader xgoja validation before final handoff.
+- [x] Run `docmgr --root ttmp doctor --ticket GOJA-XGOJA-SOURCEGRAPH-PARSER-001 --stale-after 30`.

--- a/ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-PARSER-001--replace-xgoja-sourcegraph-regex-import-scanning-with-parser-backed-runtime-alias-resolution/tasks.md
+++ b/ttmp/2026/06/14/GOJA-XGOJA-SOURCEGRAPH-PARSER-001--replace-xgoja-sourcegraph-regex-import-scanning-with-parser-backed-runtime-alias-resolution/tasks.md
@@ -43,7 +43,7 @@
 
 ### 5. Documentation, validation, and handoff
 
-- [ ] Update xgoja docs if parser behavior or dynamic import diagnostics become user-visible.
+- [x] Update xgoja docs if parser behavior or dynamic import diagnostics become user-visible.
 - [x] Update the ticket design doc with final implementation decisions.
 - [x] Keep the investigation diary updated after each implementation step.
 - [x] Relate modified code/example files to the ticket design doc.

--- a/ttmp/vocabulary.yaml
+++ b/ttmp/vocabulary.yaml
@@ -131,6 +131,10 @@ topics:
       description: Developer experience improvements, ergonomics, and usability
     - slug: typescript
       description: TypeScript type definitions, d.ts generation, and type safety for JS modules
+    - slug: sourcegraph
+      description: xgoja source graph and import resolution planning
+    - slug: runtime
+      description: runtime behavior and execution model
 docTypes:
     - slug: index
       description: Index document for a ticket


### PR DESCRIPTION
## Summary

- replace regex-based xgoja sourcegraph import extraction with tree-sitter-backed JS/TS/TSX parsing
- propagate configured RuntimePlan module aliases into source scans so literal aliases like `require("fs:assets")` validate correctly
- add broad sourcegraph/runtime alias coverage example and ticket documentation/experiments
- document static sourcegraph import rules in the xgoja v2 reference

## Validation

- `go test ./cmd/xgoja/internal/plan ./pkg/xgoja/sourcegraph ./pkg/xgoja/app ./pkg/xgoja/providers/http -count=1`
- `go test ./cmd/xgoja/internal/... ./cmd/xgoja ./pkg/xgoja/... -count=1`
- `make -C examples/xgoja/17-sourcegraph-runtime-aliases smoke`
- pre-commit/pre-push hooks: lint, `go generate ./...`, `go test ./...`
- `docmgr --root ttmp doctor --ticket GOJA-XGOJA-SOURCEGRAPH-PARSER-001 --stale-after 30`
