### PR TITLE
Fix protobuf tooling in release builds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,10 +24,11 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
-      - name: Install arm64 cross-compiler
+      - name: Install release build tools
         run: |
           sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu protobuf-compiler
+          make install-generate-tools
       - uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser-pro
@@ -53,6 +54,10 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+      - name: Install release build tools
+        run: |
+          brew install protobuf
+          make install-generate-tools
       - uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser-pro

--- a/examples/xgoja/15-protobuf-builder-provider/proto/generate.go
+++ b/examples/xgoja/15-protobuf-builder-provider/proto/generate.go
@@ -1,3 +1,3 @@
 package taskpb
 
-//go:generate protoc -I . -I /usr/include --go_out=. --go_opt=paths=source_relative --goja-builder_out=. --goja-builder_opt=paths=source_relative,module_name=examples.xgoja.protobuf.v1 task.proto
+//go:generate protoc -I . --go_out=. --go_opt=paths=source_relative --goja-builder_out=. --goja-builder_opt=paths=source_relative,module_name=examples.xgoja.protobuf.v1 task.proto


### PR DESCRIPTION
## Summary
- install `protoc` and the repository protobuf generators on Linux and macOS release runners
- remove the Linux-specific `/usr/include` path from the protobuf example generator
- unblock GoReleaser so the dependent docsctl publication job can run

## Root cause
Every Goja release since v0.8.9 has failed in the GoReleaser `go generate ./...` hook because `protoc` was absent. Since `publish-docs` needs `goreleaser-merge`, documentation publication was skipped.

## Validation
- `make install-generate-tools && go generate ./...`
- `go test ./...`
- repository Lefthook pre-commit and pre-push pipelines
- YAML parse and `git diff --check`

After merge, publish a new patch tag (v0.10.3) and verify both GoReleaser and docsctl publication.