### PR TITLE
chore(security): add Ségur v1/v2 baseline and harden CI

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Summary
+
+Describe the change, the problem it solves, and the affected packages, commands, generated artifacts, or deployment paths.
+
+## Verification
+
+List the commands, automated tests, manual tests, and environments used to verify the change.
+
+## Security review
+
+Complete the applicable items. Mark an item `N/A` only when the reason is clear from the pull request.
+
+- [ ] The trust boundary and attacker-controlled inputs are identified.
+- [ ] New or changed native modules document their host capabilities and safe-mode status.
+- [ ] Authentication, authorization, tenant isolation, CSRF, rate limiting, or audit behavior is unchanged, or the change includes negative-path tests.
+- [ ] The change does not expose secrets, credentials, session identifiers, authorization headers, personal data, or health data in logs, errors, examples, fixtures, or artifacts.
+- [ ] File, command, database, network, parser, and template inputs are bounded and validated.
+- [ ] Timeouts, cancellation, cleanup, and dependency-failure behavior are covered where applicable.
+- [ ] Dependency, tool, image, and GitHub Action references are intentionally versioned or pinned.
+- [ ] Scanner suppressions are narrow, documented, and supported by tests or design rationale.
+- [ ] Migration, rollback, backup/restore, and operational effects are documented where applicable.
+- [ ] Security, deployment, user, and generated-code documentation is updated.
+
+## Residual risk
+
+State any accepted risk, follow-up issue, deployment assumption, or evidence that is intentionally deferred.

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,21 +8,26 @@ on:
   schedule:
     - cron: '0 0 * * 0'  # Run weekly on Sunday at midnight
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
+      contents: read
       security-events: write
-      
+
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v6
+      - name: Checkout repository
+        uses: actions/checkout@v6
 
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
-      with:
-        languages: go
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: go
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4 
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/dependency-scanning.yml
+++ b/.github/workflows/dependency-scanning.yml
@@ -43,7 +43,28 @@ jobs:
         run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
 
       - name: Run govulncheck
-        run: govulncheck ./...
+        id: govulncheck
+        shell: bash
+        run: |
+          set +e
+          govulncheck -json ./... > govulncheck.json
+          status=$?
+          echo "exit_code=${status}" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Upload govulncheck report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: govulncheck-report-${{ github.sha }}
+          path: govulncheck.json
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Enforce govulncheck result
+        if: steps.govulncheck.outputs.exit_code != '0'
+        env:
+          SCAN_EXIT_CODE: ${{ steps.govulncheck.outputs.exit_code }}
+        run: exit "$SCAN_EXIT_CODE"
 
   gosec:
     name: GoSec Security Scan
@@ -62,4 +83,25 @@ jobs:
         run: go install github.com/securego/gosec/v2/cmd/gosec@v2.25.0
 
       - name: Run Gosec Security Scanner
-        run: gosec -exclude=G101,G304,G301,G306,G204,G703 -exclude-generated -exclude-dir=.history ./...
+        id: gosec
+        shell: bash
+        run: |
+          set +e
+          gosec -exclude=G101,G304,G301,G306,G204,G703 -exclude-generated -exclude-dir=.history -fmt=json -out=gosec.json ./...
+          status=$?
+          echo "exit_code=${status}" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Upload gosec report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: gosec-report-${{ github.sha }}
+          path: gosec.json
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Enforce gosec result
+        if: steps.gosec.outputs.exit_code != '0'
+        env:
+          SCAN_EXIT_CODE: ${{ steps.gosec.outputs.exit_code }}
+        run: exit "$SCAN_EXIT_CODE"

--- a/.github/workflows/dependency-scanning.yml
+++ b/.github/workflows/dependency-scanning.yml
@@ -8,15 +8,19 @@ on:
   schedule:
     - cron: '0 0 * * 0'  # Run weekly on Sunday at midnight
 
+permissions:
+  contents: read
+
 jobs:
   dependency-review:
     name: Dependency Review
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-      
+
       - name: Dependency Review
         uses: actions/dependency-review-action@v4
         with:
@@ -25,35 +29,37 @@ jobs:
   govulncheck:
     name: Go Vulnerability Check
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-      
+
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      
+
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
-      
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
+
       - name: Run govulncheck
         run: govulncheck ./...
-        
+
   gosec:
     name: GoSec Security Scan
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-      
+
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      
+
       - name: Install gosec
-        run: go install github.com/securego/gosec/v2/cmd/gosec@latest
+        run: go install github.com/securego/gosec/v2/cmd/gosec@v2.25.0
 
       - name: Run Gosec Security Scanner
         run: gosec -exclude=G101,G304,G301,G306,G204,G703 -exclude-generated -exclude-dir=.history ./...

--- a/.github/workflows/dependency-scanning.yml
+++ b/.github/workflows/dependency-scanning.yml
@@ -87,7 +87,7 @@ jobs:
         shell: bash
         run: |
           set +e
-          gosec -exclude=G101,G304,G301,G306,G204,G703 -exclude-generated -exclude-dir=.history -fmt=json -out=gosec.json ./...
+          gosec -exclude=G101,G304,G301,G306,G204,G703 -exclude-generated -exclude-dir=.history -track-suppressions -fmt=json -out=gosec.json ./...
           status=$?
           echo "exit_code=${status}" >> "$GITHUB_OUTPUT"
           exit 0

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -3,12 +3,16 @@ name: golang-pipeline
 on:
   push:
     branches:
-      - 'main'
+      - main
   pull_request:
+
+permissions:
+  contents: read
 
 jobs:
   inspector-validation:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
         with:
@@ -23,6 +27,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: inspector-validation
     steps:
       - uses: actions/checkout@v6
@@ -40,9 +45,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
       - name: Install protoc generation plugins
         run: make install-generate-tools
