### PR TITLE
feat(xgoja): Implement command-compatible artifact selection

### DIFF
--- a/cmd/xgoja/cmd_build.go
+++ b/cmd/xgoja/cmd_build.go
@@ -26,6 +26,7 @@ var _ cmds.BareCommand = (*buildCommand)(nil)
 
 type buildSettings struct {
 	File         string `glazed:"file"`
+	Artifact     string `glazed:"artifact"`
 	Output       string `glazed:"output"`
 	WorkDir      string `glazed:"work-dir"`
 	KeepWork     bool   `glazed:"keep-work"`
@@ -48,6 +49,7 @@ to point generated builds at that checkout.
 
 Examples:
   xgoja build -f xgoja.yaml
+  xgoja build -f xgoja.yaml --artifact release-binary
   xgoja build -f examples/xgoja/08-provider-shipped-jsverbs/xgoja.yaml --output ./dist/provider
   xgoja build -f xgoja.yaml --xgoja-replace /path/to/go-go-goja --keep-work
   xgoja build -f xgoja.yaml --dry-run --keep-work
@@ -57,6 +59,8 @@ Examples:
 					fields.WithDefault("xgoja.yaml"),
 					fields.WithShortFlag("f"),
 					fields.WithHelp("Path to the xgoja build specification")),
