### PR TITLE
Use Vault GitHub App tokens for Goja GitOps promotion

### DIFF
--- a/.github/workflows/publish-auth-host-image.yaml
+++ b/.github/workflows/publish-auth-host-image.yaml
@@ -30,7 +30,7 @@ on:
 permissions:
   contents: read
   packages: write
-  pull-requests: write
+  id-token: write
 
 concurrency:
   group: publish-auth-host-image-${{ github.ref }}
@@ -116,24 +116,39 @@ jobs:
         with:
           python-version: '3.x'
 
+      - name: Read GitHub App credentials from Vault
+        uses: hashicorp/vault-action@v3
+        with:
+          url: https://vault.yolo.scapegoat.dev
+          method: jwt
+          path: github-actions
+          role: go-go-goja-gitops-pr
+          jwtGithubAudience: https://vault.yolo.scapegoat.dev
+          exportToken: true
+          secrets: |
+            kv/data/ci/github/tiny-idp/gitops-pr-app app_id | GITOPS_APP_ID ;
+            kv/data/ci/github/tiny-idp/gitops-pr-app private_key | GITOPS_APP_PRIVATE_KEY
+
+      - name: Mint GitHub App token for GitOps repository
+        id: gitops-app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ env.GITOPS_APP_ID }}
+          private-key: ${{ env.GITOPS_APP_PRIVATE_KEY }}
+          owner: wesen
+          repositories: 2026-03-27--hetzner-k3s
+
       - name: Open GitOps pull request for published image
         env:
-          GH_TOKEN: ${{ secrets.GITOPS_PR_TOKEN }}
+          GH_TOKEN: ${{ steps.gitops-app-token.outputs.token }}
           GITOPS_PR_GIT_AUTHOR_NAME: github-actions[bot]
           GITOPS_PR_GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
           GHCR_IMAGE: ghcr.io/${{ github.repository_owner }}/go-go-goja-auth-host
         run: |
-          if [ -z "${GH_TOKEN}" ]; then
-            echo "::warning::GITOPS_PR_TOKEN is not configured; skipping GitOps PR creation."
-            exit 0
-          fi
           image_tag="sha-${GITHUB_SHA::7}"
-          if ! python3 scripts/open_gitops_pr.py \
+          python3 scripts/open_gitops_pr.py \
             --config deploy/gitops-targets.json \
             --target goja-auth-host-demo \
             --image "${GHCR_IMAGE}:${image_tag}" \
             --push \
-            --open-pr; then
-            echo "::warning::GitOps PR creation failed after image publish; investigate token/target access separately."
-            exit 0
-          fi
+            --open-pr


### PR DESCRIPTION
## What changed

Replaces the legacy `GITOPS_PR_TOKEN` secret in the auth-host image workflow with the established Vault OIDC and GitHub App pattern.

The workflow now:

1. uses its GitHub Actions OIDC identity to authenticate to Vault;
2. reads only the existing App credential record at `kv/ci/github/tiny-idp/gitops-pr-app`;
3. mints a short-lived installation token scoped to `wesen/2026-03-27--hetzner-k3s`; and
4. passes that token only to the GitOps PR helper.

A failed GitOps PR creation now fails visibly instead of being silently downgraded to a warning.

## Validation

- YAML parsed successfully.
- Full repository pre-push lint and test hooks passed.