-      -
-        name: generate assets
+      - name: generate assets
         run: go generate ./...
-      -
-        name: run unit tests
+      - name: run unit tests
         run: go test ./...

--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -6,19 +6,23 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   trufflehog:
     name: TruffleHog Secret Scan
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      
+
       - name: TruffleHog OSS
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@17456f8c7d042d8c82c9a8ca9e937231f9f42e26 # v3.95.2
         with:
           path: ./
           base: ${{ github.event.repository.default_branch }}
-          head: HEAD 
+          head: HEAD

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,62 @@
+# Security policy
+
+## Scope
+
+`go-go-goja` is a Go library and toolchain for embedding JavaScript, exposing native Go modules, and building HTTP hosts. It is not a security boundary by itself and it is not a complete healthcare application.
+
+Some modules intentionally provide powerful host capabilities, including file-system access, command execution, database access, networking, and access to host configuration. Code that executes untrusted or tenant-supplied JavaScript must use an explicit allowlist or `engine.MiddlewareSafe()` and must not expose `exec`, `fs`, `database`, `process.env`, or equivalent host capabilities unless the deployment threat model permits them.
+
+The Ségur numérique applicability assessment and evidence checklist are documented in [`docs/compliance/segur-v1-v2.md`](docs/compliance/segur-v1-v2.md). That document does not claim ANS certification or Ségur referencing.
+
+## Supported versions
+
+Security fixes are developed against the default branch and the latest published release. Older releases may receive fixes when practical, but no long-term support period is implied unless a release announcement states otherwise.
+
+Users should reproduce reported issues against the latest release or the current default branch before reporting them.
+
+## Reporting a vulnerability
+
+Do not open a public issue for a suspected vulnerability.
+
+1. Use GitHub private vulnerability reporting when the repository Security tab exposes **Report a vulnerability**.
+2. If private reporting is unavailable, contact a repository maintainer privately through the contact information on their GitHub profile or through an established private organization channel.
+3. Include only the minimum sensitive information needed to reproduce the issue. Do not include production credentials, patient data, access tokens, session cookies, private keys, or unredacted logs.
+
+A useful report contains:
+
+- affected commit, release, package, command, or generated-host configuration;
+- deployment assumptions and whether JavaScript input is trusted;
+- reproduction steps or a minimal proof of concept;
+- expected and observed behavior;
+- impact, required privileges, and reachable data or capabilities;
+- suggested mitigation, when known;
+- whether the issue is already public or under an embargo.
+
+## Triage and disclosure
+
+Maintainers will validate the report, determine affected versions, and coordinate remediation and disclosure with the reporter. Response times depend on severity, reproducibility, and maintainer availability; this policy does not establish a contractual service-level agreement.
+
+When a vulnerability is confirmed, the remediation process should produce:
+
+- a private reproduction and regression test;
+- a minimal fix that preserves the intended trust boundary;
+- a review of adjacent call paths and generated code;
+- updated documentation or deployment guidance where configuration contributed to the issue;
+- a release or advisory describing affected versions and mitigations without exposing secrets.
+
+## Security expectations for contributors
+
+Contributions must follow [`docs/security/secure-development.md`](docs/security/secure-development.md). In particular:
+
+- security decisions that can be enforced by the Go host must not be delegated to JavaScript;
+- new native modules must document their host capabilities and be excluded from safe-mode defaults unless they are data-only;
+- authentication, authorization, CSRF, rate limiting, and audit enforcement must fail closed;
+- secrets and bearer credentials must not be placed in logs, audit attributes, errors, tests, examples, fixtures, or generated artifacts;
+- third-party tools and GitHub Actions must use immutable or versioned references rather than mutable development branches;
+- scanner suppressions require a narrow, documented justification and a regression test when applicable.
+
+## Deployment responsibilities
+
+Operators remain responsible for the security of the complete deployed system, including TLS termination, trusted-proxy configuration, identity-provider policy, secret management, database access, backups, restore tests, log retention, monitoring, incident response, vulnerability remediation, and penetration testing.
+
+A deployment that processes French health data must separately assess all applicable legal, regulatory, contractual, interoperability, hosting, and Ségur requirements. The presence of security features in this repository is not evidence that a derived product is compliant, certified, HDS-hosted, or referenced by the Agence du Numérique en Santé.

--- a/docs/compliance/segur-v1-v2.md
+++ b/docs/compliance/segur-v1-v2.md
@@ -73,7 +73,7 @@ Status values:
 | Security awareness (`SC.SSI/GEN.02 BIS` family) | `docs/security/secure-development.md`; PR security checklist | Added by this baseline | Conduct and record role-specific training; include healthcare-data, identity, incident, and operational topics. |
 | Secure-development guide (`SC.SSI/GEN.11`, `SC.SSI/GEN.20` family) | Secure-development standard; host-owned route enforcement; safe module selection; tests, lint, CodeQL, gosec | Implemented / added | Apply the standard through the complete product SDLC, generated code, client applications, integrations, and infrastructure. |
 | Technology and threat watch (`SC.SSI/GEN.03 BIS` family) | Scheduled CodeQL, `govulncheck`, `gosec`, dependency review, secret scanning; dependency-update PRs | Partial | Assign an owner, define review frequency and severity targets, monitor CERT Santé/ANSSI/vendor sources, and retain remediation decisions. |