+				fields.New("artifact", fields.TypeString,
+					fields.WithHelp("Select a build-compatible artifact ID when the spec has multiple build targets")),
 				fields.New("output", fields.TypeString,
 					fields.WithHelp("Override the output binary path from the build spec")),
 				fields.New("work-dir", fields.TypeString,
@@ -87,7 +91,7 @@ func (c *buildCommand) Run(ctx context.Context, vals *values.Values) error {
 	if err != nil {
 		return err
 	}
-	target, scopedPlan, err := selectPlanTarget(compiledPlan, artifactCommandBuild)
+	target, scopedPlan, err := selectPlanTarget(compiledPlan, artifactCommandBuild, settings.Artifact)
 	if err != nil {
 		return err
 	}

--- a/cmd/xgoja/cmd_build.go
+++ b/cmd/xgoja/cmd_build.go
@@ -87,11 +87,12 @@ func (c *buildCommand) Run(ctx context.Context, vals *values.Values) error {
 	if err != nil {
 		return err
 	}
-	target := targetFromPlan(compiledPlan)
-	_, _ = fmt.Fprintf(c.out, "validated xgoja/v2 plan for %s\n", settings.File)
-	if kind := strings.TrimSpace(target.Kind); kind == "package" || kind == "source" || kind == "template" {
-		return fmt.Errorf("target.kind %s is source generation only; use xgoja generate -f %s", kind, settings.File)
+	target, scopedPlan, err := selectPlanTarget(compiledPlan, artifactCommandBuild)
+	if err != nil {
+		return err
 	}
+	compiledPlan = scopedPlan
+	_, _ = fmt.Fprintf(c.out, "validated xgoja/v2 plan for %s\n", settings.File)
 	output := settings.Output
 	if output == "" {
 		output = target.Output

--- a/cmd/xgoja/cmd_generate.go
+++ b/cmd/xgoja/cmd_generate.go
@@ -89,15 +89,13 @@ func (c *generateCommand) Run(ctx context.Context, vals *values.Values) error {
 	if err != nil {
 		return err
 	}
-	target := targetFromPlan(compiledPlan)
+	target, scopedPlan, err := selectPlanTarget(compiledPlan, artifactCommandGenerate)
+	if err != nil {
+		return err
+	}
+	compiledPlan = scopedPlan
 	_, _ = fmt.Fprintf(c.out, "validated xgoja/v2 plan for %s\n", settings.File)
 	kind := strings.TrimSpace(target.Kind)
-	if kind == "" {
-		kind = "xgoja"
-	}
-	if kind != "package" && kind != "source" && kind != "template" {
-		return fmt.Errorf("xgoja generate supports target.kind package, source, or template; got %q", kind)
-	}
 	output := strings.TrimSpace(settings.Output)
 	if output == "" {
 		output = target.Output

--- a/cmd/xgoja/cmd_generate.go
+++ b/cmd/xgoja/cmd_generate.go
@@ -23,6 +23,7 @@ var _ cmds.BareCommand = (*generateCommand)(nil)
 
 type generateSettings struct {
 	File         string `glazed:"file"`
+	Artifact     string `glazed:"artifact"`
 	Output       string `glazed:"output"`
 	Package      string `glazed:"package"`
 	Template     string `glazed:"template"`
@@ -38,15 +39,16 @@ func newGenerateCommand(out io.Writer) *generateCommand {
 			cmds.WithLong(`
 Generate reads xgoja.yaml and writes source files into an existing Go module.
 
-Generation supports target.kind: package, source, and template. Package mode
-writes one reusable runtime package file. Source-fragment mode splits the same
+Generation supports runtime-package, source, and template artifacts. Use
+--artifact <id> when the specification has more than one generate-compatible
+artifact. Package mode writes one reusable runtime package file. Source-fragment mode splits the same
 API across spec/providers/embed/bundle files. Template mode renders a caller
 provided Go template with the same data contract. Generate does not create
 go.mod, run go mod tidy, or compile a binary.
 
 Examples:
   xgoja generate -f xgoja.yaml
-  xgoja generate -f xgoja.yaml --output ./internal/xgojaruntime --package xgojaruntime
+  xgoja generate -f xgoja.yaml --artifact runtime-package --output ./internal/xgojaruntime --package xgojaruntime
   xgoja generate -f xgoja.yaml --template ./runtime.go.tmpl --output ./internal/runtime/custom.gen.go
   xgoja generate -f xgoja.yaml --template-data
   xgoja generate -f xgoja.yaml --clean
@@ -57,6 +59,8 @@ Examples:
 					fields.WithDefault("xgoja.yaml"),
 					fields.WithShortFlag("f"),
 					fields.WithHelp("Path to the xgoja build specification")),
+				fields.New("artifact", fields.TypeString,
+					fields.WithHelp("Select a generate-compatible artifact ID when the spec has multiple generation targets")),
 				fields.New("output", fields.TypeString,
 					fields.WithShortFlag("o"),
 					fields.WithHelp("Override the generated package output directory from target.output")),
@@ -89,7 +93,7 @@ func (c *generateCommand) Run(ctx context.Context, vals *values.Values) error {
 	if err != nil {
 		return err
 	}
-	target, scopedPlan, err := selectPlanTarget(compiledPlan, artifactCommandGenerate)
+	target, scopedPlan, err := selectPlanTarget(compiledPlan, artifactCommandGenerate, settings.Artifact)
 	if err != nil {
 		return err
 	}

--- a/cmd/xgoja/doc/17-xgoja-v2-reference.md
+++ b/cmd/xgoja/doc/17-xgoja-v2-reference.md
@@ -421,10 +421,18 @@ order works with both commands. `build` generates from the binary and
 control embedded jsverb/help files. `embedded-assets` artifacts remain global
 support artifacts and are retained by both commands.
 
-If no compatible primary exists, or more than one compatible primary exists,
-the command fails and names the relevant artifact IDs and types. xgoja does not
-yet provide `--artifact` selection or multi-output orchestration; split an
-ambiguous configuration until a concrete need for that larger feature exists.
+If no compatible primary exists, the command fails and names the configured
+artifact IDs and types. If more than one compatible primary exists, pass
+`--artifact <id>` to choose one explicitly:
+
+```bash
+xgoja build -f xgoja.yaml --artifact release-binary
+xgoja generate -f xgoja.yaml --artifact runtime-package
+```
+
+The selected primary's sources are embedded along with global support artifacts.
+xgoja still does not orchestrate multiple outputs in one invocation; run the
+command once for each intended output.
 
 Generated hosts can configure Go-owned auth services with a top-level `auth:`
 block. `app.NewHostWithOptions` installs a lazy `hostauth.ServiceFactoryKey`
@@ -641,7 +649,7 @@ The normal command path is v2-plan-native: `doctor`, `build`, `generate`, `gen-d
 Known limits:
 
 - v2 doctor uses a synthetic provider registry for static validation. It cannot fully validate provider package implementation details unless a provider is linked into a generated sidecar or described by future provider manifests.
-- Multiple compatible primary artifacts are not orchestrated. `xgoja build` and `xgoja generate` each require exactly one compatible primary artifact; use one build primary and one generation primary per spec today. `dts` and `embedded-assets` remain support artifacts.
+- Multiple compatible primary artifacts are not orchestrated in one invocation. `xgoja build` and `xgoja generate` auto-select when exactly one compatible primary exists; use `--artifact <id>` when more than one is intentional. `dts` and `embedded-assets` remain support artifacts.
 - Provider package import path and Go module path are inferred when a provider does not specify replacement/version metadata.
 
 ## Migration policy

--- a/cmd/xgoja/doc/17-xgoja-v2-reference.md
+++ b/cmd/xgoja/doc/17-xgoja-v2-reference.md
@@ -403,6 +403,29 @@ help source sets that should be copied into the generated embedded filesystem.
 For assets, use a separate `embedded-assets` artifact with `sources` pointing at
 asset source IDs.
 
+### Artifact selection by command
+
+`xgoja build` and `xgoja generate` select a primary artifact by command
+compatibility, not YAML order. Each command requires exactly one compatible
+primary artifact:
+
+| Command | Compatible primary artifact types | Retained support artifacts |
+| --- | --- | --- |
+| `xgoja build` | `binary`, `adapter`, `cobra` | `dts`, `embedded-assets` |
+| `xgoja generate` | `runtime-package`, `source`, `template` | `dts`, `embedded-assets` |
+| `xgoja gen-dts` | first `dts` artifact (existing behavior) | N/A |
+
+A spec may therefore contain one `binary` and one `runtime-package`; either
+order works with both commands. `build` generates from the binary and
+`generate` generates from the runtime package. The selected primary's `sources`
+control embedded jsverb/help files. `embedded-assets` artifacts remain global
+support artifacts and are retained by both commands.
+
+If no compatible primary exists, or more than one compatible primary exists,
+the command fails and names the relevant artifact IDs and types. xgoja does not
+yet provide `--artifact` selection or multi-output orchestration; split an
+ambiguous configuration until a concrete need for that larger feature exists.
+
 Generated hosts can configure Go-owned auth services with a top-level `auth:`
 block. `app.NewHostWithOptions` installs a lazy `hostauth.ServiceFactoryKey`
 from the runtime plan, and the HTTP `serve` provider builds concrete
@@ -618,7 +641,7 @@ The normal command path is v2-plan-native: `doctor`, `build`, `generate`, `gen-d
 Known limits:
 
 - v2 doctor uses a synthetic provider registry for static validation. It cannot fully validate provider package implementation details unless a provider is linked into a generated sidecar or described by future provider manifests.
-- Multiple artifacts are not fully orchestrated by `xgoja build`. The first binary-style artifact controls the current build target.
+- Multiple compatible primary artifacts are not orchestrated. `xgoja build` and `xgoja generate` each require exactly one compatible primary artifact; use one build primary and one generation primary per spec today. `dts` and `embedded-assets` remain support artifacts.
 - Provider package import path and Go module path are inferred when a provider does not specify replacement/version metadata.
 
 ## Migration policy

--- a/cmd/xgoja/internal/specv2/defaults.go
+++ b/cmd/xgoja/internal/specv2/defaults.go
@@ -46,6 +46,7 @@ func ApplyDefaults(cfg *Config) {
 		applySourceDefaults(&cfg.Sources[i])
 	}
 	for i := range cfg.Artifacts {
+		cfg.Artifacts[i].Type = strings.TrimSpace(cfg.Artifacts[i].Type)
 		if cfg.Artifacts[i].Type == "binary" && strings.TrimSpace(cfg.Artifacts[i].Output) == "" {
 			cfg.Artifacts[i].Output = filepath.ToSlash(filepath.Join("dist", sanitizeModulePathPart(cfg.Name)))
 		}

--- a/cmd/xgoja/internal/specv2/defaults.go
+++ b/cmd/xgoja/internal/specv2/defaults.go
@@ -46,6 +46,7 @@ func ApplyDefaults(cfg *Config) {
 		applySourceDefaults(&cfg.Sources[i])
 	}
 	for i := range cfg.Artifacts {
+		cfg.Artifacts[i].ID = strings.TrimSpace(cfg.Artifacts[i].ID)
 		cfg.Artifacts[i].Type = strings.TrimSpace(cfg.Artifacts[i].Type)
 		if cfg.Artifacts[i].Type == "binary" && strings.TrimSpace(cfg.Artifacts[i].Output) == "" {
 			cfg.Artifacts[i].Output = filepath.ToSlash(filepath.Join("dist", sanitizeModulePathPart(cfg.Name)))

--- a/cmd/xgoja/internal/specv2/specv2_test.go
+++ b/cmd/xgoja/internal/specv2/specv2_test.go
@@ -129,6 +129,17 @@ func TestValidateRejectsDuplicateRuntimeAliases(t *testing.T) {
 	}
 }
 
+func TestApplyDefaultsNormalizesArtifactType(t *testing.T) {
+	cfg := &Config{Artifacts: []ArtifactSpec{{ID: "binary", Type: " binary "}}}
+	ApplyDefaults(cfg)
+	if got := cfg.Artifacts[0].Type; got != "binary" {
+		t.Fatalf("artifact type = %q, want binary", got)
+	}
+	if got := cfg.Artifacts[0].Output; got != "dist/xgoja-app" {
+		t.Fatalf("default binary output = %q, want dist/xgoja-app", got)
+	}
+}
+
 func TestRenderAppliesStableDefaults(t *testing.T) {
 	out, err := Render(Config{
 		Name: "My App",

--- a/cmd/xgoja/internal/specv2/specv2_test.go
+++ b/cmd/xgoja/internal/specv2/specv2_test.go
@@ -130,8 +130,11 @@ func TestValidateRejectsDuplicateRuntimeAliases(t *testing.T) {
 }
 
 func TestApplyDefaultsNormalizesArtifactType(t *testing.T) {
-	cfg := &Config{Artifacts: []ArtifactSpec{{ID: "binary", Type: " binary "}}}
+	cfg := &Config{Artifacts: []ArtifactSpec{{ID: " binary ", Type: " binary "}}}
 	ApplyDefaults(cfg)
+	if got := cfg.Artifacts[0].ID; got != "binary" {
+		t.Fatalf("artifact id = %q, want binary", got)
+	}
 	if got := cfg.Artifacts[0].Type; got != "binary" {
 		t.Fatalf("artifact type = %q, want binary", got)
 	}

--- a/cmd/xgoja/root_test.go
+++ b/cmd/xgoja/root_test.go
@@ -92,7 +92,7 @@ func TestBuildAndGenerateSelectCompatibleArtifactsRegardlessOfOrder(t *testing.T
 				t.Fatalf("new build root command: %v", err)
 			}
 			workDir := filepath.Join(t.TempDir(), "build")
-			buildRoot.SetArgs([]string{"build", "-f", specPath, "--work-dir", workDir, "--dry-run"})
+			buildRoot.SetArgs([]string{"build", "-f", specPath, "--artifact", "binary", "--work-dir", workDir, "--dry-run"})
 			if err := buildRoot.Execute(); err != nil {
 				t.Fatalf("execute build: %v\n%s", err, buildOut.String())
 			}
@@ -110,7 +110,7 @@ func TestBuildAndGenerateSelectCompatibleArtifactsRegardlessOfOrder(t *testing.T
 				t.Fatalf("new generate root command: %v", err)
 			}
 			packageDir := filepath.Join(t.TempDir(), "runtime")
-			generateRoot.SetArgs([]string{"generate", "-f", specPath, "--output", packageDir})
+			generateRoot.SetArgs([]string{"generate", "-f", specPath, "--artifact", "runtime", "--output", packageDir})
 			if err := generateRoot.Execute(); err != nil {
 				t.Fatalf("execute generate: %v\n%s", err, generateOut.String())
 			}

--- a/cmd/xgoja/root_test.go
+++ b/cmd/xgoja/root_test.go
@@ -81,6 +81,82 @@ func TestBuildCommandWired(t *testing.T) {
 	}
 }
 
+func TestBuildAndGenerateSelectCompatibleArtifactsRegardlessOfOrder(t *testing.T) {
+	for _, packageFirst := range []bool{false, true} {
+		t.Run(map[bool]string{false: "binary-first", true: "package-first"}[packageFirst], func(t *testing.T) {
+			specPath := writeBinaryAndPackageSpec(t, packageFirst)
+
+			buildOut := &bytes.Buffer{}
+			buildRoot, err := newRootCommand(buildOut)
+			if err != nil {
+				t.Fatalf("new build root command: %v", err)
+			}
+			workDir := filepath.Join(t.TempDir(), "build")
+			buildRoot.SetArgs([]string{"build", "-f", specPath, "--work-dir", workDir, "--dry-run"})
+			if err := buildRoot.Execute(); err != nil {
+				t.Fatalf("execute build: %v\n%s", err, buildOut.String())
+			}
+			buildPlan, err := os.ReadFile(filepath.Join(workDir, "xgoja.runtime.json"))
+			if err != nil {
+				t.Fatalf("read generated build runtime plan: %v", err)
+			}
+			if !strings.Contains(string(buildPlan), `"kind": "xgoja"`) || strings.Contains(string(buildPlan), `"kind": "package"`) {
+				t.Fatalf("build runtime target did not select binary:\n%s", buildPlan)
+			}
+
+			generateOut := &bytes.Buffer{}
+			generateRoot, err := newRootCommand(generateOut)
+			if err != nil {
+				t.Fatalf("new generate root command: %v", err)
+			}
+			packageDir := filepath.Join(t.TempDir(), "runtime")
+			generateRoot.SetArgs([]string{"generate", "-f", specPath, "--output", packageDir})
+			if err := generateRoot.Execute(); err != nil {
+				t.Fatalf("execute generate: %v\n%s", err, generateOut.String())
+			}
+			generatedPackage, err := os.ReadFile(filepath.Join(packageDir, "xgoja_runtime.gen.go"))
+			if err != nil {
+				t.Fatalf("read generated package: %v", err)
+			}
+			if !strings.Contains(string(generatedPackage), `"kind": "package"`) || strings.Contains(string(generatedPackage), `"kind": "xgoja"`) {
+				t.Fatalf("generated runtime target did not select package:\n%s", generatedPackage)
+			}
+		})
+	}
+}
+
+func TestBuildAndGenerateScopeEmbeddedSourcesToSelectedPrimary(t *testing.T) {
+	specPath, binaryVerbs, packageVerbs, assets := writeScopedArtifactSourcesSpec(t)
+
+	buildOut := &bytes.Buffer{}
+	buildRoot, err := newRootCommand(buildOut)
+	if err != nil {
+		t.Fatalf("new build root command: %v", err)
+	}
+	workDir := filepath.Join(t.TempDir(), "build")
+	buildRoot.SetArgs([]string{"build", "-f", specPath, "--work-dir", workDir, "--dry-run"})
+	if err := buildRoot.Execute(); err != nil {
+		t.Fatalf("execute build: %v\n%s", err, buildOut.String())
+	}
+	assertExists(t, filepath.Join(workDir, "xgoja_embed", "jsverbs", "binary_verbs", filepath.Base(binaryVerbs)))
+	assertNotExists(t, filepath.Join(workDir, "xgoja_embed", "jsverbs", "package_verbs", filepath.Base(packageVerbs)))
+	assertExists(t, filepath.Join(workDir, "xgoja_embed", "assets", "webapp", filepath.Base(assets)))
+
+	generateOut := &bytes.Buffer{}
+	generateRoot, err := newRootCommand(generateOut)
+	if err != nil {
+		t.Fatalf("new generate root command: %v", err)
+	}
+	packageDir := filepath.Join(t.TempDir(), "runtime")
+	generateRoot.SetArgs([]string{"generate", "-f", specPath, "--output", packageDir})
+	if err := generateRoot.Execute(); err != nil {
+		t.Fatalf("execute generate: %v\n%s", err, generateOut.String())
+	}
+	assertExists(t, filepath.Join(packageDir, "xgoja_embed", "jsverbs", "package_verbs", filepath.Base(packageVerbs)))
+	assertNotExists(t, filepath.Join(packageDir, "xgoja_embed", "jsverbs", "binary_verbs", filepath.Base(binaryVerbs)))
+	assertExists(t, filepath.Join(packageDir, "xgoja_embed", "assets", "webapp", filepath.Base(assets)))
+}
+
 func TestGenerateCommandWired(t *testing.T) {
 	out := &bytes.Buffer{}
 	root, err := newRootCommand(out)
@@ -540,6 +616,116 @@ func TestListModulesCommandWired(t *testing.T) {
 	root.SetArgs([]string{"list-modules", "-f", specPath, "--output", "json"})
 	if err := root.Execute(); err != nil {
 		t.Fatalf("execute list-modules: %v", err)
+	}
+}
+
+func writeBinaryAndPackageSpec(t *testing.T, packageFirst bool) string {
+	t.Helper()
+	binary := `
+  - id: binary
+    type: binary
+    output: dist/fixture
+`
+	runtimePackage := `
+  - id: runtime
+    type: runtime-package
+    output: internal/xgojaruntime
+    package: xgojaruntime
+`
+	artifacts := binary + runtimePackage
+	if packageFirst {
+		artifacts = runtimePackage + binary
+	}
+	return writeFile(t, "xgoja.yaml", `
+schema: xgoja/v2
+name: binary-and-package
+go:
+  module: xgoja.generated/binary-and-package
+  version: "1.26"
+workspace:
+  mode: off
+providers:
+  - id: fixture
+    import: github.com/go-go-golems/go-go-goja/pkg/xgoja/testprovider
+    register: Register
+runtime:
+  modules:
+    - provider: fixture
+      name: hello
+      as: hello
+artifacts:`+artifacts)
+}
+
+func writeScopedArtifactSourcesSpec(t *testing.T) (string, string, string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	binaryDir := filepath.Join(dir, "binary-verbs")
+	packageDir := filepath.Join(dir, "package-verbs")
+	assetsDir := filepath.Join(dir, "assets")
+	binaryVerbs := filepath.Join(binaryDir, "binary.js")
+	packageVerbs := filepath.Join(packageDir, "package.js")
+	assets := filepath.Join(assetsDir, "app.css")
+	for path, content := range map[string]string{
+		binaryVerbs:  "export const binary = true;\n",
+		packageVerbs: "export const runtimePackage = true;\n",
+		assets:       "body { color: black; }\n",
+	} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", path, err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	specPath := writeFile(t, "xgoja.yaml", `
+schema: xgoja/v2
+name: scoped-artifact-sources
+go:
+  module: xgoja.generated/scoped-artifact-sources
+  version: "1.26"
+workspace:
+  mode: off
+sources:
+  - id: binary-verbs
+    kind: jsverbs
+    from:
+      dir: `+filepath.ToSlash(binaryDir)+`
+  - id: package-verbs
+    kind: jsverbs
+    from:
+      dir: `+filepath.ToSlash(packageDir)+`
+  - id: webapp
+    kind: assets
+    from:
+      dir: `+filepath.ToSlash(assetsDir)+`
+artifacts:
+  - id: runtime
+    type: runtime-package
+    output: internal/xgojaruntime
+    package: xgojaruntime
+    sources: [package-verbs]
+  - id: assets
+    type: embedded-assets
+    sources: [webapp]
+  - id: binary
+    type: binary
+    output: dist/fixture
+    sources: [binary-verbs]
+`)
+	return specPath, binaryVerbs, packageVerbs, assets
+}
+
+func assertExists(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected %s: %v", path, err)
+	}
+}
+
+func assertNotExists(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("expected %s to be absent, err=%v", path, err)
 	}
 }
 

--- a/cmd/xgoja/v2_plan_helpers.go
+++ b/cmd/xgoja/v2_plan_helpers.go
@@ -77,7 +77,7 @@ func selectPlanTarget(compiled *plan.Plan, command artifactCommand, artifactID s
 		selected = candidates[0]
 	}
 
-	scoped, err := scopePlanToPrimary(compiled, selected.Spec.ID)
+	scoped, err := scopePlanToPrimary(compiled, normalizedArtifactID(selected.Spec.ID))
 	if err != nil {
 		return v2PlanTarget{}, nil, err
 	}
@@ -103,6 +103,10 @@ func isSupportArtifact(artifactType string) bool {
 
 func normalizedArtifactType(artifactType string) string {
 	return strings.TrimSpace(artifactType)
+}
+
+func normalizedArtifactID(artifactID string) string {
+	return strings.TrimSpace(artifactID)
 }
 
 func compatibleArtifactTypes(command artifactCommand) string {
@@ -169,6 +173,7 @@ func scopePlanToPrimary(compiled *plan.Plan, selectedID string) (*plan.Plan, err
 }
 
 func normalizedArtifactSpec(artifact specv2.ArtifactSpec) specv2.ArtifactSpec {
+	artifact.ID = normalizedArtifactID(artifact.ID)
 	artifact.Type = normalizedArtifactType(artifact.Type)
 	return artifact
 }
@@ -180,7 +185,7 @@ func normalizedArtifactPlan(artifact plan.ArtifactPlan) plan.ArtifactPlan {
 
 func artifactByID(artifacts []specv2.ArtifactSpec, id string) (specv2.ArtifactSpec, bool) {
 	for _, artifact := range artifacts {
-		if artifact.ID == id {
+		if normalizedArtifactID(artifact.ID) == id {
 			return artifact, true
 		}
 	}
@@ -189,7 +194,7 @@ func artifactByID(artifacts []specv2.ArtifactSpec, id string) (specv2.ArtifactSp
 
 func artifactPlanByID(artifacts []plan.ArtifactPlan, id string) (plan.ArtifactPlan, bool) {
 	for _, artifact := range artifacts {
-		if artifact.Spec.ID == id {
+		if normalizedArtifactID(artifact.Spec.ID) == id {
 			return artifact, true
 		}
 	}
@@ -202,7 +207,7 @@ func formatArtifacts(artifacts []plan.ArtifactPlan) string {
 	}
 	parts := make([]string, 0, len(artifacts))
 	for _, artifact := range artifacts {
-		parts = append(parts, fmt.Sprintf("%s (%s)", artifact.Spec.ID, normalizedArtifactType(artifact.Spec.Type)))
+		parts = append(parts, fmt.Sprintf("%s (%s)", normalizedArtifactID(artifact.Spec.ID), normalizedArtifactType(artifact.Spec.Type)))
 	}
 	return strings.Join(parts, ", ")
 }

--- a/cmd/xgoja/v2_plan_helpers.go
+++ b/cmd/xgoja/v2_plan_helpers.go
@@ -1,35 +1,165 @@
 package main
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/go-go-golems/go-go-goja/cmd/xgoja/internal/plan"
+	"github.com/go-go-golems/go-go-goja/cmd/xgoja/internal/specv2"
+)
+
+type artifactCommand string
+
+const (
+	artifactCommandBuild    artifactCommand = "build"
+	artifactCommandGenerate artifactCommand = "generate"
 )
 
 type v2PlanTarget struct {
+	ID       string
+	Type     string
 	Kind     string
 	Output   string
 	Package  string
 	Template string
 }
 
-func targetFromPlan(compiled *plan.Plan) v2PlanTarget {
+func selectPlanTarget(compiled *plan.Plan, command artifactCommand) (v2PlanTarget, *plan.Plan, error) {
 	if compiled == nil {
-		return v2PlanTarget{Kind: "xgoja", Output: "dist/xgoja-app"}
+		return v2PlanTarget{}, nil, fmt.Errorf("xgoja %s: compiled plan is nil", command)
+	}
+
+	candidates := make([]plan.ArtifactPlan, 0, len(compiled.Artifacts))
+	for _, artifact := range compiled.Artifacts {
+		if isCompatiblePrimary(command, artifact.Spec.Type) {
+			candidates = append(candidates, artifact)
+		}
+	}
+	if len(candidates) == 0 {
+		return v2PlanTarget{}, nil, fmt.Errorf(
+			"xgoja %s found no compatible primary artifact; accepts %s; configured artifacts: %s",
+			command,
+			compatibleArtifactTypes(command),
+			formatArtifacts(compiled.Artifacts),
+		)
+	}
+	if len(candidates) > 1 {
+		return v2PlanTarget{}, nil, fmt.Errorf(
+			"xgoja %s requires exactly one compatible primary artifact; found %d: %s",
+			command,
+			len(candidates),
+			formatArtifacts(candidates),
+		)
+	}
+
+	selected := candidates[0].Spec
+	scoped, err := scopePlanToPrimary(compiled, selected.ID)
+	if err != nil {
+		return v2PlanTarget{}, nil, err
+	}
+	return targetFromArtifact(selected), scoped, nil
+}
+
+func isCompatiblePrimary(command artifactCommand, artifactType string) bool {
+	switch command {
+	case artifactCommandBuild:
+		return artifactType == "binary" || artifactType == "adapter" || artifactType == "cobra"
+	case artifactCommandGenerate:
+		return artifactType == "runtime-package" || artifactType == "source" || artifactType == "template"
+	default:
+		return false
+	}
+}
+
+func isSupportArtifact(artifactType string) bool {
+	return artifactType == "dts" || artifactType == "embedded-assets"
+}
+
+func compatibleArtifactTypes(command artifactCommand) string {
+	switch command {
+	case artifactCommandBuild:
+		return "binary, adapter, or cobra"
+	case artifactCommandGenerate:
+		return "runtime-package, source, or template"
+	default:
+		return "no artifact types"
+	}
+}
+
+func targetFromArtifact(artifact specv2.ArtifactSpec) v2PlanTarget {
+	kind := artifact.Type
+	switch kind {
+	case "binary":
+		kind = "xgoja"
+	case "runtime-package":
+		kind = "package"
+	}
+	return v2PlanTarget{
+		ID:       artifact.ID,
+		Type:     artifact.Type,
+		Kind:     kind,
+		Output:   artifact.Output,
+		Package:  artifact.Package,
+		Template: artifact.Template,
+	}
+}
+
+func scopePlanToPrimary(compiled *plan.Plan, selectedID string) (*plan.Plan, error) {
+	if compiled == nil {
+		return nil, fmt.Errorf("scope plan: compiled plan is nil")
+	}
+
+	selectedConfig, ok := artifactByID(compiled.Config.Artifacts, selectedID)
+	if !ok {
+		return nil, fmt.Errorf("scope plan: selected artifact %q is missing from config", selectedID)
+	}
+	selectedPlan, ok := artifactPlanByID(compiled.Artifacts, selectedID)
+	if !ok {
+		return nil, fmt.Errorf("scope plan: selected artifact %q is missing from compiled artifacts", selectedID)
+	}
+
+	scoped := *compiled
+	scoped.Config = compiled.Config
+	scoped.Config.Artifacts = []specv2.ArtifactSpec{selectedConfig}
+	scoped.Artifacts = []plan.ArtifactPlan{selectedPlan}
+	for _, artifact := range compiled.Config.Artifacts {
+		if isSupportArtifact(artifact.Type) {
+			scoped.Config.Artifacts = append(scoped.Config.Artifacts, artifact)
+		}
 	}
 	for _, artifact := range compiled.Artifacts {
-		spec := artifact.Spec
-		kind := strings.TrimSpace(spec.Type)
-		if kind == "" || kind == "dts" || kind == "embedded-assets" {
-			continue
+		if isSupportArtifact(artifact.Spec.Type) {
+			scoped.Artifacts = append(scoped.Artifacts, artifact)
 		}
-		if kind == "binary" {
-			kind = "xgoja"
-		}
-		if kind == "runtime-package" {
-			kind = "package"
-		}
-		return v2PlanTarget{Kind: kind, Output: spec.Output, Package: spec.Package, Template: spec.Template}
 	}
-	return v2PlanTarget{Kind: "xgoja", Output: "dist/xgoja-app"}
+	return &scoped, nil
+}
+
+func artifactByID(artifacts []specv2.ArtifactSpec, id string) (specv2.ArtifactSpec, bool) {
+	for _, artifact := range artifacts {
+		if artifact.ID == id {
+			return artifact, true
+		}
+	}
+	return specv2.ArtifactSpec{}, false
+}
+
+func artifactPlanByID(artifacts []plan.ArtifactPlan, id string) (plan.ArtifactPlan, bool) {
+	for _, artifact := range artifacts {
+		if artifact.Spec.ID == id {
+			return artifact, true
+		}
+	}
+	return plan.ArtifactPlan{}, false
+}
+
+func formatArtifacts(artifacts []plan.ArtifactPlan) string {
+	if len(artifacts) == 0 {
+		return "none"
+	}
+	parts := make([]string, 0, len(artifacts))
+	for _, artifact := range artifacts {
+		parts = append(parts, fmt.Sprintf("%s (%s)", artifact.Spec.ID, artifact.Spec.Type))
+	}
+	return strings.Join(parts, ", ")
 }

--- a/cmd/xgoja/v2_plan_helpers.go
+++ b/cmd/xgoja/v2_plan_helpers.go
@@ -24,40 +24,64 @@ type v2PlanTarget struct {
 	Template string
 }
 
-func selectPlanTarget(compiled *plan.Plan, command artifactCommand) (v2PlanTarget, *plan.Plan, error) {
+func selectPlanTarget(compiled *plan.Plan, command artifactCommand, artifactID string) (v2PlanTarget, *plan.Plan, error) {
 	if compiled == nil {
 		return v2PlanTarget{}, nil, fmt.Errorf("xgoja %s: compiled plan is nil", command)
 	}
 
-	candidates := make([]plan.ArtifactPlan, 0, len(compiled.Artifacts))
-	for _, artifact := range compiled.Artifacts {
-		if isCompatiblePrimary(command, artifact.Spec.Type) {
-			candidates = append(candidates, artifact)
+	artifactID = strings.TrimSpace(artifactID)
+	var selected plan.ArtifactPlan
+	if artifactID != "" {
+		var ok bool
+		selected, ok = artifactPlanByID(compiled.Artifacts, artifactID)
+		if !ok {
+			return v2PlanTarget{}, nil, fmt.Errorf(
+				"xgoja %s requested unknown artifact %q; configured artifacts: %s",
+				command,
+				artifactID,
+				formatArtifacts(compiled.Artifacts),
+			)
 		}
-	}
-	if len(candidates) == 0 {
-		return v2PlanTarget{}, nil, fmt.Errorf(
-			"xgoja %s found no compatible primary artifact; accepts %s; configured artifacts: %s",
-			command,
-			compatibleArtifactTypes(command),
-			formatArtifacts(compiled.Artifacts),
-		)
-	}
-	if len(candidates) > 1 {
-		return v2PlanTarget{}, nil, fmt.Errorf(
-			"xgoja %s requires exactly one compatible primary artifact; found %d: %s",
-			command,
-			len(candidates),
-			formatArtifacts(candidates),
-		)
+		if !isCompatiblePrimary(command, selected.Spec.Type) {
+			return v2PlanTarget{}, nil, fmt.Errorf(
+				"xgoja %s artifact %q has type %q; accepts %s",
+				command,
+				selected.Spec.ID,
+				normalizedArtifactType(selected.Spec.Type),
+				compatibleArtifactTypes(command),
+			)
+		}
+	} else {
+		candidates := make([]plan.ArtifactPlan, 0, len(compiled.Artifacts))
+		for _, artifact := range compiled.Artifacts {
+			if isCompatiblePrimary(command, artifact.Spec.Type) {
+				candidates = append(candidates, artifact)
+			}
+		}
+		if len(candidates) == 0 {
+			return v2PlanTarget{}, nil, fmt.Errorf(
+				"xgoja %s found no compatible primary artifact; accepts %s; configured artifacts: %s",
+				command,
+				compatibleArtifactTypes(command),
+				formatArtifacts(compiled.Artifacts),
+			)
+		}
+		if len(candidates) > 1 {
+			return v2PlanTarget{}, nil, fmt.Errorf(
+				"xgoja %s requires exactly one compatible primary artifact; found %d: %s; use --artifact <id> to select one",
+				command,
+				len(candidates),
+				formatArtifacts(candidates),
+			)
+		}
+		selected = candidates[0]
 	}
 
-	selected := candidates[0].Spec
-	scoped, err := scopePlanToPrimary(compiled, selected.ID)
+	scoped, err := scopePlanToPrimary(compiled, selected.Spec.ID)
 	if err != nil {
 		return v2PlanTarget{}, nil, err
 	}
-	return targetFromArtifact(selected), scoped, nil
+	return targetFromArtifact(selected.Spec), scoped, nil
 }
 
 func isCompatiblePrimary(command artifactCommand, artifactType string) bool {

--- a/cmd/xgoja/v2_plan_helpers.go
+++ b/cmd/xgoja/v2_plan_helpers.go
@@ -61,6 +61,7 @@ func selectPlanTarget(compiled *plan.Plan, command artifactCommand) (v2PlanTarge
 }
 
 func isCompatiblePrimary(command artifactCommand, artifactType string) bool {
+	artifactType = normalizedArtifactType(artifactType)
 	switch command {
 	case artifactCommandBuild:
 		return artifactType == "binary" || artifactType == "adapter" || artifactType == "cobra"
@@ -72,7 +73,12 @@ func isCompatiblePrimary(command artifactCommand, artifactType string) bool {
 }
 
 func isSupportArtifact(artifactType string) bool {
+	artifactType = normalizedArtifactType(artifactType)
 	return artifactType == "dts" || artifactType == "embedded-assets"
+}
+
+func normalizedArtifactType(artifactType string) string {
+	return strings.TrimSpace(artifactType)
 }
 
 func compatibleArtifactTypes(command artifactCommand) string {
@@ -87,6 +93,7 @@ func compatibleArtifactTypes(command artifactCommand) string {
 }
 
 func targetFromArtifact(artifact specv2.ArtifactSpec) v2PlanTarget {
+	artifact = normalizedArtifactSpec(artifact)
 	kind := artifact.Type
 	switch kind {
 	case "binary":
@@ -117,6 +124,8 @@ func scopePlanToPrimary(compiled *plan.Plan, selectedID string) (*plan.Plan, err
 	if !ok {
 		return nil, fmt.Errorf("scope plan: selected artifact %q is missing from compiled artifacts", selectedID)
 	}
+	selectedConfig = normalizedArtifactSpec(selectedConfig)
+	selectedPlan = normalizedArtifactPlan(selectedPlan)
 
 	scoped := *compiled
 	scoped.Config = compiled.Config
@@ -124,15 +133,25 @@ func scopePlanToPrimary(compiled *plan.Plan, selectedID string) (*plan.Plan, err
 	scoped.Artifacts = []plan.ArtifactPlan{selectedPlan}
 	for _, artifact := range compiled.Config.Artifacts {
 		if isSupportArtifact(artifact.Type) {
-			scoped.Config.Artifacts = append(scoped.Config.Artifacts, artifact)
+			scoped.Config.Artifacts = append(scoped.Config.Artifacts, normalizedArtifactSpec(artifact))
 		}
 	}
 	for _, artifact := range compiled.Artifacts {
 		if isSupportArtifact(artifact.Spec.Type) {
-			scoped.Artifacts = append(scoped.Artifacts, artifact)
+			scoped.Artifacts = append(scoped.Artifacts, normalizedArtifactPlan(artifact))
 		}
 	}
 	return &scoped, nil
+}
+
+func normalizedArtifactSpec(artifact specv2.ArtifactSpec) specv2.ArtifactSpec {
+	artifact.Type = normalizedArtifactType(artifact.Type)
+	return artifact
+}
+
+func normalizedArtifactPlan(artifact plan.ArtifactPlan) plan.ArtifactPlan {
+	artifact.Spec = normalizedArtifactSpec(artifact.Spec)
+	return artifact
 }
 
 func artifactByID(artifacts []specv2.ArtifactSpec, id string) (specv2.ArtifactSpec, bool) {
@@ -159,7 +178,7 @@ func formatArtifacts(artifacts []plan.ArtifactPlan) string {
 	}
 	parts := make([]string, 0, len(artifacts))
 	for _, artifact := range artifacts {
-		parts = append(parts, fmt.Sprintf("%s (%s)", artifact.Spec.ID, artifact.Spec.Type))
+		parts = append(parts, fmt.Sprintf("%s (%s)", artifact.Spec.ID, normalizedArtifactType(artifact.Spec.Type)))
 	}
 	return strings.Join(parts, ", ")
 }

--- a/cmd/xgoja/v2_plan_helpers_test.go
+++ b/cmd/xgoja/v2_plan_helpers_test.go
@@ -115,6 +115,24 @@ func TestSelectPlanTargetExplicitArtifactResolvesAmbiguity(t *testing.T) {
 	assertArtifactIDs(t, scoped.Config.Artifacts, "cobra")
 }
 
+func TestSelectPlanTargetExplicitArtifactNormalizesID(t *testing.T) {
+	compiled := artifactSelectionPlan(specv2.ArtifactSpec{ID: " binary ", Type: "binary"})
+
+	target, scoped, err := selectPlanTarget(compiled, artifactCommandBuild, " binary ")
+	if err != nil {
+		t.Fatalf("select whitespace-padded artifact id: %v", err)
+	}
+	if target.ID != "binary" {
+		t.Fatalf("target id = %q, want binary", target.ID)
+	}
+	if got := scoped.Config.Artifacts[0].ID; got != "binary" {
+		t.Fatalf("scoped config artifact id = %q, want binary", got)
+	}
+	if got := compiled.Config.Artifacts[0].ID; got != " binary " {
+		t.Fatalf("original config was mutated: %q", got)
+	}
+}
+
 func TestSelectPlanTargetExplicitArtifactRejectsUnknownOrIncompatible(t *testing.T) {
 	compiled := artifactSelectionPlan(
 		specv2.ArtifactSpec{ID: "binary", Type: "binary"},

--- a/cmd/xgoja/v2_plan_helpers_test.go
+++ b/cmd/xgoja/v2_plan_helpers_test.go
@@ -40,6 +40,34 @@ func TestSelectPlanTargetSelectsCommandCompatiblePrimaryAndScopesPlan(t *testing
 	assertArtifactPlanIDs(t, compiled.Artifacts, "runtime", "assets", "binary", "declarations")
 }
 
+func TestSelectPlanTargetNormalizesArtifactTypesInScopedPlan(t *testing.T) {
+	compiled := artifactSelectionPlan(
+		specv2.ArtifactSpec{ID: "runtime", Type: " runtime-package "},
+		specv2.ArtifactSpec{ID: "assets", Type: " embedded-assets "},
+		specv2.ArtifactSpec{ID: "binary", Type: " binary "},
+	)
+
+	buildTarget, buildPlan, err := selectPlanTarget(compiled, artifactCommandBuild)
+	if err != nil {
+		t.Fatalf("select whitespace-padded build target: %v", err)
+	}
+	if buildTarget.Type != "binary" || buildTarget.Kind != "xgoja" {
+		t.Fatalf("unexpected normalized build target: %#v", buildTarget)
+	}
+	if got := buildPlan.Config.Artifacts[0].Type; got != "binary" {
+		t.Fatalf("scoped config primary type = %q, want binary", got)
+	}
+	if got := buildPlan.Config.Artifacts[1].Type; got != "embedded-assets" {
+		t.Fatalf("scoped config support type = %q, want embedded-assets", got)
+	}
+	if got := buildPlan.Artifacts[0].Spec.Type; got != "binary" {
+		t.Fatalf("scoped plan primary type = %q, want binary", got)
+	}
+	if got := compiled.Config.Artifacts[2].Type; got != " binary " {
+		t.Fatalf("original config was mutated: %q", got)
+	}
+}
+
 func TestSelectPlanTargetRejectsNoCompatiblePrimary(t *testing.T) {
 	compiled := artifactSelectionPlan(specv2.ArtifactSpec{ID: "runtime", Type: "runtime-package"})
 

--- a/cmd/xgoja/v2_plan_helpers_test.go
+++ b/cmd/xgoja/v2_plan_helpers_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/go-go-golems/go-go-goja/cmd/xgoja/internal/plan"
+	"github.com/go-go-golems/go-go-goja/cmd/xgoja/internal/specv2"
+)
+
+func TestSelectPlanTargetSelectsCommandCompatiblePrimaryAndScopesPlan(t *testing.T) {
+	compiled := artifactSelectionPlan(
+		specv2.ArtifactSpec{ID: "runtime", Type: "runtime-package", Output: "internal/runtime", Sources: []string{"package-verbs"}},
+		specv2.ArtifactSpec{ID: "assets", Type: "embedded-assets", Sources: []string{"webapp"}},
+		specv2.ArtifactSpec{ID: "binary", Type: "binary", Output: "dist/tool", Sources: []string{"binary-verbs"}},
+		specv2.ArtifactSpec{ID: "declarations", Type: "dts", Output: "types.d.ts"},
+	)
+
+	buildTarget, buildPlan, err := selectPlanTarget(compiled, artifactCommandBuild)
+	if err != nil {
+		t.Fatalf("select build target: %v", err)
+	}
+	if buildTarget.ID != "binary" || buildTarget.Type != "binary" || buildTarget.Kind != "xgoja" {
+		t.Fatalf("unexpected build target: %#v", buildTarget)
+	}
+	assertArtifactIDs(t, buildPlan.Config.Artifacts, "binary", "assets", "declarations")
+	assertArtifactPlanIDs(t, buildPlan.Artifacts, "binary", "assets", "declarations")
+
+	generateTarget, generatePlan, err := selectPlanTarget(compiled, artifactCommandGenerate)
+	if err != nil {
+		t.Fatalf("select generate target: %v", err)
+	}
+	if generateTarget.ID != "runtime" || generateTarget.Type != "runtime-package" || generateTarget.Kind != "package" {
+		t.Fatalf("unexpected generate target: %#v", generateTarget)
+	}
+	assertArtifactIDs(t, generatePlan.Config.Artifacts, "runtime", "assets", "declarations")
+	assertArtifactPlanIDs(t, generatePlan.Artifacts, "runtime", "assets", "declarations")
+
+	assertArtifactIDs(t, compiled.Config.Artifacts, "runtime", "assets", "binary", "declarations")
+	assertArtifactPlanIDs(t, compiled.Artifacts, "runtime", "assets", "binary", "declarations")
+}
+
+func TestSelectPlanTargetRejectsNoCompatiblePrimary(t *testing.T) {
+	compiled := artifactSelectionPlan(specv2.ArtifactSpec{ID: "runtime", Type: "runtime-package"})
+
+	_, _, err := selectPlanTarget(compiled, artifactCommandBuild)
+	if err == nil {
+		t.Fatal("expected no-compatible-primary error")
+	}
+	for _, want := range []string{"xgoja build", "binary, adapter, or cobra", "runtime (runtime-package)"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q missing %q", err, want)
+		}
+	}
+}
+
+func TestSelectPlanTargetRejectsAmbiguousPrimary(t *testing.T) {
+	compiled := artifactSelectionPlan(
+		specv2.ArtifactSpec{ID: "runtime", Type: "runtime-package"},
+		specv2.ArtifactSpec{ID: "template", Type: "template"},
+	)
+
+	_, _, err := selectPlanTarget(compiled, artifactCommandGenerate)
+	if err == nil {
+		t.Fatal("expected ambiguous-primary error")
+	}
+	for _, want := range []string{"xgoja generate", "found 2", "runtime (runtime-package)", "template (template)"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q missing %q", err, want)
+		}
+	}
+}
+
+func artifactSelectionPlan(artifacts ...specv2.ArtifactSpec) *plan.Plan {
+	artifactPlans := make([]plan.ArtifactPlan, 0, len(artifacts))
+	for _, artifact := range artifacts {
+		artifactPlans = append(artifactPlans, plan.ArtifactPlan{Spec: artifact})
+	}
+	return &plan.Plan{
+		Config:    specv2.Config{Artifacts: artifacts},
+		Artifacts: artifactPlans,
+	}
+}
+
+func assertArtifactIDs(t *testing.T, artifacts []specv2.ArtifactSpec, want ...string) {
+	t.Helper()
+	got := make([]string, 0, len(artifacts))
+	for _, artifact := range artifacts {
+		got = append(got, artifact.ID)
+	}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("artifact ids = %v, want %v", got, want)
+	}
+}
+
+func assertArtifactPlanIDs(t *testing.T, artifacts []plan.ArtifactPlan, want ...string) {
+	t.Helper()
+	got := make([]string, 0, len(artifacts))
+	for _, artifact := range artifacts {
+		got = append(got, artifact.Spec.ID)
+	}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("artifact plan ids = %v, want %v", got, want)
+	}
+}

--- a/cmd/xgoja/v2_plan_helpers_test.go
+++ b/cmd/xgoja/v2_plan_helpers_test.go
@@ -16,7 +16,7 @@ func TestSelectPlanTargetSelectsCommandCompatiblePrimaryAndScopesPlan(t *testing
 		specv2.ArtifactSpec{ID: "declarations", Type: "dts", Output: "types.d.ts"},
 	)
 
-	buildTarget, buildPlan, err := selectPlanTarget(compiled, artifactCommandBuild)
+	buildTarget, buildPlan, err := selectPlanTarget(compiled, artifactCommandBuild, "")
 	if err != nil {
 		t.Fatalf("select build target: %v", err)
 	}
@@ -26,7 +26,7 @@ func TestSelectPlanTargetSelectsCommandCompatiblePrimaryAndScopesPlan(t *testing
 	assertArtifactIDs(t, buildPlan.Config.Artifacts, "binary", "assets", "declarations")
 	assertArtifactPlanIDs(t, buildPlan.Artifacts, "binary", "assets", "declarations")
 
-	generateTarget, generatePlan, err := selectPlanTarget(compiled, artifactCommandGenerate)
+	generateTarget, generatePlan, err := selectPlanTarget(compiled, artifactCommandGenerate, "")
 	if err != nil {
 		t.Fatalf("select generate target: %v", err)
 	}
@@ -47,7 +47,7 @@ func TestSelectPlanTargetNormalizesArtifactTypesInScopedPlan(t *testing.T) {
 		specv2.ArtifactSpec{ID: "binary", Type: " binary "},
 	)
 
-	buildTarget, buildPlan, err := selectPlanTarget(compiled, artifactCommandBuild)
+	buildTarget, buildPlan, err := selectPlanTarget(compiled, artifactCommandBuild, "")
 	if err != nil {
 		t.Fatalf("select whitespace-padded build target: %v", err)
 	}
@@ -71,7 +71,7 @@ func TestSelectPlanTargetNormalizesArtifactTypesInScopedPlan(t *testing.T) {
 func TestSelectPlanTargetRejectsNoCompatiblePrimary(t *testing.T) {
 	compiled := artifactSelectionPlan(specv2.ArtifactSpec{ID: "runtime", Type: "runtime-package"})
 
-	_, _, err := selectPlanTarget(compiled, artifactCommandBuild)
+	_, _, err := selectPlanTarget(compiled, artifactCommandBuild, "")
 	if err == nil {
 		t.Fatal("expected no-compatible-primary error")
 	}
@@ -88,7 +88,7 @@ func TestSelectPlanTargetRejectsAmbiguousPrimary(t *testing.T) {
 		specv2.ArtifactSpec{ID: "template", Type: "template"},
 	)
 
-	_, _, err := selectPlanTarget(compiled, artifactCommandGenerate)
+	_, _, err := selectPlanTarget(compiled, artifactCommandGenerate, "")
 	if err == nil {
 		t.Fatal("expected ambiguous-primary error")
 	}
@@ -96,6 +96,45 @@ func TestSelectPlanTargetRejectsAmbiguousPrimary(t *testing.T) {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("error %q missing %q", err, want)
 		}
+	}
+}
+
+func TestSelectPlanTargetExplicitArtifactResolvesAmbiguity(t *testing.T) {
+	compiled := artifactSelectionPlan(
+		specv2.ArtifactSpec{ID: "binary", Type: "binary"},
+		specv2.ArtifactSpec{ID: "cobra", Type: "cobra"},
+	)
+
+	target, scoped, err := selectPlanTarget(compiled, artifactCommandBuild, "cobra")
+	if err != nil {
+		t.Fatalf("select explicit artifact: %v", err)
+	}
+	if target.ID != "cobra" || target.Type != "cobra" {
+		t.Fatalf("unexpected explicit target: %#v", target)
+	}
+	assertArtifactIDs(t, scoped.Config.Artifacts, "cobra")
+}
+
+func TestSelectPlanTargetExplicitArtifactRejectsUnknownOrIncompatible(t *testing.T) {
+	compiled := artifactSelectionPlan(
+		specv2.ArtifactSpec{ID: "binary", Type: "binary"},
+		specv2.ArtifactSpec{ID: "runtime", Type: "runtime-package"},
+	)
+
+	for _, test := range []struct {
+		name string
+		id   string
+		want string
+	}{
+		{name: "unknown", id: "missing", want: `requested unknown artifact "missing"`},
+		{name: "incompatible", id: "runtime", want: `artifact "runtime" has type "runtime-package"`},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, _, err := selectPlanTarget(compiled, artifactCommandBuild, test.id)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error = %v, want %q", err, test.want)
+			}
+		})
 	}
 }
 

--- a/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/README.md
+++ b/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/README.md
@@ -1,0 +1,21 @@
+# Pragmatic command-compatible artifact selection for xgoja build and generate
+
+This is the document workspace for ticket XGOJA-ARTIFACT-SELECTION-2026-07-18.
+
+## Structure
+
+- **design/**: Design documents and architecture notes
+- **reference/**: Reference documentation and API contracts
+- **playbooks/**: Operational playbooks and procedures
+- **scripts/**: Utility scripts and automation
+- **sources/**: External sources and imported documents
+- **various/**: Scratch or meeting notes, working notes
+- **archive/**: Optional space for deprecated or reference-only artifacts
+
+## Getting Started
+
+Use docmgr commands to manage this workspace:
+
+- Add documents: `docmgr doc add --ticket XGOJA-ARTIFACT-SELECTION-2026-07-18 --doc-type design-doc --title "My Design"`
+- Import sources: `docmgr import file --ticket XGOJA-ARTIFACT-SELECTION-2026-07-18 --file /path/to/doc.md`
+- Update metadata: `docmgr meta update --ticket XGOJA-ARTIFACT-SELECTION-2026-07-18 --field Status --value review`

--- a/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/changelog.md
+++ b/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/changelog.md
@@ -41,3 +41,13 @@ Implemented command-compatible primary selection and non-mutating scoped plans; 
 
 Ticket closed
 
+
+## 2026-07-18
+
+Addressed review regression: normalize whitespace-padded artifact types during compatibility/support classification and in scoped generator plans; added non-mutation regression coverage (commit 30d0d88)
+
+### Related Files
+
+- /home/manuel/workspaces/2026-07-18/improve-xgoja/go-go-goja/cmd/xgoja/v2_plan_helpers.go — Whitespace normalization at selection and scoped generation boundaries
+- /home/manuel/workspaces/2026-07-18/improve-xgoja/go-go-goja/cmd/xgoja/v2_plan_helpers_test.go — Regression coverage for padded primary/support artifact types
+

--- a/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/changelog.md
+++ b/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/changelog.md
@@ -51,3 +51,13 @@ Addressed review regression: normalize whitespace-padded artifact types during c
 - /home/manuel/workspaces/2026-07-18/improve-xgoja/go-go-goja/cmd/xgoja/v2_plan_helpers.go — Whitespace normalization at selection and scoped generation boundaries
 - /home/manuel/workspaces/2026-07-18/improve-xgoja/go-go-goja/cmd/xgoja/v2_plan_helpers_test.go — Regression coverage for padded primary/support artifact types
 
+
+## 2026-07-18
+
+Added scoped --artifact selection to build/generate and central artifact-type normalization; explicit IDs resolve ambiguity but still enforce command compatibility, while full hooks pass (commit a6f83de)
+
+### Related Files
+
+- /home/manuel/workspaces/2026-07-18/improve-xgoja/go-go-goja/cmd/xgoja/internal/specv2/defaults.go — Central whitespace normalization
+- /home/manuel/workspaces/2026-07-18/improve-xgoja/go-go-goja/cmd/xgoja/v2_plan_helpers.go — Explicit compatible-primary selection and diagnostics
+

--- a/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/changelog.md
+++ b/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/changelog.md
@@ -61,3 +61,13 @@ Added scoped --artifact selection to build/generate and central artifact-type no
 - /home/manuel/workspaces/2026-07-18/improve-xgoja/go-go-goja/cmd/xgoja/internal/specv2/defaults.go — Central whitespace normalization
 - /home/manuel/workspaces/2026-07-18/improve-xgoja/go-go-goja/cmd/xgoja/v2_plan_helpers.go — Explicit compatible-primary selection and diagnostics
 
+
+## 2026-07-18
+
+Addressed review: normalize artifact IDs during v2 defaults and explicit --artifact matching/scoping, with padded-ID regression coverage (commit 2820fad)
+
+### Related Files
+
+- /home/manuel/workspaces/2026-07-18/improve-xgoja/go-go-goja/cmd/xgoja/internal/specv2/defaults.go — Central artifact ID normalization
+- /home/manuel/workspaces/2026-07-18/improve-xgoja/go-go-goja/cmd/xgoja/v2_plan_helpers.go — Normalized explicit selector, lookup, scoped plan, and diagnostics
+

--- a/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/changelog.md
+++ b/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/changelog.md
@@ -25,3 +25,19 @@ Validated the ticket with docmgr doctor and uploaded the overview, intern guide,
 - /home/manuel/workspaces/2026-07-18/improve-xgoja/go-go-goja/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/design-doc/01-intern-guide-to-xgoja-artifact-selection.md — Primary document delivered to reMarkable
 - /home/manuel/workspaces/2026-07-18/improve-xgoja/go-go-goja/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/reference/01-investigation-diary.md — Validation and upload evidence
 
+
+## 2026-07-18
+
+Implemented command-compatible primary selection and non-mutating scoped plans; build/generate now work with binary/runtime-package in either order, reject ambiguity clearly, scope JS/help sources, retain assets, and pass full validation
+
+### Related Files
+
+- /home/manuel/workspaces/2026-07-18/improve-xgoja/go-go-goja/cmd/xgoja/doc/17-xgoja-v2-reference.md — Documented public command/artifact behavior (commit 4003433)
+- /home/manuel/workspaces/2026-07-18/improve-xgoja/go-go-goja/cmd/xgoja/root_test.go — Order and embedded-source regression coverage (commit 4003433)
+- /home/manuel/workspaces/2026-07-18/improve-xgoja/go-go-goja/cmd/xgoja/v2_plan_helpers.go — Core selection and scoped-plan implementation (commit 7caaee6)
+
+
+## 2026-07-18
+
+Ticket closed
+

--- a/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/changelog.md
+++ b/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/changelog.md
@@ -1,0 +1,27 @@
+# Changelog
+
+## 2026-07-18
+
+- Initial workspace created
+
+
+## 2026-07-18
+
+Created ticket, reproduced order-dependent build/generate failures and support-first runtime metadata mismatch, mapped planner/generator architecture, and wrote the pragmatic intern implementation guide
+
+### Related Files
+
+- /home/manuel/workspaces/2026-07-18/improve-xgoja/go-go-goja/cmd/xgoja/internal/generate/templates.go — Independent generator target derivation requiring a scoped plan
+- /home/manuel/workspaces/2026-07-18/improve-xgoja/go-go-goja/cmd/xgoja/v2_plan_helpers.go — First-artifact selection root cause
+- /home/manuel/workspaces/2026-07-18/improve-xgoja/go-go-goja/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/scripts/01-reproduce-artifact-order.log — Captured reproducible evidence
+
+
+## 2026-07-18
+
+Validated the ticket with docmgr doctor and uploaded the overview, intern guide, and diary as the XGOJA Artifact Selection Intern Guide reMarkable bundle
+
+### Related Files
+
+- /home/manuel/workspaces/2026-07-18/improve-xgoja/go-go-goja/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/design-doc/01-intern-guide-to-xgoja-artifact-selection.md — Primary document delivered to reMarkable
+- /home/manuel/workspaces/2026-07-18/improve-xgoja/go-go-goja/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/reference/01-investigation-diary.md — Validation and upload evidence
+

--- a/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/design-doc/01-intern-guide-to-xgoja-artifact-selection.md
+++ b/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/design-doc/01-intern-guide-to-xgoja-artifact-selection.md
@@ -1,0 +1,1124 @@
+---
+Title: Intern guide to pragmatic xgoja artifact selection
+Ticket: XGOJA-ARTIFACT-SELECTION-2026-07-18
+Status: active
+Topics:
+    - xgoja
+    - backend
+    - testing
+DocType: design-doc
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: ws://go-go-goja/cmd/xgoja/cmd_build.go
+      Note: Build command selection and WriteAllPlan call site
+    - Path: ws://go-go-goja/cmd/xgoja/cmd_generate.go
+      Note: Generate command selection and package/source/template call sites
+    - Path: ws://go-go-goja/cmd/xgoja/doc/17-xgoja-v2-reference.md
+      Note: Public artifact contract and current limitation to update
+    - Path: ws://go-go-goja/cmd/xgoja/internal/generate/plan.go
+      Note: Embedded primary-source union and global asset selection
+    - Path: ws://go-go-goja/cmd/xgoja/internal/generate/templates.go
+      Note: Independent generator target and runtime metadata derivation
+    - Path: ws://go-go-goja/cmd/xgoja/internal/plan/plan.go
+      Note: Compiled plan has both Config.Artifacts and Artifacts representations
+    - Path: ws://go-go-goja/cmd/xgoja/v2_plan_helpers.go
+      Note: Current first-primary selector and primary implementation location
+ExternalSources: []
+Summary: Evidence-backed design and implementation guide for making xgoja build and generate select command-compatible artifacts without introducing generalized multi-target orchestration.
+LastUpdated: 0001-01-01T00:00:00Z
+WhatFor: Give a new intern enough architectural, API, file, testing, and operational context to implement and review the artifact-selection fix safely.
+WhenToUse: Use before changing xgoja build/generate artifact selection, generated-plan target metadata, or multi-artifact documentation.
+---
+
+
+# Intern guide to pragmatic xgoja artifact selection
+
+## 1. Executive summary
+
+`xgoja` turns a declarative `xgoja/v2` YAML specification into either a generated Go executable workspace or reusable generated Go source. A specification may contain several artifacts, such as a binary, a reusable runtime package, TypeScript declarations, and static web assets. Today, however, both `xgoja build` and `xgoja generate` call the same `targetFromPlan` helper. That helper chooses the first non-support artifact, without considering which command is running.
+
+This creates an order-dependent failure:
+
+- When `binary` is first, `xgoja build` works and `xgoja generate` rejects the binary-derived target.
+- When `runtime-package` is first, `xgoja generate` works and `xgoja build` rejects the package-derived target.
+
+There is a second, subtler problem. Command-level selection and generator-level selection are separate. `targetFromPlan` skips `dts` and `embedded-assets`, but generator functions inspect `Config.Artifacts` from the beginning. A support artifact placed first can therefore produce a build that reports selecting the binary while embedding runtime metadata whose target kind is `embedded-assets`.
+
+The proposed fix is intentionally pragmatic:
+
+1. Define which primary artifact types are compatible with `build` and `generate`.
+2. Require exactly one compatible primary for the invoked command.
+3. Return clear no-match or ambiguity errors containing artifact IDs and types.
+4. Create a shallow command-scoped copy of `plan.Plan` containing:
+   - the selected primary artifact first, and
+   - the existing global `dts` and `embedded-assets` support artifacts.
+5. Pass that scoped plan to all generator/rendering calls.
+6. Add focused unit, command, and embedding tests.
+7. Document the command/artifact matrix and the one-compatible-primary limitation.
+
+This design does **not** add `--artifact`, artifact dependency graphs, arbitrary target closures, or a generalized build orchestrator. Those features should wait until a real consumer needs multiple build-compatible or multiple generate-compatible primaries in one invocation.
+
+## 2. Problem statement
+
+### 2.1 User-visible requirement
+
+A consumer wants one canonical specification containing both outputs:
+
+```yaml
+artifacts:
+  - id: binary
+    type: binary
+    output: dist/my-tool
+    sources: [local-verbs, app-help]
+
+  - id: runtime-package
+    type: runtime-package
+    output: internal/xgojaruntime
+    package: xgojaruntime
+    sources: [local-verbs, app-help]
+
+  - id: web-assets
+    type: embedded-assets
+    sources: [webapp]
+```
+
+The expected command behavior is uncomplicated:
+
+```bash
+xgoja build -f xgoja.yaml
+xgoja generate -f xgoja.yaml
+```
+
+`build` should choose the sole build-compatible primary (`binary`). `generate` should choose the sole generate-compatible primary (`runtime-package`). The order of those two entries should not matter.
+
+### 2.2 Current failure matrix
+
+The ticket reproduction script is:
+
+```text
+ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/scripts/01-reproduce-artifact-order.sh
+```
+
+Its captured output is beside it in `01-reproduce-artifact-order.log`.
+
+Observed behavior at repository commit `69b69b6`:
+
+| Artifact order | `xgoja build` | `xgoja generate` |
+| --- | --- | --- |
+| binary, runtime-package | succeeds | fails with `got "xgoja"` |
+| runtime-package, binary | fails with `target.kind package` | succeeds |
+| embedded-assets, binary | command selects binary | generated runtime metadata says `kind: embedded-assets` |
+
+Exact errors:
+
+```text
+Error: xgoja generate supports target.kind package, source, or template; got "xgoja"
+```
+
+```text
+Error: target.kind package is source generation only; use xgoja generate -f ...
+```
+
+These errors mention `target.kind`, but `target` is not a top-level field in the v2 YAML schema. It is derived from an artifact. A user cannot fix the error by adding `target:` to the file.
+
+### 2.3 Why this matters beyond output selection
+
+Selecting only the output path is not enough. The artifact order also influences:
+
+- generated `main.go` target behavior,
+- `RuntimePlan.Target.Kind`,
+- `RuntimePlan.Target.Output`,
+- which JS/help sources are copied into `xgoja_embed`,
+- which artifacts appear in embedded runtime metadata,
+- package and custom-template generation.
+
+A fix that changes only the command's local `target` variable can still generate internally inconsistent output.
+
+## 3. Scope and non-goals
+
+### 3.1 In scope
+
+- Command-compatible primary artifact classification.
+- Exactly-one-compatible-primary selection.
+- Clear diagnostics for no compatible primary and ambiguous compatible primaries.
+- A shallow, command-scoped plan copy.
+- Preservation of existing global `dts` and `embedded-assets` support artifacts.
+- Correct selected target metadata and selected-primary source embedding.
+- Focused tests at helper, CLI command, and generated-output levels.
+- A concise documentation update.
+- Preservation of existing single-primary behavior.
+
+### 3.2 Explicit non-goals
+
+- No `--artifact <id>` flag.
+- No dependency graph between artifacts.
+- No `depends-on`, `for`, or target-specific support-artifact schema.
+- No command that builds every binary or generates every package.
+- No parallel artifact execution.
+- No redesign of `specv2.ArtifactSpec`.
+- No changes to provider resolution, source-graph resolution, runtime modules, host services, or authentication.
+- No redesign of `NewBundle`, `AttachDefaultCommands`, or generated runtime-package APIs.
+- No attempt to recover or preserve undocumented first-artifact behavior when multiple compatible primaries exist; ambiguity becomes an actionable error.
+
+### 3.3 Pragmatic quality rule
+
+Add a safeguard when it is local, easy to test, and closes a demonstrated failure. Do not introduce an abstraction whose value depends on hypothetical future artifact graphs.
+
+The shallow scoped plan qualifies because the current reproduction already demonstrates contradictory command and generated-runtime target selection. A dependency model does not qualify because no current consumer requires target-specific asset ownership.
+
+## 4. System orientation for a new intern
+
+### 4.1 What xgoja is
+
+Goja is a JavaScript runtime implemented in Go. `xgoja` is the repository's generator and CLI layer around that runtime. It lets an application author describe:
+
+- Go provider packages,
+- JavaScript-visible runtime modules,
+- local or provider-owned source sets,
+- generated command surfaces,
+- generated output artifacts.
+
+The CLI then validates the spec, resolves providers and sources, generates Go code and embedded files, and optionally invokes the Go toolchain.
+
+### 4.2 Main directories involved
+
+| Path | Responsibility |
+| --- | --- |
+| `cmd/xgoja/main.go` | Process entrypoint. Builds the root command and executes it. |
+| `cmd/xgoja/root.go` | Registers Glazed-backed `build`, `generate`, `gen-dts`, `doctor`, and related commands on Cobra. |
+| `cmd/xgoja/v2_bridge.go` | Loads only native v2 specs and compiles them into `plan.Plan`. |
+| `cmd/xgoja/v2_plan_helpers.go` | Current first-artifact target derivation; primary implementation location for this ticket. |
+| `cmd/xgoja/cmd_build.go` | Build command: generates a temporary Go workspace and invokes `go mod tidy` / `go build`. |
+| `cmd/xgoja/cmd_generate.go` | Generate command: emits runtime package, source fragments, or custom-template output. |
+| `cmd/xgoja/internal/specv2/` | YAML schema, defaults, validation, rendering, and v1 migration. |
+| `cmd/xgoja/internal/plan/` | Compiles validated config into provider, source, command, artifact, and workspace plans. |
+| `cmd/xgoja/internal/generate/` | Copies embedded files and renders generated Go/runtime-plan files. |
+| `cmd/xgoja/root_test.go` | End-to-end command tests through the Cobra/Glazed root. |
+| `cmd/xgoja/internal/generate/generate_test.go` | Generator rendering and embedded-file tests. |
+| `cmd/xgoja/doc/17-xgoja-v2-reference.md` | Main v2 schema and artifact reference. |
+| `examples/xgoja/14-generated-runtime-package/` | Runnable single-runtime-package example and generated host API reference. |
+
+### 4.3 CLI composition
+
+`cmd/xgoja/root.go:17-65` constructs the Cobra root. The actual `build` and `generate` commands implement Glazed `cmds.BareCommand` and are adapted into Cobra commands.
+
+```text
+main.go
+  |
+  v
+newRootCommand(stdout)
+  |
+  +-- newBuildCommand
+  +-- newGenerateCommand
+  +-- newGenDTSCommand
+  +-- newDoctorCommand
+  +-- ...
+  |
+  v
+Cobra Execute
+```
+
+Settings are decoded from Glazed values inside each command's `Run` method. This ticket does not need to change the root command or settings schema.
+
+### 4.4 V2 loading and compilation
+
+`cmd/xgoja/v2_bridge.go:11-32` performs the loading pipeline:
+
+```text
+YAML file
+  -> DetectSchema
+  -> specv2.LoadFile
+       -> parse
+       -> defaults
+       -> validation
+  -> plan.Compile
+       -> provider graph
+       -> Go workspace plan
+       -> source graph
+       -> command plans
+       -> artifact plans
+  -> *plan.Plan
+```
+
+`plan.Plan` is defined at `cmd/xgoja/internal/plan/plan.go:21-29`:
+
+```go
+type Plan struct {
+    Config         specv2.Config
+    GoModules      *workspace.Plan
+    ProviderGraph  *providergraph.Graph
+    SourceGraph    *sourcegraph.Graph
+    Commands       []CommandPlan
+    Artifacts      []ArtifactPlan
+    RuntimeAliases []string
+}
+```
+
+Two artifact representations matter:
+
+- `Plan.Config.Artifacts` is consumed by generator rendering and embedded-source logic.
+- `Plan.Artifacts` is consumed by `targetFromPlan`.
+
+A scoped copy must update **both** slices or later stages can disagree.
+
+### 4.5 Artifact schema
+
+`specv2.ArtifactSpec` is defined at `cmd/xgoja/internal/specv2/types.go:153-163`:
+
+```go
+type ArtifactSpec struct {
+    ID       string
+    Type     string
+    Output   string
+    Package  string
+    Import   string
+    Root     string
+    Template string
+    Sources  []string
+    Strict   bool
+}
+```
+
+Validation accepts these types at `cmd/xgoja/internal/specv2/validate.go:218-242`:
+
+- `binary`
+- `runtime-package`
+- `dts`
+- `embedded-assets`
+- `adapter`
+- `cobra`
+- `source`
+- `template`
+
+For this design, types are grouped by command role:
+
+| Role | Artifact types | Consuming command |
+| --- | --- | --- |
+| Build primary | `binary`, `adapter`, `cobra` | `xgoja build` |
+| Generate primary | `runtime-package`, `source`, `template` | `xgoja generate` |
+| Support | `dts`, `embedded-assets` | Retained beside the selected primary; `gen-dts` separately owns DTS output |
+
+The mapping between artifact type and existing internal target kind is:
+
+| Artifact type | Internal target kind |
+| --- | --- |
+| `binary` | `xgoja` |
+| `runtime-package` | `package` |
+| all other primary types | unchanged |
+
+### 4.6 Build flow
+
+The important portion of `cmd/xgoja/cmd_build.go` is at lines 81-126:
+
+```text
+loadV2Plan
+  -> targetFromPlan
+  -> reject source-generation kinds
+  -> choose output
+  -> generate.WriteAllPlan
+  -> optional dry-run return
+  -> go mod tidy
+  -> go build
+```
+
+`generate.WriteAllPlan` writes:
+
+- copied embedded JS verbs,
+- copied help sources,
+- copied static assets,
+- `go.mod`,
+- `main.go`,
+- `xgoja.runtime.json`.
+
+The command currently passes the original compiled plan to `WriteAllPlan`. Therefore any command-compatible selection fix must also change the plan supplied to that call.
+
+### 4.7 Generate flow
+
+The important portion of `cmd/xgoja/cmd_generate.go` is at lines 82-164:
+
+```text
+loadV2Plan
+  -> targetFromPlan
+  -> require package/source/template kind
+  -> resolve output/package/template overrides
+  -> template-data OR dry-run OR clean
+  -> WritePackagePlan / WriteSourceFragmentsPlan / WriteCustomTemplatePlan
+```
+
+All rendering paths must receive the same scoped plan, including `--template-data`. Otherwise dry runs or template data can describe a different target than actual generated files.
+
+### 4.8 Generator target derivation
+
+`cmd/xgoja/internal/generate/templates.go` independently derives target information:
+
+- `targetDataFromPlanArtifacts`, lines 287-300
+- `RenderRuntimePlanJSONFromPlan`, lines 343-385
+- `targetOutputFromPlanArtifacts`, lines 388-395
+
+The current `targetDataFromPlanArtifacts` does not skip support artifacts. This is why a leading `embedded-assets` artifact can become `RuntimePlan.Target.Kind` even though command-level selection chose a binary.
+
+### 4.9 Embedded source selection
+
+`cmd/xgoja/internal/generate/plan.go:199-227` currently unions sources across every executable-style primary:
+
+```text
+binary sources ---------+
+runtime-package sources +--> copied JS/help source IDs
+source/template sources -+
+
+all embedded-assets sources --> copied static asset IDs
+```
+
+If both a binary and runtime package are present with different source lists, generating either output currently embeds their union. The scoped plan solves this without adding new generator APIs:
+
+```text
+selected primary sources --> copied JS/help source IDs
+retained embedded-assets --> copied static asset IDs
+unselected primaries ----> absent from scoped plan
+```
+
+## 5. Root cause analysis
+
+### 5.1 First non-support artifact wins
+
+`cmd/xgoja/v2_plan_helpers.go:16-35` loops over artifacts, skips empty/`dts`/`embedded-assets`, maps two types, and immediately returns. It has no command context.
+
+Pseudocode of current behavior:
+
+```text
+for artifact in plan.artifacts:
+    if artifact is support:
+        continue
+    return map_to_target(artifact)
+return default_binary_target
+```
+
+Both build and generate call this same function.
+
+### 5.2 Command validation happens too late
+
+The command selects an arbitrary primary first and only afterward asks whether the selected kind is compatible. It never searches for another compatible primary.
+
+```text
+select first primary
+  |
+  +-- build: reject package/source/template
+  |
+  +-- generate: reject anything except package/source/template
+```
+
+The command should instead classify first and select among compatible candidates.
+
+### 5.3 Generator reselects from the original list
+
+Even if command selection were corrected, generator helpers receive the complete original artifact list and derive their own first target and source union. This violates a useful invariant:
+
+> One command execution must have one selected primary artifact, and every downstream rendering decision must see that same primary.
+
+The scoped-plan copy establishes that invariant without changing generator function signatures.
+
+## 6. Proposed design
+
+### 6.1 API shape
+
+Keep the implementation in `cmd/xgoja/v2_plan_helpers.go`. It is command glue, not a reusable domain package.
+
+Suggested private types:
+
+```go
+type artifactCommand string
+
+const (
+    artifactCommandBuild    artifactCommand = "build"
+    artifactCommandGenerate artifactCommand = "generate"
+)
+
+type selectedPlanTarget struct {
+    ID      string
+    Type    string
+    Kind    string
+    Output  string
+    Package string
+    Template string
+    Plan    *plan.Plan
+}
+```
+
+Suggested entrypoint:
+
+```go
+func selectPlanTarget(
+    compiled *plan.Plan,
+    command artifactCommand,
+) (*selectedPlanTarget, error)
+```
+
+Returning the scoped plan together with target metadata makes it harder for callers to accidentally select correctly and then generate from the original plan.
+
+### 6.2 Compatibility predicates
+
+Keep these as small explicit switches rather than a registry or plugin mechanism:
+
+```go
+func isCompatiblePrimary(command artifactCommand, artifactType string) bool {
+    switch command {
+    case artifactCommandBuild:
+        return artifactType == "binary" ||
+            artifactType == "adapter" ||
+            artifactType == "cobra"
+    case artifactCommandGenerate:
+        return artifactType == "runtime-package" ||
+            artifactType == "source" ||
+            artifactType == "template"
+    default:
+        return false
+    }
+}
+
+func isSupportArtifact(artifactType string) bool {
+    return artifactType == "dts" || artifactType == "embedded-assets"
+}
+```
+
+Do not infer compatibility from today's rejection conditions. An allow-list documents intended behavior and makes tests obvious.
+
+### 6.3 Selection algorithm
+
+```text
+function selectPlanTarget(plan, command):
+    if plan is nil:
+        return error("xgoja <command>: plan is nil")
+
+    candidates = []
+    allArtifacts = []
+
+    for artifact in plan.Artifacts:
+        record artifact ID/type in allArtifacts
+        if compatible(command, artifact.type):
+            append artifact to candidates
+
+    if candidates is empty:
+        return error containing command and all artifact IDs/types
+
+    if candidates has more than one item:
+        return error containing command and candidate IDs/types
+
+    selected = candidates[0]
+    scoped = scopePlan(plan, selected.ID)
+
+    return target metadata + scoped plan
+```
+
+Use artifact ID to correlate `Plan.Artifacts` and `Config.Artifacts`; IDs are validated as unique by `specv2.Validate`.
+
+### 6.4 Scoped-plan algorithm
+
+The copy should be shallow except for artifact slices:
+
+```text
+function scopePlan(original, selectedID):
+    clone = shallow copy of original
+    clone.Config = shallow copy of original.Config
+
+    selectedConfigArtifact = find selectedID in original.Config.Artifacts
+    selectedPlanArtifact   = find selectedID in original.Artifacts
+
+    clone.Config.Artifacts = [selectedConfigArtifact]
+    clone.Artifacts        = [selectedPlanArtifact]
+
+    for artifact in original order:
+        if artifact is dts or embedded-assets:
+            append to corresponding clone slice
+
+    return &clone
+```
+
+Resulting shape:
+
+```text
+Original plan
+  artifacts: [runtime-package, assets, binary, dts]
+                     |
+             select for build
+                     v
+Build-scoped plan
+  artifacts: [binary, assets, dts]
+
+Original plan
+                     |
+             select for generate
+                     v
+Generate-scoped plan
+  artifacts: [runtime-package, assets, dts]
+```
+
+The selected primary is always first. This preserves the existing generator's first-primary assumptions while removing unselected primary source leakage.
+
+### 6.5 Diagnostic contract
+
+No compatible primary:
+
+```text
+xgoja build found no compatible primary artifact; build accepts binary, adapter, or cobra; configured artifacts: runtime-package (runtime-package), web-assets (embedded-assets)
+```
+
+Ambiguous compatible primaries:
+
+```text
+xgoja generate requires exactly one compatible primary artifact; found 2: runtime (runtime-package), custom (template)
+```
+
+Properties of good errors:
+
+- Name the invoked command.
+- Use YAML-facing artifact type names, not only derived `target.kind` names.
+- Include IDs so the user can find the entries.
+- State accepted types.
+- Do not suggest adding a nonexistent `target:` field.
+- Do not suggest `--artifact`, because this ticket does not implement that option.
+
+### 6.6 Command integration
+
+Build:
+
+```go
+selection, err := selectPlanTarget(compiledPlan, artifactCommandBuild)
+if err != nil {
+    return err
+}
+compiledPlan = selection.Plan
+target := selection.Target
+
+// Existing output/work-dir/build logic follows.
+generate.WriteAllPlan(workDir, compiledPlan, opts)
+```
+
+Generate:
+
+```go
+selection, err := selectPlanTarget(compiledPlan, artifactCommandGenerate)
+if err != nil {
+    return err
+}
+compiledPlan = selection.Plan
+target := selection.Target
+
+// Every branch uses compiledPlan, including template-data.
+generate.TemplateDataJSONFromPlan(compiledPlan, packageName)
+generate.WritePackagePlan(output, compiledPlan, opts)
+```
+
+Delete the old post-selection kind rejection blocks once compatibility is enforced by selection. Keep output/package/template validation because those validate selected-artifact fields and CLI overrides.
+
+### 6.7 Why no `--artifact` yet
+
+An explicit selector is attractive but unnecessary for the current consumer. It also creates a public promise that multiple compatible primaries are supported correctly. That promise would force decisions about target-specific assets, DTS output, source isolation, and multi-output invocation.
+
+Failing on ambiguity gives users deterministic behavior and tells maintainers exactly when a real need for `--artifact` has appeared.
+
+## 7. Architecture diagrams
+
+### 7.1 Current flow
+
+```text
+                         +------------------+
+                         | xgoja/v2 YAML    |
+                         +---------+--------+
+                                   |
+                                   v
+                         +------------------+
+                         | loadV2Plan       |
+                         | spec + compile   |
+                         +---------+--------+
+                                   |
+                                   v
+                         +------------------+
+                         | plan.Plan        |
+                         | all artifacts    |
+                         +---------+--------+
+                                   |
+                         v         v
+                  +--------+       +----------+
+                  | build  |       | generate |
+                  +---+----+       +----+-----+
+                      |                 |
+                      +--------+--------+
+                               v
+                    first non-support artifact
+                               |
+                   +-----------+-----------+
+                   | incompatible? reject  |
+                   +-----------+-----------+
+                               |
+                               v
+                    generator sees original
+                    all-artifact plan again
+```
+
+### 7.2 Proposed flow
+
+```text
+                         +------------------+
+                         | xgoja/v2 YAML    |
+                         +---------+--------+
+                                   |
+                                   v
+                         +------------------+
+                         | plan.Plan        |
+                         | all artifacts    |
+                         +---------+--------+
+                                   |
+                         +---------+---------+
+                         | command context   |
+                         | build / generate  |
+                         +---------+---------+
+                                   |
+                                   v
+                    +-----------------------------+
+                    | compatible candidate scan   |
+                    | require exactly one primary |
+                    +--------------+--------------+
+                                   |
+                                   v
+                    +-----------------------------+
+                    | shallow scoped plan         |
+                    | selected primary + supports |
+                    +--------------+--------------+
+                                   |
+                                   v
+                    +-----------------------------+
+                    | existing generator APIs     |
+                    | consistent target + sources |
+                    +-----------------------------+
+```
+
+### 7.3 Source embedding after scoping
+
+```text
+binary.sources --------------------+
+                                    | build-scoped plan
+embedded-assets.sources ------------+----> generated binary embeds
+runtime-package.sources -- removed -+
+
+runtime-package.sources ------------+
+                                    | generate-scoped plan
+embedded-assets.sources ------------+----> generated package embeds
+binary.sources ----------- removed -+
+```
+
+## 8. Design decisions
+
+### Decision: Select by command compatibility
+
+- **Context:** One spec needs a binary and runtime package, while both commands currently choose the same first primary.
+- **Options considered:** Preserve first-primary behavior; reorder consumer YAML; use separate specs; scan for command-compatible artifacts.
+- **Decision:** Scan for artifact types compatible with the invoked command.
+- **Rationale:** It directly models user intent and removes order dependence with a small local change.
+- **Consequences:** Specs with one compatible primary per command work in either order. Multiple compatible primaries become errors.
+- **Status:** accepted
+
+### Decision: Require exactly one compatible primary
+
+- **Context:** Silently choosing the first of two binaries or two generate targets remains order-dependent.
+- **Options considered:** First compatible wins; add `--artifact`; generate all; reject ambiguity.
+- **Decision:** Reject zero or multiple compatible primaries with IDs/types in the error.
+- **Rationale:** Deterministic, safe, and small. It avoids publishing an underdesigned selection API.
+- **Consequences:** Existing ambiguous specs must be simplified. A future ticket may add explicit selection when a concrete consumer exists.
+- **Status:** accepted
+
+### Decision: Pass a shallow scoped plan to generators
+
+- **Context:** Generator target and source logic re-reads the complete artifact list, producing contradictory metadata and source unions.
+- **Options considered:** Change every generator API to accept a target; mutate the original plan; reorder only; shallow-copy and filter.
+- **Decision:** Shallow-copy `plan.Plan` and `Config`, retain selected primary plus global support artifacts, and update both artifact slices.
+- **Rationale:** It establishes one-primary consistency using existing generator APIs and avoids mutation shared across dry-run/template/render paths.
+- **Consequences:** Generated runtime metadata no longer lists unselected primaries. Source embedding is scoped automatically. Global support artifacts remain global.
+- **Status:** accepted
+
+### Decision: Keep support artifacts global
+
+- **Context:** The schema has no relationship from `embedded-assets` or `dts` to a primary artifact.
+- **Options considered:** Drop supports; infer by order; add dependency fields; retain all supports.
+- **Decision:** Retain all `dts` and `embedded-assets` artifacts in the scoped plan.
+- **Rationale:** This matches current semantics and supports the real binary/runtime-package consumer, which shares web assets.
+- **Consequences:** Different primaries cannot yet own different asset sets. That is an explicit limitation, not silently invented behavior.
+- **Status:** accepted
+
+### Decision: Do not add `--artifact`
+
+- **Context:** Explicit selection could resolve ambiguity but expands the public API and implied orchestration semantics.
+- **Options considered:** Add the flag now; support it only partially; defer until needed.
+- **Decision:** Defer.
+- **Rationale:** The current shipping case has exactly one compatible primary for each command.
+- **Consequences:** Ambiguous specs fail clearly rather than being selectable.
+- **Status:** accepted
+
+## 9. Implementation guide
+
+### Phase 1: Add helper-level selection
+
+Primary file:
+
+```text
+cmd/xgoja/v2_plan_helpers.go
+```
+
+Steps:
+
+1. Replace `targetFromPlan` with command-aware selection.
+2. Add ID and original artifact type to target metadata.
+3. Add small compatibility/support predicates.
+4. Add deterministic artifact formatting for errors.
+5. Add shallow plan scoping.
+6. Avoid modifying `specv2`, `plan.Compile`, or generator public APIs.
+
+Recommended new test file:
+
+```text
+cmd/xgoja/v2_plan_helpers_test.go
+```
+
+Helper tests should construct `plan.Plan` directly. They should not parse YAML or invoke Cobra.
+
+### Phase 2: Integrate build and generate
+
+Files:
+
+```text
+cmd/xgoja/cmd_build.go
+cmd/xgoja/cmd_generate.go
+```
+
+Build changes:
+
+- Call selection with build mode after `loadV2Plan`.
+- Replace `compiledPlan` with the scoped copy.
+- Remove the old generate-kind rejection.
+- Continue honoring CLI `--output` over the selected artifact output.
+- Ensure dry-run reports selected kind/output.
+
+Generate changes:
+
+- Call selection with generate mode.
+- Replace `compiledPlan` with the scoped copy before template-data/dry-run/clean/render branches.
+- Remove the old general kind rejection; keep the kind switch as an internal exhaustiveness check.
+- Continue honoring CLI overrides.
+
+### Phase 3: Add command-level regressions
+
+Primary file:
+
+```text
+cmd/xgoja/root_test.go
+```
+
+Prefer small YAML helpers that accept an artifact slice. Command tests should exercise the real Glazed/Cobra path using `newRootCommand` and `root.SetArgs`.
+
+Required matrix:
+
+| Test | Expected result |
+| --- | --- |
+| build with binary before package | success; target binary |
+| build with package before binary | success; target binary |
+| generate with binary before package | success; target package |
+| generate with package before binary | success; target package |
+| support artifact before binary | generated runtime target is `xgoja`, not support type |
+| two binaries | build ambiguity error containing both IDs/types |
+| runtime-package plus template | generate ambiguity error containing both IDs/types |
+| package only, invoke build | no-compatible error |
+| binary only, invoke generate | no-compatible error |
+
+### Phase 4: Test scoped embedding
+
+Use generator or command integration tests with two local source directories:
+
+```yaml
+sources:
+  - id: binary-verbs
+    kind: jsverbs
+    from: { dir: ./binary-verbs }
+
+  - id: package-verbs
+    kind: jsverbs
+    from: { dir: ./package-verbs }
+
+  - id: webapp
+    kind: assets
+    from: { dir: ./assets }
+
+artifacts:
+  - id: binary
+    type: binary
+    sources: [binary-verbs]
+
+  - id: runtime-package
+    type: runtime-package
+    sources: [package-verbs]
+
+  - id: assets
+    type: embedded-assets
+    sources: [webapp]
+```
+
+Assertions:
+
+- Build workspace contains `binary-verbs`, not `package-verbs`.
+- Generated package contains `package-verbs`, not `binary-verbs`.
+- Both contain `webapp` assets.
+- Embedded runtime target kind/output matches the selected primary.
+
+This test is the main reason to scope rather than merely reorder.
+
+### Phase 5: Documentation
+
+Update:
+
+```text
+cmd/xgoja/doc/17-xgoja-v2-reference.md
+```
+
+Add a compact command matrix:
+
+| Command | Compatible primary artifacts | Supporting artifacts |
+| --- | --- | --- |
+| `xgoja build` | `binary`, `adapter`, `cobra` | `dts`, `embedded-assets` |
+| `xgoja generate` | `runtime-package`, `source`, `template` | `dts`, `embedded-assets` |
+| `xgoja gen-dts` | first `dts` artifact, existing behavior | N/A |
+
+State:
+
+- Artifact order does not choose between build and generate primaries.
+- Each command requires exactly one compatible primary.
+- Multiple compatible primaries are not orchestrated and produce an error.
+- `sources` on the selected primary control embedded JS/help.
+- `embedded-assets` remain global support artifacts.
+- Runtime-package hosts that need standalone verbs/help must list those source IDs.
+
+Replace the current line saying the first binary-style artifact controls build with the new exactly-one-compatible-primary rule.
+
+### Phase 6: Validation
+
+Run from the repository root:
+
+```bash
+gofmt -w cmd/xgoja/v2_plan_helpers.go \
+  cmd/xgoja/v2_plan_helpers_test.go \
+  cmd/xgoja/cmd_build.go \
+  cmd/xgoja/cmd_generate.go \
+  cmd/xgoja/root_test.go
+
+go test ./cmd/xgoja/... -count=1
+go test ./... -count=1
+go vet ./...
+```
+
+Then run the ticket reproduction script. After the fix, both build and generate cases should succeed regardless of binary/package order. Update the script's labels and expected statuses as part of implementation, or add a separate verification script so the original failure evidence remains preserved.
+
+## 10. Testing strategy in detail
+
+### 10.1 Unit tests
+
+Target the pure selection/scoping helper. Unit tests should verify:
+
+- artifact compatibility table,
+- mapping from YAML type to internal kind,
+- selected primary is first,
+- support order is preserved,
+- unselected primaries are removed,
+- original plan is not mutated,
+- `Config.Artifacts` and `Artifacts` remain synchronized,
+- errors include stable IDs/types.
+
+### 10.2 Command tests
+
+Command tests prove settings decoding, plan loading, and command wiring use the helper correctly. Use dry-run where possible to avoid invoking `go mod tidy` or compilation.
+
+Note: build dry-run still writes the generated workspace before returning. This makes `xgoja.runtime.json` and `main.go` available for assertions.
+
+Generate dry-run returns before writing files. For generated package assertions, invoke generate normally with a fixture provider or a provider-free valid plan.
+
+### 10.3 Generator tests
+
+Most generator functions do not need modification. Add tests only if helper/command tests cannot clearly prove source scoping. Avoid moving command-selection policy into `internal/generate`; generators should consume the already-scoped plan.
+
+### 10.4 Full regression suite
+
+The baseline before implementation is green:
+
+```text
+go test ./cmd/xgoja/... -count=1
+```
+
+Observed baseline result:
+
+```text
+ok github.com/go-go-golems/go-go-goja/cmd/xgoja
+ok github.com/go-go-golems/go-go-goja/cmd/xgoja/internal/generate
+ok github.com/go-go-golems/go-go-goja/cmd/xgoja/internal/plan
+ok github.com/go-go-golems/go-go-goja/cmd/xgoja/internal/specv2
+...
+```
+
+Run the full repository suite after focused tests because generated runtime metadata is shared by examples and provider integrations.
+
+## 11. Risks and mitigations
+
+### Risk: Existing ambiguous specs begin failing
+
+This is intentional. Current behavior silently depends on order and only one primary is actually generated. The error must identify candidates clearly. Search repository examples before merging; current examples contain no specification with both a binary and runtime package, and no known example contains multiple primaries compatible with the same command.
+
+### Risk: Scoped plan loses required support artifacts
+
+Mitigation: retain all `dts` and `embedded-assets` artifacts and test embedded web assets. Do not filter providers, runtime modules, commands, sources, or Go workspace data.
+
+### Risk: Only one artifact representation is scoped
+
+`plan.Plan` contains both `Config.Artifacts` and `Artifacts`. Tests must assert both. Prefer one helper that constructs both slices from the same selected ID.
+
+### Risk: Template-data uses the wrong plan
+
+`--template-data` returns before file generation. Rebind `compiledPlan` to the scoped copy immediately after selection, before any command branch.
+
+### Risk: Error wording leaks internal target kinds
+
+Use YAML artifact types in selection errors. Internal kind remains useful in dry-run output but should not be the only diagnostic.
+
+### Risk: The change grows into an orchestration framework
+
+Stop if implementation proposes artifact dependency fields, an execution DAG, parallel output loops, or a public selector API. Those are separate designs requiring real consumers.
+
+## 12. Alternatives considered
+
+### Keep two near-identical YAML files
+
+Rejected. It works operationally but duplicates providers, modules, sources, commands, and application settings. Drift is likely and already produced a runtime package with no embedded application files in the motivating consumer.
+
+### Require users to reorder artifacts before each command
+
+Rejected. A canonical declarative spec should not need mutation based on the command being run.
+
+### First compatible artifact wins
+
+Rejected. It fixes binary/package coexistence but leaves two binaries or package+template order-dependent. Exactly-one checking is a small, valuable safeguard.
+
+### Add `--artifact` now
+
+Deferred. It is simple at the CLI surface but implies broader support for multiple compatible primaries. A clear ambiguity error is sufficient for the current shipping case.
+
+### Generate every compatible artifact
+
+Rejected. `build` and `generate` currently accept one output override and have singular lifecycle/reporting semantics. Multi-output orchestration is a different feature.
+
+### Change all generator APIs to take a selected artifact
+
+Rejected for this ticket. A scoped plan works with existing APIs and keeps target/source decisions consistent. Explicit generator parameters may be worthwhile in a larger future refactor.
+
+### Add artifact dependency metadata
+
+Rejected. The current consumer shares global static assets. There is no demonstrated need for target-specific support closure.
+
+## 13. Intern implementation checklist
+
+Before editing:
+
+- [ ] Run `go test ./cmd/xgoja/... -count=1`.
+- [ ] Run the reproduction script and read its log.
+- [ ] Read `v2_plan_helpers.go`, both command `Run` methods, and generator artifact helpers.
+- [ ] Confirm the branch is `task/improve-xgoja` and preserve unrelated changes.
+
+While implementing:
+
+- [ ] Keep command policy in `cmd/xgoja`, not `internal/generate`.
+- [ ] Use explicit allow-lists for compatibility.
+- [ ] Require exactly one compatible primary.
+- [ ] Include IDs/types in errors.
+- [ ] Shallow-copy; do not mutate the original plan.
+- [ ] Update both artifact slices.
+- [ ] Retain global support artifacts.
+- [ ] Pass the scoped plan through every branch.
+
+Before review:
+
+- [ ] Run focused helper tests.
+- [ ] Run command tests.
+- [ ] Run all `cmd/xgoja/...` tests.
+- [ ] Run full repository tests and vet.
+- [ ] Verify build/generate in both orders.
+- [ ] Verify support-first runtime target metadata.
+- [ ] Verify source isolation and shared assets.
+- [ ] Update the v2 reference.
+- [ ] Keep the implementation local; no new public feature surface.
+
+## 14. Review guide
+
+Review in this order:
+
+1. `cmd/xgoja/v2_plan_helpers.go`: compatibility, candidate counting, error contract, and shallow-copy correctness.
+2. `cmd/xgoja/v2_plan_helpers_test.go`: policy matrix and non-mutation tests.
+3. `cmd/xgoja/cmd_build.go`: selected/scoped plan reaches `WriteAllPlan`.
+4. `cmd/xgoja/cmd_generate.go`: selected/scoped plan reaches template-data and all write modes.
+5. `cmd/xgoja/root_test.go`: real command regressions.
+6. `cmd/xgoja/doc/17-xgoja-v2-reference.md`: public behavior matches tests.
+
+The central review invariant is:
+
+> For one command invocation, command diagnostics, output selection, generated target metadata, artifact metadata, and embedded primary sources must all refer to the same selected primary artifact.
+
+## 15. API and file references
+
+### CLI and loading
+
+- `cmd/xgoja/main.go`
+- `cmd/xgoja/root.go:17-65` — root construction and command registration.
+- `cmd/xgoja/v2_bridge.go:11-32` — v2 file loading and plan compilation.
+- `cmd/xgoja/cmd_build.go:81-126` — build selection and generation path.
+- `cmd/xgoja/cmd_generate.go:82-164` — generate selection and rendering path.
+
+### Schema and plan
+
+- `cmd/xgoja/internal/specv2/types.go:153-163` — `ArtifactSpec` API.
+- `cmd/xgoja/internal/specv2/validate.go:218-242` — accepted types, IDs, and source references.
+- `cmd/xgoja/internal/specv2/defaults.go:48-52` — default binary output.
+- `cmd/xgoja/internal/plan/plan.go:18-37` — compiled plan and artifact wrappers.
+- `cmd/xgoja/internal/plan/plan.go:46-82` — compilation pipeline.
+
+### Existing defect
+
+- `cmd/xgoja/v2_plan_helpers.go:9-35` — singular first-primary target selection.
+- `cmd/xgoja/internal/generate/templates.go:165-190` — main template target derivation.
+- `cmd/xgoja/internal/generate/templates.go:287-315` — independent target and embedded-path derivation.
+- `cmd/xgoja/internal/generate/templates.go:343-395` — embedded runtime target/artifact metadata.
+- `cmd/xgoja/internal/generate/plan.go:14-76` — binary/package generation entrypoints.
+- `cmd/xgoja/internal/generate/plan.go:199-227` — executable-source and asset-source union.
+
+### Tests and documentation
+
+- `cmd/xgoja/root_test.go:52-220` — current build/generate command tests.
+- `cmd/xgoja/internal/generate/generate_test.go:50-153` — runtime metadata and embedded-file tests.
+- `cmd/xgoja/doc/17-xgoja-v2-reference.md:376-405` — artifact schema documentation.
+- `cmd/xgoja/doc/17-xgoja-v2-reference.md:615-625` — current multi-artifact limitation.
+- `examples/xgoja/14-generated-runtime-package/README.md` — generated runtime-package API.
+- `examples/xgoja/14-generated-runtime-package/xgoja.yaml` — single-package example.
+
+## 16. Open questions
+
+No open question blocks implementation. Confirm these details during coding:
+
+1. `adapter` and `cobra` are intentionally build-compatible because the generated main template has dedicated branches for them at `templates/main.go.tmpl:48-58`.
+2. `dts` remains globally retained in the scoped plan even though `gen-dts` is its actual output command; this preserves metadata and current support-artifact semantics.
+3. If a repository fixture without any primary artifacts exists outside `examples/xgoja`, decide whether to produce the new no-compatible-primary error or retain implicit binary behavior. The preferred design is a clear error because generation requires an explicit artifact contract.
+
+## 17. Definition of done
+
+The ticket is complete when:
+
+- One spec containing one binary, one runtime package, and support artifacts works with both build and generate in either order.
+- No command silently chooses among multiple compatible primaries.
+- Errors name artifact IDs and types.
+- Generated target metadata matches the command-selected primary.
+- Unselected-primary JS/help sources are not embedded.
+- Global static assets remain embedded.
+- Existing single-primary examples and tests pass.
+- The public v2 reference documents the actual behavior.
+- No `--artifact`, dependency graph, or multi-output orchestration was introduced.

--- a/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/design-doc/01-intern-guide-to-xgoja-artifact-selection.md
+++ b/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/design-doc/01-intern-guide-to-xgoja-artifact-selection.md
@@ -57,7 +57,7 @@ The proposed fix is intentionally pragmatic:
 6. Add focused unit, command, and embedding tests.
 7. Document the command/artifact matrix and the one-compatible-primary limitation.
 
-This design does **not** add `--artifact`, artifact dependency graphs, arbitrary target closures, or a generalized build orchestrator. Those features should wait until a real consumer needs multiple build-compatible or multiple generate-compatible primaries in one invocation.
+The initial design deferred `--artifact`; implementation later added it as a small, local extension after command-compatible scoping existed. `--artifact <id>` selects one compatible primary when a spec intentionally has multiple candidates. The design still does **not** add artifact dependency graphs, arbitrary target closures, or a generalized build orchestrator.
 
 ## 2. Problem statement
 
@@ -151,7 +151,6 @@ A fix that changes only the command's local `target` variable can still generate
 
 ### 3.2 Explicit non-goals
 
-- No `--artifact <id>` flag.
 - No dependency graph between artifacts.
 - No `depends-on`, `for`, or target-specific support-artifact schema.
 - No command that builds every binary or generates every package.
@@ -576,19 +575,19 @@ Properties of good errors:
 - Include IDs so the user can find the entries.
 - State accepted types.
 - Do not suggest adding a nonexistent `target:` field.
-- Do not suggest `--artifact`, because this ticket does not implement that option.
+- Suggest `--artifact <id>` only when more than one primary is compatible with the invoked command.
+- Do not imply that one invocation builds or generates every artifact.
 
 ### 6.6 Command integration
 
 Build:
 
 ```go
-selection, err := selectPlanTarget(compiledPlan, artifactCommandBuild)
+target, scopedPlan, err := selectPlanTarget(compiledPlan, artifactCommandBuild, settings.Artifact)
 if err != nil {
     return err
 }
-compiledPlan = selection.Plan
-target := selection.Target
+compiledPlan = scopedPlan
 
 // Existing output/work-dir/build logic follows.
 generate.WriteAllPlan(workDir, compiledPlan, opts)
@@ -597,12 +596,11 @@ generate.WriteAllPlan(workDir, compiledPlan, opts)
 Generate:
 
 ```go
-selection, err := selectPlanTarget(compiledPlan, artifactCommandGenerate)
+target, scopedPlan, err := selectPlanTarget(compiledPlan, artifactCommandGenerate, settings.Artifact)
 if err != nil {
     return err
 }
-compiledPlan = selection.Plan
-target := selection.Target
+compiledPlan = scopedPlan
 
 // Every branch uses compiledPlan, including template-data.
 generate.TemplateDataJSONFromPlan(compiledPlan, packageName)
@@ -611,11 +609,11 @@ generate.WritePackagePlan(output, compiledPlan, opts)
 
 Delete the old post-selection kind rejection blocks once compatibility is enforced by selection. Keep output/package/template validation because those validate selected-artifact fields and CLI overrides.
 
-### 6.7 Why no `--artifact` yet
+### 6.7 Explicit `--artifact` selection (implementation amendment)
 
-An explicit selector is attractive but unnecessary for the current consumer. It also creates a public promise that multiple compatible primaries are supported correctly. That promise would force decisions about target-specific assets, DTS output, source isolation, and multi-output invocation.
+The initial design deferred an explicit selector. It was subsequently added because command-compatible scoping already makes its behavior local and deterministic: the flag chooses one compatible primary, while the existing scoped-plan rule still retains global support artifacts and excludes unselected primary JS/help sources.
 
-Failing on ambiguity gives users deterministic behavior and tells maintainers exactly when a real need for `--artifact` has appeared.
+`--artifact` does not build or generate multiple outputs, add artifact dependencies, or assign target-specific assets. It only resolves an otherwise actionable ambiguity. Unknown or incompatible IDs fail with a command-specific error naming accepted artifact types.
 
 ## 7. Architecture diagrams
 
@@ -745,13 +743,13 @@ binary.sources ----------- removed -+
 - **Consequences:** Different primaries cannot yet own different asset sets. That is an explicit limitation, not silently invented behavior.
 - **Status:** accepted
 
-### Decision: Do not add `--artifact`
+### Decision: Add scoped `--artifact` selection
 
-- **Context:** Explicit selection could resolve ambiguity but expands the public API and implied orchestration semantics.
-- **Options considered:** Add the flag now; support it only partially; defer until needed.
-- **Decision:** Defer.
-- **Rationale:** The current shipping case has exactly one compatible primary for each command.
-- **Consequences:** Ambiguous specs fail clearly rather than being selectable.
+- **Context:** Explicit selection resolves a real ambiguity without requiring multi-output orchestration because selected-plan scoping already controls metadata and embedded sources.
+- **Options considered:** Continue rejecting ambiguity; add an explicit selector; generate all candidates.
+- **Decision:** Add `--artifact <id>` to `build` and `generate`.
+- **Rationale:** It is a small, testable CLI extension that selects one command-compatible primary and retains existing scoped support-artifact semantics.
+- **Consequences:** Multiple compatible primaries are now usable one-at-a-time. Artifact dependency graphs, target-specific assets, and build-all/generate-all remain out of scope.
 - **Status:** accepted
 
 ## 9. Implementation guide
@@ -1004,7 +1002,7 @@ Rejected. It fixes binary/package coexistence but leaves two binaries or package
 
 ### Add `--artifact` now
 
-Deferred. It is simple at the CLI surface but implies broader support for multiple compatible primaries. A clear ambiguity error is sufficient for the current shipping case.
+Implemented after the scoped-plan foundation landed. The flag chooses one compatible primary; it does not imply multi-output orchestration or target-specific support-artifact ownership.
 
 ### Generate every compatible artifact
 
@@ -1121,4 +1119,4 @@ The ticket is complete when:
 - Global static assets remain embedded.
 - Existing single-primary examples and tests pass.
 - The public v2 reference documents the actual behavior.
-- No `--artifact`, dependency graph, or multi-output orchestration was introduced.
+- `--artifact` selects a compatible primary; no dependency graph or multi-output orchestration was introduced.

--- a/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/index.md
+++ b/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/index.md
@@ -1,7 +1,7 @@
 ---
 Title: Pragmatic command-compatible artifact selection for xgoja build and generate
 Ticket: XGOJA-ARTIFACT-SELECTION-2026-07-18
-Status: active
+Status: complete
 Topics:
     - xgoja
     - backend
@@ -18,10 +18,11 @@ RelatedFiles:
       Note: Primary implementation guide
 ExternalSources: []
 Summary: Design and implementation ticket for deterministic build/generate artifact selection using one compatible primary plus global support artifacts.
-LastUpdated: 0001-01-01T00:00:00Z
+LastUpdated: 2026-07-18T17:32:01.390048914-04:00
 WhatFor: Coordinate implementation, testing, review, and delivery of the xgoja multi-artifact order fix.
 WhenToUse: Start here when implementing or reviewing command-compatible artifact selection.
 ---
+
 
 
 # Pragmatic command-compatible artifact selection for xgoja build and generate
@@ -44,10 +45,11 @@ The accepted pragmatic design selects exactly one command-compatible primary, co
 ## Current status
 
 - Failure reproduced against commit `69b69b6`.
-- Focused `go test ./cmd/xgoja/... -count=1` baseline passes.
 - Architecture and generator behavior mapped.
-- Intern design/implementation guide written.
-- Production implementation remains open.
+- Pragmatic selection/scoping implementation committed in `7caaee6`.
+- Command regressions and public documentation committed in `4003433`.
+- Focused/full test, vet, lint, and generated-code hooks pass.
+- Ready for review; release/versioning is intentionally outside this implementation ticket.
 
 ## Accepted scope
 

--- a/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/index.md
+++ b/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/index.md
@@ -1,0 +1,73 @@
+---
+Title: Pragmatic command-compatible artifact selection for xgoja build and generate
+Ticket: XGOJA-ARTIFACT-SELECTION-2026-07-18
+Status: active
+Topics:
+    - xgoja
+    - backend
+    - testing
+DocType: index
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: ws://go-go-goja/cmd/xgoja/doc/17-xgoja-v2-reference.md
+      Note: Public documentation file
+    - Path: ws://go-go-goja/cmd/xgoja/v2_plan_helpers.go
+      Note: Core implementation file
+    - Path: ws://go-go-goja/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/design-doc/01-intern-guide-to-xgoja-artifact-selection.md
+      Note: Primary implementation guide
+ExternalSources: []
+Summary: Design and implementation ticket for deterministic build/generate artifact selection using one compatible primary plus global support artifacts.
+LastUpdated: 0001-01-01T00:00:00Z
+WhatFor: Coordinate implementation, testing, review, and delivery of the xgoja multi-artifact order fix.
+WhenToUse: Start here when implementing or reviewing command-compatible artifact selection.
+---
+
+
+# Pragmatic command-compatible artifact selection for xgoja build and generate
+
+## Overview
+
+This ticket fixes an order-dependent mismatch in xgoja/v2 specifications containing both build and source-generation outputs. Today, `xgoja build` and `xgoja generate` select the same first non-support artifact and then reject kinds incompatible with the invoked command. Generator rendering also derives its target independently from the original artifact list, so command output and embedded runtime metadata can disagree.
+
+The accepted pragmatic design selects exactly one command-compatible primary, constructs a shallow scoped plan containing that primary plus global `dts` and `embedded-assets` support artifacts, and passes the scoped plan through existing generators. It deliberately defers explicit artifact flags, dependency graphs, and multi-output orchestration.
+
+## Key documents
+
+- [Intern guide to pragmatic xgoja artifact selection](design-doc/01-intern-guide-to-xgoja-artifact-selection.md)
+- [Investigation diary](reference/01-investigation-diary.md)
+- [Tasks](tasks.md)
+- [Changelog](changelog.md)
+- [Reproduction script](scripts/01-reproduce-artifact-order.sh)
+- [Captured reproduction output](scripts/01-reproduce-artifact-order.log)
+
+## Current status
+
+- Failure reproduced against commit `69b69b6`.
+- Focused `go test ./cmd/xgoja/... -count=1` baseline passes.
+- Architecture and generator behavior mapped.
+- Intern design/implementation guide written.
+- Production implementation remains open.
+
+## Accepted scope
+
+### Included
+
+- Exactly-one command-compatible primary selection.
+- Ambiguity/no-match diagnostics with artifact IDs/types.
+- Shallow scoped plan preserving global support artifacts.
+- Target metadata and embedded-source consistency.
+- Unit, command, and embedding regressions.
+- Concise v2 artifact documentation.
+
+### Deferred
+
+- `--artifact`.
+- Artifact dependency relationships.
+- Building/generating multiple compatible primaries.
+- Parallel output orchestration.
+- General planner/generator redesign.
+
+## Review invariant
+
+For one command invocation, command diagnostics, output selection, generated target metadata, artifact metadata, and embedded primary sources must all refer to the same selected primary artifact.

--- a/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/reference/01-investigation-diary.md
+++ b/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/reference/01-investigation-diary.md
@@ -10,6 +10,8 @@ DocType: reference
 Intent: long-term
 Owners: []
 RelatedFiles:
+    - Path: ws://go-go-goja/cmd/xgoja/internal/specv2/defaults.go
+      Note: Central ArtifactSpec.Type normalization before default output derivation
     - Path: ws://go-go-goja/cmd/xgoja/root_test.go
       Note: |-
         Existing command test patterns and future regression test location
@@ -26,6 +28,7 @@ LastUpdated: 0001-01-01T00:00:00Z
 WhatFor: Preserve reproduction commands, observed failures, reasoning, and implementation review instructions.
 WhenToUse: Read before implementing or reviewing XGOJA-ARTIFACT-SELECTION-2026-07-18.
 ---
+
 
 
 
@@ -454,3 +457,81 @@ Useful? React with 👍 / 👎."
 
 - Review-fix commit: `30d0d88a1ac707d8b86808b6c98391417268f0b5`.
 - Validation: focused `TestSelectPlanTarget`, `./.bin/golangci-lint run ./cmd/xgoja/...`, and successful full pre-commit test/lint hooks.
+
+## Step 5: Add explicit artifact selection and central artifact-type normalization
+
+The user chose to include two previously deferred but low-risk improvements: explicit `--artifact <id>` selection and normalization of artifact types at v2 defaulting time. The existing scoped-plan implementation made the flag a contained extension: it selects one compatible primary and reuses the same metadata/source-isolation path rather than introducing output orchestration.
+
+The implementation is committed as `a6f83de` and replaces the design guide's prior recommendation to defer the flag.
+
+### Prompt Context
+
+**User prompt (verbatim):** "do 1. and 3."
+
+**Assistant interpretation:** Implement the previously listed `--artifact` flag and central `ArtifactSpec.Type` normalization in `specv2.ApplyDefaults`.
+
+**Inferred user intent:** Improve the practical multi-artifact UX now that the small supporting architecture is in place, without adding dependency graphs or build-all behavior.
+
+### What I did
+
+- Added `--artifact` fields to both build and generate Glazed command settings and help text.
+- Extended `selectPlanTarget` with an optional artifact ID:
+  - no ID retains automatic exactly-one-compatible selection;
+  - an ID selects one compatible primary even if others exist;
+  - unknown IDs and incompatible IDs return command-specific errors.
+- Updated ambiguity diagnostics to recommend `--artifact <id>`.
+- Trimmed every `ArtifactSpec.Type` in `specv2.ApplyDefaults` before binary default-output logic.
+- Added unit tests for explicit selection, unknown/incompatible IDs, and central type normalization.
+- Updated command integration tests to pass `--artifact binary` and `--artifact runtime`.
+- Updated the v2 reference and the intern guide to reflect the new public contract.
+
+### Why
+
+- `--artifact` resolves legitimate multiple-binary or multiple-generation-target specs without changing the scoped-plan model.
+- Central normalization aligns defaults, validation, selection, and downstream generator comparisons for all normal v2 load paths.
+
+### What worked
+
+- Focused `go test ./cmd/xgoja/... -count=1` passed.
+- `./.bin/golangci-lint run ./cmd/xgoja/...` passed.
+- Commit hook passed `go generate ./...`, `go test ./...`, golangci-lint, and Glazed vet.
+
+### What didn't work
+
+- The first help-text revision put Markdown backticks inside Go's raw string literal, causing:
+
+  ```text
+  cmd/xgoja/cmd_generate.go:42:22: syntax error: unexpected name runtime in argument list
+  ```
+
+  Fix: use plain text in the raw CLI help string; Markdown backticks remain appropriate in Markdown docs.
+
+### What I learned
+
+- The scoped plan converts explicit selection from an architectural feature into a local policy choice: once a primary is selected, existing source/asset handling already follows it.
+- Central `ApplyDefaults` normalization makes the later defensive scoped-copy normalization redundant for normal loaded specs, but retaining it protects direct manually constructed plans used by tests/internal callers.
+
+### What was tricky to build
+
+- `--artifact` must not bypass compatibility checks. Allowing a runtime-package ID on `build`, for example, would recreate the original wrong-command failure under a different path. The helper therefore validates the selected artifact against the command's allow-list before scoping.
+
+### What warrants a second pair of eyes
+
+- Review exact artifact-ID matching semantics. The flag trims its input; artifact IDs otherwise retain existing schema behavior. This is intentionally narrower than normalizing all artifact fields.
+
+### What should be done in the future
+
+- Continue to defer dependency graphs, target-specific support assets, and multi-output orchestration; `--artifact` selects one output per invocation.
+
+### Code review instructions
+
+- Start with `selectPlanTarget`'s explicit-ID branch and verify unknown/incompatible errors.
+- Verify build/generate decode and pass `settings.Artifact`.
+- Verify `specv2.ApplyDefaults` trims type before checking `binary` default output.
+- Run the focused tests and inspect documentation examples.
+
+### Technical details
+
+- Code commit: `a6f83de3bc0808ba871462bd88b11b19b0426683`.
+- New CLI forms: `xgoja build --artifact <id>` and `xgoja generate --artifact <id>`.
+- Non-goals remain: dependency graphs, target-specific assets, and multiple outputs per invocation.

--- a/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/reference/01-investigation-diary.md
+++ b/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/reference/01-investigation-diary.md
@@ -11,7 +11,11 @@ Intent: long-term
 Owners: []
 RelatedFiles:
     - Path: ws://go-go-goja/cmd/xgoja/root_test.go
-      Note: Existing command test patterns and future regression test location
+      Note: |-
+        Existing command test patterns and future regression test location
+        End-to-end order, target metadata, source-isolation, and shared-asset regressions
+    - Path: ws://go-go-goja/cmd/xgoja/v2_plan_helpers_test.go
+      Note: Unit coverage for compatibility, ambiguity/no-match diagnostics, scoping, and non-mutation
     - Path: ws://go-go-goja/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/scripts/01-reproduce-artifact-order.log
       Note: Captured baseline failures and inconsistent runtime target metadata
     - Path: ws://go-go-goja/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/scripts/01-reproduce-artifact-order.sh
@@ -22,6 +26,7 @@ LastUpdated: 0001-01-01T00:00:00Z
 WhatFor: Preserve reproduction commands, observed failures, reasoning, and implementation review instructions.
 WhenToUse: Read before implementing or reviewing XGOJA-ARTIFACT-SELECTION-2026-07-18.
 ---
+
 
 
 # Diary
@@ -277,3 +282,96 @@ The upload command reported success directly, so no additional cloud listing was
 - Destination: `/ai/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18`
 - ToC depth: 2
 - Documents: `index.md`, design doc, investigation diary.
+
+## Step 3: Implement command-compatible selection and scoped generation
+
+I replaced the order-dependent first-primary helper with command-aware selection, then passed a scoped plan to both build and generate. The implementation selects exactly one primary compatible with the invoked command, preserves support artifacts, and makes the command's selected target consistent with generator metadata and embedded sources.
+
+The change was committed in two focused code commits: `7caaee6` contains the selector, plan scoping, caller integration, and helper tests; `4003433` contains command-level regression tests and public documentation. No new public selection flag or artifact dependency model was added.
+
+### Prompt Context
+
+**User prompt (verbatim):** "Implement"
+
+**Assistant interpretation:** Implement the accepted pragmatic xgoja artifact-selection design in the local `task/improve-xgoja` workspace.
+
+**Inferred user intent:** Replace the duplicate-spec workaround with deterministic, well-tested build/generate behavior without feature astronauting.
+
+### What I did
+
+- Replaced `targetFromPlan` in `cmd/xgoja/v2_plan_helpers.go` with:
+  - `selectPlanTarget(compiled, command)`;
+  - explicit build/generate compatibility predicates;
+  - no-compatible and ambiguous-primary errors naming YAML artifact IDs/types;
+  - `scopePlanToPrimary`, which shallow-copies `plan.Plan` and its config, puts the selected primary first, retains `dts`/`embedded-assets`, and removes unselected primaries.
+- Updated `cmd/xgoja/cmd_build.go` and `cmd/xgoja/cmd_generate.go` to rebind their plan to the scoped copy before every generator path, including `--template-data`.
+- Added helper tests in `cmd/xgoja/v2_plan_helpers_test.go` for selection, support retention, error diagnostics, and non-mutation of the original plan.
+- Added command regressions in `cmd/xgoja/root_test.go` for binary/package in both YAML orders and for JS/help source isolation with shared assets.
+- Updated `cmd/xgoja/doc/17-xgoja-v2-reference.md` with the command/artifact matrix and ambiguity behavior.
+
+### Why
+
+- Command-local target selection alone would leave `internal/generate` deriving target metadata and embedded sources from the full artifact list.
+- Scoped plans reuse existing generator APIs while guaranteeing one selected primary across command output, runtime metadata, and copied source roots.
+
+### What worked
+
+- `go test ./cmd/xgoja -run 'Test(BuildAndGenerate|SelectPlanTarget)' -count=1` passed.
+- `go test ./cmd/xgoja/... -count=1` passed.
+- `go test ./... -count=1` passed.
+- `go vet ./...` passed.
+- Both commits' pre-commit hooks passed the repository's `go generate`, full test, golangci-lint, and Glazed vet checks.
+- Regression tests prove that binary/package order no longer matters; build receives `kind: xgoja`, generate receives `kind: package`, each receives only its selected JS source, and both receive global assets.
+
+### What didn't work
+
+- The first focused test after deleting the obsolete helper failed because the two command callers still referenced it:
+
+  ```text
+  cmd/xgoja/cmd_build.go:90:12: undefined: targetFromPlan
+  cmd/xgoja/cmd_generate.go:92:12: undefined: targetFromPlan
+  ```
+
+  Fix: wire both callers to `selectPlanTarget` in the planned core integration.
+- An initial command-test helper had an unused local `dir`; removed it.
+- The first follow-up commit attempt failed lint with:
+
+  ```text
+  cmd/xgoja/root_test.go:659:1: named return "specPath" with type "string" found (nonamedreturns)
+  ```
+
+  Removing named returns initially left local path variables undeclared; the resumed fix declared them explicitly. Focused tests and `./.bin/golangci-lint run ./cmd/xgoja/...` then passed before retrying the commit.
+
+### What I learned
+
+- A shallow scoped plan is enough because generator functions already consume `plan.Plan`; changing their public signatures was unnecessary.
+- Updating both `Plan.Config.Artifacts` and `Plan.Artifacts` is mandatory: the generator reads the former while selection reads the latter.
+- Keeping support artifacts after the selected primary preserves existing global asset behavior while preventing selected-source leakage.
+
+### What was tricky to build
+
+- The generator has separate target and source paths, so a fix that only changed `cmd_build.go`/`cmd_generate.go` would have produced correct command output with incorrect generated metadata. Scoping the artifact lists before calling generators aligned those independent paths without introducing a new architecture.
+
+### What warrants a second pair of eyes
+
+- Confirm the intentional no-compatible-primary behavior for v2 specs that declare only support artifacts.
+- Confirm `adapter` and `cobra` should remain build-compatible primary types; their existing generated-main branches support this classification.
+
+### What should be done in the future
+
+- Add `--artifact` only when a real configuration needs multiple compatible primaries; current ambiguity errors deliberately make that need visible.
+- Do not add target-specific asset dependency modeling until a real consumer needs non-global support assets.
+
+### Code review instructions
+
+- Start at `cmd/xgoja/v2_plan_helpers.go` and verify compatibility, errors, and non-mutating plan scope.
+- Verify `cmd_build.go` and `cmd_generate.go` pass the scoped plan through all generator branches.
+- Read `v2_plan_helpers_test.go` and the two new root tests for policy and end-to-end regressions.
+- Verify documentation matches the test contract in `cmd/xgoja/doc/17-xgoja-v2-reference.md`.
+
+### Technical details
+
+- Code commits: `7caaee6fb803a69785d00b8c36918c0b9d9cdfb0`, `400343331a188ed372d647ecb959d659134dc3d2`.
+- Selected build primary types: `binary`, `adapter`, `cobra`.
+- Selected generate primary types: `runtime-package`, `source`, `template`.
+- Retained support types: `dts`, `embedded-assets`.

--- a/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/reference/01-investigation-diary.md
+++ b/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/reference/01-investigation-diary.md
@@ -1,0 +1,279 @@
+---
+Title: Investigation diary
+Ticket: XGOJA-ARTIFACT-SELECTION-2026-07-18
+Status: active
+Topics:
+    - xgoja
+    - backend
+    - testing
+DocType: reference
+Intent: long-term
+Owners: []
+RelatedFiles:
+    - Path: ws://go-go-goja/cmd/xgoja/root_test.go
+      Note: Existing command test patterns and future regression test location
+    - Path: ws://go-go-goja/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/scripts/01-reproduce-artifact-order.log
+      Note: Captured baseline failures and inconsistent runtime target metadata
+    - Path: ws://go-go-goja/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/scripts/01-reproduce-artifact-order.sh
+      Note: Self-contained artifact-order and support-first reproduction
+ExternalSources: []
+Summary: Chronological evidence and design record for the pragmatic xgoja command-compatible artifact-selection ticket.
+LastUpdated: 0001-01-01T00:00:00Z
+WhatFor: Preserve reproduction commands, observed failures, reasoning, and implementation review instructions.
+WhenToUse: Read before implementing or reviewing XGOJA-ARTIFACT-SELECTION-2026-07-18.
+---
+
+
+# Diary
+
+## Goal
+
+Investigate and design the smallest production-quality fix that lets one xgoja/v2 specification contain a binary, a runtime package, and support artifacts while `xgoja build` and `xgoja generate` select the correct output independently of YAML order.
+
+## Step 1: Reproduce artifact-order failures and write the intern implementation guide
+
+I created the requested docmgr ticket in the isolated `task/improve-xgoja` workspace, mapped the CLI-to-planner-to-generator path, reproduced the order failures against commit `69b69b6`, and wrote the implementation guide. The design deliberately avoids a public artifact-selection feature or dependency framework.
+
+The investigation found one additional concrete defect that changes the minimum safe fix: command selection and generated runtime metadata can disagree even when `build` succeeds. Therefore the design uses a shallow scoped plan containing the selected primary plus global support artifacts, rather than changing only the command's local output selection.
+
+### Prompt Context
+
+**User prompt (verbatim):** "Create a new docmgr ticket in /home/manuel/workspaces/2026-07-18/improve-xgoja/go-go-goja/ttmp (use docmgr --root ...) and Create  a detailed analysis / design / implementation guide that is for a new intern, explaining all the parts of the system needed to understand what it is, with prose paragraphs and bullet point sand pseudocode and diagrams and api references and file references. It should be very clear and technical. Store in the ticket and the nupload to remarkable."
+
+**Assistant interpretation:** Create a standalone xgoja ticket and an evidence-backed, intern-oriented design package for the pragmatic artifact-selection fix, validate it with docmgr, and deliver it as a reMarkable bundle.
+
+**Inferred user intent:** Hand implementation to a new engineer without requiring them to rediscover xgoja's planner/generator architecture, while preserving the agreed boundary against feature and architecture astronauting.
+
+### What I did
+
+- Created ticket `XGOJA-ARTIFACT-SELECTION-2026-07-18` with `docmgr --root /home/manuel/workspaces/2026-07-18/improve-xgoja/go-go-goja/ttmp`.
+- Added a design doc and investigation diary.
+- Read repository and parent `AGENT.md` guidance.
+- Inspected:
+  - `cmd/xgoja/root.go`
+  - `cmd/xgoja/v2_bridge.go`
+  - `cmd/xgoja/v2_plan_helpers.go`
+  - `cmd/xgoja/cmd_build.go`
+  - `cmd/xgoja/cmd_generate.go`
+  - `cmd/xgoja/internal/specv2/types.go`
+  - `cmd/xgoja/internal/specv2/validate.go`
+  - `cmd/xgoja/internal/plan/plan.go`
+  - `cmd/xgoja/internal/generate/plan.go`
+  - `cmd/xgoja/internal/generate/templates.go`
+  - existing root/generator tests and v2 documentation.
+- Ran the focused baseline:
+
+  ```bash
+  go test ./cmd/xgoja/... -count=1
+  ```
+
+  All focused packages passed.
+- Created and ran:
+
+  ```bash
+  ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/scripts/01-reproduce-artifact-order.sh
+  ```
+
+- Captured output in `scripts/01-reproduce-artifact-order.log`.
+- Wrote the detailed design and implementation guide with architecture diagrams, API sketches, pseudocode, decision records, phased implementation, tests, risks, and file references.
+
+### Why
+
+- The prior recommendation to add only command-compatible scanning was incomplete: generator target and source logic independently reads the original artifact list.
+- An intern needs to understand both `Plan.Artifacts` and `Plan.Config.Artifacts`; changing only one produces internally inconsistent behavior.
+- Reproduction and line-anchored code evidence prevent the design from drifting into speculative architecture.
+
+### What worked
+
+- The focused baseline passed:
+
+  ```text
+  ok github.com/go-go-golems/go-go-goja/cmd/xgoja
+  ok github.com/go-go-golems/go-go-goja/cmd/xgoja/internal/generate
+  ok github.com/go-go-golems/go-go-goja/cmd/xgoja/internal/plan
+  ok github.com/go-go-golems/go-go-goja/cmd/xgoja/internal/specv2
+  ```
+
+- The reproduction cleanly demonstrated all four binary/package order outcomes.
+- A support-first case demonstrated the second selector mismatch:
+
+  ```text
+  === support artifact first: build command selects binary ===
+  xgoja dry run ok: ... target=xgoja ...
+
+  === support artifact first: generated runtime metadata still uses support artifact ===
+    "target": {
+      "kind": "embedded-assets",
+      "output": ".../binary"
+    },
+  ```
+
+- Existing generator APIs can consume a shallow scoped plan; no public generator API redesign is needed.
+- Current examples contain binary/support combinations and a runtime-package-only example, but no checked-in binary+runtime-package example. This limits compatibility risk.
+
+### What didn't work
+
+- An exploratory shell loop used `rg -c` under command substitution and assumed it always printed `0`. For files without a match, the variable was empty, producing repeated errors:
+
+  ```text
+  /bin/bash: line 39: [: : integer expression expected
+  ```
+
+  The useful matched output still appeared, but the command was not robust. The later search used `rg -c ... || true` and did not rely on the first loop for conclusions.
+- The first version of the reproduction script calculated the repository root with one too many `..` components. I corrected:
+
+  ```text
+  ../../../../../../..  ->  ../../../../../..
+  ```
+
+  before running it. No evidence was recorded from the incorrect version.
+- Current `generate` behavior fails for binary-first order exactly as expected:
+
+  ```text
+  Error: xgoja generate supports target.kind package, source, or template; got "xgoja"
+  exit status 1
+  ```
+
+- Current `build` behavior fails for runtime-package-first order exactly as expected:
+
+  ```text
+  Error: target.kind package is source generation only; use xgoja generate -f ...
+  exit status 1
+  ```
+
+### What I learned
+
+- `targetFromPlan` uses `Plan.Artifacts`, while generator rendering uses `Plan.Config.Artifacts`. They are parallel representations populated by `plan.Compile`.
+- `targetFromPlan` skips `dts` and `embedded-assets`; `targetDataFromPlanArtifacts` does not. This is the cause of support-first target metadata corruption.
+- Generator embedding unions JS/help sources across all primary artifact types and assets across all `embedded-assets` artifacts.
+- A shallow plan copy that filters unselected primaries and retains support artifacts is small enough for the pragmatic scope and directly fixes both metadata and source-selection inconsistencies.
+- `adapter` and `cobra` belong to build-compatible primaries because `main.go.tmpl` contains dedicated host-integration branches for them. `runtime-package`, `source`, and `template` belong to generate.
+- A no-ambiguity rule gives deterministic behavior without prematurely adding `--artifact`.
+
+### What was tricky to build
+
+- **Keeping the plan internally synchronized:** `Plan.Config` is a value, but it contains slices. A safe shallow scope operation must copy `Plan`, copy `Config`, allocate new artifact slices, and update both config-level and compiled artifact slices. Mutating or reusing the original slice backing arrays could alter the caller's plan.
+- **Drawing the pragmatic boundary:** reordering only the selected primary is simpler but still leaves source leakage from unselected primaries. Filtering to selected primary plus global support artifacts is only slightly more code and closes an observed class of mismatch. Adding target-specific support dependencies would cross into unsupported architecture.
+- **Separating command compatibility from internal target kind:** user errors should name YAML artifact types and IDs, while existing rendering still uses mapped kinds (`binary` to `xgoja`, `runtime-package` to `package`).
+
+### What warrants a second pair of eyes
+
+- Confirm that `adapter` and `cobra` should remain build-compatible and are not intended for `generate` despite the broad wording in the artifact documentation.
+- Review slice copying carefully to ensure the original plan and config are not mutated.
+- Confirm desired behavior for a v2 spec with no primary artifacts. The design prefers a clear no-compatible-primary error rather than the current implicit binary fallback.
+- Verify that retaining every global `dts` and `embedded-assets` artifact is the intended support behavior for this phase.
+
+### What should be done in the future
+
+- Add `--artifact` only when a real consumer needs multiple compatible primary artifacts in one spec.
+- Model target-specific support artifacts only when global assets become insufficient.
+- Consider consolidating command and generator target derivation in a larger refactor only if further divergence appears; it is not needed for this ticket.
+
+### Code review instructions
+
+- Start with the design doc's sections 4-6 for system architecture and the proposed helper contract.
+- Review implementation in this order:
+  1. `cmd/xgoja/v2_plan_helpers.go`
+  2. `cmd/xgoja/v2_plan_helpers_test.go`
+  3. `cmd/xgoja/cmd_build.go`
+  4. `cmd/xgoja/cmd_generate.go`
+  5. `cmd/xgoja/root_test.go`
+  6. `cmd/xgoja/doc/17-xgoja-v2-reference.md`
+- Validate with:
+
+  ```bash
+  go test ./cmd/xgoja/... -count=1
+  go test ./... -count=1
+  go vet ./...
+  ```
+
+- Rerun the ticket reproduction and verify both commands succeed in either binary/package order, while ambiguity/no-match cases fail clearly.
+
+### Technical details
+
+- Repository: `/home/manuel/workspaces/2026-07-18/improve-xgoja/go-go-goja`
+- Branch: `task/improve-xgoja`
+- Baseline commit: `69b69b6`
+- Ticket root: `/home/manuel/workspaces/2026-07-18/improve-xgoja/go-go-goja/ttmp`
+- Ticket: `XGOJA-ARTIFACT-SELECTION-2026-07-18`
+- Current helper: `cmd/xgoja/v2_plan_helpers.go:16-35`
+- Build call site: `cmd/xgoja/cmd_build.go:86-125`
+- Generate call site: `cmd/xgoja/cmd_generate.go:88-159`
+- Generator target derivation: `cmd/xgoja/internal/generate/templates.go:287-300`
+- Runtime metadata target: `cmd/xgoja/internal/generate/templates.go:343-395`
+- Source unions: `cmd/xgoja/internal/generate/plan.go:199-227`
+
+## Step 2: Validate and deliver the design bundle
+
+I validated the ticket metadata and relationships, ran docmgr doctor successfully, previewed the reMarkable bundle, and uploaded the overview, intern guide, and diary as one PDF with a depth-two table of contents.
+
+The upload command reported success directly, so no additional cloud listing was needed.
+
+### Prompt Context
+
+**User prompt (verbatim):** (same as Step 1)
+
+**Assistant interpretation:** Complete ticket bookkeeping and deliver the validated guide to the requested reMarkable destination.
+
+**Inferred user intent:** Make the implementation guide immediately available for offline review and intern handoff.
+
+### What I did
+
+- Validated frontmatter on the design and diary documents.
+- Ran:
+
+  ```bash
+  docmgr --root /home/manuel/workspaces/2026-07-18/improve-xgoja/go-go-goja/ttmp \
+    doctor --ticket XGOJA-ARTIFACT-SELECTION-2026-07-18 --stale-after 30
+  ```
+
+- Ran a `remarquee upload bundle --dry-run` with the ticket index, design doc, and diary.
+- Uploaded the same bundle as `XGOJA Artifact Selection Intern Guide.pdf`.
+
+### Why
+
+- The dry run catches document ordering, destination, and rendering-command errors before upload.
+- A single PDF with a table of contents is easier to review than separate documents.
+
+### What worked
+
+- Both frontmatter validations passed.
+- `docmgr doctor` reported `All checks passed`.
+- Dry run selected the expected three Markdown documents and destination.
+- Actual upload returned:
+
+  ```text
+  OK: uploaded XGOJA Artifact Selection Intern Guide.pdf -> /ai/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18
+  ```
+
+### What didn't work
+
+- N/A.
+
+### What I learned
+
+- The 1,124-line design document and supporting diary render successfully as one remarquee bundle without changes to Markdown diagrams or code fences.
+
+### What was tricky to build
+
+- The bundle needed enough context for a new intern without including tasks/changelog noise. The selected order is overview, implementation guide, then investigation evidence.
+
+### What warrants a second pair of eyes
+
+- Review the scoped-plan non-mutation pseudocode and the explicit decision that a spec with no compatible primary should error.
+
+### What should be done in the future
+
+- Upload a revised bundle only after implementation changes materially alter the accepted design; avoid overwriting annotated copies casually.
+
+### Code review instructions
+
+- Open the reMarkable bundle and begin with the design's executive summary, then sections 4-6 and 9-10.
+- Use the repository ticket as the authoritative mutable copy.
+
+### Technical details
+
+- Bundle: `XGOJA Artifact Selection Intern Guide.pdf`
+- Destination: `/ai/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18`
+- ToC depth: 2
+- Documents: `index.md`, design doc, investigation diary.

--- a/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/reference/01-investigation-diary.md
+++ b/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/reference/01-investigation-diary.md
@@ -535,3 +535,83 @@ The implementation is committed as `a6f83de` and replaces the design guide's pri
 - Code commit: `a6f83de3bc0808ba871462bd88b11b19b0426683`.
 - New CLI forms: `xgoja build --artifact <id>` and `xgoja generate --artifact <id>`.
 - Non-goals remain: dependency graphs, target-specific assets, and multiple outputs per invocation.
+
+## Step 6: Address review — normalize artifact IDs for `--artifact`
+
+A second review correctly found that `validateArtifacts` trims artifact IDs for validation while the initial `--artifact` implementation trimmed the flag but compared it with the raw stored ID. A valid `id: " release "` therefore could not be selected as `--artifact release` in an ambiguous spec.
+
+I made artifact-ID normalization central for normal v2 loading and defensive for direct plans. This gives the CLI, validation, selection, scoped generation, and diagnostics one identifier representation without expanding the feature surface.
+
+### Prompt Context
+
+**User prompt (verbatim):** "Address
+cmd/xgoja/v2_plan_helpers.go
+Comment on lines +32 to +36
+    artifactID = strings.TrimSpace(artifactID)
+    var selected plan.ArtifactPlan
+    if artifactID != \"\" {
+        var ok bool
+        selected, ok = artifactPlanByID(compiled.Artifacts, artifactID)
+@chatgpt-codex-connector
+chatgpt-codex-connector Bot
+now
+
+P2 Badge Normalize artifact IDs before matching --artifact
+
+When a valid spec uses an artifact ID with surrounding whitespace (for example, id: \" release \"), validation accepts it because validateArtifacts trims IDs, but this code trims the flag value and then compares it exactly with the unnormalized stored ID. Consequently --artifact release is reported as unknown—and passing the padded value cannot work because it is trimmed here—so an ambiguous spec containing that artifact cannot be resolved explicitly. Normalize artifact IDs during defaulting or compare their trimmed forms consistently.
+
+Useful? React with 👍 / 👎."
+
+**Assistant interpretation:** Align artifact-ID defaulting and explicit selection with validation's existing whitespace semantics, then prove the flag handles a padded declared ID.
+
+**Inferred user intent:** Remove the remaining accepted-spec regression from `--artifact` without adding unrelated identifier redesign.
+
+### What I did
+
+- Added `cfg.Artifacts[i].ID = strings.TrimSpace(cfg.Artifacts[i].ID)` in `specv2.ApplyDefaults`.
+- Added `normalizedArtifactID` and used it when matching IDs, scoping artifacts, rendering diagnostics, and copying artifact specs.
+- Added an explicit-selection regression with `ID: " binary "` and `--artifact " binary "`; the selected/scoped ID becomes `binary`, while the manually constructed original plan remains unchanged.
+- Extended the existing defaults test to assert normalized ID, type, and binary output.
+- Committed code/tests as `2820fad`.
+
+### Why
+
+- The explicit selector must use the same normalized identifier representation as v2 validation.
+- Defensive helper normalization keeps direct internal test plans correct even before they pass through `ApplyDefaults`.
+
+### What worked
+
+- Focused `go test ./cmd/xgoja/... -count=1` passed.
+- Focused xgoja lint passed.
+- The full pre-commit hook passed generation, all tests, lint, and Glazed vet.
+
+### What didn't work
+
+- N/A.
+
+### What I learned
+
+- The artifact-ID and artifact-type fixes share a pattern: central defaulting establishes correct normal behavior, while scoped helper normalization guards manually assembled `plan.Plan` values without mutating them.
+
+### What was tricky to build
+
+- The selected `ArtifactPlan` can originate with a raw padded ID, so scoping must pass the normalized ID into lookup; normalizing lookup comparisons alone is insufficient if the next lookup receives the unnormalized selected ID.
+
+### What warrants a second pair of eyes
+
+- Confirm that normalizing artifact IDs in defaults is consistent with the existing validation behavior and other normalized identifier fields such as provider/source IDs.
+
+### What should be done in the future
+
+- N/A.
+
+### Code review instructions
+
+- Verify `ApplyDefaults` trims artifact IDs before deriving binary defaults.
+- Verify explicit selection, config lookup, plan lookup, scoped copies, target metadata, and diagnostics use normalized IDs.
+- Run the padded-ID explicit-selection regression.
+
+### Technical details
+
+- Code commit: `2820fadd440b79018266ac038df79cc7d04130f1`.
+- Validation: focused xgoja tests/lint plus successful full pre-commit hook.

--- a/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/reference/01-investigation-diary.md
+++ b/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/reference/01-investigation-diary.md
@@ -375,3 +375,82 @@ The change was committed in two focused code commits: `7caaee6` contains the sel
 - Selected build primary types: `binary`, `adapter`, `cobra`.
 - Selected generate primary types: `runtime-package`, `source`, `template`.
 - Retained support types: `dts`, `embedded-assets`.
+
+## Step 4: Address review — normalize whitespace-padded artifact types
+
+A review correctly identified that `specv2.validateArtifacts` accepts whitespace around `artifact.type`, while the new compatibility checks initially compared raw strings. That would reject an accepted `type: " binary "` configuration and regress the previous selector's trimming behavior.
+
+I normalized artifact types at the selection boundary and in the scoped copies sent to generators. The latter matters because generator code compares artifact types directly; merely trimming candidate checks would select a binary but still leave downstream rendering with a whitespace-padded type.
+
+### Prompt Context
+
+**User prompt (verbatim):** "Address code review
+cmd/xgoja/v2_plan_helpers.go
+Comment on lines +63 to +68
+func isCompatiblePrimary(command artifactCommand, artifactType string) bool {
+    switch command {
+    case artifactCommandBuild:
+        return artifactType == \"binary\" || artifactType == \"adapter\" || artifactType == \"cobra\"
+    case artifactCommandGenerate:
+        return artifactType == \"runtime-package\" || artifactType == \"source\" || artifactType == \"template\"
+@chatgpt-codex-connector
+chatgpt-codex-connector Bot
+3 minutes ago
+
+P2 Badge Normalize artifact types before compatibility checks
+
+When an artifact type contains surrounding whitespace (for example, YAML type: \" binary \"), specv2.validateArtifacts accepts it because validation switches on strings.TrimSpace(artifact.Type), but this exact comparison finds no build candidate and rejects the otherwise valid plan. The previous targetFromPlan also trimmed the type before selecting it, so this introduces a regression for accepted specs; trim or normalize artifact types before compatibility and support classification.
+
+Useful? React with 👍 / 👎."
+
+**Assistant interpretation:** Correct the artifact-type whitespace regression identified in code review and add regression coverage, without widening the feature scope.
+
+**Inferred user intent:** Preserve compatibility with accepted v2 YAML while keeping selected plans safe for existing generator code.
+
+### What I did
+
+- Added `normalizedArtifactType`, used by primary compatibility and support-artifact classification.
+- Normalized `ArtifactSpec.Type` and `ArtifactPlan.Spec.Type` only in the shallow scoped copies, preserving the caller's original plan unchanged.
+- Normalized target metadata and diagnostic type formatting.
+- Added `TestSelectPlanTargetNormalizesArtifactTypesInScopedPlan` for whitespace-padded binary, runtime-package, and embedded-assets types.
+- Committed the fix as `30d0d88`.
+
+### Why
+
+- Validation's `strings.TrimSpace` contract should match selection semantics.
+- Generator helpers perform direct artifact-type comparisons, so normalized candidates alone would not make the generated runtime plan or embedding behavior correct.
+
+### What worked
+
+- Focused selection test and xgoja golangci-lint passed before commit.
+- The pre-commit hook passed repository generation, full tests, lint, and Glazed vet.
+
+### What didn't work
+
+- N/A.
+
+### What I learned
+
+- Normalization belongs at the boundary where validation-normalized semantics meet raw config values. Scoped copies provide a safe normalization point because they are already intended for downstream generation and do not mutate the original compiled plan.
+
+### What was tricky to build
+
+- The review specifically mentioned compatibility checks, but direct comparisons also occur in downstream generator logic. Normalizing scoped config and compiled artifact representations prevents a partial fix where selection succeeds but runtime metadata remains malformed.
+
+### What warrants a second pair of eyes
+
+- Confirm that preserving raw whitespace in the original plan while normalizing only generation-scoped copies is preferred over normalizing all spec fields at load time. This matches the narrow review fix and avoids unrelated schema behavior changes.
+
+### What should be done in the future
+
+- Consider normalizing artifact types centrally in `specv2.ApplyDefaults` only as part of a broader normalization policy with tests for all schema fields; it is not needed for this targeted correction.
+
+### Code review instructions
+
+- Review `normalizedArtifactType`, `normalizedArtifactSpec`, and `normalizedArtifactPlan` in `cmd/xgoja/v2_plan_helpers.go`.
+- Confirm the new test proves selection and support retention while asserting original config non-mutation.
+
+### Technical details
+
+- Review-fix commit: `30d0d88a1ac707d8b86808b6c98391417268f0b5`.
+- Validation: focused `TestSelectPlanTarget`, `./.bin/golangci-lint run ./cmd/xgoja/...`, and successful full pre-commit test/lint hooks.

--- a/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/scripts/01-reproduce-artifact-order.log
+++ b/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/scripts/01-reproduce-artifact-order.log
@@ -1,0 +1,41 @@
+=== binary first: build succeeds ===
+validated xgoja/v2 plan for /tmp/tmp.5pZ9jAAEdc/binary-first.yaml
+generated build workspace: /tmp/tmp.5pZ9jAAEdc/build-binary-first
+generated module: xgoja.generated/artifact-order-reproduction
+xgoja builds from the generated module root: cd /tmp/tmp.5pZ9jAAEdc/build-binary-first && go mod tidy && go build -buildvcs=false .
+release note: if you check this generated host into a repository as a nested Go module, configure GoReleaser with dir: <generated-module-dir> and main: .
+xgoja dry run ok: name=artifact-order-reproduction target=xgoja output=/tmp/tmp.5pZ9jAAEdc/binary modules=0 packages=0
+exit=0
+
+=== binary first: generate fails ===
+validated xgoja/v2 plan for /tmp/tmp.5pZ9jAAEdc/binary-first.yaml
+Error: xgoja generate supports target.kind package, source, or template; got "xgoja"
+exit status 1
+exit=1
+
+=== runtime-package first: build fails ===
+validated xgoja/v2 plan for /tmp/tmp.5pZ9jAAEdc/package-first.yaml
+Error: target.kind package is source generation only; use xgoja generate -f /tmp/tmp.5pZ9jAAEdc/package-first.yaml
+exit status 1
+exit=1
+
+=== runtime-package first: generate succeeds ===
+validated xgoja/v2 plan for /tmp/tmp.5pZ9jAAEdc/package-first.yaml
+xgoja generate dry run ok: name=artifact-order-reproduction target=package output=/tmp/tmp.5pZ9jAAEdc/runtime-package package=xgojaruntime template= clean=false modules=0 packages=0
+exit=0
+
+=== support artifact first: build command selects binary ===
+validated xgoja/v2 plan for /tmp/tmp.5pZ9jAAEdc/support-first.yaml
+generated build workspace: /tmp/tmp.5pZ9jAAEdc/build-support-first
+generated module: xgoja.generated/artifact-order-reproduction
+xgoja builds from the generated module root: cd /tmp/tmp.5pZ9jAAEdc/build-support-first && go mod tidy && go build -buildvcs=false .
+release note: if you check this generated host into a repository as a nested Go module, configure GoReleaser with dir: <generated-module-dir> and main: .
+xgoja dry run ok: name=artifact-order-reproduction target=xgoja output=/tmp/tmp.5pZ9jAAEdc/binary modules=0 packages=0
+exit=0
+
+=== support artifact first: generated runtime metadata still uses support artifact ===
+  "target": {
+    "kind": "embedded-assets",
+    "output": "/tmp/tmp.5pZ9jAAEdc/binary"
+  },
+

--- a/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/scripts/01-reproduce-artifact-order.sh
+++ b/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/scripts/01-reproduce-artifact-order.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -u
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../../.." && pwd)
+work_dir=$(mktemp -d)
+trap 'rm -rf "$work_dir"' EXIT
+
+write_spec() {
+  local path=$1
+  local first_type=$2
+  local first_id=$3
+  local second_type=$4
+  local second_id=$5
+  cat >"$path" <<YAML
+schema: xgoja/v2
+name: artifact-order-reproduction
+go:
+  module: xgoja.generated/artifact-order-reproduction
+  version: "1.26"
+workspace:
+  mode: off
+artifacts:
+  - id: $first_id
+    type: $first_type
+    output: $work_dir/$first_id
+    package: xgojaruntime
+  - id: $second_id
+    type: $second_type
+    output: $work_dir/$second_id
+    package: xgojaruntime
+YAML
+}
+
+run_case() {
+  local label=$1
+  local spec=$2
+  shift 2
+  echo "=== $label ==="
+  set +e
+  (cd "$repo_root" && go run ./cmd/xgoja "$@" -f "$spec") 2>&1
+  local status=$?
+  set -e
+  echo "exit=$status"
+  echo
+}
+
+set -e
+binary_first="$work_dir/binary-first.yaml"
+package_first="$work_dir/package-first.yaml"
+support_first="$work_dir/support-first.yaml"
+write_spec "$binary_first" binary binary runtime-package runtime-package
+write_spec "$package_first" runtime-package runtime-package binary binary
+write_spec "$support_first" embedded-assets assets binary binary
+
+run_case "binary first: build succeeds" "$binary_first" build --dry-run --work-dir "$work_dir/build-binary-first"
+run_case "binary first: generate fails" "$binary_first" generate --dry-run
+run_case "runtime-package first: build fails" "$package_first" build --dry-run --work-dir "$work_dir/build-package-first"
+run_case "runtime-package first: generate succeeds" "$package_first" generate --dry-run
+run_case "support artifact first: build command selects binary" "$support_first" build --dry-run --work-dir "$work_dir/build-support-first"
+echo "=== support artifact first: generated runtime metadata still uses support artifact ==="
+grep -A3 '"target"' "$work_dir/build-support-first/xgoja.runtime.json"
+echo

--- a/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/tasks.md
+++ b/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/tasks.md
@@ -5,9 +5,9 @@
 - [x] Reproduce artifact-order and support-first metadata failures <!-- t:58qb -->
 - [x] Map CLI, v2 plan, artifact schema, and generator architecture <!-- t:t9c7 -->
 - [x] Write the intern analysis/design/implementation guide <!-- t:bb5z -->
-- [ ] Implement command-compatible selection and scoped-plan helper <!-- t:r79v -->
-- [ ] Integrate scoped selection into build and generate <!-- t:4g49 -->
-- [ ] Add helper, command-order, ambiguity, metadata, and embedding tests <!-- t:tq45 -->
-- [ ] Update the xgoja v2 artifact reference <!-- t:a5wt -->
-- [ ] Run focused/full tests and vet <!-- t:1omp -->
+- [x] Implement command-compatible selection and scoped-plan helper <!-- t:r79v -->
+- [x] Integrate scoped selection into build and generate <!-- t:4g49 -->
+- [x] Add helper, command-order, ambiguity, metadata, and embedding tests <!-- t:tq45 -->
+- [x] Update the xgoja v2 artifact reference <!-- t:a5wt -->
+- [x] Run focused/full tests and vet <!-- t:1omp -->
 - [x] Upload the design bundle to reMarkable <!-- t:3z3p -->

--- a/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/tasks.md
+++ b/ttmp/2026/07/18/XGOJA-ARTIFACT-SELECTION-2026-07-18--pragmatic-command-compatible-artifact-selection-for-xgoja-build-and-generate/tasks.md
@@ -1,0 +1,13 @@
+# Tasks
+
+## TODO
+
+- [x] Reproduce artifact-order and support-first metadata failures <!-- t:58qb -->
+- [x] Map CLI, v2 plan, artifact schema, and generator architecture <!-- t:t9c7 -->
+- [x] Write the intern analysis/design/implementation guide <!-- t:bb5z -->
+- [ ] Implement command-compatible selection and scoped-plan helper <!-- t:r79v -->
+- [ ] Integrate scoped selection into build and generate <!-- t:4g49 -->
+- [ ] Add helper, command-order, ambiguity, metadata, and embedding tests <!-- t:tq45 -->
+- [ ] Update the xgoja v2 artifact reference <!-- t:a5wt -->
+- [ ] Run focused/full tests and vet <!-- t:1omp -->
+- [x] Upload the design bundle to reMarkable <!-- t:3z3p -->


### PR DESCRIPTION
This change refactors the artifact selection logic for `xgoja build` and
`xgoja generate` to be based on command compatibility rather than YAML
definition order.

Previously, the commands would select the first artifact in the list, leading
to unpredictable behavior and failures if, for example, a `runtime-package`
artifact was defined before a `binary` artifact in a spec used with `xgoja
build`.

Key changes:

- **Command-based Selection**: Each command now selects exactly one "primary"
  artifact compatible with its function:
    - `build`: Selects a `binary`, `adapter`, or `cobra` artifact.
    - `generate`: Selects a `runtime-package`, `source`, or `template`
      artifact.

- **Strict Validation**: The commands will now fail with an informative error
  if zero or more than one compatible primary artifact is found in the spec.

- **Scoped Plan**: The execution plan is now "scoped" to the selected
  primary artifact. This ensures that only the `sources` (e.g., `jsverbs`)
  associated with that artifact are processed and embedded.

- **Support Artifacts**: `dts` and `embedded-assets` are treated as global
  "support" artifacts and are always included alongside the selected primary
  artifact.

- **Testing**: Added comprehensive tests to verify that selection is
  order-independent and that sources are correctly scoped for both `build` and
  `generate` commands.