-| Vulnerability management and proactive patching | `govulncheck`, gosec, CodeQL, dependency review; version-pinned scanner installation | Partial | Define remediation SLAs, asset/version inventory, supported-version policy, emergency patch process, exception register, and customer notification process. |
+| Vulnerability management and proactive patching | `govulncheck`, gosec, CodeQL, dependency review; version-pinned scanner installation; commit-scoped scan artifacts | Partial | Define remediation SLAs, asset/version inventory, supported-version policy, emergency patch process, exception register, and customer notification process. |
 | Penetration testing | Testable HTTP/auth surfaces and deployment runbook | External/product obligation | Commission the ANS-required test against the complete candidate solution using the current ANS form and guide. The guide requires an organization qualified PASSI, while clarifying that the engagement itself need not be a formal PASSI audit. Remediate and retest findings. |
 | Least privilege and runtime capability control | `engine.MiddlewareSafe()`, module allowlist/exclusion middleware, opt-in `process.env`, explicit documentation of privileged modules | Implemented | Enforce the selected capability policy in the product; add OS/container/network isolation and tenant-specific threat analysis. |
 | Authentication and session security | Server-side opaque sessions, secure cookie defaults, idle/absolute expiry, CSRF, OIDC state/nonce/PKCE, revocation, recent-MFA support | Implemented / partial | Integrate the required healthcare identity services, including Pro Santé Connect when applicable; define privileged-account policy and operational access reviews. |
@@ -82,20 +82,24 @@ Status values:
 | Audit trace generation | `pkg/gojahttp/auth/audit`, structured records, secret-key redaction, bounded queries, durable store interfaces | Implemented / partial | Define events, retention, integrity, access controls, export, monitoring, clock synchronization, legal basis, and deletion rules for the product. |
 | Backup and restore | `cmd/xgoja/doc/23-auth-host-production-runbook.md` includes backup, isolated restore rehearsal, migration, and rollback guidance | Partial | Implement scheduled encrypted backups, off-site protection, recovery objectives, periodic restore evidence, key recovery, and healthcare-data obligations. |
 | Secure deployment and operations | Single-node production profile, trusted-proxy configuration, durable stores, SQL readiness, external secret management guidance | Partial | Produce the candidate architecture, hardening baseline, HDS analysis where applicable, monitoring, incident response, business continuity, capacity, and supplier controls. |
-| Software supply-chain evidence | Go module manifests, lockfiles, CI scanners, release checksums/signing mechanisms in release tooling | Partial | Generate and retain an SBOM for each candidate artifact, provenance, artifact digest, signature verification, dependency exception register, and reproducible evidence bundle. |
+| Software supply-chain evidence | Go module manifests, lockfiles, CI scanners, immutable report artifacts, release checksums/signing mechanisms in release tooling | Partial | Generate and retain an SBOM for each candidate artifact, provenance, artifact digest, signature verification, dependency exception register, and reproducible evidence bundle. |
 | Vulnerability disclosure and incident intake | `SECURITY.md` | Added by this baseline | Operate a private intake channel, incident classification, CERT Santé/authority notification analysis, customer communication, exercises, and post-incident review. |
 
 ## CI changes in this baseline
 
-The associated repository change applies the following low-risk controls:
+The associated repository change applies the following controls:
 
 - explicit read-only default GitHub token permissions for test and security workflows;
 - only the CodeQL job receives `security-events: write`;
 - job timeouts to bound runner and token exposure;
-- immutable pinning of the TruffleHog action;
+- immutable pinning of the TruffleHog and scan-report upload actions;
 - released-version pinning of `govulncheck` and `gosec` rather than build-time `@latest` resolution;
+- machine-readable, commit-scoped `govulncheck` and gosec reports retained for 30 days while preserving blocking exit status;
+- tracked gosec suppression metadata for reviewable false-positive decisions;
 - public vulnerability-reporting and secure-development guidance;
 - a pull-request security review checklist.
+
+The baseline scan identified one `G705` XSS-taint warning in the SPA fallback handler. Review confirmed that request input only determines whether fallback occurs; response bytes come from a host-configured read-only `fs.FS` and are not interpolated with the request. The change records a rule-specific inline justification, adds `X-Content-Type-Options: nosniff`, and adds a regression test using an attacker-controlled URL path to verify that only the trusted index document is returned.
 
 These changes improve evidence quality and software-supply-chain hygiene. They do not replace artifact signing, SBOM generation, branch protection, protected environments, independent review, or penetration testing.
 

--- a/docs/compliance/segur-v1-v2.md
+++ b/docs/compliance/segur-v1-v2.md
@@ -1,0 +1,192 @@
+# Ségur numérique Vague 1 / Vague 2 applicability and security baseline
+
+**Assessment date:** 2026-07-22  
+**Repository:** `go-go-golems/go-go-goja`  
+**Assessment type:** source-repository gap analysis, not a conformity assessment
+
+## Executive conclusion
+
+`go-go-goja` is a general-purpose Go/JavaScript runtime, native-module framework, code generator, and HTTP-host toolkit. It is not a Logiciel de Gestion de Cabinet (LGC) and does not implement the minimum LGC product perimeter: patient records, appointments, prescriptions, medical decision support, healthcare document workflows, and exchanges with health services.
+
+Therefore:
+
+- this repository cannot, by itself, be referenced as a Ségur LGC solution;
+- this document does not claim Ségur conformity, ANS referencing, HDS compliance, Pro Santé Connect approval, CNDA approval, or any healthcare certification;
+- a derived healthcare product may reuse this repository as a technical component, but the complete candidate solution, its publisher, its operating model, and its evidence dossier must satisfy every applicable REM requirement and verification scenario;
+- the reusable controls in this repository are relevant mainly to the **Sécurité des SI** portion of Vague 2 and to retained Vague 1 security expectations.
+
+## Official research basis
+
+The authoritative sources must be rechecked for each candidate version and submission date. This assessment used:
+
+- ANS Ségur resources index: <https://esante.gouv.fr/ens/segur-numerique-sante/ressources-segur>
+- ANS LGC Vague 2 device page: <https://esante.gouv.fr/ens/segur-numerique-sante/vague-2/dispositif-lgc-couloir-medecin-ville>
+- REM LGC Vague 1: <https://esante.gouv.fr/sites/default/files/media_entity/documents/REM-MDV-LGC-Va1.xlsx>
+- REM MDV-LGC Vague 2, version 08/06/2026: <https://industriels.esante.gouv.fr/sites/default/files/media/document/REM-MDV-LGC-Va2.xlsx>
+- DSR MDV-LGC Vague 2, June 2026: <https://esante.gouv.fr/sites/default/files/media/document/DSR-MDV-LGC-Va2.pdf>
+- ANS LGC penetration-test guide: <https://esante.gouv.fr/sites/default/files/media/document/ANS_Guide-utilisation_Test-intrusion_LGC.pdf>
+
+The REM spreadsheet is the requirement-level source of truth. The DSR explains scope, evidence, and the referencing process. This repository document is only an engineering crosswalk.
+
+## Vague 1 and Vague 2 relationship
+
+The Vague 2 LGC profile retains applicable Vague 1 requirements and adds Vague 2 requirements. A product that was not previously referenced must not treat Vague 2 as a security-only delta: it must evaluate the full applicable Vague 1 and Vague 2 perimeter.
+
+For a derived product, maintain a machine-readable traceability matrix with at least:
+
+- REM requirement ID and version;
+- applicability decision and rationale;
+- implementation component and owner;
+- verification scenario;
+- automated test, manual test, or external evidence reference;
+- result, date, immutable candidate version, and reviewer;
+- residual finding and remediation status.
+
+## Vague 2 security themes
+
+The June 2026 DSR groups the security work around a common technical and organizational baseline, including:
+
+- security governance, named responsibilities, and team awareness;
+- a secure-development standard applied to new products and new functionality;
+- continuous technology and threat monitoring;
+- proactive identification and remediation of vulnerabilities, including penetration testing;
+- preventive and corrective controls for common critical weaknesses;
+- identity, authentication, access, privileged-account, login, and logout controls;
+- backup and restore arrangements;
+- creation and conservation of security-relevant traces.
+
+The DSR associates these areas with REM identifiers including the `SC.SSI/GEN.*`, `SC.SSI/IAM.*`, and `SC.SSI/IE.*` families. Exact wording, applicability, proof type, and verification steps must be taken from the current REM rather than inferred from this summary.
+
+## Repository crosswalk
+
+Status values:
+
+- **Implemented** - source control contains a reusable control and tests or CI evidence.
+- **Added by this baseline** - repository governance/evidence added in the associated change.
+- **Partial** - a useful primitive exists, but product or deployment controls remain necessary.
+- **External/product obligation** - cannot be satisfied by this component repository.
+- **Not applicable to this component** - health-domain feature outside the repository's role.
+
+| Ségur-related control area | Repository evidence | Status | Remaining work for a candidate healthcare product |
+| --- | --- | --- | --- |
+| Security roles and governance (`SC.SSI/GEN.01` family) | `SECURITY.md`; this crosswalk; repository ownership and review history | Added by this baseline | Name accountable product-security, DPO/privacy, operations, incident, and regulatory owners; retain approval records. |
+| Security awareness (`SC.SSI/GEN.02 BIS` family) | `docs/security/secure-development.md`; PR security checklist | Added by this baseline | Conduct and record role-specific training; include healthcare-data, identity, incident, and operational topics. |
+| Secure-development guide (`SC.SSI/GEN.11`, `SC.SSI/GEN.20` family) | Secure-development standard; host-owned route enforcement; safe module selection; tests, lint, CodeQL, gosec | Implemented / added | Apply the standard through the complete product SDLC, generated code, client applications, integrations, and infrastructure. |
+| Technology and threat watch (`SC.SSI/GEN.03 BIS` family) | Scheduled CodeQL, `govulncheck`, `gosec`, dependency review, secret scanning; dependency-update PRs | Partial | Assign an owner, define review frequency and severity targets, monitor CERT Santé/ANSSI/vendor sources, and retain remediation decisions. |
+| Vulnerability management and proactive patching | `govulncheck`, gosec, CodeQL, dependency review; version-pinned scanner installation | Partial | Define remediation SLAs, asset/version inventory, supported-version policy, emergency patch process, exception register, and customer notification process. |
+| Penetration testing | Testable HTTP/auth surfaces and deployment runbook | External/product obligation | Commission the ANS-required test against the complete candidate solution using the current ANS form and guide. The guide requires an organization qualified PASSI, while clarifying that the engagement itself need not be a formal PASSI audit. Remediate and retest findings. |
+| Least privilege and runtime capability control | `engine.MiddlewareSafe()`, module allowlist/exclusion middleware, opt-in `process.env`, explicit documentation of privileged modules | Implemented | Enforce the selected capability policy in the product; add OS/container/network isolation and tenant-specific threat analysis. |
+| Authentication and session security | Server-side opaque sessions, secure cookie defaults, idle/absolute expiry, CSRF, OIDC state/nonce/PKCE, revocation, recent-MFA support | Implemented / partial | Integrate the required healthcare identity services, including Pro Santé Connect when applicable; define privileged-account policy and operational access reviews. |
+| Authorization and tenant isolation | Host-owned route plans, resource resolution, authorization actions, negative-path tests | Implemented / partial | Provide product-specific policy, exhaustive cross-tenant tests, administrative separation, and evidence for every sensitive operation. |
+| Login/logout hardening | OIDC callback verification, CSRF-protected POST logout, session revocation and cookie clearing | Implemented / partial | Validate the complete UI and identity-provider configuration, account lifecycle, lockout/rate limiting, privileged sessions, and user messaging. |
+| Audit trace generation | `pkg/gojahttp/auth/audit`, structured records, secret-key redaction, bounded queries, durable store interfaces | Implemented / partial | Define events, retention, integrity, access controls, export, monitoring, clock synchronization, legal basis, and deletion rules for the product. |
+| Backup and restore | `cmd/xgoja/doc/23-auth-host-production-runbook.md` includes backup, isolated restore rehearsal, migration, and rollback guidance | Partial | Implement scheduled encrypted backups, off-site protection, recovery objectives, periodic restore evidence, key recovery, and healthcare-data obligations. |
+| Secure deployment and operations | Single-node production profile, trusted-proxy configuration, durable stores, SQL readiness, external secret management guidance | Partial | Produce the candidate architecture, hardening baseline, HDS analysis where applicable, monitoring, incident response, business continuity, capacity, and supplier controls. |
+| Software supply-chain evidence | Go module manifests, lockfiles, CI scanners, release checksums/signing mechanisms in release tooling | Partial | Generate and retain an SBOM for each candidate artifact, provenance, artifact digest, signature verification, dependency exception register, and reproducible evidence bundle. |
+| Vulnerability disclosure and incident intake | `SECURITY.md` | Added by this baseline | Operate a private intake channel, incident classification, CERT Santé/authority notification analysis, customer communication, exercises, and post-incident review. |
+
+## CI changes in this baseline
+
+The associated repository change applies the following low-risk controls:
+
+- explicit read-only default GitHub token permissions for test and security workflows;
+- only the CodeQL job receives `security-events: write`;
+- job timeouts to bound runner and token exposure;
+- immutable pinning of the TruffleHog action;
+- released-version pinning of `govulncheck` and `gosec` rather than build-time `@latest` resolution;
+- public vulnerability-reporting and secure-development guidance;
+- a pull-request security review checklist.
+
+These changes improve evidence quality and software-supply-chain hygiene. They do not replace artifact signing, SBOM generation, branch protection, protected environments, independent review, or penetration testing.
+
+## Known repository gaps
+
+The following items should be resolved or explicitly accepted before using a derived host for health data:
+
+1. **Scanner exclusions are broad.** The gosec workflow currently excludes several rules globally, including command execution and filesystem rules. Some exclusions reflect deliberate runtime capabilities, but each should be narrowed to paths or inline justifications and reviewed for new call sites.
+2. **Not every GitHub Action is immutable.** Existing actions generally use major-version tags; the mutable TruffleHog `main` reference is fixed by this baseline, but a complete supply-chain program would pin every third-party action to a reviewed commit and automate controlled updates.
+3. **No repository-enforced SBOM/provenance gate.** Release tooling has signing-related configuration, but the repository does not yet expose a single verified SBOM/provenance policy for all artifacts.
+4. **Security ownership is not named in source control.** This baseline defines roles but does not appoint individuals or an organizational security function.
+5. **Audit retention is deployment-specific.** The code normalizes and stores records but intentionally does not impose a legal/operational retention duration.
+6. **The JavaScript runtime is not a hostile-code sandbox.** Safe module selection reduces exposed capabilities but does not provide process, kernel, network, CPU, or memory isolation.
+7. **No Ségur penetration-test evidence exists for this repository.** A test must target the complete, configured candidate product and its actual architecture.
+8. **The repository contains demos and development modes.** In-memory stores, insecure HTTP options, permissive module configurations, and demonstration identity setups must not be carried into production merely because they are present in examples.
+
+## Health-domain requirements outside this repository
+
+For an LGC candidate, the following Vague 1/Vague 2 areas are product obligations and are not implemented merely by adopting this repository:
+
+- patient-record, appointment, prescription, clinical decision-support, dashboard, document, and professional-exchange functions;
+- Identité Nationale de Santé (INS) identity lifecycle and qualification;
+- DMP / Mon espace santé consultation and alimentation;
+- MSSanté integration;
+- Pro Santé Connect and applicable Espace de Confiance flows;
+- healthcare document formats, including applicable CDA profiles and terminology/value sets;
+- e-prescription and CNDA homologation requirements;
+- consent, medical workflow, user-interface, accessibility, and ergonomic scenarios;
+- production of Ségur indicators;
+- healthcare hosting, privacy, data-protection, retention, interoperability, and contractual obligations;
+- every retained Vague 1 requirement and every applicable Vague 2 profile.
+
+A product architecture should map these obligations to dedicated components. Do not represent generic OIDC, generic audit logging, or generic document handling as equivalent to the named French health services.
+
+## Candidate release evidence checklist
+
+Before asserting compliance for a derived product, create an evidence bundle tied to the exact candidate version:
+
+### Governance and scope
+
+- [ ] accountable publisher and security roles named;
+- [ ] current REM version frozen and archived;
+- [ ] complete Vague 1/Vague 2 applicability matrix approved;
+- [ ] architecture, data flows, trust boundaries, suppliers, and hosting documented;
+- [ ] inventory of web, mobile, desktop, API, proxy, and background components complete.
+
+### Engineering evidence
+
+- [ ] immutable source commit and artifact digests;
+- [ ] SBOM for every shipped component;
+- [ ] build provenance and signature-verification records;
+- [ ] unit, integration, end-to-end, negative authorization, migration, and recovery results;
+- [ ] CodeQL, `govulncheck`, gosec, secret-scan, dependency-review, and container/infrastructure scan results;
+- [ ] scanner suppressions and accepted risks reviewed;
+- [ ] threat model and secure-design review current;
+- [ ] no production secrets or health data in source, logs, fixtures, or artifacts.
+
+### Identity, access, and audit
+
+- [ ] user and privileged-account lifecycle tested;
+- [ ] authentication, logout, timeout, revocation, MFA, and failure behavior tested;
+- [ ] authorization and cross-tenant isolation tested;
+- [ ] audit event catalogue, redaction, integrity, access, export, monitoring, and retention approved;
+- [ ] trusted-proxy and client-address behavior verified in the deployed topology.
+
+### Operations and resilience
+
+- [ ] hardened production configuration reviewed;
+- [ ] secrets and keys stored, rotated, backed up, and recoverable;
+- [ ] database migrations and rollback constraints recorded;
+- [ ] backup coverage, encryption, checksum, and isolated restore rehearsal evidenced;
+- [ ] liveness/readiness, monitoring, alerting, capacity, cleanup, and incident runbooks tested;
+- [ ] vulnerability monitoring and remediation targets operating.
+
+### External and regulatory evidence
+
+- [ ] ANS verification scenarios completed for every applicable REM requirement;
+- [ ] required service approvals and homologations obtained;
+- [ ] ANS penetration-test form completed, signed, current, and tied to the candidate major version;
+- [ ] all high-severity disqualifying findings corrected and required counter-audits completed;
+- [ ] privacy, healthcare hosting, data-processing, supplier, and contractual reviews complete;
+- [ ] final dossier independently reviewed before submission.
+
+## Maintenance rule
+
+Review this document when any of the following changes:
+
+- ANS publishes a new REM, DSR, penetration-test guide, or regulatory text;
+- the repository adds a new privileged native module or authentication mechanism;
+- production deployment topology or identity provider changes;
+- a vulnerability, penetration-test finding, or incident changes the threat model;
+- a derived product begins a formal Ségur referencing process.
+
+Do not copy this crosswalk into a conformity dossier without validating every statement against the exact product version and current official source documents.

--- a/docs/security/secure-development.md
+++ b/docs/security/secure-development.md
@@ -1,0 +1,146 @@
+# Secure development standard
+
+This document defines the repository's minimum secure-development rules. It is intended to support routine engineering and evidence collection; it is not a substitute for a product-specific threat model, independent security assessment, or regulatory review.
+
+## 1. Define the trust boundary before coding
+
+Every feature must identify:
+
+- who controls the JavaScript, HTTP request, configuration, database content, and generated artifacts;
+- which host resources can be reached;
+- which identities and tenants are involved;
+- what must fail closed when a dependency is unavailable;
+- which security events and audit records are required.
+
+`goja` is an execution engine, not an isolation boundary for hostile code. A runtime that exposes native modules can reach the privileges of its host process.
+
+For untrusted or tenant-supplied JavaScript:
+
+- start with `engine.MiddlewareSafe()` or an explicit `engine.MiddlewareOnly(...)` allowlist;
+- do not expose `exec`, `fs`, `database`, `process.env`, unrestricted HTTP clients, or plugin loading without a documented capability model;
+- use a dedicated operating-system identity, constrained filesystem, network policy, resource limits, and process supervision;
+- assume that any value returned to JavaScript can be copied or exfiltrated.
+
+A new native module must document its capability class:
+
+- **data-only**: transforms supplied values without accessing host resources;
+- **bounded host access**: accesses an explicitly scoped resource;
+- **privileged host access**: executes commands, reads arbitrary files or environment variables, opens arbitrary connections, or modifies host state.
+
+Only data-only modules are candidates for safe-mode defaults.
+
+## 2. Keep security enforcement in Go
+
+Authentication, authorization, CSRF protection, rate limiting, resource resolution, and audit dispatch must be enforced by the Go host before a JavaScript handler runs.
+
+Planned HTTP routes must:
+
+- declare `.public()` or an authenticated mode explicitly;
+- require a host-owned authorization action for authenticated routes;
+- resolve tenant and resource identifiers through typed host-owned logic;
+- require CSRF protection for state-changing browser-session requests;
+- emit a stable audit event for security-sensitive operations;
+- reject missing security services rather than silently disabling enforcement.
+
+Do not trust JavaScript to assert that a request is authenticated, that a user owns a resource, or that a client-supplied tenant identifier is authorized.
+
+## 3. Authentication and session rules
+
+Browser sessions must use server-side state and opaque, unpredictable identifiers. Production cookies must be `Secure`, `HttpOnly`, use an appropriate `SameSite` policy, and have explicit idle and absolute expiry.
+
+OIDC browser login must validate issuer, audience/client ID, signature, expiry, state, nonce, and PKCE. Identity mapping must use the stable issuer/subject pair; email addresses and display names are attributes, not durable identity keys.
+
+Logout and other state-changing session operations must require CSRF verification. Session rotation, revocation, expiry, and recent-MFA requirements must have negative tests.
+
+Programmatic credentials must be scoped, revocable, and excluded from request context, audit attributes, error messages, and logs in raw form.
+
+## 4. Input, output, and resource handling
+
+- Validate sizes, counts, formats, enumerations, and time ranges at the host boundary.
+- Use structured arguments rather than shell command construction.
+- Use parameterized database queries and bounded result sets.
+- Normalize and validate paths before file access; prefer an application-owned root.
+- Set request, database, subprocess, and shutdown deadlines.
+- Propagate `context.Context` and stop background work when the runtime or request is closed.
+- Avoid reflecting internal errors, stack traces, SQL text, filesystem paths, or identity-provider responses to clients.
+- Treat generated code, templates, schemas, and embedded assets as security-relevant source.
+
+## 5. Secrets and privacy
+
+Never commit or log:
+
+- passwords, private keys, client secrets, bearer tokens, refresh tokens, capability tokens, device codes, session IDs, cookies, authorization headers, or unredacted connection strings;
+- production personal data or health data;
+- full identity-provider responses when a minimal normalized claim set is sufficient.
+
+Audit data must be minimized. Use stable identifiers only when operationally necessary, hash network identifiers when appropriate, and define retention and access control at the deployment level. Redaction must recurse into nested maps and lists.
+
+Examples and tests must use synthetic data and non-working credentials.
+
+## 6. Dependencies and build-chain controls
+
+- Review changes to direct and transitive dependencies.
+- Run `govulncheck` for reachable Go vulnerabilities and `gosec` for source-level issues.
+- Run CodeQL and secret scanning on pull requests and on a schedule.
+- Pin installed security tools to an intentional released version.
+- Pin GitHub Actions to an immutable commit when practical; otherwise use a reviewed version tag, never a mutable development branch such as `main`.
+- Keep lockfiles and generated dependency metadata under review.
+- Record exceptions for scanner suppressions close to the affected code. Repository-wide exclusions must have an owner and a removal plan.
+
+A green scanner result is evidence for a specific commit, not a general assertion that the system is secure.
+
+## 7. Testing requirements
+
+Security-sensitive changes require tests covering both acceptance and rejection paths. Depending on the feature, include:
+
+- unauthenticated, wrong-tenant, wrong-resource, and insufficient-scope requests;
+- expired, revoked, replayed, malformed, and rotated credentials;
+- CSRF failures and unsafe HTTP-method handling;
+- proxy-header spoofing and trusted-proxy boundaries;
+- rate-limit bypass attempts and concurrency;
+- oversized or malformed input;
+- cancellation, timeout, partial failure, and dependency outage behavior;
+- audit redaction and absence of secrets;
+- backup/restore and migration compatibility for persistent security state;
+- fuzzing for parsers, protocol adapters, and serialization boundaries.
+
+Tests that prove an authorization invariant should state the invariant in the test name.
+
+## 8. Review and release evidence
+
+A security-relevant pull request should identify:
+
+- the changed trust boundary;
+- threat scenarios considered;
+- controls added or changed;
+- test and scanner evidence;
+- migration, rollback, and operational effects;
+- documentation updates;
+- accepted residual risk.
+
+For a release used in a regulated or health-data environment, retain an evidence bundle tied to the immutable commit or artifact digest:
+
+- dependency inventory or SBOM;
+- test, lint, CodeQL, `govulncheck`, `gosec`, and secret-scan results;
+- reviewed scanner exceptions;
+- build provenance, checksums, and signatures where available;
+- configuration baseline and deployment architecture;
+- migration and rollback records;
+- backup and restore-test records;
+- penetration-test report and remediation register;
+- incident-response and vulnerability-disclosure procedures.
+
+## 9. Operational baseline for generated auth hosts
+
+Production generated hosts must use the repository's production preflight and runbook guidance. In particular:
+
+- use durable stores for sessions, audit records, credentials, and OIDC transactions;
+- apply schema migrations outside the serving process;
+- enable secure cookies and HTTPS;
+- trust forwarding headers only from measured proxy source ranges;
+- separate liveness from SQL-backed readiness;
+- manage secrets outside source control;
+- test database backup, restore, and rollback;
+- configure audit retention, monitoring, alerting, cleanup, and incident response.
+
+See `cmd/xgoja/doc/23-auth-host-production-runbook.md` for the current deployment runbook.

--- a/modules/fs/http.go
+++ b/modules/fs/http.go
@@ -83,10 +83,14 @@ func (h *spaHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	} else {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	}
+	w.Header().Set("X-Content-Type-Options", "nosniff")
 	if r.Method == http.MethodHead {
 		return
 	}
-	_, _ = w.Write(data)
+	// Request data only determines whether the fallback is reached. The response
+	// bytes come from a host-configured read-only fs.FS and are not derived from
+	// or interpolated with the URL, headers, query, or body.
+	_, _ = w.Write(data) // #nosec G705 -- serving the host-owned SPA index document as HTML is the intended behavior.
 }
 
 func readOnlyBackendFromModule(vm *goja.Runtime, moduleValue goja.Value) (*ReadOnlyFSBackend, bool) {

--- a/modules/fs/http_security_test.go
+++ b/modules/fs/http_security_test.go
@@ -28,7 +28,7 @@ func TestSPAHTTPHandlerFallbackDoesNotReflectRequestInput(t *testing.T) {
 	}
 
 	const attackerInput = `<script>alert(1)</script>`
-	req := httptest.NewRequest(http.MethodGet, "https://example.test/missing?next=%3Cscript%3Ealert%281%29%3C%2Fscript%3E", nil)
+	req := httptest.NewRequest(http.MethodGet, "https://example.test/%3Cscript%3Ealert%281%29%3C%2Fscript%3E", nil)
 	recorder := httptest.NewRecorder()
 
 	handler.ServeHTTP(recorder, req)

--- a/modules/fs/http_security_test.go
+++ b/modules/fs/http_security_test.go
@@ -1,0 +1,51 @@
+package fs
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+func TestSPAHTTPHandlerFallbackDoesNotReflectRequestInput(t *testing.T) {
+	const indexDocument = `<!doctype html><html><body><main>trusted application shell</main></body></html>`
+	backend := NewReadOnlyFSBackend(FSMount{
+		FS: fstest.MapFS{
+			"assets/index.html": &fstest.MapFile{Data: []byte(indexDocument), Mode: 0o444},
+		},
+		Root:  "assets",
+		Mount: "/",
+	})
+	handler := &spaHTTPHandler{
+		backend:   backend,
+		root:      "/",
+		indexPath: "/index.html",
+		fileServer: http.FileServer(http.FS(&readOnlyHTTPFS{
+			backend: backend,
+			root:    "/",
+		})),
+	}
+
+	const attackerInput = `<script>alert(1)</script>`
+	req := httptest.NewRequest(http.MethodGet, "https://example.test/missing?next=%3Cscript%3Ealert%281%29%3C%2Fscript%3E", nil)
+	recorder := httptest.NewRecorder()
+
+	handler.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+	if got := recorder.Body.String(); got != indexDocument {
+		t.Fatalf("body = %q, want trusted index document", got)
+	}
+	if strings.Contains(recorder.Body.String(), attackerInput) {
+		t.Fatalf("response reflected request input: %q", recorder.Body.String())
+	}
+	if got := recorder.Header().Get("Content-Type"); !strings.HasPrefix(got, "text/html") {
+		t.Fatalf("Content-Type = %q, want text/html", got)
+	}
+	if got := recorder.Header().Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Fatalf("X-Content-Type-Options = %q, want nosniff", got)
+	}
+}


### PR DESCRIPTION
## Summary

Researches the current French **Ségur du numérique en santé** Vague 1/Vague 2 LGC material and applies the controls that are appropriate to this repository.

The central scope conclusion is explicit: `go-go-goja` is a general Go/JavaScript runtime and host toolkit, not a Logiciel de Gestion de Cabinet. This PR therefore does **not** claim Ségur conformity, ANS referencing, HDS compliance, or approval for any French health service. It creates a reusable security and evidence baseline for products that embed the repository and separates that baseline from the health-domain obligations of a complete LGC.

Assessment date: **2026-07-22**.

## Official sources reviewed

- ANS Ségur resources index: https://esante.gouv.fr/ens/segur-numerique-sante/ressources-segur
- LGC Vague 2 device and functional perimeter: https://esante.gouv.fr/ens/segur-numerique-sante/vague-2/dispositif-lgc-couloir-medecin-ville
- REM LGC Vague 1
- REM MDV-LGC Vague 2, version 08/06/2026
- DSR MDV-LGC Vague 2, June 2026
- ANS LGC penetration-test guide

## Changes

### Governance and traceability

- add `SECURITY.md` with private-reporting guidance, triage expectations, supported-version policy, contributor rules, and deployment responsibilities;
- add `docs/security/secure-development.md` covering trust boundaries, native-module capabilities, Go-owned authorization, session/OIDC rules, secret handling, dependency controls, security testing, and release evidence;
- add `docs/compliance/segur-v1-v2.md` with:
  - the non-LGC applicability decision;
  - the Vague 1/Vague 2 relationship;
  - a Ségur security-theme-to-repository crosswalk;
  - current controls, known gaps, and residual obligations;
  - health-domain requirements outside this repository;
  - an evidence checklist for a derived candidate product;
- add a pull-request security review checklist.

### CI and supply-chain hardening

- set read-only default GitHub token permissions on test and security workflows;
- grant `security-events: write` only to the CodeQL analysis job;
- add bounded job timeouts;
- pin TruffleHog to the immutable commit for `v3.95.2` instead of `@main`;
- pin `govulncheck` to `v1.1.4` and `gosec` to `v2.25.0` instead of resolving `@latest` at run time;
- pin the scan-report upload action to the immutable commit for `v7.0.1`;
- retain commit-scoped machine-readable `govulncheck` and gosec reports for 30 days while preserving blocking scan status;
- enable gosec suppression tracking so accepted findings remain visible in evidence.

### Security finding resolved during application

The first pinned gosec run exposed one `G705` XSS-taint warning in the SPA fallback handler. Review established that request input only selects the fallback path; the response body is read from a host-configured read-only `fs.FS` and is not built from or interpolated with the URL, query, headers, or request body.

This PR:

- adds `X-Content-Type-Options: nosniff` to the SPA fallback response;
- records a narrow rule-specific `G705` justification at the sink rather than adding a global exclusion;
- adds a regression test with an attacker-controlled encoded URL path proving that only the trusted index document is returned;
- retains the suppression and justification in the machine-readable gosec report.

## Existing controls documented by the assessment

The repository already provides reusable controls including safe native-module selection, opt-in environment exposure, host-owned route authentication/authorization/CSRF/audit/rate limiting, server-side sessions with secure cookie defaults and expiry, OIDC state/nonce/PKCE verification, credential revocation, audit redaction and bounded queries, durable auth stores, trusted-proxy policy, production preflight, SQL readiness, and backup/restore runbook guidance.

## Explicit scope boundaries

This PR does not implement or assert INS, DMP/Mon espace santé, MSSanté, Pro Santé Connect, CDA profiles, e-prescription, CNDA homologation, HDS hosting, patient-record workflows, or other LGC functional requirements. Those apply to the complete healthcare product, publisher, deployment, and operating organization.

It also does not create Ségur penetration-test evidence, an SBOM/provenance release gate, named organizational security owners, or a product-specific REM proof matrix. These remain documented obligations or gaps.

## Verification

Final branch state:

- 14 commits ahead of `main`, 0 behind;
- 10 changed files;
- full Go generation and unit-test suite: passed;
- inspector migration validation: passed;
- golangci-lint: passed;
- CodeQL: passed;
- dependency review: passed;
- `govulncheck`: passed, report retained;
- gosec: passed with zero unsuppressed findings, tracked report retained;
- TruffleHog secret scan: passed;
- generated auth-host smoke test: passed;
- Docker image build and loaded-image smoke test: passed.

Final scan-artifact digests:

- gosec: `sha256:9eac66e25574f73b0ca9d5d006c26e171b74381c67f210dd043f50792ff8fa76`
- govulncheck: `sha256:aae4e17d5b53efbe0c449d8d27aaf5bafb93c7f7d34bcba9e238a88fb67c1895`

## Remaining risk

The repository's pre-existing gosec configuration still globally excludes several command-execution and filesystem rules because those capabilities are intentional parts of the runtime. The crosswalk records this as follow-up work: replace broad exclusions with path-specific policy or justified in-source suppressions as the codebase is reviewed.

The JavaScript runtime is not a hostile-code isolation boundary. Derived products must add process, operating-system, filesystem, network, CPU, memory, tenancy, secret-management, monitoring, backup, incident-response, and healthcare-specific controls appropriate to their threat model.